### PR TITLE
Upgrade UHC & skip AfterSuite when setup has failed

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 661810e1817ecbc197d0cc9cbe6b384614545cede77fe2c6a3fa1462f8c9675e
-updated: 2019-05-08T11:45:25.163046314-07:00
+hash: 7f3381052e94f79d42ffed22078730d7839c36d2d02d51c429549a04a3d863aa
+updated: 2019-05-15T17:28:46.933970132-07:00
 imports:
 - name: cloud.google.com/go
   version: 8c41231e01b2085512d98153bcffb847ff9b4b9f
@@ -12,7 +12,7 @@ imports:
   - internal/version
   - storage
 - name: github.com/dgrijalva/jwt-go
-  version: 3af4c746e1c248ee8491a3e0c6f7a9cd831e95f8
+  version: 06ea1031745cb8b3dab3f6a236daf2b0aa468b7e
 - name: github.com/gogo/protobuf
   version: 342cbe0a04158f6dcb03ca0079991a51a4248c02
   subpackages:
@@ -101,7 +101,7 @@ imports:
   - matchers/support/goraph/util
   - types
 - name: github.com/openshift-online/uhc-sdk-go
-  version: 7be443c20df031c5abc5244716375489e525133e
+  version: 722cf7c05ce9e442a11a3008aad490c1c075fac5
   subpackages:
   - pkg/client
   - pkg/client/accountsmgmt
@@ -112,7 +112,7 @@ imports:
   - pkg/client/helpers
   - pkg/client/internal
 - name: github.com/openshift/api
-  version: d111834310a57dbb9a14140149477f91e055ba45
+  version: 81d064c11ff2d62705dbb09ed9ac200ef9557716
   subpackages:
   - image/docker10
   - image/dockerpre012
@@ -171,6 +171,7 @@ imports:
   - internal/timeseries
   - lex/httplex
   - trace
+  - websocket
 - name: golang.org/x/oauth2
   version: 9f3314589c9a9136388751d9adae6b0ed400978a
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,10 +1,12 @@
 package: github.com/openshift/osde2e
 import:
 - package: github.com/openshift-online/uhc-sdk-go
-  version: v0.1.10
+  version: v0.1.11
   subpackages:
   - pkg/client
   - pkg/client/clustersmgmt/v1
+- package: github.com/dgrijalva/jwt-go
+  version: 06ea1031745cb8b3dab3f6a236daf2b0aa468b7e
 - package: github.com/openshift/api
   subpackages:
   - project/v1

--- a/pkg/osd/cluster.go
+++ b/pkg/osd/cluster.go
@@ -20,11 +20,6 @@ func (u *OSD) LaunchCluster(cfg *config.Config) (string, error) {
 			ID("4")).
 		Region(v1.NewCloudRegion().
 			ID("us-east-1")).
-		DNS(v1.NewDNS().
-			BaseDomain("devcluster.openshift.com")).
-		AWS(v1.NewAWS().
-			AccessKeyID(cfg.AWSKeyID).
-			SecretAccessKey(cfg.AWSAccessKey)).
 		Version(v1.NewVersion().
 			ID(cfg.ClusterVersion)).
 		Build()

--- a/setup.go
+++ b/setup.go
@@ -42,7 +42,11 @@ var _ = ginkgo.AfterSuite(func() {
 	defer ginkgo.GinkgoRecover()
 	cfg := config.Cfg
 
-	if OSD != nil {
+	if OSD == nil {
+		log.Println("OSD was not configured. Skipping AfterSuite...")
+	} else if cfg.ClusterID == "" {
+		log.Println("CLUSTER_ID is not set, likely due to a setup failure. Skipping AfterSuite...")
+	} else {
 		log.Printf("Getting logs for cluster '%s'...", cfg.ClusterID)
 
 		logs, err := OSD.Logs(cfg.ClusterID, 200)


### PR DESCRIPTION
This PR:
* upgrades to uhc-sdk-go to [v0.1.11](https://github.com/openshift-online/uhc-sdk-go/releases/tag/v0.1.11)
* silences any failures in the `AfterSuite` if they are related to setup issues