### PR TITLE
Use latest nightly when CLUSTER_VERSION is not specified

### DIFF
--- a/e2e.go
+++ b/e2e.go
@@ -8,7 +8,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"strings"
 	"testing"
 	"time"
 
@@ -30,17 +29,8 @@ func RunE2ETests(t *testing.T, cfg *config.Config) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 
 	// set defaults
-	if cfg.ClusterVersion == "" {
-		cfg.ClusterVersion = DefaultVersion
-	}
-
 	if cfg.Suffix == "" {
 		cfg.Suffix = randomStr(5)
-	}
-
-	if cfg.ClusterName == "" {
-		safeVersion := strings.Replace(cfg.ClusterVersion, ".", "-", -1)
-		cfg.ClusterName = "ci-cluster-" + safeVersion + "-" + cfg.Suffix
 	}
 
 	if cfg.ReportDir == "" {

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 7f3381052e94f79d42ffed22078730d7839c36d2d02d51c429549a04a3d863aa
-updated: 2019-05-15T17:28:46.933970132-07:00
+hash: d6cf7abfcd9508d3cb687ca0accee5419d62a6511bf827f2412879ebfa4b7d10
+updated: 2019-05-17T12:24:10.991406828-07:00
 imports:
 - name: cloud.google.com/go
   version: 8c41231e01b2085512d98153bcffb847ff9b4b9f
@@ -62,6 +62,8 @@ imports:
   version: 9316a62528ac99aaecb4e47eadd6dc8aa6533d58
 - name: github.com/json-iterator/go
   version: ab8a2e0c74be9d3be70b3184d9acc634935ded82
+- name: github.com/Masterminds/semver
+  version: c7af12943936e8c39859482e61f0574c2fd7fc75
 - name: github.com/modern-go/concurrent
   version: bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94
 - name: github.com/modern-go/reflect2
@@ -112,7 +114,7 @@ imports:
   - pkg/client/helpers
   - pkg/client/internal
 - name: github.com/openshift/api
-  version: 81d064c11ff2d62705dbb09ed9ac200ef9557716
+  version: d5b34b957e91dbf64013a866951c3ed5770db0b5
   subpackages:
   - image/docker10
   - image/dockerpre012

--- a/glide.yaml
+++ b/glide.yaml
@@ -45,3 +45,5 @@ import:
 - package: k8s.io/test-infra
   subpackages:
   - testgrid/metadata
+- package: github.com/Masterminds/semver
+  version: ~1.4.2

--- a/pkg/osd/versions.go
+++ b/pkg/osd/versions.go
@@ -1,0 +1,97 @@
+package osd
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver"
+	"github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1"
+	"github.com/openshift-online/uhc-sdk-go/pkg/client/errors"
+)
+
+// LatestNightly returns the latest nightly for given major and minor versions. Negative versions match all.
+func (u *OSD) LatestNightly(major, minor int64) (string, error) {
+	resp, err := u.getVersionList()
+	if err != nil {
+		return "", fmt.Errorf("failed getting list of OSD versions: %v", err)
+	} else if resp != nil {
+		err = errResp(resp.Error())
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("couldn't retrieve available versions: %v", err)
+	}
+
+	// parse versions, filter for major+minor nightlies, then sort
+	var versions []*semver.Version
+	resp.Items().Each(func(v *v1.Version) bool {
+		name := strings.TrimPrefix(v.ID(), "openshift-")
+		if version, err := semver.NewVersion(name); err != nil {
+			log.Printf("could not parse version '%s': %v", v.ID(), err)
+		} else if version.Major() != major && major >= 0 {
+			return true
+		} else if version.Minor() != minor && minor >= 0 {
+			return true
+		} else if strings.Contains(version.Prerelease(), "nightly") {
+			versions = append(versions, version)
+		}
+		return true
+	})
+
+	if len(versions) == 0 {
+		return "", fmt.Errorf("no nightlies available for '%d.%d'", major, minor)
+	}
+
+	// return latest nightly
+	sort.Sort(semver.Collection(versions))
+	latest := versions[len(versions)-1]
+	return "openshift-" + latest.Original(), nil
+}
+
+// TODO: remove when retrieving versions using uhc-sdk-go is supported
+func (u *OSD) getVersionList() (*versionListResponse, error) {
+	resp := new(versionListResponse)
+
+	// retrieve version list
+	versionEndpoint := "/api/clusters_mgmt/v1/versions"
+	if rawResp, err := u.conn.Get().Path(versionEndpoint).Send(); err != nil {
+		return nil, err
+	} else if rawResp.Status() != http.StatusOK {
+		if resp.err, err = errors.UnmarshalError(err); err != nil {
+			return nil, err
+		}
+		return resp, nil
+	} else if err = json.Unmarshal(rawResp.Bytes(), resp); err != nil {
+		return nil, err
+	}
+
+	// convert list into uhc-sdk-go types
+	if data, err := resp.Raw.MarshalJSON(); err != nil {
+		return nil, err
+	} else if resp.list, err = v1.UnmarshalVersionList(data); err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+type versionListResponse struct {
+	Kind  string          `json:"kind"`
+	Page  int             `json:"page"`
+	Size  int             `json:"size"`
+	Total int             `json:"total"`
+	Raw   json.RawMessage `json:"items"`
+
+	list *v1.VersionList
+	err  *errors.Error
+}
+
+func (r *versionListResponse) Items() *v1.VersionList {
+	return r.list
+}
+func (r *versionListResponse) Error() *errors.Error {
+	return r.err
+}


### PR DESCRIPTION
PR checks UHC versions for available versions and chooses the latest nightly that exists.