### PR TITLE
Run openshift-tests as part of suite

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/openshift/osde2e/pkg/config"
 
 	// import suites to be tested
+	_ "github.com/openshift/osde2e/test/openshift"
 	_ "github.com/openshift/osde2e/test/verify"
 )
 

--- a/pkg/helper/clientsets.go
+++ b/pkg/helper/clientsets.go
@@ -7,6 +7,7 @@ import (
 	project "github.com/openshift/client-go/project/clientset/versioned"
 	route "github.com/openshift/client-go/route/clientset/versioned"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 // Kube returns the clientset for Kubernetes upstream.
@@ -34,5 +35,12 @@ func (h *H) Route() route.Interface {
 func (h *H) Project() project.Interface {
 	client, err := project.NewForConfig(h.restConfig)
 	Expect(err).ShouldNot(HaveOccurred(), "failed to configure Project clientset")
+	return client
+}
+
+// REST returns a client for generic operations.
+func (h *H) REST() *rest.RESTClient {
+	client, err := rest.RESTClientFor(h.restConfig)
+	Expect(err).ShouldNot(HaveOccurred(), "failed to configure REST client")
 	return client
 }

--- a/pkg/helper/helper.go
+++ b/pkg/helper/helper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	projectv1 "github.com/openshift/api/project/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -35,7 +36,7 @@ type H struct {
 
 	// internal
 	restConfig *rest.Config
-	proj       string
+	proj       *projectv1.Project
 }
 
 // Setup configures a *rest.Config using the embedded kubeconfig then sets up a Project for tests to run in.
@@ -50,19 +51,20 @@ func (h *H) Setup() {
 	Expect(err).ShouldNot(HaveOccurred(), "failed to create project")
 	Expect(proj).ShouldNot(BeNil())
 
-	h.proj = proj.Name
+	h.proj = proj
 }
 
 // Cleanup deletes a Project after tests have been ran.
 func (h *H) Cleanup() {
-	err := h.cleanup(h.proj)
+	err := h.cleanup(h.proj.Name)
 	Expect(err).ShouldNot(HaveOccurred(), "could not delete project '%s'", h.proj)
 
 	h.restConfig = nil
-	h.proj = ""
+	h.proj = nil
 }
 
 // CurrentProject returns the project being used for testing.
 func (h *H) CurrentProject() string {
-	return h.proj
+	Expect(h.proj).NotTo(BeNil(), "no project is currently set")
+	return h.proj.Name
 }

--- a/pkg/helper/pods.go
+++ b/pkg/helper/pods.go
@@ -1,0 +1,34 @@
+package helper
+
+import (
+	"log"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	kubev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// WaitForPodPhase until in target, checking n times and sleeping dur between them. Last known phase is returned.
+func (h *H) WaitForPodPhase(pod *kubev1.Pod, target kubev1.PodPhase, n int, dur time.Duration) (phase kubev1.PodPhase) {
+	var err error
+	for i := 0; i < n; i++ {
+		if pod, err = h.Kube().CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{}); err != nil {
+			log.Println(err)
+		} else if pod != nil {
+			phase = pod.Status.Phase
+
+			// stop checking if Pod has reached state or failed
+			if phase == target || phase == kubev1.PodFailed {
+				return
+			}
+		}
+
+		log.Printf("Waiting for Pod '%s/%s' to be %s, currently %s...", pod.Namespace, pod.Name, target, phase)
+		time.Sleep(dur)
+	}
+
+	Expect(phase).NotTo(BeEmpty())
+	return
+}

--- a/pkg/helper/projects.go
+++ b/pkg/helper/projects.go
@@ -4,9 +4,44 @@ import (
 	"fmt"
 	"math/rand"
 
+	. "github.com/onsi/gomega"
+
 	projectv1 "github.com/openshift/api/project/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+// GiveCurrentProjectClusterAdmin to default service account and ensure its removed after project deletion.
+func (h *H) GiveCurrentProjectClusterAdmin() {
+	// use OwnerReference of project to ensure deletion
+	Expect(h.proj).NotTo(BeNil())
+	gvk := schema.FromAPIVersionAndKind("project.openshift.io/v1", "Project")
+	projRef := *metav1.NewControllerRef(h.proj, gvk)
+
+	// create binding with OwnerReference
+	_, err := h.Kube().RbacV1().ClusterRoleBindings().Create(&rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "osde2e-test-access-",
+			OwnerReferences: []metav1.OwnerReference{
+				projRef,
+			},
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      "default",
+				Namespace: h.CurrentProject(),
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     "cluster-admin",
+		},
+	})
+	Expect(err).NotTo(HaveOccurred(), "couldn't set correct permissions for OpenShift E2E")
+}
 
 func (h *H) createProject(suffix string) (*projectv1.Project, error) {
 	proj := &projectv1.Project{

--- a/test/openshift/openshift.go
+++ b/test/openshift/openshift.go
@@ -1,0 +1,45 @@
+// Package openshift runs the OpenShift extended test suite.
+package openshift
+
+import (
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/osde2e/pkg/helper"
+)
+
+const (
+	testsNamespace   = "openshift"
+	testsImageStream = "tests"
+)
+
+var _ = ginkgo.Describe("OpenShift E2E", func() {
+	defer ginkgo.GinkgoRecover()
+	h := helper.New()
+
+	ginkgo.It("should run until completion", func() {
+		// setup permissions
+		h.GiveCurrentProjectClusterAdmin()
+
+		// get name of latest test image from ImageStream
+		testImageName := ""
+		stream, err := h.Image().ImageV1().ImageStreams(testsNamespace).Get(testsImageStream, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		for _, tag := range stream.Spec.Tags {
+			if tag.Name == "latest" {
+				Expect(tag.From).NotTo(BeNil())
+				testImageName = tag.From.Name
+			}
+		}
+		Expect(testImageName).NotTo(BeEmpty(), "no latest tests")
+
+		// run tests inside Pod
+		testPod, err := createOpenShiftTestsPod(h, testImageName)
+		Expect(err).NotTo(HaveOccurred())
+
+		// get results of test
+		gatherResults(h, testPod)
+	})
+})

--- a/test/openshift/pod.go
+++ b/test/openshift/pod.go
@@ -23,8 +23,8 @@ oc config set-context {{.Name}} --cluster={{.Name}} --user={{.Name}}
 oc config use-context {{.Name}}
 
 mkdir ./results
-#openshift-tests run openshift/conformance --dry-run --loglevel=10 --include-success --junit-dir=./results
-cd results && touch helo && echo "Starting server" && python -m SimpleHTTPServer
+openshift-tests run openshift/conformance --dry-run --loglevel=10 --include-success --junit-dir=./results
+cd results && echo "Starting server" && python -m SimpleHTTPServer
 `
 )
 
@@ -86,6 +86,6 @@ func createOpenShiftTestsPod(h *helper.H, testImageName string) (*kubev1.Pod, er
 	})
 
 	phase := h.WaitForPodPhase(pod, kubev1.PodRunning, 25, 6*time.Second)
-	Expect(phase).To(Equal(kubev1.PodSucceeded))
+	Expect(phase).To(Equal(kubev1.PodRunning))
 	return pod, err
 }

--- a/test/openshift/pod.go
+++ b/test/openshift/pod.go
@@ -1,0 +1,91 @@
+package openshift
+
+import (
+	"bytes"
+	"html/template"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	kubev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/osde2e/pkg/helper"
+)
+
+const (
+	serviceAccountDir = "/var/run/secrets/kubernetes.io/serviceaccount"
+
+	testCmd = `
+oc config set-cluster {{.Name}} --server={{.Server}} --certificate-authority={{.CA}}
+oc config set-credentials {{.Name}} --token=$(cat {{.TokenFile}})
+oc config set-context {{.Name}} --cluster={{.Name}} --user={{.Name}}
+oc config use-context {{.Name}}
+
+mkdir ./results
+#openshift-tests run openshift/conformance --dry-run --loglevel=10 --include-success --junit-dir=./results
+cd results && touch helo && echo "Starting server" && python -m SimpleHTTPServer
+`
+)
+
+var (
+	testCmdT    = template.Must(template.New("testCmd").Parse(testCmd))
+	testCmdArgs = struct {
+		Name      string
+		Server    string
+		CA        string
+		TokenFile string
+	}{
+		Name:      "osde2e",
+		Server:    "https://kubernetes.default",
+		CA:        serviceAccountDir + "/ca.crt",
+		TokenFile: serviceAccountDir + "/token",
+	}
+)
+
+func createOpenShiftTestsPod(h *helper.H, testImageName string) (*kubev1.Pod, error) {
+	var finalCmd bytes.Buffer
+	err := testCmdT.Execute(&finalCmd, testCmdArgs)
+	Expect(err).NotTo(HaveOccurred())
+
+	pod, err := h.Kube().CoreV1().Pods(h.CurrentProject()).Create(&kubev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "openshift-tests-",
+			Labels: map[string]string{
+				"osde2e": "openshift-tests",
+			},
+		},
+		Spec: kubev1.PodSpec{
+			Containers: []kubev1.Container{
+				{
+					Name:  "openshift-tests",
+					Image: testImageName,
+					Env: []kubev1.EnvVar{
+						{
+							Name:  "KUBECONFIG",
+							Value: "/kubeconfig",
+						},
+					},
+					Args: []string{
+						"/bin/bash",
+						"-c",
+						finalCmd.String(),
+					},
+					Ports: []kubev1.ContainerPort{
+						{
+							Name:          "results",
+							ContainerPort: 8000,
+							Protocol:      kubev1.ProtocolTCP,
+						},
+					},
+					ImagePullPolicy: kubev1.PullAlways,
+				},
+			},
+			RestartPolicy: kubev1.RestartPolicyNever,
+		},
+	})
+
+	phase := h.WaitForPodPhase(pod, kubev1.PodRunning, 25, 6*time.Second)
+	Expect(phase).To(Equal(kubev1.PodSucceeded))
+	return pod, err
+}

--- a/test/openshift/results.go
+++ b/test/openshift/results.go
@@ -1,0 +1,42 @@
+package openshift
+
+import (
+	. "github.com/onsi/gomega"
+	"log"
+
+	kubev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/osde2e/pkg/helper"
+)
+
+// gatherResults setups up a Service for the Pod to expose the HTTP results server then transfers results.
+func gatherResults(h *helper.H, pod *kubev1.Pod) {
+	var ports []kubev1.ServicePort
+	for _, c := range pod.Spec.Containers {
+		for _, p := range c.Ports {
+			ports = append(ports, kubev1.ServicePort{
+				Name:     p.Name,
+				Protocol: p.Protocol,
+				Port:     p.ContainerPort,
+			})
+		}
+	}
+
+	// create result Service
+	svc, err := h.Kube().CoreV1().Services(pod.Namespace).Create(&kubev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "openshift-tests-",
+		},
+		Spec: kubev1.ServiceSpec{
+			Selector: pod.Labels,
+			Ports:    ports,
+		},
+	})
+	Expect(err).NotTo(HaveOccurred(), "couldn't create results Service")
+
+	resp := h.Kube().CoreV1().Services(pod.Namespace).ProxyGet("http", svc.Name, "8000", "/", nil)
+	data, err := resp.DoRaw()
+	Expect(err).NotTo(HaveOccurred())
+	log.Println(data)
+}

--- a/test/openshift/results.go
+++ b/test/openshift/results.go
@@ -1,8 +1,13 @@
 package openshift
 
 import (
-	. "github.com/onsi/gomega"
+	"io/ioutil"
 	"log"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/gomega"
+	"golang.org/x/net/html"
 
 	kubev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +41,35 @@ func gatherResults(h *helper.H, pod *kubev1.Pod) {
 	Expect(err).NotTo(HaveOccurred(), "couldn't create results Service")
 
 	resp := h.Kube().CoreV1().Services(pod.Namespace).ProxyGet("http", svc.Name, "8000", "/", nil)
-	data, err := resp.DoRaw()
+	rdr, err := resp.Stream()
 	Expect(err).NotTo(HaveOccurred())
-	log.Println(data)
+
+	n, err := html.Parse(rdr)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(rdr.Close()).NotTo(HaveOccurred())
+
+	downloadLinks(h, svc, n)
+}
+
+func downloadLinks(h *helper.H, svc *kubev1.Service, n *html.Node) {
+	if n.Type == html.ElementNode && n.Data == "a" {
+		for _, a := range n.Attr {
+			if a.Key == "href" {
+				resp := h.Kube().CoreV1().Services(svc.Namespace).ProxyGet("http", svc.Name, "8000", "/"+a.Val, nil)
+				data, err := resp.DoRaw()
+				Expect(err).NotTo(HaveOccurred())
+
+				filename := a.Val
+				log.Println("Downloading " + filename)
+
+				dst := filepath.Join(h.ReportDir, filename)
+				err = ioutil.WriteFile(dst, data, os.ModePerm)
+				Expect(err).NotTo(HaveOccurred())
+			}
+		}
+	}
+
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		downloadLinks(h, svc, c)
+	}
 }


### PR DESCRIPTION
This PR adds running the [OpenShift extended test suite](https://github.com/openshift/origin/tree/master/test/extended) as part of osde2e. The tests are run out of Pod using the ImageStream 'tests' that the cluster is deployed with.

Closes #8 