### PR TITLE
Use latest available rc by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ docker-test:
 	docker run \
 		-t \
 		-e CLUSTER_ID=$(CLUSTER_ID) \
-		-e CLUSTER_VERSION=openshift-v4.1.0-rc.5 \
 		-e UHC_TOKEN=$(UHC_REFRESH_TOKEN) \
 		-e AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) \
 		-e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) \

--- a/pkg/osd/versions.go
+++ b/pkg/osd/versions.go
@@ -13,8 +13,8 @@ import (
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/errors"
 )
 
-// LatestNightly returns the latest nightly for given major and minor versions. Negative versions match all.
-func (u *OSD) LatestNightly(major, minor int64) (string, error) {
+// LatestPrerelease gets latest prerelease containing str for major and minor versions. Negative versions match all.
+func (u *OSD) LatestPrerelease(major, minor int64, str string) (string, error) {
 	resp, err := u.getVersionList()
 	if err != nil {
 		return "", fmt.Errorf("failed getting list of OSD versions: %v", err)
@@ -36,14 +36,14 @@ func (u *OSD) LatestNightly(major, minor int64) (string, error) {
 			return true
 		} else if version.Minor() != minor && minor >= 0 {
 			return true
-		} else if strings.Contains(version.Prerelease(), "nightly") {
+		} else if strings.Contains(version.Prerelease(), str) {
 			versions = append(versions, version)
 		}
 		return true
 	})
 
 	if len(versions) == 0 {
-		return "", fmt.Errorf("no nightlies available for '%d.%d'", major, minor)
+		return "", fmt.Errorf("no versions available with prerelease '%s' for '%d.%d'", str, major, minor)
 	}
 
 	// return latest nightly

--- a/setup.go
+++ b/setup.go
@@ -75,10 +75,10 @@ func setupCluster(cfg *config.Config) (err error) {
 	if cfg.ClusterID == "" {
 		// use latest nightly if no version specified
 		if cfg.ClusterVersion == "" {
-			if cfg.ClusterVersion, err = OSD.LatestNightly(-1, -1); err != nil {
+			if cfg.ClusterVersion, err = OSD.LatestPrerelease(-1, -1, "rc"); err != nil {
 				return fmt.Errorf("CLUSTER_VERSION not set and failed to get latest nightly: %v", err)
 			}
-			log.Printf("Using latest nightly '%s' as CLUSTER_VERSION", cfg.ClusterVersion)
+			log.Printf("Using latest rc '%s' as CLUSTER_VERSION", cfg.ClusterVersion)
 		}
 
 		if cfg.ClusterName == "" {


### PR DESCRIPTION
This change uses the newest rc available for tests.