### PR TITLE
remove docker containers after use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ test: out/osde2e
 docker-test:
 	docker run \
 		-t \
+		--rm \
 		-e CLUSTER_ID=$(CLUSTER_ID) \
 		-e DEBUG_OSD=1 \
 		-e USE_PROD=$(USE_PROD) \


### PR DESCRIPTION
Currently docker containers after use stopped but not deleted.
This may prevent obsoleted docker images to be garbage collected, because they are referenced by stopped container.
That in turn leads to disk full situation for jenkins.