### PR TITLE
Upgrades

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,4 +53,10 @@ type Config struct {
 
 	// DebugOSD shows debug level messages when enabled.
 	DebugOSD bool `env:"DEBUG_OSD"`
+
+	// UpgradeReleaseStream used to retrieve latest release images. If set, it will be used to perform an upgrade.
+	UpgradeReleaseStream string `env:"UPGRADE_RELEASE_STREAM"`
+
+	// UpgradeImage is the release image a cluster is upgraded to. If set, it overrides the release stream and upgrades.
+	UpgradeImage string `env:"UPGRADE_IMAGE"`
 }

--- a/pkg/helper/clientsets.go
+++ b/pkg/helper/clientsets.go
@@ -3,6 +3,7 @@ package helper
 import (
 	. "github.com/onsi/gomega"
 
+	config "github.com/openshift/client-go/config/clientset/versioned"
 	image "github.com/openshift/client-go/image/clientset/versioned"
 	project "github.com/openshift/client-go/project/clientset/versioned"
 	route "github.com/openshift/client-go/route/clientset/versioned"
@@ -10,6 +11,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
+
+// Cfg return a client for the Config API.
+func (h *H) Cfg() config.Interface {
+	client, err := config.NewForConfig(h.restConfig)
+	Expect(err).ShouldNot(HaveOccurred(), "failed to configure Config client")
+	return client
+}
 
 // Dynamic returns a client that works on arbitrary types.
 func (h *H) Dynamic() dynamic.Interface {

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -8,19 +8,27 @@ import (
 
 // testCmd configures default Service Account as a kubeconfig, runs openshift-tests, and serves results over HTTP
 const testCmd = `
+# setup cluster credentials
 oc config set-cluster {{.Name}} --server={{.Server}} --certificate-authority={{.CA}}
 oc config set-credentials {{.Name}} --token=$(cat {{.TokenFile}})
 oc config set-context {{.Name}} --cluster={{.Name}} --user={{.Name}}
 oc config use-context {{.Name}}
 
+# create OutputDir
 mkdir -p {{.OutputDir}}
-{{.Cmd}}
+
+# run Cmd and preserve it's stdout and stderr
+{{.Cmd}} > >(tee {{.OutputDir}}/runner-out.txt) 2> >(tee {{.OutputDir}}/runner-err.txt >&2)
+
+# create a Tarball of OutputDir if requested
 {{$outDir := .OutputDir}}
 {{if .Tarball}}
 	{{$outDir = "/tmp/out"}}
         mkdir -p {{$outDir}}
 	tar cvfz {{$outDir}}/{{.Name}}.tgz {{.OutputDir}}
 {{end}}
+
+# make results available using HTTP
 cd {{$outDir}} && echo "Starting server" && python -m SimpleHTTPServer
 `
 

--- a/pkg/upgrade/releases.go
+++ b/pkg/upgrade/releases.go
@@ -1,0 +1,43 @@
+package upgrade
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+const (
+	// format string for release stream latest
+	latestReleaseURLFmt = "https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/%s/latest"
+)
+
+// LatestRelease retrieves latest release information for given releaseStream.
+func LatestRelease(releaseStream string) (name, pullSpec string, err error) {
+	latestURL := fmt.Sprintf(latestReleaseURLFmt, releaseStream)
+	resp, err := http.Get(latestURL)
+	if err != nil {
+		err = fmt.Errorf("failed to get latest for stream '%s': %v", releaseStream, err)
+		return
+	}
+
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		err = fmt.Errorf("failed reading body: %v", err)
+		return
+	}
+
+	latest := latestAccepted{}
+	if err = json.Unmarshal(data, &latest); err != nil {
+		err = fmt.Errorf("error decoding body of '%s': %v", data, err)
+	}
+
+	return latest.Name, latest.PullSpec, nil
+}
+
+// latestAccepted information from release controller.
+type latestAccepted struct {
+	Name        string `json:"name"`
+	PullSpec    string `json:"pullSpec"`
+	DownloadURL string `json:"downloadURL"`
+}

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -1,0 +1,144 @@
+// Package upgrade provides utilities to per
+package upgrade
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/osde2e/pkg/config"
+	"github.com/openshift/osde2e/pkg/helper"
+)
+
+const (
+	// ClusterVersionName is used to identify the default ClusterVersion.
+	ClusterVersionName = "version"
+)
+
+var (
+	// ActiveConditions have true statuses when an upgrade is ongoing.
+	ActiveConditions = []configv1.ClusterStatusConditionType{
+		configv1.OperatorProgressing,
+		configv1.OperatorDegraded,
+		configv1.ClusterStatusConditionType("Failing"),
+	}
+
+	// MaxDuration is how long an upgrade will run before failing.
+	MaxDuration = 90 * time.Minute
+)
+
+// RunUpgrade uses the OpenShift extended suite to upgrade a cluster to the image provided in cfg.
+func RunUpgrade(cfg *config.Config) error {
+	// setup helper
+	h := &helper.H{
+		Config: cfg,
+	}
+	h.Setup()
+	defer h.Cleanup()
+
+	log.Printf("Upgrading cluster to UPGRADE_IMAGE '%s'", cfg.UpgradeImage)
+	desired, err := TriggerUpgrade(h, cfg)
+	if err != nil {
+		return fmt.Errorf("failed triggering upgrade: %v", err)
+	}
+	log.Println("Cluster acknowledged update request.")
+
+	log.Println("Upgrading...")
+	if err = wait.PollImmediate(10*time.Second, MaxDuration, func() (bool, error) {
+		done, msg, err := IsUpgradeDone(h, desired.Spec.DesiredUpdate)
+		if !done {
+			log.Printf("Upgrade in progress: %s", msg)
+		}
+		return done, err
+	}); err != nil {
+		return fmt.Errorf("failed to upgrade cluster: %v", err)
+	}
+	log.Println("Upgrade complete!")
+	return nil
+}
+
+// TriggerUpgrade uses a helper to perform an upgrade.
+func TriggerUpgrade(h *helper.H, cfg *config.Config) (*configv1.ClusterVersion, error) {
+	// setup Config client
+	cfgClient := h.Cfg()
+
+	// get current Version
+	getOpts := metav1.GetOptions{}
+	cVersion, err := cfgClient.ConfigV1().ClusterVersions().Get(ClusterVersionName, getOpts)
+	if err != nil {
+		return cVersion, fmt.Errorf("couldn't get current ClusterVersion '%s': %v", ClusterVersionName, err)
+	}
+
+	// split image into name and tag
+	imageParts := strings.Split(cfg.UpgradeImage, ":")
+	if len(imageParts) != 2 {
+		return cVersion, fmt.Errorf("an UPGRADE_IMAGE should have a name and an a tag, got %v", imageParts)
+	}
+
+	// set requested upgrade targets
+	cVersion.Spec.DesiredUpdate = &configv1.Update{
+		Version: imageParts[1],
+		Image:   cfg.UpgradeImage,
+		Force:   true,
+	}
+	updatedCV, err := cfgClient.ConfigV1().ClusterVersions().Update(cVersion)
+	if err != nil {
+		return updatedCV, fmt.Errorf("couldn't update desired ClusterVersion: %v", err)
+	}
+
+	// wait for update acknowledgement
+	updateGeneration := updatedCV.Generation
+	if err = wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+		if cVersion, err = cfgClient.ConfigV1().ClusterVersions().Get(ClusterVersionName, getOpts); err != nil {
+			return false, err
+		}
+		return cVersion.Status.ObservedGeneration >= updateGeneration, nil
+	}); err != nil {
+		return updatedCV, fmt.Errorf("cluster did to acknowledge update in a timely manner: %v", err)
+	}
+
+	return updatedCV, nil
+}
+
+// IsUpgradeDone returns with done true when an upgrade is complete at desired and any available msg.
+func IsUpgradeDone(h *helper.H, desired *configv1.Update) (done bool, msg string, err error) {
+	// retrieve current ClusterVersion
+	cfgClient, getOpts := h.Cfg(), metav1.GetOptions{}
+	cVersion, err := cfgClient.ConfigV1().ClusterVersions().Get(ClusterVersionName, getOpts)
+	if err != nil {
+		log.Printf("error getting ClusterVersion '%s': %v", ClusterVersionName, err)
+	}
+
+	// ensure working towards correct desired
+	curDesired := cVersion.Status.Desired
+	if curDesired.Image != desired.Image || curDesired.Version != desired.Version {
+		return false, fmt.Sprintf("desired not yet updated; desired: %v, cur: %v", desired, curDesired), nil
+	}
+
+	// check if any ActiveConditions indicate an upgrade is ongoing
+	for _, aCondition := range ActiveConditions {
+		for _, c := range cVersion.Status.Conditions {
+			if c.Type == aCondition && c.Status == configv1.ConditionTrue {
+				return false, c.Message, nil
+			}
+		}
+	}
+
+	// check that latest history entry is desired and completed
+	if len(cVersion.Status.History) > 0 {
+		latest := &cVersion.Status.History[0]
+		if latest == nil || latest.State != configv1.CompletedUpdate {
+			return false, "history doesn't have a completed update", nil
+		} else if latest.Image != desired.Image || latest.Version != desired.Version {
+			return false, fmt.Sprintf("latest in history doesn't match desired; desired: %v, cur: %v", desired, latest), nil
+		}
+	}
+
+	done = true
+	return
+}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,47 @@
+package osde2e
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/openshift/osde2e/pkg/config"
+	"github.com/openshift/osde2e/pkg/osd"
+	"github.com/openshift/osde2e/pkg/upgrade"
+)
+
+// ChooseVersions sets versions in cfg if not set based on defaults and upgrade options.
+// If a release stream is set for an upgrade the previous available version is used and it's image is used for upgrade.
+func ChooseVersions(cfg *config.Config, osd *osd.OSD) (err error) {
+	// when defined, use set version
+	if len(cfg.ClusterVersion) != 0 {
+		return nil
+	}
+
+	// if release stream target is set, try to use previous version
+	if cfg.UpgradeImage == "" && cfg.UpgradeReleaseStream != "" {
+		if osd == nil {
+			return errors.New("osd must be setup when upgrading with release stream")
+		}
+
+		name, pullSpec, err := upgrade.LatestRelease(cfg.UpgradeReleaseStream)
+		if err != nil {
+			return fmt.Errorf("couldn't get latest release from release-controller: %v", err)
+		}
+
+		// get earlier available version from OSD
+		if cfg.ClusterVersion, err = osd.PreviousVersion(name); err != nil {
+			return fmt.Errorf("failed retrieving previous version to '%s': %v", name, err)
+		}
+
+		// set upgrade image
+		log.Printf("Selecting version '%s' to be able to upgrade to '%s' on release stream '%s'",
+			cfg.ClusterVersion, name, cfg.UpgradeReleaseStream)
+		cfg.UpgradeImage = pullSpec
+	} else if cfg.ClusterVersion, err = OSD.DefaultVersion(); err != nil {
+		return fmt.Errorf("failed to get default version: %v", err)
+	} else {
+		log.Printf("CLUSTER_VERSION not set, using the current default '%s'", cfg.ClusterVersion)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR:
- Adds function to osd to get previous available version given a semver
- Adds environment vars to configure update targets
- Adds a Config API client into helper
- Modify runner to preserve stdout & stderr
- Integrates with release-controller to get latest version
- Performs an upgrade on osde2e, if configured

First stage of  #16 