### PR TITLE
Enable NodeVertical scale tests

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -7,6 +7,7 @@ import (
 
 	// import suites to be tested
 	_ "github.com/openshift/osde2e/test/openshift"
+	_ "github.com/openshift/osde2e/test/scale"
 	_ "github.com/openshift/osde2e/test/state"
 	_ "github.com/openshift/osde2e/test/verify"
 )

--- a/test/scale/nodevertical.go
+++ b/test/scale/nodevertical.go
@@ -5,6 +5,8 @@ import (
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	kubev1 "k8s.io/api/core/v1"
+
 	"github.com/openshift/osde2e/pkg/helper"
 )
 
@@ -19,6 +21,12 @@ var _ = ginkgo.Describe("Scaling", func() {
 			PlaybookPath: "workloads/nodevertical.yml",
 		}
 		r := scaleCfg.Runner(h)
+
+		// only test on 3 nodes
+		r.PodSpec.Containers[0].Env = append(r.PodSpec.Containers[0].Env, kubev1.EnvVar{
+			Name: "NODEVERTICAL_NODE_COUNT",
+			Value: "3",
+		})
 
 		// run tests
 		stopCh := make(chan struct{})


### PR DESCRIPTION
This PR:
* includes the NodeVertical test to be run as part of the suite
* Uses environment variable `NODEVERTICAL_NODE_COUNT` to lower the number of nodevertical nodes to 3. In the future this should be set programmatically based on the cluster.