### PR TITLE
Require at least 3 CLEAN_RUNS, remove NEW_ONLY

### DIFF
--- a/ci/upgrade_events.sh
+++ b/ci/upgrade_events.sh
@@ -1,3 +1,4 @@
 #!/bin/bash -e
 
-NEW_ONLY=1 make docker-test
+# Requires 3 successful passing builds before skipping
+CLEAN_RUNS=3 make docker-test

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,8 +54,8 @@ type Config struct {
 	// DebugOSD shows debug level messages when enabled.
 	DebugOSD bool `env:"DEBUG_OSD"`
 
-	// NewOnly only runs if the build-version is different than the last run.
-	NewOnly bool `env:"NEW_ONLY"`
+	// CleanRuns is the number of times the test-version is run before skipping.
+	CleanRuns int `env:"CLEAN_RUNS"`
 
 	// UpgradeReleaseStream used to retrieve latest release images. If set, it will be used to perform an upgrade.
 	UpgradeReleaseStream string `env:"UPGRADE_RELEASE_STREAM"`

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"reflect"
+	"strconv"
 )
 
 func init() {
@@ -24,6 +25,10 @@ func (c *Config) LoadFromEnv() {
 					field.SetBool(true)
 				case reflect.Slice:
 					field.SetBytes([]byte(envVal))
+				case reflect.Int:
+					if num, err := strconv.ParseInt(envVal, 10, 0); err == nil {
+						field.SetInt(num)
+					}
 				}
 			}
 		}

--- a/pkg/testgrid/latest.go
+++ b/pkg/testgrid/latest.go
@@ -17,21 +17,23 @@ const (
 )
 
 // LatestStarted returns the started record for the latest build.
-func (t *TestGrid) LatestStarted(ctx context.Context) (testgrid.Started, error) {
-	buildNum, err := t.getLatestBuild(ctx)
+func (t *TestGrid) LatestStarted(ctx context.Context) (started testgrid.Started, buildNum int, err error) {
+	buildNum, err = t.getLatestBuild(ctx)
 	if err != nil {
-		return testgrid.Started{}, fmt.Errorf("couldn't get latest build: %v", err)
+		return started, buildNum, fmt.Errorf("couldn't get latest build: %v", err)
 	}
-	return t.Started(ctx, buildNum)
+	started, err = t.Started(ctx, buildNum)
+	return
 }
 
 // LatestFinished returns the started record for the latest build.
-func (t *TestGrid) LatestFinished(ctx context.Context) (testgrid.Finished, error) {
-	buildNum, err := t.getLatestBuild(ctx)
+func (t *TestGrid) LatestFinished(ctx context.Context) (finished testgrid.Finished, buildNum int, err error) {
+	buildNum, err = t.getLatestBuild(ctx)
 	if err != nil {
-		return testgrid.Finished{}, fmt.Errorf("couldn't get latest build: %v", err)
+		return finished, buildNum, fmt.Errorf("couldn't get latest build: %v", err)
 	}
-	return t.Finished(ctx, buildNum)
+	finished, err = t.Finished(ctx, buildNum)
+	return
 }
 
 func (t *TestGrid) getLatestBuild(ctx context.Context) (int, error) {

--- a/pkg/testgrid/testgrid_test.go
+++ b/pkg/testgrid/testgrid_test.go
@@ -37,16 +37,11 @@ func TestStartTestGridBuild(t *testing.T) {
 		t.Fatalf("Could not start build: %v", err)
 	}
 
-	// check latest build has updated
-	if curBuildNum, err := tg.getLatestBuild(ctx); err != nil {
-		t.Errorf("Failed to get build number: %v", err)
+	// confirm started file
+	if startedFile, curBuildNum, err := tg.LatestStarted(ctx); err != nil {
+		t.Errorf("Failed to get started record: %v", err)
 	} else if curBuildNum != buildNum {
 		t.Errorf("Current build (%d) does not match created build (%d)", curBuildNum, buildNum)
-	}
-
-	// confirm started file
-	if startedFile, err := tg.LatestStarted(ctx); err != nil {
-		t.Errorf("Failed to get started record: %v", err)
 	} else if startedFile.Timestamp == 0 {
 		t.Error("Timestamp was not set")
 	}
@@ -97,7 +92,7 @@ func setupTestGrid(t *testing.T) *TestGrid {
 
 	tg, err := NewTestGrid(cfg.TestGridBucket, cfg.TestGridPrefix, []byte(cfg.TestGridServiceAccount))
 	if err != nil {
-		t.Fatalf("Failed setting up TestGrid: %v", err)
+		t.Fatalf("Failed setting up TestGrid: %v ", err)
 	}
 	return tg
 }


### PR DESCRIPTION
This change:
    - add environment variable `CLEAN_RUNS` which species the number of passing runs with the same build-version
    - removes `NEW_ONLY` which functionality can be accomplished with `CLEAN_RUNS=1`
    - sets osde2e to run with `CLEAN_RUNS=3`