### PR TITLE
Support retrieving JUnit results for a build

### DIFF
--- a/pkg/testgrid/builds.go
+++ b/pkg/testgrid/builds.go
@@ -43,8 +43,8 @@ func (t *TestGrid) Finished(ctx context.Context, buildNum int) (finished testgri
 	return
 }
 
-func (t *TestGrid) getBuildFile(ctx context.Context, buildNum int, filename string) ([]byte, error) {
-	key := t.buildFileKey(buildNum, filename)
+func (t *TestGrid) getBuildFile(ctx context.Context, buildNum int, filename ...string) ([]byte, error) {
+	key := t.buildFileKey(buildNum, filename...)
 	rdr, err := t.bucket.Object(key).NewReader(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to request file '%s' for build %d: %v", key, buildNum, err)
@@ -84,6 +84,7 @@ func (t *TestGrid) writeBuildFile(ctx context.Context, buildNum int, filename st
 	return nil
 }
 
-func (t *TestGrid) buildFileKey(buildNum int, filename string) string {
-	return filepath.Join(t.prefix, strconv.Itoa(buildNum), filename)
+func (t *TestGrid) buildFileKey(buildNum int, filenames ...string) string {
+	buildPath := append([]string{t.prefix, strconv.Itoa(buildNum)}, filenames...)
+	return filepath.Join(buildPath...)
 }

--- a/pkg/testgrid/junit.go
+++ b/pkg/testgrid/junit.go
@@ -1,0 +1,71 @@
+package testgrid
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"path/filepath"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+	"k8s.io/test-infra/testgrid/metadata/junit"
+)
+
+const (
+	// prefix all testsuites start with
+	junitPrefix = "junit_"
+)
+
+// Suites returns the combined testsuites for the build.
+func (t *TestGrid) Suites(ctx context.Context, buildNum int) (suites junit.Suites, err error) {
+	suiteList, err := t.listSuites(ctx, buildNum)
+	if err != nil {
+		return suites, err
+	}
+
+	// combine into a single suites
+	for _, suiteEntry := range suiteList {
+		suites.Suites = append(suites.Suites, suiteEntry.Suites...)
+	}
+	return
+}
+
+func (t *TestGrid) listSuites(ctx context.Context, buildNum int) (suites []junit.Suites, err error) {
+	// list all JUnit xml files for build
+	suitePrefix := t.buildFileKey(buildNum, artifactsDir, junitPrefix)
+	suiteIt := t.bucket.Objects(ctx, &storage.Query{
+		Prefix:    suitePrefix,
+		Delimiter: "/",
+	})
+
+	for {
+		obj, err := suiteIt.Next()
+		// stop when done, return errs, and skip non-XML
+		if err == iterator.Done {
+			break
+		} else if err != nil {
+			return suites, err
+		} else if !strings.HasSuffix(obj.Name, ".xml") {
+			continue
+		}
+
+		// download suite data
+		baseName := filepath.Base(obj.Name)
+		data, err := t.getBuildFile(ctx, buildNum, artifactsDir, baseName)
+		if err != nil {
+			return suites, fmt.Errorf("failed getting suite data: %v", err)
+		}
+
+		// decode suites
+		suite, err := junit.Parse(data)
+		if err != nil {
+			log.Printf("Failed to decode suite in '%s': %v", obj.Name, err)
+			continue
+		}
+
+		// add to suites
+		suites = append(suites, suite)
+	}
+	return suites, nil
+}

--- a/pkg/testgrid/junit_test.go
+++ b/pkg/testgrid/junit_test.go
@@ -1,0 +1,111 @@
+package testgrid
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	testgrid "k8s.io/test-infra/testgrid/metadata"
+)
+
+const (
+	junitSuiteText = `
+<testsuite failures="0" tests="2" time="2378.33176853">
+<testcase classname="e2e.go" name="Extract" time="17.897214866"/>
+<testcase classname="e2e.go" name="TearDown Previous" time="33.737494067"/>
+</testsuite>`
+)
+
+func init() {
+	rand.Seed(time.Now().Unix())
+}
+
+func TestListSuites(t *testing.T) {
+	tg := setupTestGrid(t)
+
+	// initiate a new build
+	now := time.Now().UTC()
+	ctx := context.Background()
+	buildNum := startBuild(t, ctx, tg, now)
+
+	// setup writing testsuites
+	count := 5
+	dir := ""
+	for i := 0; i < count; i++ {
+		dir, _, _ = writeTestSuite(t, dir)
+	}
+	defer os.RemoveAll(dir)
+
+	// upload results
+	finishTimestamp := time.Now().UTC().Unix()
+	passed := true
+	finishedFile := testgrid.Finished{
+		Timestamp: &finishTimestamp,
+		Passed:    &passed,
+		Result:    "PASSED",
+	}
+	if err := tg.FinishBuild(ctx, buildNum, &finishedFile, dir); err != nil {
+		t.Fatalf("Failed to report results: %v", err)
+	}
+
+	// get suites
+	suites, err := tg.Suites(ctx, buildNum)
+	if err != nil {
+		t.Fatalf("Error retrieving suites for build %d: %v", buildNum, err)
+	}
+
+	// count test occurrence
+	testCount := map[string]int{}
+	for _, s := range suites.Suites {
+		for _, r := range s.Results {
+			curCount, _ := testCount[r.Name]
+			testCount[r.Name] = curCount + 1
+		}
+	}
+
+	// check if counts match
+	for testName, c := range testCount {
+		if c != count {
+			t.Fatalf("test count for '%s' doesn't match: have %d, wanted %d", testName, c, count)
+		}
+	}
+}
+
+func writeTestSuite(t *testing.T, dirIn string) (dir, name string, suiteData []byte) {
+	var err error
+
+	// if dirIn empty, create temporary dir
+	if dirIn == "" {
+		dir, err = ioutil.TempDir("", "osde2e-test")
+		if err != nil {
+			t.Fatalf("Failed to create result dir: %v", err)
+		}
+	} else {
+		dir = dirIn
+	}
+
+	// set report
+	name = fmt.Sprintf("junit_%s.xml", randomStr(4))
+	suiteData = []byte(junitSuiteText)
+
+	// write file
+	junitPath := filepath.Join(dir, name)
+	if err = ioutil.WriteFile(junitPath, suiteData, os.ModePerm); err != nil {
+		t.Fatalf("failed to write junit report: %v", err)
+	}
+	return
+}
+
+func randomStr(length int) (str string) {
+	chars := "0123456789abcdefghijklmnopqrstuvwxyz"
+	for i := 0; i < length; i++ {
+		c := string(chars[rand.Intn(len(chars))])
+		str += c
+	}
+	return
+}


### PR DESCRIPTION
This change:
- adds method to `TestGrid` to collect JUnit testsuites for builds