### PR TITLE
Support integration environment

### DIFF
--- a/e2e.go
+++ b/e2e.go
@@ -47,9 +47,14 @@ func RunE2ETests(t *testing.T, cfg *config.Config) {
 		}
 	}
 
+	// support deprecated USE_PROD option
+	if cfg.UseProd {
+		cfg.OSDEnv = "prod"
+	}
+
 	// setup OSD client
 	var err error
-	if OSD, err = osd.New(cfg.UHCToken, !cfg.UseProd, cfg.DebugOSD); err != nil {
+	if OSD, err = osd.New(cfg.UHCToken, cfg.OSDEnv, cfg.DebugOSD); err != nil {
 		t.Fatalf("could not setup OSD: %v", err)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,6 +40,8 @@ type Config struct {
 	TestGridServiceAccount []byte `env:"TESTGRID_SERVICE_ACCOUNT"`
 
 	// UseProd sends requests to production OSD.
+	//
+	// Deprecated: Use OSD_ENV=prod instead.
 	UseProd bool `env:"USE_PROD"`
 
 	// NoDestroy leaves the cluster running after testing.
@@ -50,6 +52,9 @@ type Config struct {
 
 	// Kubeconfig is used to access a cluster.
 	Kubeconfig []byte `env:"TEST_KUBECONFIG"`
+
+	// OSDEnv is the OpenShift Dedicated environment used to provision clusters.
+	OSDEnv string `env:"OSD_ENV"`
 
 	// DebugOSD shows debug level messages when enabled.
 	DebugOSD bool `env:"DEBUG_OSD"`

--- a/pkg/osd/environments.go
+++ b/pkg/osd/environments.go
@@ -1,0 +1,23 @@
+package osd
+
+// Environments are known instance of OSD.
+var Environments = environments{
+	// default to using integration environment
+	"": "int",
+
+	// environments available
+	"int":   "https://api-integration.6943.hive-integration.openshiftapps.com",
+	"stage": "https://api.stage.openshift.com",
+	"prod":  "https://api.openshift.com",
+}
+
+type environments map[string]string
+
+// Choose returns the endpoint for the desired OSD environment. If desired is URL, it will be returned as the endpoint.
+func (e environments) Choose(desired string) string {
+	if val, ok := e[desired]; !ok || desired == val {
+		return desired
+	} else {
+		return e.Choose(val)
+	}
+}

--- a/pkg/osd/osd.go
+++ b/pkg/osd/osd.go
@@ -10,9 +10,6 @@ import (
 )
 
 const (
-	// StagingURL is the API endpoint for the OSD staging environment.
-	StagingURL = "https://api.stage.openshift.com"
-
 	// APIVersion is the version of the OSD API to use.
 	APIVersion = "v1"
 
@@ -24,7 +21,7 @@ const (
 )
 
 // New setups a client to connect to OSD.
-func New(token string, staging, debug bool) (*OSD, error) {
+func New(token, env string, debug bool) (*OSD, error) {
 	logger, err := uhc.NewGoLoggerBuilder().
 		Debug(debug).
 		Build()
@@ -32,15 +29,15 @@ func New(token string, staging, debug bool) (*OSD, error) {
 		return nil, fmt.Errorf("couldn't build logger: %v", err)
 	}
 
+	// select correct environment
+	url := Environments.Choose(env)
+
 	builder := uhc.NewConnectionBuilder().
+		URL(url).
 		TokenURL(TokenURL).
 		Client(ClientID, "").
 		Logger(logger).
 		Tokens(token)
-
-	if staging {
-		builder.URL(StagingURL)
-	}
 
 	conn, err := builder.Build()
 	if err != nil {


### PR DESCRIPTION
This change:
- Adds new option `OSD_ENV` to specify which environment should be tested.
- Supports integration environment
- Deprecrates `USE_PROD`