### PR TITLE
Produce more debug information

### DIFF
--- a/e2e.go
+++ b/e2e.go
@@ -44,6 +44,12 @@ func RunE2ETests(t *testing.T, cfg *config.Config) {
 		}
 	}
 
+	// ensure to wait longer than infra alerting rules thresholds
+	// otherwise startup failures won't trigger alerts
+	if cfg.ClusterUpTimeout == 0 {
+		cfg.ClusterUpTimeout = 135 * time.Minute
+	}
+
 	// support deprecated USE_PROD option
 	if cfg.UseProd {
 		cfg.OSDEnv = "prod"

--- a/e2e.go
+++ b/e2e.go
@@ -27,9 +27,6 @@ var OSD *osd.OSD
 const (
 	// metadata key holding build-version
 	buildVersionKey = "build-version"
-
-	// id given by osd
-	clusterIDKey = "cluster-id"
 )
 
 // RunE2ETests runs the osde2e test suite using the given cfg.
@@ -109,14 +106,15 @@ func reportToTestGrid(t *testing.T, cfg *config.Config, tg *testgrid.TestGrid, b
 			result = "SUCCESS"
 		}
 
+		// create metadata from config and set build version
+		meta := cfg.TestGrid()
+		meta[buildVersionKey] = buildVersion(cfg)
+
 		finished := metadata.Finished{
 			Timestamp: &end,
 			Passed:    &passed,
 			Result:    result,
-			Metadata: metadata.Metadata{
-				buildVersionKey: buildVersion(cfg),
-				clusterIDKey:    cfg.ClusterID,
-			},
+			Metadata:  meta,
 		}
 
 		ctx := context.Background()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,10 @@
 // Package config provides the configuration for tests run as part of the osde2e suite.
 package config
 
+import (
+	"time"
+)
+
 // Cfg is the configuration used for end to end testing.
 var Cfg = new(Config)
 
@@ -23,6 +27,9 @@ type Config struct {
 
 	// ClusterVersion is the version of the cluster being deployed.
 	ClusterVersion string `env:"CLUSTER_VERSION"`
+
+	// ClusterUpTimeout is how long to wait before failing a cluster launch.
+	ClusterUpTimeout time.Duration
 
 	// TestGridBucket is the Google Cloud Storage bucket where results are reported for TestGrid.
 	TestGridBucket string `env:"TESTGRID_BUCKET"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,16 +19,10 @@ type Config struct {
 	ClusterID string `env:"CLUSTER_ID"`
 
 	// ClusterName is the name of the cluster being created.
-	ClusterName string
+	ClusterName string `env:"CLUSTER_NAME"`
 
 	// ClusterVersion is the version of the cluster being deployed.
 	ClusterVersion string `env:"CLUSTER_VERSION"`
-
-	// AWSKeyID is used by OSD.
-	AWSKeyID string `env:"AWS_ACCESS_KEY_ID"`
-
-	// AWSAccessKey is used by OSD.
-	AWSAccessKey string `env:"AWS_SECRET_ACCESS_KEY"`
 
 	// TestGridBucket is the Google Cloud Storage bucket where results are reported for TestGrid.
 	TestGridBucket string `env:"TESTGRID_BUCKET"`

--- a/pkg/config/testgrid.go
+++ b/pkg/config/testgrid.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"fmt"
+	"reflect"
+
+	testgrid "k8s.io/test-infra/testgrid/metadata"
+)
+
+var (
+	// sensitiveFields removed from output
+	sensitiveFields = []string{
+		"UHC_TOKEN",
+		"TESTGRID_SERVICE_ACCOUNT",
+		"TEST_KUBECONFIG",
+	}
+)
+
+// TestGrid returns a version of c suitable for reporting with any secrets removed.
+func (c *Config) TestGrid() testgrid.Metadata {
+	fmt.Print(c)
+	v := reflect.ValueOf(c).Elem()
+	metadata := make(testgrid.Metadata, v.Type().NumField())
+	for i := 0; i < v.Type().NumField(); i++ {
+		f := v.Type().Field(i)
+		if env, ok := f.Tag.Lookup("env"); ok {
+			if isSensitive(env) {
+				continue
+			}
+
+			field := v.Field(i)
+			metadata[env] = field.Interface()
+		}
+	}
+	return metadata
+}
+
+// returns true if sensitive config
+func isSensitive(s string) bool {
+	for _, sStr := range sensitiveFields {
+		if s == sStr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/osd/logs.go
+++ b/pkg/osd/logs.go
@@ -2,6 +2,7 @@ package osd
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1"
 )
@@ -32,6 +33,11 @@ func (u *OSD) Logs(clusterID string, length int, ids ...string) (logs map[string
 		logs[logID] = []byte(resp.Body().Content())
 	}
 	return
+}
+
+// FullLogs returns as much Logs as it can.
+func (u *OSD) FullLogs(clusterID string, ids ...string) (map[string][]byte, error) {
+	return u.Logs(clusterID, math.MaxInt32-1, ids...)
 }
 
 func (u *OSD) getLogList(clusterID string) ([]string, error) {

--- a/setup.go
+++ b/setup.go
@@ -52,7 +52,7 @@ var _ = ginkgo.AfterSuite(func() {
 	} else {
 		log.Printf("Getting logs for cluster '%s'...", cfg.ClusterID)
 
-		logs, err := OSD.Logs(cfg.ClusterID, 200)
+		logs, err := OSD.FullLogs(cfg.ClusterID)
 		Expect(err).NotTo(HaveOccurred(), "failed to collect cluster logs")
 		writeLogs(cfg, logs)
 

--- a/setup.go
+++ b/setup.go
@@ -88,7 +88,7 @@ func setupCluster(cfg *config.Config) (err error) {
 		log.Printf("CLUSTER_ID of '%s' was provided, skipping cluster creation and using it instead", cfg.ClusterID)
 	}
 
-	if err = OSD.WaitForClusterReady(cfg.ClusterID); err != nil {
+	if err = OSD.WaitForClusterReady(cfg.ClusterID, cfg.ClusterUpTimeout); err != nil {
 		return fmt.Errorf("failed waiting for cluster ready: %v", err)
 	}
 


### PR DESCRIPTION
This PR:
- includes the testing configuration (including name) in TestGrid metadata
- extends the cluster up timeout to longer than the threshold where alerts are triggered in stage
- stops truncating log output and instead gets as much as possible
