### PR TITLE
Check if enough quota exists for a test

### DIFF
--- a/e2e.go
+++ b/e2e.go
@@ -61,6 +61,14 @@ func RunE2ETests(t *testing.T, cfg *config.Config) {
 		t.Fatalf("could not setup OSD: %v", err)
 	}
 
+	// check that enough quota exists for this test
+	if enoughQuota, err := OSD.CheckQuota(cfg); err != nil {
+		log.Printf("Failed to check if enough quota is available: %v", err)
+	} else if !enoughQuota {
+		log.Println("Currently not enough quota exists to run this test, skipping...")
+		t.SkipNow()
+	}
+
 	// configure cluster and upgrade versions
 	if err = ChooseVersions(cfg, OSD); err != nil {
 		t.Fatalf("failed to configure versions: %v", err)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 01fe5dfe1e50d03085658d96d55f61da9da5066b284c8d6dfa0d421d949dde31
-updated: 2019-06-27T10:35:46.983073708-07:00
+hash: 21d9fd04f37290e9d27fe462463bb6d9ed149e60bea1ed33de8a29c6829a61d6
+updated: 2019-07-24T09:29:40.295722705-07:00
 imports:
 - name: cloud.google.com/go
   version: 8c41231e01b2085512d98153bcffb847ff9b4b9f
@@ -111,7 +111,7 @@ imports:
   - matchers/support/goraph/util
   - types
 - name: github.com/openshift-online/uhc-sdk-go
-  version: 22fe296e1f1d57bad08ad9db1ed280c05bbe1e55
+  version: a3b78ca878b88ed68595bea724168eed5c4beb7c
   subpackages:
   - pkg/client
   - pkg/client/accountsmgmt
@@ -124,14 +124,18 @@ imports:
 - name: github.com/openshift/api
   version: dafd2647cb03b7e8b3ccec0eba3f7af85df898d6
   subpackages:
+  - config/v1
   - image/docker10
   - image/dockerpre012
   - image/v1
   - project/v1
   - route/v1
 - name: github.com/openshift/client-go
-  version: 8892c0adc000741c33af70e05f4ede47725d0773
+  version: a85ea6a6b3a5d2dbe41582ee35695dd4683e1f02
   subpackages:
+  - config/clientset/versioned
+  - config/clientset/versioned/scheme
+  - config/clientset/versioned/typed/config/v1
   - image/clientset/versioned
   - image/clientset/versioned/fake
   - image/clientset/versioned/scheme
@@ -503,6 +507,7 @@ imports:
   version: 31df46e6f68bfbc12894d299bc92e13316584543
   subpackages:
   - testgrid/metadata
+  - testgrid/metadata/junit
 - name: k8s.io/utils
   version: c2654d5206da6b7b6ace12841e8f359bb89b443c
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,7 +25,7 @@ import:
   - project/clientset/versioned
   - image/clientset/versioned/fake
 - package: github.com/openshift-online/uhc-sdk-go
-  version: v0.1.23
+  version: v0.1.25
   subpackages:
   - pkg/client
   - pkg/client/clustersmgmt/v1

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,6 +45,9 @@ type Config struct {
 	// Deprecated: Use OSD_ENV=prod instead.
 	UseProd bool `env:"USE_PROD"`
 
+	// MultiAZ deploys a cluster across multiple availability zones.
+	MultiAZ bool `env:"MULTI_AZ"`
+
 	// NoDestroy leaves the cluster running after testing.
 	NoDestroy bool `env:"NO_DESTROY"`
 

--- a/pkg/osd/quota.go
+++ b/pkg/osd/quota.go
@@ -1,0 +1,129 @@
+package osd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"path"
+
+	accounts "github.com/openshift-online/uhc-sdk-go/pkg/client/accountsmgmt/v1"
+	osderrors "github.com/openshift-online/uhc-sdk-go/pkg/client/errors"
+
+	"github.com/openshift/osde2e/pkg/config"
+)
+
+const (
+	// ResourceAWSCluster is the quota resource type for a cluster on AWS.
+	ResourceAWSCluster = "cluster.aws"
+)
+
+// CheckQuota determines if enough quota is available to launch with cfg.
+func (u *OSD) CheckQuota(cfg *config.Config) (bool, error) {
+	// get flavour being deployed
+	flavourId := u.Flavour(cfg)
+	flavourReq, err := u.conn.ClustersMgmt().V1().Flavours().Flavour(flavourId).Get().Send()
+	if err == nil && flavourReq != nil {
+		err = errResp(flavourReq.Error())
+	} else if flavourReq == nil || flavourReq.Body().Empty() {
+		return false, errors.New("returned flavour can't be empty")
+	}
+	flavour := flavourReq.Body()
+
+	// get quota
+	quota, err := u.CurrentAccountQuota()
+	if err != nil {
+		return false, fmt.Errorf("could not get quota: %v", err)
+	}
+
+	// TODO: use compute_machine_type when available in UHC SDK
+	_ = flavour.Nodes()
+	machineType := ""
+
+	return IsQuotaFor(quota, ResourceAWSCluster, machineType, cfg.MultiAZ), nil
+}
+
+// CurrentAccountQuota returns quota available for the current account's organization in the environment.
+func (u *OSD) CurrentAccountQuota() (*accounts.ResourceQuotaList, error) {
+	acc, err := u.CurrentAccount()
+	if err != nil || acc == nil {
+		return nil, fmt.Errorf("couldn't get current account: %v", err)
+	} else if acc.Organization() == nil || acc.Organization().ID() == "" {
+		return nil, fmt.Errorf("organization for account '%s' must be set to get quota", acc.ID())
+	}
+
+	orgId := acc.Organization().ID()
+	quotaList, err := u.getQuotaSummary(orgId)
+	if err == nil && quotaList != nil {
+		err = errResp(quotaList.Error())
+	} else if quotaList == nil {
+		return nil, errors.New("QuotaList can't be nil")
+	}
+	return quotaList.Items(), err
+}
+
+// IsQuotaFor the desired configuration available. If mac is empty a default will try to be selected.
+func IsQuotaFor(quota *accounts.ResourceQuotaList, resourceType, machineType string, multiAz bool) (quotaExists bool) {
+	azType := "single"
+	if multiAz {
+		azType = "multi"
+	}
+
+	quota.Each(func(q *accounts.ResourceQuota) bool {
+		if q.ResourceType() == resourceType && q.ResourceName() == machineType || machineType == "" {
+			if q.AvailabilityZoneType() == azType {
+				if q.Reserved() < q.Allowed() {
+					quotaExists = true
+				}
+			}
+		}
+		return !quotaExists
+	})
+	return
+}
+
+// TODO: use uhc-sdk-go resource_summary method once available
+func (u *OSD) getQuotaSummary(orgId string) (*resourceSummaryListResponse, error) {
+	resp := new(resourceSummaryListResponse)
+	summaryPath := path.Join("/api/accounts_mgmt", APIVersion, "organizations", orgId, "quota_summary")
+	rawResp, err := u.conn.Get().Path(summaryPath).Send()
+	if err == nil && rawResp.Status() != http.StatusOK {
+		resp.err, err = osderrors.UnmarshalError(rawResp.Bytes())
+	} else if rawResp != nil {
+		err = json.Unmarshal(rawResp.Bytes(), resp)
+	}
+
+	if err != nil {
+		return resp, err
+	}
+
+	// allow reading QuotaSummary as ResourceQuota
+	for i := range resp.List {
+		resp.List[i]["kind"] = "ResourceQuota"
+	}
+
+	// convert formats by writing to bytes and unmarshalling typed
+	var listData []byte
+	if listData, err = json.Marshal(resp.List); err == nil {
+		resp.list, err = accounts.UnmarshalResourceQuotaList(listData)
+	}
+	return resp, err
+}
+
+type resourceSummaryListResponse struct {
+	Kind  string                   `json:"kind"`
+	Page  int                      `json:"page"`
+	Size  int                      `json:"size"`
+	Total int                      `json:"total"`
+	List  []map[string]interface{} `json:"items"`
+
+	list *accounts.ResourceQuotaList
+	err  *osderrors.Error
+}
+
+func (r *resourceSummaryListResponse) Items() *accounts.ResourceQuotaList {
+	return r.list
+}
+func (r *resourceSummaryListResponse) Error() *osderrors.Error {
+	return r.err
+}


### PR DESCRIPTION
This change:
- Adds new OSD methods for checking if the current environment has enough quota to run the suite
- Enables checking on new test runs
- Adds a temporary client to access the resource_summary endpoint of the accounts API