### PR TITLE
Allow specifying specific nightlies

### DIFF
--- a/e2e.go
+++ b/e2e.go
@@ -35,7 +35,7 @@ func RunE2ETests(t *testing.T, cfg *config.Config) {
 
 	// set defaults
 	if cfg.Suffix == "" {
-		cfg.Suffix = randomStr(5)
+		cfg.Suffix = randomStr(3)
 	}
 
 	if cfg.ReportDir == "" {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -28,6 +28,12 @@ type Config struct {
 	// ClusterVersion is the version of the cluster being deployed.
 	ClusterVersion string `env:"CLUSTER_VERSION"`
 
+	// TargetMajor is the major version to target. If specified, it is used in version selection.
+	TargetMajor int64 `env:"TARGET_MAJOR"`
+
+	// TargetMinor is the minor version to target. If specified, it is used in version selection.
+	TargetMinor int64 `env:"TARGET_MINOR"`
+
 	// ClusterUpTimeout is how long to wait before failing a cluster launch.
 	ClusterUpTimeout time.Duration
 

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -26,6 +26,8 @@ func (c *Config) LoadFromEnv() {
 				case reflect.Slice:
 					field.SetBytes([]byte(envVal))
 				case reflect.Int:
+					fallthrough
+				case reflect.Int64:
 					if num, err := strconv.ParseInt(envVal, 10, 0); err == nil {
 						field.SetInt(num)
 					}

--- a/pkg/osd/versions.go
+++ b/pkg/osd/versions.go
@@ -15,8 +15,8 @@ const (
 	// query used to retrieve the current default version.
 	defaultVersionSearch = "default = 't'"
 
-	// prefix before semver
-	versionPrefix = "openshift-"
+	// VersionPrefix is the string that every OSD version begins with.
+	VersionPrefix = "openshift-"
 )
 
 // DefaultVersion returns the default version currently offered by OSD.
@@ -43,7 +43,7 @@ func (u *OSD) DefaultVersion() (string, error) {
 
 // PreviousVersion returns the first available previous version for the given version.
 func (u *OSD) PreviousVersion(verStr string) (string, error) {
-	verStr = strings.TrimPrefix(verStr, versionPrefix)
+	verStr = strings.TrimPrefix(verStr, VersionPrefix)
 	vers, err := semver.NewVersion(verStr)
 	if err != nil {
 		return "", fmt.Errorf("couldn't  parse given verStr '%s': %v", verStr, err)
@@ -57,7 +57,7 @@ func (u *OSD) PreviousVersion(verStr string) (string, error) {
 	for i := len(versions) - 1; i >= 0; i-- {
 		v := versions[i]
 		if v.LessThan(vers) {
-			return versionPrefix + v.Original(), nil
+			return VersionPrefix + v.Original(), nil
 		}
 	}
 	return "", fmt.Errorf("no versions available before '%s'", verStr)
@@ -76,7 +76,7 @@ func (u *OSD) LatestPrerelease(major, minor int64, str string) (string, error) {
 
 	// return latest nightly
 	latest := versions[len(versions)-1]
-	return versionPrefix + latest.Original(), nil
+	return VersionPrefix + latest.Original(), nil
 }
 
 // getSemverList as sorted semvers containing str for major and minor versions. Negative versions match all.
@@ -95,7 +95,7 @@ func (u *OSD) getSemverList(major, minor int64, str string) (versions []*semver.
 
 	// parse versions, filter for major+minor nightlies, then sort
 	resp.Items().Each(func(v *v1.Version) bool {
-		name := strings.TrimPrefix(v.ID(), versionPrefix)
+		name := strings.TrimPrefix(v.ID(), VersionPrefix)
 		if version, err := semver.NewVersion(name); err != nil {
 			log.Printf("could not parse version '%s': %v", v.ID(), err)
 		} else if version.Major() != major && major >= 0 {

--- a/setup.go
+++ b/setup.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift/osde2e/pkg/config"
+	"github.com/openshift/osde2e/pkg/osd"
 	"github.com/openshift/osde2e/pkg/upgrade"
 )
 
@@ -77,8 +78,7 @@ func setupCluster(cfg *config.Config) (err error) {
 	// create a new cluster if no ID is specified
 	if cfg.ClusterID == "" {
 		if cfg.ClusterName == "" {
-			safeVersion := strings.Replace(cfg.ClusterVersion, ".", "-", -1)
-			cfg.ClusterName = "ci-cluster-" + safeVersion + "-" + cfg.Suffix
+			cfg.ClusterName = clusterName(cfg)
 		}
 
 		if cfg.ClusterID, err = OSD.LaunchCluster(cfg); err != nil {
@@ -107,6 +107,13 @@ func useKubeconfig(cfg *config.Config) (err error) {
 	}
 	log.Printf("Using a set TEST_KUBECONFIG of '%s' for Origin API calls.", filename)
 	return nil
+}
+
+// cluster name format must be short enough to support all versions
+func clusterName(cfg *config.Config) string {
+	vers := strings.TrimPrefix(cfg.ClusterVersion, osd.VersionPrefix)
+	safeVersion := strings.Replace(vers, ".", "-", -1)
+	return "ci-cluster-" + safeVersion + "-" + cfg.Suffix
 }
 
 func randomStr(length int) (str string) {

--- a/version.go
+++ b/version.go
@@ -16,33 +16,51 @@ func ChooseVersions(cfg *config.Config, osd *osd.OSD) (err error) {
 	// when defined, use set version
 	if len(cfg.ClusterVersion) != 0 {
 		return nil
-	}
-
-	// if release stream target is set, try to use previous version
-	if cfg.UpgradeImage == "" && cfg.UpgradeReleaseStream != "" {
-		if osd == nil {
-			return errors.New("osd must be setup when upgrading with release stream")
-		}
-
-		cfg.UpgradeReleaseName, cfg.UpgradeImage, err = upgrade.LatestRelease(cfg.UpgradeReleaseStream)
-		if err != nil {
-			return fmt.Errorf("couldn't get latest release from release-controller: %v", err)
-		}
-
-		// get earlier available version from OSD
-		if cfg.ClusterVersion, err = osd.PreviousVersion(cfg.UpgradeReleaseName); err != nil {
-			return fmt.Errorf("failed retrieving previous version to '%s': %v", cfg.UpgradeReleaseName, err)
-		}
-
-		// set upgrade image
-		log.Printf("Selecting version '%s' to be able to upgrade to '%s' on release stream '%s'",
-			cfg.ClusterVersion, cfg.UpgradeReleaseName, cfg.UpgradeReleaseStream)
-	} else if cfg.ClusterVersion, err = OSD.DefaultVersion(); err != nil {
-		return fmt.Errorf("failed to get default version: %v", err)
+	} else if osd == nil {
+		return errors.New("osd must be setup when upgrading with release stream")
+	} else if cfg.UpgradeImage == "" && cfg.UpgradeReleaseStream != "" {
+		return setupUpgradeVersion(cfg, osd)
 	} else {
-		log.Printf("CLUSTER_VERSION not set, using the current default '%s'", cfg.ClusterVersion)
+		return setupVersion(cfg, osd)
 	}
-	return nil
+}
+
+// chooses between default version and nightly based on target versions.
+func setupVersion(cfg *config.Config, osd *osd.OSD) (err error) {
+	if cfg.TargetMajor == 0 && cfg.TargetMinor == 0 {
+		// use defaults if no version targets
+		if cfg.ClusterVersion, err = OSD.DefaultVersion(); err == nil {
+			log.Printf("CLUSTER_VERSION not set, using the current default '%s'", cfg.ClusterVersion)
+		}
+	} else {
+		// don't require major to be set
+		if cfg.TargetMajor == 0 {
+			cfg.TargetMajor = -1
+		}
+
+		if cfg.ClusterVersion, err = osd.LatestPrerelease(cfg.TargetMajor, cfg.TargetMinor, "nightly"); err == nil {
+			log.Printf("CLUSTER_VERSION not set but a TARGET is, running nightly '%s'", cfg.ClusterVersion)
+		}
+	}
+	return
+}
+
+// chooses version based on optimal upgrade path
+func setupUpgradeVersion(cfg *config.Config, osd *osd.OSD) (err error) {
+	cfg.UpgradeReleaseName, cfg.UpgradeImage, err = upgrade.LatestRelease(cfg.UpgradeReleaseStream)
+	if err != nil {
+		return fmt.Errorf("couldn't get latest release from release-controller: %v", err)
+	}
+
+	// get earlier available version from OSD
+	if cfg.ClusterVersion, err = osd.PreviousVersion(cfg.UpgradeReleaseName); err != nil {
+		return fmt.Errorf("failed retrieving previous version to '%s': %v", cfg.UpgradeReleaseName, err)
+	}
+
+	// set upgrade image
+	log.Printf("Selecting version '%s' to be able to upgrade to '%s' on release stream '%s'",
+		cfg.ClusterVersion, cfg.UpgradeReleaseName, cfg.UpgradeReleaseStream)
+	return
 }
 
 func buildVersion(cfg *config.Config) string {


### PR DESCRIPTION
This change:
- Creates new `TARGET_MAJOR` and `TARGET_MINOR` config to launch with a specific version of nightly
- Defaults to a shorter name to be under OSD's 60 character limit
- Adds support for loading `int64` config variables