### PR TITLE
take NO_DESTROY env for docker-test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ docker-test:
 	docker run \
 		-t \
 		--rm \
+		-e NO_DESTROY=$(NO_DESTROY) \
 		-e CLUSTER_ID=$(CLUSTER_ID) \
 		-e CLEAN_RUNS=$(CLEAN_RUNS) \
 		-e MAJOR_TARGET=$(MAJOR_TARGET) \


### PR DESCRIPTION
Allow NO_DESTROY environment variable to be used by default in the Makefile target for docker-test. If unset, cluster will continue to be destroyed as it currently is.

In practice, this considerably reduces the amount of times I accidentally delete a test cluster while doing iterative tests (I can source a file with cluster details and NO_DESTROY=true).

Signed-off-by: Christopher Collins <collins.christpher@gmail.com>