### PR TITLE
SDAR-22. Modify stage and prod to use Cincinnati.

### DIFF
--- a/pkg/osd/versions.go
+++ b/pkg/osd/versions.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver"
-	"github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1"
+	v1 "github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1"
 )
 
 const (
@@ -46,7 +46,7 @@ func (u *OSD) PreviousVersion(verStr string) (string, error) {
 	verStr = strings.TrimPrefix(verStr, VersionPrefix)
 	vers, err := semver.NewVersion(verStr)
 	if err != nil {
-		return "", fmt.Errorf("couldn't  parse given verStr '%s': %v", verStr, err)
+		return "", fmt.Errorf("couldn't parse given verStr '%s': %v", verStr, err)
 	}
 
 	versions, err := u.getSemverList(-1, -1, "")

--- a/pkg/upgrade/releases.go
+++ b/pkg/upgrade/releases.go
@@ -4,35 +4,106 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
+
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/config"
 )
 
 const (
-	// format string for release stream latest
-	latestReleaseURLFmt = "https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/%s/latest"
+	// format string for release stream latest from release controller
+	latestReleaseControllerURLFmt = "https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/%s/latest"
+	// format string for Cincinnati releases
+	cincinnatiURLFmt = "https://api%s.openshift.com/api/upgrades_info/v1/graph?channel=%s"
 )
 
-// LatestRelease retrieves latest release information for given releaseStream.
-func LatestRelease(releaseStream string) (name, pullSpec string, err error) {
-	latestURL := fmt.Sprintf(latestReleaseURLFmt, releaseStream)
-	resp, err := http.Get(latestURL)
+// LatestRelease retrieves latest release information for given releaseStream. Will use Cincinnati for stage/prod.
+func LatestRelease(cfg *config.Config) (name, pullSpec string, err error) {
+	releaseStream := cfg.UpgradeReleaseStream
+
+	var resp *http.Response
+	var data []byte
+	if cfg.OSDEnv == "int" {
+		latestURL := fmt.Sprintf(latestReleaseControllerURLFmt, releaseStream)
+		resp, err = http.Get(latestURL)
+		if err != nil {
+			err = fmt.Errorf("failed to get latest for stream '%s': %v", releaseStream, err)
+			return
+		}
+
+		data, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			err = fmt.Errorf("failed reading body: %v", err)
+			return
+		}
+
+		latest := latestAccepted{}
+		if err = json.Unmarshal(data, &latest); err != nil {
+			err = fmt.Errorf("error decoding body of '%s': %v", data, err)
+		}
+
+		return latest.Name, latest.PullSpec, nil
+	}
+
+	// If stage or prod, use Cincinnati instead of the release controller
+	stage := ""
+
+	// Add in stage to the URL if necessary
+	if cfg.OSDEnv == "stage" {
+		stage = ".stage"
+	}
+
+	cincinnatiFormattedURL := fmt.Sprintf(cincinnatiURLFmt, stage, releaseStream)
+
+	var req *http.Request
+
+	// Cincinnati requires an Accept header, so we add it in here
+	req, err = http.NewRequest("GET", cincinnatiFormattedURL, nil)
+	req.Header.Set("Accept", "application/json")
+
 	if err != nil {
-		err = fmt.Errorf("failed to get latest for stream '%s': %v", releaseStream, err)
+		err = fmt.Errorf("failed to create Cincinnati request for URL '%s': %v", cincinnatiFormattedURL, err)
 		return
 	}
 
-	data, err := ioutil.ReadAll(resp.Body)
+	resp, err = (&http.Client{}).Do(req)
+
 	if err != nil {
-		err = fmt.Errorf("failed reading body: %v", err)
+		err = fmt.Errorf("Request failed for URL '%s': %v", cincinnatiFormattedURL, err)
 		return
 	}
 
-	latest := latestAccepted{}
-	if err = json.Unmarshal(data, &latest); err != nil {
+	data, err = ioutil.ReadAll(resp.Body)
+
+	if err != nil {
+		err = fmt.Errorf("Failed reading body: %v", err)
+		return
+	}
+
+	var cincinnatiReleases cincinnatiReleaseNodes
+	var latestVersion *semver.Version
+	var latestCincinnatiRelease cincinnatiRelease
+
+	if err = json.Unmarshal(data, &cincinnatiReleases); err != nil {
 		err = fmt.Errorf("error decoding body of '%s': %v", data, err)
 	}
 
-	return latest.Name, latest.PullSpec, nil
+	for _, release := range cincinnatiReleases.Nodes {
+		currentVersion, err := semver.NewVersion(release.Version)
+
+		if err != nil {
+			log.Printf("Unable to parse version for %s, skipping", release.Version)
+			continue
+		}
+
+		if latestVersion == nil || currentVersion.GreaterThan(latestVersion) {
+			latestVersion = currentVersion
+			latestCincinnatiRelease = release
+		}
+	}
+
+	return latestCincinnatiRelease.Version, latestCincinnatiRelease.Payload, nil
 }
 
 // latestAccepted information from release controller.
@@ -40,4 +111,12 @@ type latestAccepted struct {
 	Name        string `json:"name"`
 	PullSpec    string `json:"pullSpec"`
 	DownloadURL string `json:"downloadURL"`
+}
+
+type cincinnatiReleaseNodes struct {
+	Nodes []cincinnatiRelease `json:"nodes"`
+}
+type cincinnatiRelease struct {
+	Version string `json:"version"`
+	Payload string `json:"payload"`
 }

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -4,7 +4,6 @@ package upgrade
 import (
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -74,15 +73,9 @@ func TriggerUpgrade(h *helper.H, cfg *config.Config) (*configv1.ClusterVersion, 
 		return cVersion, fmt.Errorf("couldn't get current ClusterVersion '%s': %v", ClusterVersionName, err)
 	}
 
-	// split image into name and tag
-	imageParts := strings.Split(cfg.UpgradeImage, ":")
-	if len(imageParts) != 2 {
-		return cVersion, fmt.Errorf("an UPGRADE_IMAGE should have a name and an a tag, got '%s'", cfg.UpgradeImage)
-	}
-
 	// set requested upgrade targets
 	cVersion.Spec.DesiredUpdate = &configv1.Update{
-		Version: imageParts[1],
+		Version: cfg.UpgradeReleaseName,
 		Image:   cfg.UpgradeImage,
 		Force:   true,
 	}

--- a/version.go
+++ b/version.go
@@ -47,7 +47,7 @@ func setupVersion(cfg *config.Config, osd *osd.OSD) (err error) {
 
 // chooses version based on optimal upgrade path
 func setupUpgradeVersion(cfg *config.Config, osd *osd.OSD) (err error) {
-	cfg.UpgradeReleaseName, cfg.UpgradeImage, err = upgrade.LatestRelease(cfg.UpgradeReleaseStream)
+	cfg.UpgradeReleaseName, cfg.UpgradeImage, err = upgrade.LatestRelease(cfg)
 	if err != nil {
 		return fmt.Errorf("couldn't get latest release from release-controller: %v", err)
 	}


### PR DESCRIPTION
stage and prod test pipelines will now use Cincinnati instead of the
release-controller.