### PR TITLE
Increase olm grace period

### DIFF
--- a/test/operators/dedicatedadmin.go
+++ b/test/operators/dedicatedadmin.go
@@ -27,6 +27,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// timeout is the duration in minutes that the polling should last
+const globalPollingTimeout int = 60
+
 const operatorNamespace string = "openshift-dedicated-admin"
 const createdNamespace string = "dedicated-admin"
 const operatorServiceAccount string = "dedicated-admin-operator"
@@ -165,15 +168,13 @@ func pollRoleBinding(h *helper.H, projectName string, roleBindingName string) er
 	// in the specified project, and wait for it to exist, until a timeout
 
 	var err error
-	// timeout is the duration in minutes that the polling should last
 	// interval is the duration in seconds between polls
 	// values here for humans
 
-	timeout := 10
 	interval := 1
 
 	// convert time.Duration type
-	timeoutDuration := time.Duration(timeout) * time.Minute
+	timeoutDuration := time.Duration(globalPollingTimeout) * time.Minute
 	intervalDuration := time.Duration(interval) * time.Second
 
 	start := time.Now()
@@ -209,14 +210,12 @@ func pollLockFile(h *helper.H) error {
 
 	var err error
 
-	// timeout is the duration in minutes that the polling should last
 	// interval is the duration in seconds between polls
 	// values here for humans
-	timeout := 20
 	interval := 5
 
 	// convert time.Duration type
-	timeoutDuration := time.Duration(timeout) * time.Minute
+	timeoutDuration := time.Duration(globalPollingTimeout) * time.Minute
 	intervalDuration := time.Duration(interval) * time.Second
 
 	start := time.Now()
@@ -253,14 +252,12 @@ func pollDeploymentList(h *helper.H) (*appsv1.DeploymentList, error) {
 	var err error
 	var deploymentList *appsv1.DeploymentList
 
-	// timeout is the duration in minutes that the polling should last
 	// interval is the duration in seconds between polls
 	// values here for humans
-	timeout := 20
 	interval := 5
 
 	// convert time.Duration type
-	timeoutDuration := time.Duration(timeout) * time.Minute
+	timeoutDuration := time.Duration(globalPollingTimeout) * time.Minute
 	intervalDuration := time.Duration(interval) * time.Second
 
 	start := time.Now()

--- a/test/operators/dedicatedadmin.go
+++ b/test/operators/dedicatedadmin.go
@@ -52,7 +52,7 @@ var roleBindings = []string{
 	"dedicated-admins-project-1",
 }
 
-var _ = ginkgo.Describe("The Dedicated Admin Operator", func() {
+var _ = ginkgo.Describe("[OSD] Dedicated Admin Operator", func() {
 	h := helper.New()
 
 	// Check that the operator deployment exists in the operator namespace
@@ -126,12 +126,8 @@ var _ = ginkgo.Describe("The Dedicated Admin Operator", func() {
 		})
 	})
 
-})
-
-// Test the controller; make sure new rolebindings are created for new project
-var _ = ginkgo.Describe("The Operator Controller", func() {
-	h := helper.New()
-	ginkgo.Context("when a new project is created", func() {
+    // Test the controller; make sure new rolebindings are created for new project
+	ginkgo.Context("controller", func() {
 		ginkgo.It("should create the expected roleBindings", func() {
 			projectRequest := v1.ProjectRequest{}
 			projectRequest.Kind = "ProjectRequest"


### PR DESCRIPTION
Moved poller timeouts to single global setting for pollers; increased to 60m.  OLM in normal operation takes ~15 minutes to be installed and begin installing operators, so the previous 20m timeout left little wiggle room for any other latency.

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>