### PR TITLE
SDAR-30. Remove CLEAN_RUNS from upgrade tests.

### DIFF
--- a/ci/upgrade_events.sh
+++ b/ci/upgrade_events.sh
@@ -1,4 +1,3 @@
 #!/bin/bash -e
 
-# Requires 3 successful passing builds before skipping
-CLEAN_RUNS=3 make docker-test
+make docker-test


### PR DESCRIPTION
CLEAN_RUNS have been removed from upgrade tests so that upgrade tests
run more regularly.