### PR TITLE
SDAR-31. Add an hour wait after test completion.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,9 @@ type Config struct {
 	// MinorTarget is the minor version to target. If specified, it is used in version selection.
 	MinorTarget int64 `env:"MINOR_TARGET" sect:"version"`
 
+	// AfterTestClusterWait is how long to keep a cluster around after tests have run.
+	AfterTestClusterWait time.Duration
+
 	// ClusterUpTimeout is how long to wait before failing a cluster launch.
 	ClusterUpTimeout time.Duration
 

--- a/setup.go
+++ b/setup.go
@@ -62,6 +62,19 @@ var _ = ginkgo.AfterSuite(func() {
 			return
 		}
 
+		// Default to 1 hour wait before terminating a cluster
+		if cfg.AfterTestClusterWait == 0 {
+			cfg.AfterTestClusterWait = 60 * time.Minute
+		}
+
+		log.Printf("Sleeping for %d minutes before destroying cluster '%s'", cfg.AfterTestClusterWait/time.Minute, cfg.ClusterID)
+		startTime := time.Now()
+		for time.Now().Sub(startTime) < cfg.AfterTestClusterWait {
+			time.Sleep(1 * time.Minute)
+			log.Print(".")
+		}
+		log.Printf("Done")
+
 		log.Printf("Destroying cluster '%s'...", cfg.ClusterID)
 		err = OSD.DeleteCluster(cfg.ClusterID)
 		Expect(err).NotTo(HaveOccurred(), "failed to destroy cluster")


### PR DESCRIPTION
After tests complete (successfully or otherwise), wait one hour to allow
for any active debugging.

Note: The lack of env/sect for time.Duration is intended, as apparently the doc generation barfs otherwise.