### PR TITLE
SDAR-31. Increase test.timeout to 4h.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ push-latest:
 	@docker --config=$(DOCKER_CONF) push "$(IMAGE_NAME):latest"
 
 test: out/osde2e
-	$< -test.v -test.timeout 3h
+	$< -test.v -test.timeout 4h
 
 docker-test:
 	docker run \

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A properly setup [Go workspace](https://golang.org/doc/code.html#GOPATH) and [Gl
     ```
 1. Run tests:
     ```bash
-    go test -v . -test.timeout 2h
+    go test -v . -test.timeout 4h
     ```
 
 ## Configuring


### PR DESCRIPTION
The test timeout has been increased to 4 hours to accommodate for the
hour long bake time after tests have been run.