### PR TITLE
Remove operator testing, make debug sleep optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ push-latest:
 	@docker --config=$(DOCKER_CONF) push "$(IMAGE_NAME):latest"
 
 test: out/osde2e
-	$< -test.v -test.timeout 4h
+	$< -test.v -ginkgo.skip=$(GINKGO_SKIP) -test.timeout 4h
 
 docker-test:
 	docker run \
@@ -35,6 +35,8 @@ docker-test:
 		-e MAJOR_TARGET=$(MAJOR_TARGET) \
 		-e MINOR_TARGET=$(MINOR_TARGET) \
 		-e CLUSTER_VERSION=$(CLUSTER_VERSION) \
+		-e NO_DESTROY_DELAY=$(NO_DESTROY_DELAY) \
+		-e GINKGO_SKIP=$(GINKGO_SKIP) \
 		-e UPGRADE_RELEASE_STREAM=$(UPGRADE_RELEASE_STREAM) \
 		-e DEBUG_OSD=1 \
 		-e OSD_ENV=$(OSD_ENV) \

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ push-latest:
 	@docker --config=$(DOCKER_CONF) push "$(IMAGE_NAME):latest"
 
 test: out/osde2e
-	$< -test.v -ginkgo.skip=$(GINKGO_SKIP) -test.timeout 4h
+	$< -test.v -ginkgo.skip="$(GINKGO_SKIP)" -test.timeout 4h
 
 docker-test:
 	docker run \

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -30,6 +30,12 @@ These options are required to run osde2e.
 
 - Type: `int`
 
+### `GINKGO_SKIP`
+
+- GinkgoSkip is a regex passed to Ginkgo that skips any test suites matching the regex. ex. "Operator"
+
+- Type: `string`
+
 ### `REPORT_DIR`
 
 - ReportDir is the location JUnit XML results are written.
@@ -48,6 +54,13 @@ These options are required to run osde2e.
 ### `DEBUG_OSD`
 
 - DebugOSD shows debug level messages when enabled.
+
+- Type: `bool`
+
+### `NO_DESTROY_DELAY`
+
+- NoDestroyDelay circumvents the 60min delay before a cluster is deleted
+This is highly useful when trying to debug things locally. :)
 
 - Type: `bool`
 

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -7,9 +7,9 @@ import (
 
 	// import suites to be tested
 	_ "github.com/openshift/osde2e/test/openshift"
+	_ "github.com/openshift/osde2e/test/operators"
 	_ "github.com/openshift/osde2e/test/state"
 	_ "github.com/openshift/osde2e/test/verify"
-	_ "github.com/openshift/osde2e/test/operators"
 )
 
 func TestE2E(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -80,6 +80,13 @@ type Config struct {
 	// DebugOSD shows debug level messages when enabled.
 	DebugOSD bool `env:"DEBUG_OSD" sect:"environment"`
 
+	// NoDestroyDelay circumvents the 60min delay before a cluster is deleted
+	// This is highly useful when trying to debug things locally. :)
+	NoDestroyDelay bool `env:"NO_DESTROY_DELAY" sect:"environment"`
+
+	// GinkgoSkip is a regex passed to Ginkgo that skips any test suites matching the regex. ex. "Operator"
+	GinkgoSkip string `env:"GINKGO_SKIP" sect:"tests"`
+
 	// CleanRuns is the number of times the test-version is run before skipping.
 	CleanRuns int `env:"CLEAN_RUNS" sect:"tests"`
 

--- a/setup.go
+++ b/setup.go
@@ -67,13 +67,17 @@ var _ = ginkgo.AfterSuite(func() {
 			cfg.AfterTestClusterWait = 60 * time.Minute
 		}
 
-		log.Printf("Sleeping for %d minutes before destroying cluster '%s'", cfg.AfterTestClusterWait/time.Minute, cfg.ClusterID)
-		startTime := time.Now()
-		for time.Now().Sub(startTime) < cfg.AfterTestClusterWait {
-			time.Sleep(1 * time.Minute)
-			log.Print(".")
+		if cfg.NoDestroyDelay {
+			log.Printf("Skipping sleep for cluster debugging")
+		} else {
+			log.Printf("Sleeping for %d minutes before destroying cluster '%s'", cfg.AfterTestClusterWait/time.Minute, cfg.ClusterID)
+			startTime := time.Now()
+			for time.Now().Sub(startTime) < cfg.AfterTestClusterWait {
+				time.Sleep(1 * time.Minute)
+				log.Print(".")
+			}
+			log.Printf("Done")
 		}
-		log.Printf("Done")
 
 		log.Printf("Destroying cluster '%s'...", cfg.ClusterID)
 		err = OSD.DeleteCluster(cfg.ClusterID)


### PR DESCRIPTION
The debug sleep thing kind of hurts doing local testing/development because the clusters linger around. So, being able to toggle it with an env var seemed appropriate.

Also this PR comments out the dedicatedadmin test while we try to achieve some cleaner signal and I try to optimize its testing 

/cc @clcollins 
/assign @meowfaceman 