### PR TITLE
SDAR-36. Use DefaultVersion instead of PreviousVersion for upgrades.

### DIFF
--- a/version.go
+++ b/version.go
@@ -63,7 +63,7 @@ func setupUpgradeVersion(cfg *config.Config, osd *osd.OSD) (err error) {
 		}
 	} else {
 		// get earlier available version from OSD
-		if cfg.ClusterVersion, err = osd.PreviousVersion(cfg.UpgradeReleaseName); err != nil {
+		if cfg.ClusterVersion, err = osd.DefaultVersion(); err != nil {
 			return fmt.Errorf("failed retrieving previous version to '%s': %v", cfg.UpgradeReleaseName, err)
 		}
 	}


### PR DESCRIPTION
The DefaultVersion in OSD is now used instead of the PreviousVersion for
upgrades.

Note: Haven't tested this yet, as I'm waiting on the PR to fix the dedicatedadmin.go syntax issues.