### PR TITLE
Fix condition where targetstream would not be honored

### DIFF
--- a/version.go
+++ b/version.go
@@ -29,7 +29,7 @@ func ChooseVersions(cfg *config.Config, osd *osd.OSD) (err error) {
 func setupVersion(cfg *config.Config, osd *osd.OSD) (err error) {
 	if cfg.MajorTarget == 0 && cfg.MinorTarget == 0 {
 		// use defaults if no version targets
-		if cfg.ClusterVersion, err = OSD.DefaultVersion(); err == nil {
+		if cfg.ClusterVersion, err = osd.DefaultVersion(); err == nil {
 			log.Printf("CLUSTER_VERSION not set, using the current default '%s'", cfg.ClusterVersion)
 		}
 	} else {
@@ -52,14 +52,14 @@ func setupUpgradeVersion(cfg *config.Config, osd *osd.OSD) (err error) {
 		return fmt.Errorf("couldn't get latest release from release-controller: %v", err)
 	}
 
-	if cfg.MajorTarget == 0 && cfg.MinorTarget == 0 {
-		// use defaults if no version targets
-		if cfg.ClusterVersion, err = OSD.DefaultVersion(); err == nil {
-			log.Printf("CLUSTER_VERSION not set, using the current default '%s'", cfg.ClusterVersion)
-		}
-	} else if len(cfg.TargetStream) != 0 {
+	if len(cfg.TargetStream) != 0 {
 		if cfg.ClusterVersion, _, err = upgrade.LatestRelease(cfg, cfg.TargetStream); err == nil {
 			log.Printf("Target Release Stream set, using version  '%s'", cfg.ClusterVersion)
+		}
+	} else if cfg.MajorTarget == 0 && cfg.MinorTarget == 0 {
+		// use defaults if no version targets
+		if cfg.ClusterVersion, err = osd.DefaultVersion(); err == nil {
+			log.Printf("CLUSTER_VERSION not set, using the current default '%s'", cfg.ClusterVersion)
 		}
 	} else {
 		// get earlier available version from OSD


### PR DESCRIPTION
The `if` statements were ordered in such a way that it was possible for TargetStream to not be honored. 