### PR TITLE
SDAR-34. Fail when no quota is available.

### DIFF
--- a/e2e.go
+++ b/e2e.go
@@ -66,8 +66,8 @@ func RunE2ETests(t *testing.T, cfg *config.Config) {
 		if enoughQuota, err := OSD.CheckQuota(cfg); err != nil {
 			log.Printf("Failed to check if enough quota is available: %v", err)
 		} else if !enoughQuota {
-			log.Println("Currently not enough quota exists to run this test, skipping...")
-			t.SkipNow()
+			log.Println("Currently not enough quota exists to run this test, failing...")
+			t.FailNow()
 		}
 	}
 


### PR DESCRIPTION
We should fail when no quota is available. With this, we'll be able to
more accurately identify how often we're running out of quota, and
justify further quota increases if needed.

Note: Verified the test fails when there's no quota.