### PR TITLE
Look for version prefix expected by cluster

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -30,6 +30,10 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	err := setupCluster(cfg)
 	Expect(err).ShouldNot(HaveOccurred(), "failed to setup cluster for testing")
 
+	// Give the cluster some breathing room.
+	log.Println("OSD cluster installed. Sleeping for 300s.")
+	time.Sleep(300)
+
 	// upgrade cluster if requested
 	if cfg.UpgradeImage != "" || cfg.UpgradeReleaseStream != "" {
 		err = upgrade.RunUpgrade(cfg)


### PR DESCRIPTION
Clusters are expecting versions (from streams) to have `openshift-v`. This looks to see if the returned version contains the string and, if not, prepends it. Tested extensively locally with great success~

Also sneaking in a 300s wait time between cluster-install and tests. 

/assign @meowfaceman @clcollins 