### PR TITLE
Resolve SDAR-44 - only use an enabled version

### DIFF
--- a/pkg/osd/versions.go
+++ b/pkg/osd/versions.go
@@ -102,7 +102,7 @@ func (u *OSD) getSemverList(major, minor int64, str string) (versions []*semver.
 			return true
 		} else if version.Minor() != minor && minor >= 0 {
 			return true
-		} else if strings.Contains(version.Prerelease(), str) {
+		} else if strings.Contains(version.Prerelease(), str) && v.Enabled() {
 			versions = append(versions, version)
 		}
 		return true


### PR DESCRIPTION
When building a list of available versions, only use versions that have been enabled in the API.

Resolves [SDAR-44](https://jira.coreos.com/browse/SDAR-44)