### PR TITLE
SDAR-46 - Bump upgrade acknowledgement timeout to 5min

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ docker-test:
 		--rm \
 		-e NO_DESTROY=$(NO_DESTROY) \
 		-e CLUSTER_ID=$(CLUSTER_ID) \
+		-e CLUSTER_NAME=$(CLUSTER_NAME) \
 		-e CLEAN_RUNS=$(CLEAN_RUNS) \
 		-e DRY_RUN=$(DRY_RUN) \
 		-e MAJOR_TARGET=$(MAJOR_TARGET) \

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -86,7 +86,7 @@ func TriggerUpgrade(h *helper.H, cfg *config.Config) (*configv1.ClusterVersion, 
 
 	// wait for update acknowledgement
 	updateGeneration := updatedCV.Generation
-	if err = wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+	if err = wait.PollImmediate(15*time.Second, 5*time.Minute, func() (bool, error) {
 		if cVersion, err = cfgClient.ConfigV1().ClusterVersions().Get(ClusterVersionName, getOpts); err != nil {
 			return false, err
 		}

--- a/setup.go
+++ b/setup.go
@@ -32,7 +32,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 
 	// Give the cluster some breathing room.
 	log.Println("OSD cluster installed. Sleeping for 300s.")
-	time.Sleep(300)
+	time.Sleep(300 * time.Second)
 
 	// upgrade cluster if requested
 	if cfg.UpgradeImage != "" || cfg.UpgradeReleaseStream != "" {


### PR DESCRIPTION
Addresses [SDAR-46](https://jira.coreos.com/browse/SDAR-46)

While there, noticed two small quick fixes:
- Cluster Name wasn't being passed to the container 
- The install-to-action buffer was set to 300ms not 300s. 