### PR TITLE
SDAR-50. Use Cincinnati for source Openshift version for integration.

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -132,6 +132,8 @@ This is highly useful when trying to debug things locally. :)
 ### `TARGET_STREAM`
 
 - TargetStream lets you select a specific release stream from Cincinnati or the Release Controller to install.
+For stage and prod, this will always refer to Cincinnati. For int, this will refer to Cincinnati for upgrades and
+release controller for regular installs.
 
 - Type: `string`
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -45,7 +45,9 @@ type Config struct {
 	// MinorTarget is the minor version to target. If specified, it is used in version selection.
 	MinorTarget int64 `env:"MINOR_TARGET" sect:"version"`
 
-	//TargetStream lets you select a specific release stream from Cincinnati or the Release Controller to install.
+	// TargetStream lets you select a specific release stream from Cincinnati or the Release Controller to install.
+	// For stage and prod, this will always refer to Cincinnati. For int, this will refer to Cincinnati for upgrades and
+	// release controller for regular installs.
 	TargetStream string `env:"TARGET_STREAM" sect:"version"`
 
 	// AfterTestClusterWait is how long to keep a cluster around after tests have run.

--- a/version.go
+++ b/version.go
@@ -21,12 +21,12 @@ func ChooseVersions(cfg *config.Config, osd *osd.OSD) (err error) {
 	} else if cfg.UpgradeImage == "" && cfg.UpgradeReleaseStream != "" {
 		return setupUpgradeVersion(cfg, osd)
 	} else {
-		return setupVersion(cfg, osd)
+		return setupVersion(cfg, osd, false)
 	}
 }
 
 // chooses between default version and nightly based on target versions.
-func setupVersion(cfg *config.Config, osd *osd.OSD) (err error) {
+func setupVersion(cfg *config.Config, osd *osd.OSD, isUpgrade bool) (err error) {
 	if len(cfg.ClusterVersion) > 0 {
 		return
 	}
@@ -34,7 +34,7 @@ func setupVersion(cfg *config.Config, osd *osd.OSD) (err error) {
 		// check to see if a target stream is set.
 		// a target stream and a major/minor target should not be set at the same time.
 		if len(cfg.TargetStream) > 0 {
-			if cfg.ClusterVersion, _, err = upgrade.LatestRelease(cfg, cfg.TargetStream); err == nil {
+			if cfg.ClusterVersion, _, err = upgrade.LatestRelease(cfg, cfg.TargetStream, !isUpgrade); err == nil {
 				log.Printf("Target Release Stream set, using version  '%s'", cfg.ClusterVersion)
 				// use defaults if no version targets
 			} else {
@@ -65,12 +65,12 @@ func setupVersion(cfg *config.Config, osd *osd.OSD) (err error) {
 // chooses version based on optimal upgrade path
 func setupUpgradeVersion(cfg *config.Config, osd *osd.OSD) (err error) {
 	// Decide the version to install
-	err = setupVersion(cfg, osd)
+	err = setupVersion(cfg, osd, true)
 	if err != nil {
 		return err
 	}
 
-	cfg.UpgradeReleaseName, cfg.UpgradeImage, err = upgrade.LatestRelease(cfg, cfg.UpgradeReleaseStream)
+	cfg.UpgradeReleaseName, cfg.UpgradeImage, err = upgrade.LatestRelease(cfg, cfg.UpgradeReleaseStream, true)
 	if err != nil {
 		return fmt.Errorf("couldn't get latest release from release-controller: %v", err)
 	}


### PR DESCRIPTION
The source Openshift version pulls from Cincinnati for integration
upgrade tests. This is done to support 4.1 -> 4.1 upgrades.

There are several reasons for doing this:
* The current 4.1 nightly is set as default in integration OSD. This
means that the upgrade version is set to the current default in OSD.
This, in turn, falls back on the logic to go to the previous enabled
version to upgrade from.
* The previous version selected is also a nightly, which means the
delta between the two images isn't relevant from a user perspective.
* The 4-stable stream in the release controller includes 4.2, which
means the latest version selected as a source version doesn't make sense
for a 4.1 -> 4.2 upgrade. In other words, there's no way currently to
get a stable stream in the release controller for a major and minor
version, only a major version.
* Finally, 4.1 nightlies are labeled as "4.1.0-0.nightly," which from a
semver perspective is less than 4.1.18. We can't scrub the 4-stable
release controller stream for versions that are less than the nightly
since all of the versions in the 4-stable stream in the release
controller are greater than the nightly.

The end result is that there's no real way of selecting a relevant
lesser version as the source verson of the upgrade to the nightly on
integration. By using Cincinnati, we can use channels that are specific
to the minor version. This allows us to grab the latest stable image as
the source version, then flip over to the release controller to grab the
current nightly version.

This has been done in a way to preserve existing behavior, so other
tests should not change.