### PR TITLE
SDAR-51 - Don't send verbose version to upgrade

### DIFF
--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -4,6 +4,7 @@ package upgrade
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -75,7 +76,7 @@ func TriggerUpgrade(h *helper.H, cfg *config.Config) (*configv1.ClusterVersion, 
 
 	// set requested upgrade targets
 	cVersion.Spec.DesiredUpdate = &configv1.Update{
-		Version: cfg.UpgradeReleaseName,
+		Version: strings.Replace(cfg.UpgradeReleaseName, "openshift-v", "", -1),
 		Image:   cfg.UpgradeImage,
 		Force:   true,
 	}


### PR DESCRIPTION
To install, you're required to set the full version to have `openshift-v` prepended. The same is not true when setting the version for an upgrade. This ensures that the prefix is stripped before submitting the version for upgrade.