### PR TITLE
SDAR-53 (partial fix) - use wait.PollImmediate and have a timeout

### DIFF
--- a/pkg/runner/pod.go
+++ b/pkg/runner/pod.go
@@ -91,7 +91,7 @@ func (r *Runner) createPod() (pod *kubev1.Pod, err error) {
 }
 
 func (r *Runner) waitForPodRunning(pod *kubev1.Pod) error {
-	runningCondition := func() (done bool, err error) {
+	return wait.PollImmediate(10*time.Second, 3*time.Minute, func() (done bool, err error) {
 		pod, err = r.Kube.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
 		if err != nil && !kerror.IsNotFound(err) {
 			return
@@ -105,6 +105,5 @@ func (r *Runner) waitForPodRunning(pod *kubev1.Pod) error {
 			r.Printf("Waiting for Pod '%s/%s' to start Running...", pod.Namespace, pod.Name)
 		}
 		return
-	}
-	return wait.PollImmediateUntil(10*time.Second, runningCondition, r.stopCh)
+	})
 }

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -32,7 +32,7 @@ func (r *Runner) createService(pod *kubev1.Pod) (svc *kubev1.Service, err error)
 
 func (r *Runner) waitForEndpoints() error {
 	var endpoints *kubev1.Endpoints
-	endpointsReadyCondition := func() (done bool, err error) {
+	return wait.PollImmediate(15*time.Second, 30*time.Minute, func() (done bool, err error) {
 		endpoints, err = r.Kube.CoreV1().Endpoints(r.svc.Namespace).Get(r.svc.Name, metav1.GetOptions{})
 		if err != nil && !kerror.IsNotFound(err) {
 			r.Printf("Encountered error getting endpoint '%s/%s': %v", r.svc.Namespace, r.svc.Name, err)
@@ -45,6 +45,5 @@ func (r *Runner) waitForEndpoints() error {
 		}
 		r.Printf("Waiting for test results using Endpoint '%s/%s'...", endpoints.Namespace, endpoints.Name)
 		return false, nil
-	}
-	return wait.PollImmediateUntil(15*time.Second, endpointsReadyCondition, r.stopCh)
+	})
 }


### PR DESCRIPTION
There were conditions where `wait.PollImmediateUntil` would loop without end, and there are cases where we want to continually poll until timeout, not until success or failure. 

Partially addresses [SDAR-53](https://jira.coreos.com/browse/SDAR-53)