### PR TITLE
SDAR-53 - Bump cooldown to 10min

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -32,7 +32,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 
 	// Give the cluster some breathing room.
 	log.Println("OSD cluster installed. Sleeping for 300s.")
-	time.Sleep(300 * time.Second)
+	time.Sleep(600 * time.Second)
 
 	// upgrade cluster if requested
 	if cfg.UpgradeImage != "" || cfg.UpgradeReleaseStream != "" {


### PR DESCRIPTION
Some of the conformance tests are flaking. My guess is that they're still being run too soon after a cluster is "installed."

This bumps the delay between install and testing to ten minutes. I put this under SDAR-53 since it's still addressing tests timing out. 

We should see flakes start resolving over the next couple days with this change, or there's another issue to address :)