### PR TITLE
Refactor Operator Test Scaffold; add basic tests

### DIFF
--- a/test/operators/configurealertmanager.go
+++ b/test/operators/configurealertmanager.go
@@ -17,7 +17,7 @@ var _ = ginkgo.Describe("[OSD] Configure AlertManager Operator", func() {
 	// Test need to incorporate a regex-like test?
 	//
 	// var clusterRoles = []string{
-	// 	"configure-alertmanager-operator,
+	// 	"configure-alertmanager-operator",
 	// }
 
 	var clusterRoleBindings = []string{}

--- a/test/operators/configurealertmanager.go
+++ b/test/operators/configurealertmanager.go
@@ -1,0 +1,40 @@
+package operators
+
+import (
+	"github.com/onsi/ginkgo"
+	"github.com/openshift/osde2e/pkg/helper"
+)
+
+var _ = ginkgo.Describe("[OSD] Configure AlertManager Operator", func() {
+	var operatorName = "configure-alertmanager-operator"
+	var operatorNamespace string = "openshift-monitoring"
+	var operatorLockFile string = "configure-alertmanager-operator-lock"
+	var defaultDesiredReplicas int32 = 1
+
+	// NOTE: CAM clusterRoles have random-ish names like:
+	// configure-alertmanager-operator.v0.1.80-03136c1-l589
+	//
+	// Test need to incorporate a regex-like test?
+	//
+	// var clusterRoles = []string{
+	// 	"configure-alertmanager-operator,
+	// }
+
+	var clusterRoleBindings = []string{}
+
+	var roleBindings = []string{
+		"configure-alertmanager-operator",
+	}
+
+	var roles = []string{
+		"configure-alertmanager-operator",
+	}
+
+	h := helper.New()
+	checkClusterServiceVersion(h, operatorNamespace, operatorName)
+	checkConfigMapLockfile(h, operatorNamespace, operatorLockFile)
+	checkDeployment(h, operatorNamespace, operatorName, defaultDesiredReplicas)
+	checkClusterRoleBindings(h, clusterRoleBindings)
+	checkRole(h, operatorNamespace, roles)
+	checkRoleBindings(h, operatorNamespace, roleBindings)
+})

--- a/test/operators/dedicatedadmin.go
+++ b/test/operators/dedicatedadmin.go
@@ -1,141 +1,49 @@
 package operators
 
-// This is a test of the Dedicated Admin Operator
-// This test checks:
-// Operator Namespace exists
-// Operator Deployment exists
-// Replicas counts match, & pods are running
-// ServiceAccount exists
-// ConfigMaps exist
-// Created Namespace exists
-// When a new project is created; that the roleBindings are created in the project
-// TODO: any SyncSets exist
-
 import (
-	"errors"
-	"math/rand"
-	"strings"
-	"time"
-
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	v1 "github.com/openshift/api/project/v1"
 	"github.com/openshift/osde2e/pkg/helper"
 
-	operatorv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-
-	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Timeout is the duration in seconds that the polling should last
-// Because ginkgo requires a float64 in seconds, we do the math
-// up here. Below, for the time.Durations, we use seconds because
-// we've calculated 30min in seconds up here already.
-const globalPollingTimeout int = 30 * 60
-
-const operatorName = "dedicated-admin-operator"
-const operatorNamespace string = "openshift-dedicated-admin"
-
-// These variables are not used yet.
-// const createdNamespace string = "dedicated-admin"
-// const operatorServiceAccount string = "dedicated-admin-operator"
-const defaultDesiredReplicas int32 = 1
-const operatorLockFile string = "dedicated-admin-operator-lock"
-const testProjectPrefix string = "da-test-project"
-
-var clusterRoles = []string{
-	"dedicated-admin-operator",
-	"dedicated-admin-operator-admin",
-	"dedicated-admin-operator-edit",
-	"dedicated-admin-operator-view",
-	"dedicated-admins-cluster",
-	"dedicated-admins-project",
-}
-
-var clusterRoleBindings = []string{
-	"dedicated-admin-operator-admin",
-}
-
-var roleBindings = []string{
-	"dedicated-admins-project-0",
-	"dedicated-admins-project-1",
-}
-
 var _ = ginkgo.Describe("[OSD] Dedicated Admin Operator", func() {
+	var operatorName = "dedicated-admin-operator"
+	var operatorNamespace string = "openshift-dedicated-admin"
+	var operatorLockFile string = "dedicated-admin-operator-lock"
+	var defaultDesiredReplicas int32 = 1
+	// var operatorServiceAccount string = "dedicated-admin-operator"
+
+	// var createdNamespace string = "dedicated-admin"
+	var testProjectPrefix string = "da-test-project"
+
+	var clusterRoles = []string{
+		"dedicated-admin-operator",
+		"dedicated-admin-operator-admin",
+		"dedicated-admin-operator-edit",
+		"dedicated-admin-operator-view",
+		"dedicated-admins-cluster",
+		"dedicated-admins-project",
+	}
+
+	var clusterRoleBindings = []string{
+		"dedicated-admin-operator-admin",
+	}
+
+	var roleBindings = []string{
+		"dedicated-admins-project-0",
+		"dedicated-admins-project-1",
+	}
+
 	h := helper.New()
-	// Check that the operator clusterServiceVersion exists
-	ginkgo.Context("clusterServiceVersion", func() {
-		ginkgo.It("should exist", func() {
-			csvs, err := pollCsvList(h)
-			Expect(err).ToNot(HaveOccurred(), "failed fetching the clusterServiceVersions")
-			Expect(csvs).NotTo(BeNil())
-			Expect(csvDisplayNameMatch(operatorName, csvs)).Should(BeTrue(),
-				"no clusterServiceVersions with .spec.displayName '%v'", operatorName)
-		}, float64(globalPollingTimeout))
-	})
-
-	// Check that the operator configmap has been deployed
-	ginkgo.Context("configmaps", func() {
-		ginkgo.It("should exist", func() {
-			// Wait for lockfile to signal operator is active
-			err := pollLockFile(h)
-			Expect(err).ToNot(HaveOccurred(), "failed fetching the configMap lockfile")
-		}, float64(globalPollingTimeout))
-	})
-
-	// Check that the operator deployment exists in the operator namespace
-	ginkgo.Context("deployments", func() {
-		ginkgo.It("should exist", func() {
-			deployments, err := pollDeploymentList(h)
-			Expect(err).ToNot(HaveOccurred(), "failed fetching deployments")
-			Expect(deployments).NotTo(BeNil(), "deployment list is nil")
-			Expect(deploymentNameMatch(operatorName, deployments)).Should(BeTrue(),
-				"no deployments with name '%v'", operatorName)
-		}, float64(globalPollingTimeout))
-		ginkgo.It("should only be 1", func() {
-			expectedDeployments := 1
-			deployments, err := pollDeploymentList(h)
-			Expect(err).ToNot(HaveOccurred(), "failed fetching deployments")
-			Expect(len(deployments.Items)).To(BeNumerically("==", expectedDeployments), "There should be 1 deployment.")
-		}, float64(globalPollingTimeout))
-		ginkgo.It("should have all desired replicas ready", func() {
-			deployments, err := pollDeploymentList(h)
-			Expect(err).ToNot(HaveOccurred(), "failed fetching deployments")
-
-			for _, deployment := range deployments.Items {
-				readyReplicas := deployment.Status.ReadyReplicas
-				desiredReplicas := deployment.Status.Replicas
-
-				// The desired replicas should match the default installed replica count
-				Expect(desiredReplicas).To(BeNumerically("==", defaultDesiredReplicas), "The deployment desired replicas should not drift from the default 1.")
-
-				// Desired replica count should match ready replica count
-				Expect(readyReplicas).To(BeNumerically("==", desiredReplicas), "All desired replicas should be ready.")
-			}
-		}, float64(globalPollingTimeout))
-	})
-
-	// Check that the clusterRoles exist
-	ginkgo.Context("clusterRoles", func() {
-		ginkgo.It("should exist", func() {
-			for _, clusterRoleName := range clusterRoles {
-				_, err := h.Kube().RbacV1().ClusterRoles().Get(clusterRoleName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), "failed to get cluster role %v\n", clusterRoleName)
-			}
-		}, float64(globalPollingTimeout))
-	})
-
-	// Check that the clusterRoleBindings exist
-	ginkgo.Context("clusterRoleBindings", func() {
-		ginkgo.It("should exist", func() {
-			for _, clusterRoleBindingName := range clusterRoleBindings {
-				_, err := h.Kube().RbacV1().ClusterRoleBindings().Get(clusterRoleBindingName, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), "failed to get cluster role binding %v\n", clusterRoleBindingName)
-			}
-		}, float64(globalPollingTimeout))
-	})
+	checkClusterServiceVersion(h, operatorNamespace, operatorName)
+	checkConfigMapLockfile(h, operatorNamespace, operatorLockFile)
+	checkDeployment(h, operatorNamespace, operatorName, defaultDesiredReplicas)
+	checkClusterRoles(h, clusterRoles)
+	checkClusterRoleBindings(h, clusterRoleBindings)
 
 	// Test the controller; make sure new rolebindings are created for new project
 	ginkgo.Context("controller", func() {
@@ -167,202 +75,3 @@ var _ = ginkgo.Describe("[OSD] Dedicated Admin Operator", func() {
 		}, float64(globalPollingTimeout))
 	})
 })
-
-func pollRoleBinding(h *helper.H, projectName string, roleBindingName string) error {
-	// pollRoleBinding will check for the existence of a roleBinding
-	// in the specified project, and wait for it to exist, until a timeout
-
-	var err error
-	// interval is the duration in seconds between polls
-	// values here for humans
-
-	interval := 5
-
-	// convert time.Duration type
-	timeoutDuration := time.Duration(globalPollingTimeout) * time.Second
-	intervalDuration := time.Duration(interval) * time.Second
-
-	start := time.Now()
-
-Loop:
-	for {
-		_, err = h.Kube().RbacV1().RoleBindings(projectName).Get(roleBindingName, metav1.GetOptions{})
-		elapsed := time.Since(start)
-
-		switch {
-		case err == nil:
-			// Success
-			break Loop
-		default:
-			if elapsed < timeoutDuration {
-				time.Sleep(intervalDuration)
-			} else {
-				err = errors.New("Failed to get rolebinding %v before timeout, roleBindingName")
-				break Loop
-			}
-		}
-	}
-
-	return err
-}
-
-func pollLockFile(h *helper.H) error {
-	// GetConfigMap polls for a configMap with a timeout
-	// to handle the case when a new cluster is up but the OLM has not yet
-	// finished deploying the operator
-
-	var err error
-
-	// interval is the duration in seconds between polls
-	// values here for humans
-	interval := 30
-
-	// convert time.Duration type
-	timeoutDuration := time.Duration(globalPollingTimeout) * time.Second
-	intervalDuration := time.Duration(interval) * time.Second
-
-	start := time.Now()
-
-Loop:
-	for {
-		_, err = h.Kube().CoreV1().ConfigMaps(operatorNamespace).Get(operatorLockFile, metav1.GetOptions{})
-		elapsed := time.Since(start)
-
-		switch {
-		case err == nil:
-			// Success
-			break Loop
-		default:
-			if elapsed < timeoutDuration {
-				time.Sleep(intervalDuration)
-			} else {
-				err = errors.New("Failed to get configmap before timeout")
-				break Loop
-			}
-		}
-	}
-
-	return err
-}
-
-func pollDeploymentList(h *helper.H) (*appsv1.DeploymentList, error) {
-	// pollDeploymentList polls for deployments with a timeout
-	// to handle the case when a new cluster is up but the OLM has not yet
-	// finished deploying the operator
-
-	var err error
-	var deploymentList *appsv1.DeploymentList
-
-	// interval is the duration in seconds between polls
-	// values here for humans
-	interval := 5
-
-	// convert time.Duration type
-	timeoutDuration := time.Duration(globalPollingTimeout) * time.Second
-	intervalDuration := time.Duration(interval) * time.Second
-
-	start := time.Now()
-
-Loop:
-	for {
-		deploymentList, err = h.Kube().AppsV1().Deployments(operatorNamespace).List(metav1.ListOptions{})
-		elapsed := time.Since(start)
-
-		switch {
-		case err == nil:
-			// Success
-			break Loop
-		default:
-			if elapsed < timeoutDuration {
-				time.Sleep(intervalDuration)
-			} else {
-				deploymentList = nil
-				err = errors.New("Failed to get Deployments before timeout")
-				break Loop
-			}
-		}
-	}
-
-	return deploymentList, err
-}
-
-func pollCsvList(h *helper.H) (*operatorv1.ClusterServiceVersionList, error) {
-	// pollCsvList polls for clusterServiceVersions with a timeout
-	// to handle the case when a new cluster is up but the OLM has not yet
-	// finished deploying the operator
-
-	var err error
-	var csvList *operatorv1.ClusterServiceVersionList
-
-	// interval is the duration in seconds between polls
-	// values here for humans
-	interval := 5
-
-	// convert time.Duration type
-	timeoutDuration := time.Duration(globalPollingTimeout) * time.Second
-	intervalDuration := time.Duration(interval) * time.Second
-
-	start := time.Now()
-
-Loop:
-	for {
-		csvList, err = h.Operator().OperatorsV1alpha1().ClusterServiceVersions(operatorNamespace).List(metav1.ListOptions{})
-		elapsed := time.Since(start)
-
-		switch {
-		case err == nil:
-			// Success
-			break Loop
-		default:
-			if elapsed < timeoutDuration {
-				time.Sleep(intervalDuration)
-			} else {
-				csvList = nil
-				err = errors.New("Failed to get clusterServiceVersions before timeout")
-				break Loop
-			}
-		}
-	}
-
-	return csvList, err
-}
-
-func csvDisplayNameMatch(expected string, csvs *operatorv1.ClusterServiceVersionList) bool {
-	// csvDisplayNameMatch iterates a ClusterServiceVersionList
-	// and looks for an expected string in the .spec.displayName
-
-	for _, csv := range csvs.Items {
-		if expected == csv.Spec.DisplayName {
-			return true
-		}
-	}
-	return false
-}
-
-func deploymentNameMatch(expected string, deployments *appsv1.DeploymentList) bool {
-	// deploymentNameMatch iterates a DeploymentList
-	// and looks for an expected string in the .metadata.name
-
-	for _, deployment := range deployments.Items {
-		if expected == deployment.GetName() {
-			return true
-		}
-	}
-	return false
-}
-
-func genSuffix(prefix string) string {
-	// genSuffix creates a random 8 character string to append to object
-	// names when creating Kubernetes objects so there aren't any
-	// accidental name collisions
-
-	// Seed rand so there's actual randomness
-	// otherwise the string is always the same
-	rand.Seed(time.Now().UnixNano())
-
-	bytes := make([]byte, 8)
-	for i := 0; i < 8; i++ {
-		bytes[i] = byte(65 + rand.Intn(25))
-	}
-	return prefix + "-" + strings.ToLower(string(bytes))
-}

--- a/test/operators/managedvelero.go
+++ b/test/operators/managedvelero.go
@@ -1,0 +1,35 @@
+package operators
+
+import (
+	"github.com/onsi/ginkgo"
+	"github.com/openshift/osde2e/pkg/helper"
+)
+
+var _ = ginkgo.Describe("[OSD] Managed Velero Operator", func() {
+	var operatorName = "managed-velero-operator"
+	var operatorNamespace string = "openshift-velero"
+	var operatorLockFile string = "managed-velero-operator-lock"
+	var defaultDesiredReplicas int32 = 1
+
+	var clusterRoles = []string{
+		"managed-velero-operator",
+	}
+
+	var clusterRoleBindings = []string{
+		"managed-velero-operator",
+		"velero",
+	}
+
+	h := helper.New()
+	checkConfigMapLockfile(h, operatorNamespace, operatorLockFile)
+	checkDeployment(h, operatorNamespace, operatorName, defaultDesiredReplicas)
+	checkDeployment(h, operatorNamespace, "velero", defaultDesiredReplicas)
+	checkClusterRoles(h, clusterRoles)
+	checkClusterRoleBindings(h, clusterRoleBindings)
+	checkRoleBindings(h,
+		operatorNamespace,
+		[]string{"managed-velero-operator"})
+	checkRoleBindings(h,
+		"kube-system",
+		[]string{"managed-velero-operator-cluster-config-v1-reader"})
+})

--- a/test/operators/operators.go
+++ b/test/operators/operators.go
@@ -1,0 +1,342 @@
+package operators
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/osde2e/pkg/helper"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+)
+
+const globalPollingTimeout = 30
+
+func checkClusterServiceVersion(h *helper.H, namespace, name string) {
+	// Check that the operator clusterServiceVersion exists
+	ginkgo.Context("clusterServiceVersion", func() {
+		ginkgo.It("should exist", func() {
+			csvs, err := pollCsvList(h, namespace, name)
+			Expect(err).ToNot(HaveOccurred(), "failed fetching the clusterServiceVersions")
+			Expect(csvs).NotTo(BeNil())
+		}, float64(globalPollingTimeout))
+	})
+}
+
+func checkConfigMapLockfile(h *helper.H, namespace, operatorLockFile string) {
+	// Check that the operator configmap has been deployed
+	ginkgo.Context("configmaps", func() {
+		ginkgo.It("should exist", func() {
+			// Wait for lockfile to signal operator is active
+			err := pollLockFile(h, namespace, operatorLockFile)
+			Expect(err).ToNot(HaveOccurred(), "failed fetching the configMap lockfile")
+		}, float64(globalPollingTimeout))
+	})
+}
+
+func checkDeployment(h *helper.H, namespace string, name string, defaultDesiredReplicas int32) {
+	// Check that the operator deployment exists in the operator namespace
+	ginkgo.Context("deployment", func() {
+		ginkgo.It("should exist", func() {
+			deployment, err := pollDeployment(h, namespace, name)
+			Expect(err).ToNot(HaveOccurred(), "failed fetching deployment")
+			Expect(deployment).NotTo(BeNil(), "deployment is nil")
+		}, float64(globalPollingTimeout))
+		ginkgo.It("should have all desired replicas ready", func() {
+			deployment, err := pollDeployment(h, namespace, name)
+			Expect(err).ToNot(HaveOccurred(), "failed fetching deployment")
+
+			readyReplicas := deployment.Status.ReadyReplicas
+			desiredReplicas := deployment.Status.Replicas
+
+			// The desired replicas should match the default installed replica count
+			Expect(desiredReplicas).To(BeNumerically("==", defaultDesiredReplicas), "The deployment desired replicas should not drift from the default 1.")
+
+			// Desired replica count should match ready replica count
+			Expect(readyReplicas).To(BeNumerically("==", desiredReplicas), "All desired replicas should be ready.")
+		}, float64(globalPollingTimeout))
+	})
+}
+
+func checkClusterRoles(h *helper.H, clusterRoles []string) {
+	// Check that the clusterRoles exist
+	ginkgo.Context("clusterRoles", func() {
+		ginkgo.It("should exist", func() {
+			for _, clusterRoleName := range clusterRoles {
+				_, err := h.Kube().RbacV1().ClusterRoles().Get(clusterRoleName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred(), "failed to get clusterRole %v\n", clusterRoleName)
+			}
+		}, float64(globalPollingTimeout))
+	})
+}
+
+func checkClusterRoleBindings(h *helper.H, clusterRoleBindings []string) {
+	// Check that the clusterRoleBindings exist
+	ginkgo.Context("clusterRoleBindings", func() {
+		ginkgo.It("should exist", func() {
+			for _, clusterRoleBindingName := range clusterRoleBindings {
+				err := pollClusterRoleBinding(h, clusterRoleBindingName)
+				Expect(err).ToNot(HaveOccurred(), "failed to get clusterRoleBinding %v\n", clusterRoleBindingName)
+			}
+		}, float64(globalPollingTimeout))
+	})
+}
+
+func checkRole(h *helper.H, namespace string, roles []string) {
+	// Check that deployed roles exist
+	ginkgo.Context("roles", func() {
+		ginkgo.It("should exist", func() {
+			for _, roleName := range roles {
+				_, err := h.Kube().RbacV1().Roles(namespace).Get(roleName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred(), "failed to get role %v\n", roleName)
+			}
+		}, float64(globalPollingTimeout))
+	})
+
+}
+
+func checkRoleBindings(h *helper.H, namespace string, roleBindings []string) {
+	// Check that deployed rolebindings exist
+	ginkgo.Context("roleBindings", func() {
+		ginkgo.It("should exist", func() {
+			for _, roleBindingName := range roleBindings {
+				err := pollRoleBinding(h, namespace, roleBindingName)
+				Expect(err).NotTo(HaveOccurred(), "failed to get roleBinding %v\n", roleBindingName)
+			}
+		}, float64(globalPollingTimeout))
+	})
+}
+func pollClusterRoleBinding(h *helper.H, clusterRoleBindingName string) error {
+	// pollRoleBinding will check for the existence of a clusterRole
+	// in the specified project, and wait for it to exist, until a timeout
+
+	var err error
+	// interval is the duration in seconds between polls
+	// values here for humans
+
+	interval := 5
+
+	// convert time.Duration type
+	timeoutDuration := time.Duration(globalPollingTimeout*60) * time.Minute
+	intervalDuration := time.Duration(interval) * time.Second
+
+	start := time.Now()
+
+Loop:
+	for {
+		_, err = h.Kube().RbacV1().ClusterRoleBindings().Get(clusterRoleBindingName, metav1.GetOptions{})
+		elapsed := time.Since(start)
+
+		switch {
+		case err == nil:
+			// Success
+			break Loop
+		default:
+			if elapsed < timeoutDuration {
+				log.Printf("Waiting %v for %s clusterRoleBinding to exist", (timeoutDuration - elapsed), clusterRoleBindingName)
+				time.Sleep(intervalDuration)
+			} else {
+				err = fmt.Errorf("Failed to get clusterRolebinding %s before timeout", clusterRoleBindingName)
+				break Loop
+			}
+		}
+	}
+
+	return err
+}
+
+func pollRoleBinding(h *helper.H, projectName string, roleBindingName string) error {
+	// pollRoleBinding will check for the existence of a roleBinding
+	// in the specified project, and wait for it to exist, until a timeout
+
+	var err error
+	// interval is the duration in seconds between polls
+	// values here for humans
+
+	interval := 5
+
+	// convert time.Duration type
+	timeoutDuration := time.Duration(globalPollingTimeout*60) * time.Minute
+	intervalDuration := time.Duration(interval) * time.Second
+
+	start := time.Now()
+
+Loop:
+	for {
+		_, err = h.Kube().RbacV1().RoleBindings(projectName).Get(roleBindingName, metav1.GetOptions{})
+		elapsed := time.Since(start)
+
+		switch {
+		case err == nil:
+			// Success
+			break Loop
+		default:
+			if elapsed < timeoutDuration {
+				log.Printf("Waiting %v for %s roleBinding to exist", (timeoutDuration - elapsed), roleBindingName)
+				time.Sleep(intervalDuration)
+			} else {
+				err = fmt.Errorf("Failed to get rolebinding %s before timeout", roleBindingName)
+				break Loop
+			}
+		}
+	}
+
+	return err
+}
+
+func pollLockFile(h *helper.H, namespace, operatorLockFile string) error {
+	// GetConfigMap polls for a configMap with a timeout
+	// to handle the case when a new cluster is up but the OLM has not yet
+	// finished deploying the operator
+
+	var err error
+
+	// interval is the duration in seconds between polls
+	// values here for humans
+	interval := 30
+
+	// convert time.Duration type
+	timeoutDuration := time.Duration(globalPollingTimeout) * time.Minute
+	intervalDuration := time.Duration(interval) * time.Second
+
+	start := time.Now()
+
+Loop:
+	for {
+		_, err = h.Kube().CoreV1().ConfigMaps(namespace).Get(operatorLockFile, metav1.GetOptions{})
+		elapsed := time.Since(start)
+
+		switch {
+		case err == nil:
+			// Success
+			break Loop
+		default:
+			if elapsed < timeoutDuration {
+				log.Printf("Waiting %v for %s configMap to exist", (timeoutDuration - elapsed), operatorLockFile)
+				time.Sleep(intervalDuration)
+			} else {
+				err = fmt.Errorf("Failed to get configMap %s before timeout", operatorLockFile)
+				break Loop
+			}
+		}
+	}
+
+	return err
+}
+
+func pollDeployment(h *helper.H, namespace, deploymentName string) (*appsv1.Deployment, error) {
+	// pollDeployment polls for a deployment with a timeout
+	// to handle the case when a new cluster is up but the OLM has not yet
+	// finished deploying the operator
+
+	var err error
+	var deployment *appsv1.Deployment
+
+	// interval is the duration in seconds between polls
+	// values here for humans
+	interval := 5
+
+	// convert time.Duration type
+	timeoutDuration := time.Duration(globalPollingTimeout) * time.Minute
+	intervalDuration := time.Duration(interval) * time.Second
+
+	start := time.Now()
+
+Loop:
+	for {
+		deployment, err = h.Kube().AppsV1().Deployments(namespace).Get(deploymentName, metav1.GetOptions{})
+		elapsed := time.Since(start)
+
+		switch {
+		case err == nil:
+			// Success
+			break Loop
+		default:
+			if elapsed < timeoutDuration {
+				log.Printf("Waiting %v for %s deployment to exist", (timeoutDuration - elapsed), deploymentName)
+				time.Sleep(intervalDuration)
+			} else {
+				deployment = nil
+				err = fmt.Errorf("Failed to get %s Deployment before timeout", deploymentName)
+				break Loop
+			}
+		}
+	}
+
+	return deployment, err
+}
+
+func pollCsvList(h *helper.H, namespace, csvDisplayName string) (*operatorv1.ClusterServiceVersionList, error) {
+	// pollCsvList polls for clusterServiceVersions with a timeout
+	// to handle the case when a new cluster is up but the OLM has not yet
+	// finished deploying the operator
+
+	var err error
+	var csvList *operatorv1.ClusterServiceVersionList
+
+	// interval is the duration in seconds between polls
+	// values here for humans
+	interval := 5
+
+	// convert time.Duration type
+	timeoutDuration := time.Duration(globalPollingTimeout) * time.Minute
+	intervalDuration := time.Duration(interval) * time.Second
+
+	start := time.Now()
+
+Loop:
+	for {
+		csvList, err = h.Operator().OperatorsV1alpha1().ClusterServiceVersions(namespace).List(metav1.ListOptions{})
+		for _, csv := range csvList.Items {
+			switch {
+			case csvDisplayName == csv.Spec.DisplayName:
+				// Success
+				err = nil
+			default:
+				err = fmt.Errorf("No matching clusterServiceVersion in CSV List")
+			}
+		}
+		elapsed := time.Since(start)
+
+		switch {
+		case err == nil:
+			// Success
+			break Loop
+		default:
+			if elapsed < timeoutDuration {
+				log.Printf("Waiting %v for %s clusterServiceVersion to exist", (timeoutDuration - elapsed), csvDisplayName)
+				time.Sleep(intervalDuration)
+			} else {
+				csvList = nil
+				err = fmt.Errorf("Failed to get %s clusterServiceVersion before timeout", csvDisplayName)
+				break Loop
+			}
+		}
+	}
+
+	return csvList, err
+}
+
+func genSuffix(prefix string) string {
+	// genSuffix creates a random 8 character string to append to object
+	// names when creating Kubernetes objects so there aren't any
+	// accidental name collisions
+
+	// Seed rand so there's actual randomness
+	// otherwise the string is always the same
+	rand.Seed(time.Now().UnixNano())
+
+	bytes := make([]byte, 8)
+	for i := 0; i < 8; i++ {
+		bytes[i] = byte(65 + rand.Intn(25))
+	}
+	return prefix + "-" + strings.ToLower(string(bytes))
+}


### PR DESCRIPTION
This PR encompasses the refactored operator test scaffold; simplifies the dedicated-admin operator test; add configure-alertmanager and managed-velero operator tests.

Replaces PR #118 ; PR #110 