### PR TITLE
fixing extended timeout times; reduced from 30h to 30m

### DIFF
--- a/test/operators/operators.go
+++ b/test/operators/operators.go
@@ -125,7 +125,7 @@ func pollClusterRoleBinding(h *helper.H, clusterRoleBindingName string) error {
 	interval := 5
 
 	// convert time.Duration type
-	timeoutDuration := time.Duration(globalPollingTimeout*60) * time.Minute
+	timeoutDuration := time.Duration(globalPollingTimeout) * time.Minute
 	intervalDuration := time.Duration(interval) * time.Second
 
 	start := time.Now()
@@ -164,7 +164,7 @@ func pollRoleBinding(h *helper.H, projectName string, roleBindingName string) er
 	interval := 5
 
 	// convert time.Duration type
-	timeoutDuration := time.Duration(globalPollingTimeout*60) * time.Minute
+	timeoutDuration := time.Duration(globalPollingTimeout) * time.Minute
 	intervalDuration := time.Duration(interval) * time.Second
 
 	start := time.Now()


### PR DESCRIPTION
Fixing a regression from previous commit that does not take into account the new unit size for the globalPollingTimeout variable.

Fixes the 30h polling wait (reduced to 30m).

Signed-off-by: Christopher Collins <collins.christopher@gmail.com>