### PR TITLE
SDCICD-40. Use MAJOR_TARGET and MINOR_TARGET to target CIS versions.

### DIFF
--- a/version.go
+++ b/version.go
@@ -47,8 +47,8 @@ func setupVersion(cfg *config.Config, osd *osd.OSD, isUpgrade bool) (err error) 
 			cfg.MajorTarget = -1
 		}
 		// look for the default release and install it for this OSD cluster.
-		if cfg.ClusterVersion, err = osd.LatestPrerelease(cfg.MajorTarget, cfg.MinorTarget, "nightly"); err == nil {
-			log.Printf("CLUSTER_VERSION not set but a TARGET is, running nightly '%s'", cfg.ClusterVersion)
+		if cfg.ClusterVersion, err = osd.LatestVersion(cfg.MajorTarget, cfg.MinorTarget); err == nil {
+			log.Printf("CLUSTER_VERSION not set but a TARGET is, running '%s'", cfg.ClusterVersion)
 		}
 	}
 


### PR DESCRIPTION
The MAJOR_TARGET and MINOR_TARGET variables will now target versions
that come directly from the OSD cluster versions endpoint without being
targeted at a specific type of nightly.