### PR TITLE
SDCICD-59. Propagate timeout to waitForEndpoints.

### DIFF
--- a/pkg/runner/git_test.go
+++ b/pkg/runner/git_test.go
@@ -35,7 +35,7 @@ func TestRunnerGit(t *testing.T) {
 
 	// execute runner
 	stopCh := make(chan struct{})
-	err := runner.Run(stopCh)
+	err := runner.Run(1800, stopCh)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// get results

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -91,7 +91,7 @@ type Runner struct {
 }
 
 // Run deploys the suite into a cluster, waits for it to finish, and gathers the results.
-func (r *Runner) Run(stopCh <-chan struct{}) (err error) {
+func (r *Runner) Run(timeoutInSeconds int, stopCh <-chan struct{}) (err error) {
 	r.stopCh = stopCh
 	r.status = StatusSetup
 
@@ -120,8 +120,8 @@ func (r *Runner) Run(stopCh <-chan struct{}) (err error) {
 		return
 	}
 
-	log.Printf("Waiting for endpoints of %s runner Pod...", r.Name)
-	if err = r.waitForEndpoints(); err != nil {
+	log.Printf("Waiting for endpoints of %s runner Pod with a timeout of %d seconds...", r.Name, timeoutInSeconds)
+	if err = r.waitForEndpoints(timeoutInSeconds); err != nil {
 		return
 	}
 

--- a/pkg/runner/runner_test.go
+++ b/pkg/runner/runner_test.go
@@ -44,7 +44,7 @@ func TestRunner(t *testing.T) {
 
 	// execute runner
 	stopCh := make(chan struct{})
-	err := runner.Run(stopCh)
+	err := runner.Run(1800, stopCh)
 	g.Expect(err).NotTo(HaveOccurred())
 
 	// get results

--- a/pkg/runner/service.go
+++ b/pkg/runner/service.go
@@ -30,9 +30,9 @@ func (r *Runner) createService(pod *kubev1.Pod) (svc *kubev1.Service, err error)
 	})
 }
 
-func (r *Runner) waitForEndpoints() error {
+func (r *Runner) waitForEndpoints(timeoutInSeconds int) error {
 	var endpoints *kubev1.Endpoints
-	return wait.PollImmediate(15*time.Second, 30*time.Minute, func() (done bool, err error) {
+	return wait.PollImmediate(15*time.Second, time.Duration(timeoutInSeconds)*time.Second, func() (done bool, err error) {
 		endpoints, err = r.Kube.CoreV1().Endpoints(r.svc.Namespace).Get(r.svc.Name, metav1.GetOptions{})
 		if err != nil && !kerror.IsNotFound(err) {
 			r.Printf("Encountered error getting endpoint '%s/%s': %v", r.svc.Namespace, r.svc.Name, err)

--- a/pkg/runner/service_test.go
+++ b/pkg/runner/service_test.go
@@ -30,7 +30,7 @@ func TestResultsService(t *testing.T) {
 	done := make(chan struct{})
 	errs := make(chan error, 1)
 	go func() {
-		err := r.waitForEndpoints()
+		err := r.waitForEndpoints(1800)
 		if err != nil {
 			errs <- fmt.Errorf("Failed waiting for endpoints: %v", err)
 		} else {

--- a/test/openshift/openshift.go
+++ b/test/openshift/openshift.go
@@ -23,6 +23,7 @@ var _ = ginkgo.Describe("OpenShift E2E", func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 
+	e2eTimeoutInSeconds := 3600
 	ginkgo.It("should run until completion", func() {
 		// configure tests
 		cfg := DefaultE2EConfig
@@ -33,7 +34,7 @@ var _ = ginkgo.Describe("OpenShift E2E", func() {
 
 		// run tests
 		stopCh := make(chan struct{})
-		err := r.Run(stopCh)
+		err := r.Run(e2eTimeoutInSeconds, stopCh)
 		Expect(err).NotTo(HaveOccurred())
 
 		// get results
@@ -42,5 +43,5 @@ var _ = ginkgo.Describe("OpenShift E2E", func() {
 
 		// write results
 		h.WriteResults(results)
-	}, 3600)
+	}, float64(e2eTimeoutInSeconds+30))
 })

--- a/test/state/mustgather.go
+++ b/test/state/mustgather.go
@@ -17,6 +17,7 @@ var _ = ginkgo.Describe("Cluster state", func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 
+	mustGatherTimeoutInSeconds := 900
 	ginkgo.It("should be captured with must-gather", func() {
 		// setup runner
 		r := h.Runner(mustGatherCmd)
@@ -25,7 +26,7 @@ var _ = ginkgo.Describe("Cluster state", func() {
 
 		// run tests
 		stopCh := make(chan struct{})
-		err := r.Run(stopCh)
+		err := r.Run(mustGatherTimeoutInSeconds, stopCh)
 		Expect(err).NotTo(HaveOccurred())
 
 		// get results
@@ -34,5 +35,5 @@ var _ = ginkgo.Describe("Cluster state", func() {
 
 		// write results
 		h.WriteResults(results)
-	}, 900)
+	}, float64(mustGatherTimeoutInSeconds+30))
 })

--- a/test/state/prometheus.go
+++ b/test/state/prometheus.go
@@ -17,6 +17,7 @@ var _ = ginkgo.Describe("Cluster state", func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 
+	prometheusTimeoutInSeconds := 900
 	ginkgo.It("should include Prometheus data", func() {
 		// setup runner
 		cmd := promCollectCmd + " >" + runner.DefaultRunner.OutputDir + "/prometheus.tar.gz"
@@ -25,7 +26,7 @@ var _ = ginkgo.Describe("Cluster state", func() {
 
 		// run tests
 		stopCh := make(chan struct{})
-		err := r.Run(stopCh)
+		err := r.Run(prometheusTimeoutInSeconds, stopCh)
 		Expect(err).NotTo(HaveOccurred())
 
 		// get results
@@ -34,5 +35,5 @@ var _ = ginkgo.Describe("Cluster state", func() {
 
 		// write results
 		h.WriteResults(results)
-	}, 900)
+	}, float64(prometheusTimeoutInSeconds+30))
 })


### PR DESCRIPTION
The timeout in the Ginkgo tests is now propagated down to
waitForEndpoints. Additionally, the Ginkgo tests' timeouts are padded by
30 seconds to allow for a more edifying error message from the
waitForEndpoints timeout if it gets hit.

Note: Running some tests for this now, but I think the basic logic here should be fine.