### PR TITLE
Use cvo and osd-verify checks to determine cluster health

### DIFF
--- a/pkg/helper/nodes.go
+++ b/pkg/helper/nodes.go
@@ -1,0 +1,35 @@
+package helper
+
+import (
+	"log"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// CheckNodeHealth attempts to look at the state of all operator and returns true if things are healthy.
+func CheckNodeHealth(kubeclient kubernetes.Interface) (bool, error) {
+	fail := false
+	log.Print("Checking that all Nodes are running or completed...")
+
+	nodeClient, getOpts := kubeclient.CoreV1(), metav1.ListOptions{}
+	list, err := nodeClient.Nodes().List(getOpts)
+	if err != nil {
+		log.Printf("Error getting CVS: %v\n", err)
+		return false, nil
+	}
+
+	for _, node := range list.Items {
+		for _, ns := range node.Status.Conditions {
+			if ns.Type != "Ready" && ns.Status == "True" {
+				log.Printf("Node (%v) issue: %v=%v %v\n", node.ObjectMeta.Name, ns.Type, ns.Status, ns.Message)
+				fail = true
+			} else if ns.Type == "Ready" && ns.Status != "True" {
+				log.Printf("Node (%v) not ready: %v=%v %v\n", node.ObjectMeta.Name, ns.Type, ns.Status, ns.Message)
+				fail = true
+			}
+		}
+	}
+
+	return fail, nil
+}

--- a/pkg/helper/operators.go
+++ b/pkg/helper/operators.go
@@ -1,0 +1,32 @@
+package helper
+
+import (
+	"log"
+
+	osconfig "github.com/openshift/client-go/config/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CheckOperatorReadiness attempts to look at the state of all operator and returns true if things are healthy.
+func CheckOperatorReadiness(oscfg *osconfig.Clientset) (bool, error) {
+	success := true
+	log.Print("Checking that all Operators are running or completed...")
+
+	configClient, getOpts := oscfg.ConfigV1(), metav1.ListOptions{}
+	list, err := configClient.ClusterOperators().List(getOpts)
+	if err != nil {
+		log.Printf("Error getting CVS: %v\n", err)
+		return false, nil
+	}
+
+	for _, co := range list.Items {
+		for _, cos := range co.Status.Conditions {
+			if (cos.Type != "Available" || cos.Status != "True") && cos.Type != "Upgradable" {
+				log.Printf("Operator %v type %v is %v: %v", co.ObjectMeta.Name, cos.Type, cos.Status, cos.Message)
+				success = false
+			}
+		}
+	}
+
+	return success, nil
+}

--- a/pkg/helper/pods.go
+++ b/pkg/helper/pods.go
@@ -8,6 +8,7 @@ import (
 
 	kubev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 // WaitForPodPhase until in target, checking n times and sleeping dur between them. Last known phase is returned.
@@ -31,4 +32,32 @@ func (h *H) WaitForPodPhase(pod *kubev1.Pod, target kubev1.PodPhase, n int, dur 
 
 	Expect(phase).NotTo(BeEmpty())
 	return
+}
+
+// CheckPodHealth attempts to look at the state of all pods and returns true if things are healthy.
+func CheckPodHealth(kubeclient kubernetes.Interface) (bool, error) {
+	var notReady []kubev1.Pod
+
+	log.Print("Checking that all Pods are running or completed...")
+
+	list, err := kubeclient.CoreV1().Pods(metav1.NamespaceAll).List(metav1.ListOptions{})
+	if err != nil {
+		return false, err
+	}
+	Expect(list).NotTo(BeNil())
+
+	for _, pod := range list.Items {
+		phase := pod.Status.Phase
+		if phase != kubev1.PodRunning && phase != kubev1.PodSucceeded {
+			notReady = append(notReady, pod)
+		}
+	}
+
+	total := len(list.Items)
+	ready := float64(total - len(notReady))
+	curRatio := (ready / float64(total)) * 100
+
+	log.Printf("%v%% of pods are currently alive: ", curRatio)
+
+	return len(notReady) == 0, nil
 }

--- a/setup.go
+++ b/setup.go
@@ -31,8 +31,8 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	Expect(err).ShouldNot(HaveOccurred(), "failed to setup cluster for testing")
 
 	// Give the cluster some breathing room.
-	log.Println("OSD cluster installed. Sleeping for 600s.")
-	time.Sleep(600 * time.Second)
+	log.Println("OSD cluster installed. Sleeping for 10s.")
+	time.Sleep(10 * time.Second)
 
 	// upgrade cluster if requested
 	if cfg.UpgradeImage != "" || cfg.UpgradeReleaseStream != "" {
@@ -109,13 +109,10 @@ func setupCluster(cfg *config.Config) (err error) {
 		log.Printf("CLUSTER_ID of '%s' was provided, skipping cluster creation and using it instead", cfg.ClusterID)
 	}
 
-	if err = OSD.WaitForClusterReady(cfg.ClusterID, cfg.ClusterUpTimeout); err != nil {
+	if err = OSD.WaitForClusterReady(cfg); err != nil {
 		return fmt.Errorf("failed waiting for cluster ready: %v", err)
 	}
 
-	if cfg.Kubeconfig, err = OSD.ClusterKubeconfig(cfg.ClusterID); err != nil {
-		return fmt.Errorf("could not get kubeconfig for cluster: %v", err)
-	}
 	return nil
 }
 


### PR DESCRIPTION
This mimics the osd-verify script SREs use to determine cluster health. It's checking the CVO for cluster state, then checking operator, node, and pod health. 

Once a cluster is deemed healthy, it will continue polling until 5 clean polls occur, or will attempt to do so until the setup timeout.