### PR TITLE
SDCICD-63. Reintroduce NodeVertical tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 .PHONY: check generate build-image push-image push-latest test
 
 PKG := github.com/openshift/osde2e
+E2E_PKG := $(PKG)/suites/e2e
+SCALE_PKG := $(PKG)/suites/scale
+
 DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
 IMAGE_NAME := quay.io/app-sre/osde2e
@@ -10,9 +13,9 @@ CONTAINER_ENGINE ?= docker
 
 check: cmd/osde2e-docs
 	go run $(PKG)/$< --check
-	CGO_ENABLED=0 go test -v ./cmd/... ./pkg/... 
+	CGO_ENABLED=0 go test -v ./cmd/... ./pkg/...
 	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint && \
-    golangci-lint run ./... 
+	golangci-lint run ./...
 
 generate: docs/Options.md
 
@@ -26,10 +29,13 @@ push-latest:
 	$(CONTAINER_ENGINE) tag "$(IMAGE_NAME):$(IMAGE_TAG)" "$(IMAGE_NAME):latest"
 	@$(CONTAINER_ENGINE) --config=$(DOCKER_CONF) push "$(IMAGE_NAME):latest"
 
-test: out/osde2e
-	$< -test.v -ginkgo.skip="$(GINKGO_SKIP)" -test.timeout 8h
+test:
+	go test $(E2E_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -test.timeout 8h
 
-docker-test:
+test-scale:
+	go test $(SCALE_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -test.timeout 8h -test.run TestScale
+
+test-docker:
 	$(CONTAINER_ENGINE) run \
 		-t \
 		--rm \
@@ -50,12 +56,6 @@ docker-test:
 		-e AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) \
 		-e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) \
 		$(IMAGE_NAME):$(IMAGE_TAG)
-
-out/osde2e: out
-	CGO_ENABLED=0 go test -v -c -o $@ $(PKG)
-
-out:
-	mkdir -p $@
 
 docs/Options.md: cmd/osde2e-docs pkg/config/config.go
 	go run $(PKG)/$<

--- a/ci/prow_pr_check.sh
+++ b/ci/prow_pr_check.sh
@@ -4,5 +4,4 @@ set -o pipefail
 
 {
     make check
-    make out/osde2e
 } 2>&1 | tee -a $REPORT_DIR/test_output.log

--- a/common/e2e.go
+++ b/common/e2e.go
@@ -1,5 +1,5 @@
-// Package osde2e launches an OSD cluster, performs tests on it, and destroys it.
-package osde2e
+// Package common launches an OSD cluster, performs tests on it, and destroys it.
+package common
 
 import (
 	"fmt"

--- a/common/setup.go
+++ b/common/setup.go
@@ -1,4 +1,4 @@
-package osde2e
+package common
 
 import (
 	"fmt"

--- a/common/version.go
+++ b/common/version.go
@@ -1,4 +1,4 @@
-package osde2e
+package common
 
 import (
 	"errors"

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -121,7 +121,7 @@ func (r *Runner) Run(timeoutInSeconds int, stopCh <-chan struct{}) (err error) {
 	}
 
 	log.Printf("Waiting for endpoints of %s runner Pod with a timeout of %d seconds...", r.Name, timeoutInSeconds)
-	if err = r.waitForEndpoints(timeoutInSeconds); err != nil {
+	if err = r.waitForCompletion(timeoutInSeconds); err != nil {
 		return
 	}
 

--- a/pkg/runner/service_test.go
+++ b/pkg/runner/service_test.go
@@ -30,7 +30,7 @@ func TestResultsService(t *testing.T) {
 	done := make(chan struct{})
 	errs := make(chan error, 1)
 	go func() {
-		err := r.waitForEndpoints(1800)
+		err := r.waitForCompletion(1800)
 		if err != nil {
 			errs <- fmt.Errorf("Failed waiting for endpoints: %v", err)
 		} else {

--- a/suites/e2e/e2e_test.go
+++ b/suites/e2e/e2e_test.go
@@ -1,8 +1,9 @@
-package osde2e
+package osde2e_test
 
 import (
 	"testing"
 
+	"github.com/openshift/osde2e/common"
 	"github.com/openshift/osde2e/pkg/config"
 
 	// import suites to be tested
@@ -14,5 +15,5 @@ import (
 
 func TestE2E(t *testing.T) {
 	cfg := config.Cfg
-	RunE2ETests(t, cfg)
+	common.RunE2ETests(t, cfg)
 }

--- a/suites/scale/scale_test.go
+++ b/suites/scale/scale_test.go
@@ -1,0 +1,16 @@
+package osde2e_scale
+
+import (
+	"testing"
+
+	"github.com/openshift/osde2e/common"
+	"github.com/openshift/osde2e/pkg/config"
+
+	// import suites to be tested
+	_ "github.com/openshift/osde2e/test/scale"
+)
+
+func TestScale(t *testing.T) {
+	cfg := config.Cfg
+	common.RunE2ETests(t, cfg)
+}

--- a/test/scale/nodevertical.go
+++ b/test/scale/nodevertical.go
@@ -1,0 +1,37 @@
+// Package openshift runs the OpenShift extended test suite.
+package openshift
+
+import (
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	kubev1 "k8s.io/api/core/v1"
+
+	"github.com/openshift/osde2e/pkg/helper"
+)
+
+var _ = ginkgo.Describe("Scaling", func() {
+	defer ginkgo.GinkgoRecover()
+	h := helper.New()
+
+	nodeVerticalTimeoutInSeconds := 3600
+	ginkgo.It("should be tested with NodeVertical", func() {
+		// setup runner
+		scaleCfg := scaleRunnerConfig{
+			Name:         "node-vertical",
+			PlaybookPath: "workloads/nodevertical.yml",
+		}
+		r := scaleCfg.Runner(h)
+
+		// only test on 3 nodes
+		r.PodSpec.Containers[0].Env = append(r.PodSpec.Containers[0].Env, kubev1.EnvVar{
+			Name:  "NODEVERTICAL_NODE_COUNT",
+			Value: "3",
+		})
+
+		// run tests
+		stopCh := make(chan struct{})
+		err := r.Run(nodeVerticalTimeoutInSeconds, stopCh)
+		Expect(err).NotTo(HaveOccurred())
+	}, float64(nodeVerticalTimeoutInSeconds))
+})

--- a/test/scale/scale.go
+++ b/test/scale/scale.go
@@ -1,0 +1,93 @@
+package openshift
+
+import (
+	"bytes"
+	"text/template"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/osde2e/pkg/helper"
+	"github.com/openshift/osde2e/pkg/runner"
+)
+
+const (
+	// image used for ansible commands
+	ansibleImage = "docker.io/openshift/origin-ansible@sha256:030adfc1b9bc8b1ad0722632ecf469018c20a4aeaed0672f9466e433003e666c"
+)
+
+var (
+	// scaleRepos are the default repos cloned with scale tests.
+	scaleRepos = runner.Repos{
+		{
+			Name:      "workloads",
+			URL:       "https://github.com/openshift-scale/workloads.git",
+			MountPath: "/src/github.com/openshift-scale/workloads",
+		},
+	}
+
+	scaleRunnerCmdTpl = template.Must(template.New("scale-runner-cmd").Parse(`
+set -o pipefail
+set -eux
+
+cd /src/github.com/openshift-scale/workloads
+
+# Disable logging
+set +x
+
+# setup service account
+NS=scale-ci-tooling
+oc new-project ${NS} || true
+oc create serviceaccount useroot -n ${NS}
+oc adm policy add-scc-to-user privileged -z useroot -n ${NS}
+
+# setup inventory
+cp workloads/inventory.example inventory
+echo "localhost ansible_connection=local" >> inventory
+mkdir ~/.ssh && ssh-keygen -t rsa -f ~/.ssh/id_rsa -N ''
+
+# Re-enable logging
+set -x
+
+export NODEVERTICAL_MAXPODS=$(( NODEVERTICAL_NODE_COUNT * 250 ))
+export EXPECTED_NODEVERTICAL_DURATION=1800
+time ansible-playbook -vv -i inventory workloads/nodevertical.yml
+
+oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-nodevertical
+oc get job -n scale-ci-tooling scale-ci-nodevertical -o yaml | grep -q "succeeded:\s*1"
+
+SUCCESS=$?
+
+echo "Success value of scale-ci-nodevertical: $SUCCESS"
+exit $SUCCESS
+`))
+)
+
+type scaleRunnerConfig struct {
+	Name         string
+	PlaybookPath string
+}
+
+// Runner returns a runner with a base config for scale tests.
+func (sCfg scaleRunnerConfig) Runner(h *helper.H) *runner.Runner {
+	// template command from config
+	sCfg.Name = "scale-" + sCfg.Name
+	cmd := sCfg.cmd()
+
+	// configure runner for scale testing
+	runner := h.Runner(cmd)
+	runner.Name = sCfg.Name
+	runner.ImageName = ansibleImage
+	runner.Repos = scaleRepos
+
+	// set kubeconfig within home for ansible image
+	runner.PodSpec.Containers[0].Env[0].Value = "/opt/app-root/src/.kube/config"
+
+	return runner
+}
+
+func (sCfg scaleRunnerConfig) cmd() string {
+	var cmd bytes.Buffer
+	err := scaleRunnerCmdTpl.Execute(&cmd, sCfg)
+	Expect(err).NotTo(HaveOccurred(), "failed templating command")
+	return cmd.String()
+}


### PR DESCRIPTION
The NodeVertical tests that @ethernetdan had been working on have been
reintroduced into osde2e. Additionally, the tests have been split into
general and scale tests, as the scale tests take much longer to run than
other tests, and as a result need to be split out.