### PR TITLE
CICD-69 - Output more pod info

### DIFF
--- a/pkg/helper/pods.go
+++ b/pkg/helper/pods.go
@@ -54,6 +54,7 @@ func CheckPodHealth(podClient v1.CoreV1Interface) (bool, error) {
 		phase := pod.Status.Phase
 		if phase != kubev1.PodRunning && phase != kubev1.PodSucceeded {
 			notReady = append(notReady, pod)
+			log.Printf("%s is not ready. Phase: %s, Message: %s, Reason: %s", pod.Name, pod.Status.Phase, pod.Status.Message, pod.Status.Reason)
 		}
 	}
 

--- a/pkg/helper/pods_test.go
+++ b/pkg/helper/pods_test.go
@@ -20,7 +20,9 @@ func pod(name, namespace string, phase v1.PodPhase) *v1.Pod {
 			},
 		},
 		Status: v1.PodStatus{
-			Phase: phase,
+			Phase:   phase,
+			Message: "pod message",
+			Reason:  "pod reason",
 		},
 	}
 }


### PR DESCRIPTION
When a pod has not succeeded it will now output the message and reason. 

/assign @meowfaceman 