### PR TITLE
CICD-73 - Fix bool default logic

### DIFF
--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -21,7 +21,11 @@ func (c *Config) LoadFromEnv() {
 			case reflect.String:
 				field.SetString(defaultValue)
 			case reflect.Bool:
-				field.SetBool(true)
+				if defaultValue == "true" {
+					field.SetBool(true)
+				} else {
+					field.SetBool(false)
+				}
 			case reflect.Slice:
 				field.SetBytes([]byte(defaultValue))
 			case reflect.Int:


### PR DESCRIPTION
Original logic assumed if the default is set for a bool, it _must_ be true.

The broken tests indicate that that was a lie. 