### PR TITLE
SDCICD-27. Make cluster expiry configurable and update to ocm-go-sdk.

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -84,14 +84,6 @@ before failing the test.
 - Type: `bool`
 - Default: `false`
 
-### `NO_DESTROY_DELAY`
-
-- NoDestroyDelay circumvents the 60min delay before a cluster is deleted
-This is highly useful when trying to debug things locally. :)
-
-- Type: `bool`
-- Default: `false`
-
 ### `OSD_ENV`
 
 - OSDEnv is the OpenShift Dedicated environment used to provision clusters.
@@ -101,6 +93,13 @@ This is highly useful when trying to debug things locally. :)
 
 ## cluster
 
+
+### `CLUSTER_EXPIRY_IN_MINUTES`
+
+- ClusterExpiryInMinutes is how long before a cluster expires and is deleted by OSD.
+
+- Type: `int64`
+- Default: `210`
 
 ### `CLUSTER_ID`
 
@@ -114,16 +113,16 @@ This is highly useful when trying to debug things locally. :)
 
 - Type: `string`
 
+### `DESTROY_CLUSTER`
+
+- DestroyClusterAfterTest set to false if you want OCM to clean up the cluster itself after the test completes.
+
+- Type: `bool`
+- Default: `true`
+
 ### `MULTI_AZ`
 
 - MultiAZ deploys a cluster across multiple availability zones.
-
-- Type: `bool`
-- Default: `false`
-
-### `NO_DESTROY`
-
-- NoDestroy leaves the cluster running after testing.
 
 - Type: `bool`
 - Default: `false`

--- a/docs/Writing-Tests.md
+++ b/docs/Writing-Tests.md
@@ -127,7 +127,7 @@ Ginkgo has been configured to bring a cluster up in it's [`BeforeSuite`](https:/
 **Cluster configuration**
 - Launched clusters are setup with the [`osd`](../pkg/osd) package
 	- Changes to the way test clusters are launched should be made there
-- [uhc-sdk-go](https://github.com/openshift-online/uhc-sdk-go) is used to launch clusters
+- [ocm-sdk-go](https://github.com/openshift-online/ocm-sdk-go) is used to launch clusters
 - Configuration for launching clusters is loaded from a [`config.Config`](https://godoc.org/github.com/openshift/osde2e/pkg/config#Config) instance
 
 ## Helper

--- a/glide.lock
+++ b/glide.lock
@@ -116,8 +116,8 @@ imports:
   - matchers/support/goraph/node
   - matchers/support/goraph/util
   - types
-- name: github.com/openshift-online/uhc-sdk-go
-  version: 743491d4a657f4942eb8a8764795fd7f06582c0e
+- name: github.com/openshift-online/ocm-sdk-go
+  version: 3f971b7e42daf1e96c8d0c44d334497d092b5f71
   subpackages:
   - pkg/client
   - pkg/client/accountsmgmt

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,8 +24,8 @@ import:
   subpackages:
   - project/clientset/versioned
   - image/clientset/versioned/fake
-- package: github.com/openshift-online/uhc-sdk-go
-  version: v0.1.25
+- package: github.com/openshift-online/ocm-sdk-go
+  version: v0.1.50
   subpackages:
   - pkg/client
   - pkg/client/clustersmgmt/v1

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -51,11 +51,14 @@ type Config struct {
 	// MultiAZ deploys a cluster across multiple availability zones.
 	MultiAZ bool `env:"MULTI_AZ" sect:"cluster" default:"false"`
 
-	// NoDestroy leaves the cluster running after testing.
-	NoDestroy bool `env:"NO_DESTROY" sect:"cluster" default:"false"`
+	// DestroyClusterAfterTest set to false if you want OCM to clean up the cluster itself after the test completes.
+	DestroyClusterAfterTest bool `env:"DESTROY_CLUSTER" sect:"cluster" default:"true"`
 
 	// Kubeconfig is used to access a cluster.
 	Kubeconfig []byte `env:"TEST_KUBECONFIG" sect:"cluster"`
+
+	// ClusterExpiryInMinutes is how long before a cluster expires and is deleted by OSD.
+	ClusterExpiryInMinutes int64 `env:"CLUSTER_EXPIRY_IN_MINUTES" sect:"cluster" default:"210"`
 
 	// AfterTestClusterWait is how long to keep a cluster around after tests have run.
 	AfterTestClusterWait int64 `env:"AFTER_TEST_CLUSTER_WAIT" sect:"environment" default:"60"`
@@ -68,10 +71,6 @@ type Config struct {
 
 	// DebugOSD shows debug level messages when enabled.
 	DebugOSD bool `env:"DEBUG_OSD" sect:"environment" default:"false"`
-
-	// NoDestroyDelay circumvents the 60min delay before a cluster is deleted
-	// This is highly useful when trying to debug things locally. :)
-	NoDestroyDelay bool `env:"NO_DESTROY_DELAY" sect:"environment" default:"false"`
 
 	// GinkgoSkip is a regex passed to Ginkgo that skips any test suites matching the regex. ex. "Operator"
 	GinkgoSkip string `env:"GINKGO_SKIP" sect:"tests"`

--- a/pkg/osd/cluster.go
+++ b/pkg/osd/cluster.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"time"
 
-	v1 "github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	osconfig "github.com/openshift/client-go/config/clientset/versioned"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -29,7 +29,7 @@ func (u *OSD) LaunchCluster(cfg *config.Config) (string, error) {
 
 	// Calculate an expiration date for the cluster so that it will be automatically deleted if
 	// we happen to forget to do it:
-	expiration := time.Now().Add(8 * time.Hour)
+	expiration := time.Now().Add(time.Duration(cfg.ClusterExpiryInMinutes) * time.Minute).UTC() // UTC() to workaround SDA-1567
 
 	cluster, err := v1.NewCluster().
 		Name(cfg.ClusterName).

--- a/pkg/osd/logs.go
+++ b/pkg/osd/logs.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math"
 
-	v1 "github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 // Logs provides all logs available for clusterID, ids can be optionally provided for only specific logs.

--- a/pkg/osd/osd.go
+++ b/pkg/osd/osd.go
@@ -4,10 +4,11 @@ package osd
 import (
 	"errors"
 	"fmt"
-	uhc "github.com/openshift-online/uhc-sdk-go/pkg/client"
-	accounts "github.com/openshift-online/uhc-sdk-go/pkg/client/accountsmgmt/v1"
-	clusters "github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1"
-	uhcerr "github.com/openshift-online/uhc-sdk-go/pkg/client/errors"
+
+	ocm "github.com/openshift-online/ocm-sdk-go"
+	accounts "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+	clusters "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	ocmerr "github.com/openshift-online/ocm-sdk-go/errors"
 )
 
 const (
@@ -23,7 +24,7 @@ const (
 
 // New setups a client to connect to OSD.
 func New(token, env string, debug bool) (*OSD, error) {
-	logger, err := uhc.NewGoLoggerBuilder().
+	logger, err := ocm.NewGoLoggerBuilder().
 		Debug(debug).
 		Build()
 	if err != nil {
@@ -33,7 +34,7 @@ func New(token, env string, debug bool) (*OSD, error) {
 	// select correct environment
 	url := Environments.Choose(env)
 
-	builder := uhc.NewConnectionBuilder().
+	builder := ocm.NewConnectionBuilder().
 		URL(url).
 		TokenURL(TokenURL).
 		Client(ClientID, "").
@@ -52,7 +53,7 @@ func New(token, env string, debug bool) (*OSD, error) {
 
 // OSD acts as a client to manage an instance.
 type OSD struct {
-	conn *uhc.Connection
+	conn *ocm.Connection
 }
 
 // CurrentAccount returns the current account being used.
@@ -81,7 +82,7 @@ func (u *OSD) versions() *clusters.VersionsClient {
 	return u.conn.ClustersMgmt().V1().Versions()
 }
 
-func errResp(resp *uhcerr.Error) error {
+func errResp(resp *ocmerr.Error) error {
 	if resp != nil {
 		return fmt.Errorf("api error: %s", resp.Reason())
 	}

--- a/pkg/osd/quota.go
+++ b/pkg/osd/quota.go
@@ -8,8 +8,8 @@ import (
 	"net/http"
 	"path"
 
-	accounts "github.com/openshift-online/uhc-sdk-go/pkg/client/accountsmgmt/v1"
-	osderrors "github.com/openshift-online/uhc-sdk-go/pkg/client/errors"
+	accounts "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
+	osderrors "github.com/openshift-online/ocm-sdk-go/errors"
 
 	"github.com/openshift/osde2e/pkg/config"
 )
@@ -40,7 +40,7 @@ func (u *OSD) CheckQuota(cfg *config.Config) (bool, error) {
 		return false, fmt.Errorf("could not get quota: %v", err)
 	}
 
-	// TODO: use compute_machine_type when available in UHC SDK
+	// TODO: use compute_machine_type when available in OCM SDK
 	_ = flavour.Nodes()
 	machineType := ""
 
@@ -92,7 +92,7 @@ func HasQuotaFor(q *accounts.ResourceQuota, cfg *config.Config, resourceType, ma
 	return false
 }
 
-// TODO: use uhc-sdk-go resource_summary method once available
+// TODO: use ocm-sdk-go resource_summary method once available
 func (u *OSD) getQuotaSummary(orgId string) (*resourceSummaryListResponse, error) {
 	resp := new(resourceSummaryListResponse)
 	summaryPath := path.Join("/api/accounts_mgmt", APIVersion, "organizations", orgId, "quota_summary")

--- a/pkg/osd/versions.go
+++ b/pkg/osd/versions.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver"
-	v1 "github.com/openshift-online/uhc-sdk-go/pkg/client/clustersmgmt/v1"
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/osde2e/pkg/config"
 )
 

--- a/setup.go
+++ b/setup.go
@@ -63,26 +63,13 @@ var _ = ginkgo.AfterSuite(func() {
 		Expect(err).NotTo(HaveOccurred(), "failed to collect cluster logs")
 		writeLogs(cfg, logs)
 
-		if cfg.NoDestroy {
-			log.Println("NO_DESTROY is set, skipping deleting cluster.")
-			return
-		}
-
-		if cfg.NoDestroyDelay {
-			log.Printf("Skipping sleep for cluster debugging")
+		if cfg.DestroyClusterAfterTest {
+			log.Printf("Destroying cluster '%s'...", cfg.ClusterID)
+			err = OSD.DeleteCluster(cfg.ClusterID)
+			Expect(err).NotTo(HaveOccurred(), "failed to destroy cluster")
 		} else {
-			log.Printf("Sleeping for %d minutes before destroying cluster '%s'", cfg.AfterTestClusterWait, cfg.ClusterID)
-			startTime := time.Now()
-			for time.Since(startTime) < time.Duration(cfg.AfterTestClusterWait)*time.Minute {
-				time.Sleep(1 * time.Minute)
-				log.Print(".")
-			}
-			log.Printf("Done")
+			log.Printf("For debugging, please look for cluster ID %s in environment %s", cfg.ClusterID, cfg.OSDEnv)
 		}
-
-		log.Printf("Destroying cluster '%s'...", cfg.ClusterID)
-		err = OSD.DeleteCluster(cfg.ClusterID)
-		Expect(err).NotTo(HaveOccurred(), "failed to destroy cluster")
 	}
 })
 


### PR DESCRIPTION
Cluster expiry is now configurable and the old cluster cleanup code has
been excised. Additionally, the code has been migrated to use ocm-go-sdk
rather than uhc-go-sdk, as uhc-go-sdk is deprecated.