### PR TITLE
CICD-78: Add config option to skip certain operator health checks

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -40,6 +40,13 @@ These options are required to run osde2e.
 
 - Type: `string`
 
+### `OPERATOR_SKIP`
+
+- OperatorSkip is a comma-delimited list of operator names to ignore health checks from. ex. "insights,telemetry"
+
+- Type: `string`
+- Default: `insights`
+
 ### `POLLING_TIMEOUT`
 
 - PollingTimeout is how long (in mimutes) to wait for an object to be created

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -87,4 +87,7 @@ type Config struct {
 
 	// UpgradeImage is the release image a cluster is upgraded to. If set, it overrides the release stream and upgrades.
 	UpgradeImage string `env:"UPGRADE_IMAGE" sect:"upgrade"`
+
+	// OperatorSkip is a comma-delimited list of operator names to ignore health checks from. ex. "insights,telemetry"
+	OperatorSkip string `env:"OPERATOR_SKIP" sect:"tests" default:"insights"`
 }

--- a/pkg/helper/operators.go
+++ b/pkg/helper/operators.go
@@ -2,13 +2,15 @@ package helper
 
 import (
 	"log"
+	"strings"
 
 	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	"github.com/openshift/osde2e/pkg/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // CheckOperatorReadiness attempts to look at the state of all operator and returns true if things are healthy.
-func CheckOperatorReadiness(configClient configclient.ConfigV1Interface) (bool, error) {
+func CheckOperatorReadiness(cfg *config.Config, configClient configclient.ConfigV1Interface) (bool, error) {
 	success := true
 	log.Print("Checking that all Operators are running or completed...")
 
@@ -25,10 +27,12 @@ func CheckOperatorReadiness(configClient configclient.ConfigV1Interface) (bool, 
 	}
 
 	for _, co := range list.Items {
-		for _, cos := range co.Status.Conditions {
-			if (cos.Type != "Available" && cos.Status != "False") && cos.Type != "Upgradeable" {
-				log.Printf("Operator %v type %v is %v: %v", co.ObjectMeta.Name, cos.Type, cos.Status, cos.Message)
-				success = false
+		if !strings.Contains(cfg.OperatorSkip, co.GetName()) {
+			for _, cos := range co.Status.Conditions {
+				if (cos.Type != "Available" && cos.Status != "False") && cos.Type != "Upgradeable" {
+					log.Printf("Operator %v type %v is %v: %v", co.ObjectMeta.Name, cos.Type, cos.Status, cos.Message)
+					success = false
+				}
 			}
 		}
 	}

--- a/pkg/helper/operators.go
+++ b/pkg/helper/operators.go
@@ -26,8 +26,16 @@ func CheckOperatorReadiness(cfg *config.Config, configClient configclient.Config
 		return false, nil
 	}
 
+	operatorSkipList := make(map[string]string)
+	if len(cfg.OperatorSkip) > 0 {
+		operatorSkipVals := strings.Split(cfg.OperatorSkip, ",")
+		for _, val := range operatorSkipVals {
+			operatorSkipList[val] = ""
+		}
+	}
+
 	for _, co := range list.Items {
-		if !strings.Contains(cfg.OperatorSkip, co.GetName()) {
+		if _, ok := operatorSkipList[co.GetName()]; !ok {
 			for _, cos := range co.Status.Conditions {
 				if (cos.Type != "Available" && cos.Status != "False") && cos.Type != "Upgradeable" {
 					log.Printf("Operator %v type %v is %v: %v", co.ObjectMeta.Name, cos.Type, cos.Status, cos.Message)

--- a/pkg/osd/cluster.go
+++ b/pkg/osd/cluster.go
@@ -189,7 +189,7 @@ func (u *OSD) PollClusterHealth(cfg *config.Config) (status bool, err error) {
 		return false, nil
 	}
 
-	if check, err := helper.CheckOperatorReadiness(oscfg.ConfigV1()); !check || err != nil {
+	if check, err := helper.CheckOperatorReadiness(cfg, oscfg.ConfigV1()); !check || err != nil {
 		return false, nil
 	}
 


### PR DESCRIPTION
This lets us configure the OperatorReadiness check to ignore any operator in a comma-delimited list. 

Default is currently set to ignore `insights` but that should change in the future.