### PR TITLE
CICD-6: Run tests pre and post upgrade

### DIFF
--- a/e2e.go
+++ b/e2e.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openshift/osde2e/pkg/config"
 	"github.com/openshift/osde2e/pkg/osd"
+	"github.com/openshift/osde2e/pkg/upgrade"
 )
 
 // OSD is used to deploy and manage clusters.
@@ -60,8 +61,7 @@ func RunE2ETests(t *testing.T, cfg *config.Config) {
 	}
 
 	// setup reporter
-	err = os.Mkdir(cfg.ReportDir, os.ModePerm)
-	if err != nil {
+	if err = os.Mkdir(cfg.ReportDir, os.ModePerm); err != nil {
 		log.Printf("Could not create reporter directory: %v", err)
 	}
 	reportPath := path.Join(cfg.ReportDir, fmt.Sprintf("junit_%v.xml", cfg.Suffix))
@@ -70,5 +70,24 @@ func RunE2ETests(t *testing.T, cfg *config.Config) {
 	if !cfg.DryRun {
 		log.Println("Running e2e tests...")
 		ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "OSD e2e suite", []ginkgo.Reporter{reporter})
+		// upgrade cluster if requested
+		if cfg.UpgradeImage != "" || cfg.UpgradeReleaseStream != "" {
+			if err = upgrade.RunUpgrade(cfg, OSD); err != nil {
+				t.Errorf("Error performing upgrade: %s", err.Error())
+			}
+
+			log.Println("Running e2e tests POST-UPGRADE...")
+			ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "OSD e2e suite post-upgrade", []ginkgo.Reporter{reporter})
+		}
+
+		if cfg.DestroyClusterAfterTest {
+			log.Printf("Destroying cluster '%s'...", cfg.ClusterID)
+			if err = OSD.DeleteCluster(cfg.ClusterID); err != nil {
+				t.Errorf("Error deleting cluster: %s", err.Error())
+			}
+		} else {
+			log.Printf("For debugging, please look for cluster ID %s in environment %s", cfg.ClusterID, cfg.OSDEnv)
+		}
+
 	}
 }

--- a/pkg/helper/helper.go
+++ b/pkg/helper/helper.go
@@ -39,6 +39,13 @@ type H struct {
 	proj       *projectv1.Project
 }
 
+// SetupNoProj configures a *rest.Config using the embedded kubeconfig
+func (h *H) SetupNoProj() {
+	var err error
+	h.restConfig, err = clientcmd.RESTConfigFromKubeConfig(h.Kubeconfig)
+	Expect(err).ShouldNot(HaveOccurred(), "failed to configure client")
+}
+
 // Setup configures a *rest.Config using the embedded kubeconfig then sets up a Project for tests to run in.
 func (h *H) Setup() {
 	var err error
@@ -56,8 +63,10 @@ func (h *H) Setup() {
 
 // Cleanup deletes a Project after tests have been ran.
 func (h *H) Cleanup() {
-	err := h.cleanup(h.proj.Name)
-	Expect(err).ShouldNot(HaveOccurred(), "could not delete project '%s'", h.proj)
+	if h.proj != nil {
+		err := h.cleanup(h.proj.Name)
+		Expect(err).ShouldNot(HaveOccurred(), "could not delete project '%s'", h.proj)
+	}
 
 	h.restConfig = nil
 	h.proj = nil

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -39,7 +39,7 @@ func RunUpgrade(cfg *config.Config, OSD *osd.OSD) error {
 	h := &helper.H{
 		Config: cfg,
 	}
-	h.Setup()
+	h.SetupNoProj()
 	defer h.Cleanup()
 
 	log.Printf("Upgrading cluster to UPGRADE_IMAGE '%s'", cfg.UpgradeImage)


### PR DESCRIPTION
We should validate that a cluster is valid and healthy prior to running an upgrade. 

There was some massaging to be done because of the way the test suite set itself up (if kubeconfig was set it assumed it was a filename not a valid kubeconfig and how helpers would spin up projects)  but it's been tested locally without issue. 