### PR TITLE
SDCICD-50: Fix filewalk bug

### DIFF
--- a/pkg/helper/workloads.go
+++ b/pkg/helper/workloads.go
@@ -27,7 +27,10 @@ func ApplyYamlInFolder(folder, namespace string, kube kubernetes.Interface) ([]r
 	)
 	pwd, _ := os.Getwd()
 	err = filepath.Walk(filepath.Join(pwd, folder), func(path string, info os.FileInfo, err error) error {
-		if strings.HasSuffix(info.Name(), ".yaml") || strings.HasSuffix(info.Name(), ".yml") {
+		if err != nil {
+			return err
+		}
+		if info != nil && (strings.HasSuffix(info.Name(), ".yaml") || strings.HasSuffix(info.Name(), ".yml")) {
 			files = append(files, path)
 		}
 		return nil


### PR DESCRIPTION
Fix a condition where `info` may be nil and cause a panic. 

/assign @meowfaceman 