### PR TITLE
SDCICD-91. Collect metadata and report it during a run.

### DIFF
--- a/common/setup.go
+++ b/common/setup.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/openshift/osde2e/pkg/config"
+	"github.com/openshift/osde2e/pkg/metadata"
 	"github.com/openshift/osde2e/pkg/osd"
 )
 
@@ -78,6 +79,8 @@ func setupCluster(cfg *config.Config) (err error) {
 	} else {
 		log.Printf("CLUSTER_ID of '%s' was provided, skipping cluster creation and using it instead", cfg.ClusterID)
 	}
+
+	metadata.Instance.ClusterID = cfg.ClusterID
 
 	if err = OSD.WaitForClusterReady(cfg); err != nil {
 		return fmt.Errorf("failed waiting for cluster ready: %v", err)

--- a/common/version.go
+++ b/common/version.go
@@ -6,6 +6,7 @@ import (
 	"log"
 
 	"github.com/openshift/osde2e/pkg/config"
+	"github.com/openshift/osde2e/pkg/metadata"
 	"github.com/openshift/osde2e/pkg/osd"
 	"github.com/openshift/osde2e/pkg/upgrade"
 )
@@ -48,6 +49,9 @@ func setupVersion(cfg *config.Config, osd *osd.OSD, isUpgrade bool) (err error) 
 			return fmt.Errorf("Error finding default cluster version: %v", err)
 		}
 	}
+
+	metadata.Instance.ClusterVersion = cfg.ClusterVersion
+
 	return
 }
 
@@ -70,6 +74,8 @@ func setupUpgradeVersion(cfg *config.Config, osd *osd.OSD) (err error) {
 			return fmt.Errorf("failed retrieving previous version to '%s': %v", cfg.UpgradeReleaseName, err)
 		}
 	}
+
+	metadata.Instance.UpgradeVersion = cfg.UpgradeReleaseName
 
 	// set upgrade image
 	log.Printf("Selecting version '%s' to be able to upgrade to '%s' on release stream '%s'",

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -1,0 +1,42 @@
+package metadata
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+)
+
+// metadata houses the metadata that will be written to the report directory after
+type Metadata struct {
+	// Cluster information
+	ClusterID      string `json:"cluster-id"`
+	ClusterName    string `json:"cluster-name"`
+	ClusterVersion string `json:"cluster-version"`
+	Environment    string `json:"environment"`
+	UpgradeVersion string `json:"upgrade-version,omitempty"`
+
+	// Metrics
+	TimeToOCMReportingInstalled float64 `json:"time-to-ocm-reporting-installed,string"`
+	TimeToClusterReady          float64 `json:"time-to-cluster-ready,string"`
+}
+
+// Instance is the global metadata instance
+var Instance *Metadata
+
+func init() {
+	Instance = &Metadata{}
+}
+
+// WriteToJSON will marshall the metadata struct and write it into the given file.
+func (m *Metadata) WriteToJSON(outputFilename string) (err error) {
+	var data []byte
+	if data, err = json.Marshal(m); err != nil {
+		return err
+	}
+
+	if err = ioutil.WriteFile(outputFilename, data, os.FileMode(0644)); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -1,0 +1,96 @@
+package metadata
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		m        *Metadata
+		expected map[string]interface{}
+	}{
+		{
+			name: "test all fields",
+			m: &Metadata{
+				ClusterID:                   "test-id",
+				ClusterName:                 "test-name",
+				ClusterVersion:              "test-version",
+				Environment:                 "test-environment",
+				UpgradeVersion:              "test-upgrade",
+				TimeToOCMReportingInstalled: 123.45,
+				TimeToClusterReady:          456.78,
+			},
+			expected: map[string]interface{}{
+				"cluster-id":                      "test-id",
+				"cluster-name":                    "test-name",
+				"cluster-version":                 "test-version",
+				"environment":                     "test-environment",
+				"upgrade-version":                 "test-upgrade",
+				"time-to-ocm-reporting-installed": "123.45",
+				"time-to-cluster-ready":           "456.78",
+			},
+		},
+		{
+			name: "omit upgrade version",
+			m: &Metadata{
+				ClusterID:                   "test-id",
+				ClusterName:                 "test-name",
+				ClusterVersion:              "test-version",
+				Environment:                 "test-environment",
+				TimeToOCMReportingInstalled: 123.45,
+				TimeToClusterReady:          456.78,
+			},
+			expected: map[string]interface{}{
+				"cluster-id":                      "test-id",
+				"cluster-name":                    "test-name",
+				"cluster-version":                 "test-version",
+				"environment":                     "test-environment",
+				"time-to-ocm-reporting-installed": "123.45",
+				"time-to-cluster-ready":           "456.78",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		if err := writeAndTestMetadata(test.m, test.expected); err != nil {
+			t.Errorf("%s: error while testing metadata: %v", test.name, err)
+		}
+	}
+}
+
+func writeAndTestMetadata(m *Metadata, expected map[string]interface{}) (err error) {
+	var tempDir string
+	if tempDir, err = ioutil.TempDir("", ""); err != nil {
+		return err
+	}
+
+	defer os.RemoveAll(tempDir)
+
+	outputFilename := filepath.Join(tempDir, "test.json")
+	if err = m.WriteToJSON(outputFilename); err != nil {
+		return err
+	}
+
+	var data []byte
+	if data, err = ioutil.ReadFile(outputFilename); err != nil {
+		return err
+	}
+
+	readData := map[string]interface{}{}
+	if err = json.Unmarshal(data, &readData); err != nil {
+		return err
+	}
+
+	if !reflect.DeepEqual(expected, readData) {
+		return fmt.Errorf("expected and generated JSON do not match")
+	}
+
+	return nil
+}


### PR DESCRIPTION
osde2e will now collect metadata and serialize it to JSON when running
tests. These will then be reported in Spyglass when examining prow job
results.