### PR TITLE
SDCICD-98. Rename UHC_TOKEN to OCM_TOKEN.

### DIFF
--- a/ci/prow_run_tests.sh
+++ b/ci/prow_run_tests.sh
@@ -32,15 +32,15 @@ set -o pipefail
     fi
 
     # Test the existence of each expected file
-    UHC_TOKEN_FILE=$SECRETS/uhc-refresh-token
+    OCM_TOKEN_FILE=$SECRETS/ocm-refresh-token
     AWS_ACCESS_KEY_FILE=$SECRETS/aws-access-key
     AWS_SECRET_ACCESS_KEY_FILE=$SECRETS/aws-secret-access-key
 
-    exit_if_file_missing "UHC token file" $UHC_TOKEN_FILE
+    exit_if_file_missing "OCM token file" $OCM_TOKEN_FILE
     exit_if_file_missing "AWS access key file" $AWS_ACCESS_KEY_FILE
     exit_if_file_missing "AWS secret access key file" $AWS_SECRET_ACCESS_KEY_FILE
 
-    export UHC_TOKEN=$(cat $UHC_TOKEN_FILE)
+    export OCM_TOKEN=$(cat $OCM_TOKEN_FILE)
     export AWS_ACCESS_KEY_ID=$(cat $AWS_ACCESS_KEY_FILE)
     export AWS_SECRET_ACCESS_KEY=$(cat $AWS_SECRET_ACCESS_KEY_FILE)
 

--- a/common/e2e.go
+++ b/common/e2e.go
@@ -47,7 +47,7 @@ func RunE2ETests(t *testing.T, cfg *config.Config) {
 	if len(cfg.Kubeconfig) > 0 {
 		log.Print("Found an existing Kubeconfig!")
 	} else {
-		if OSD, err = osd.New(cfg.UHCToken, cfg.OSDEnv, cfg.DebugOSD); err != nil {
+		if OSD, err = osd.New(cfg.OCMToken, cfg.OSDEnv, cfg.DebugOSD); err != nil {
 			t.Fatalf("could not setup OSD: %v", err)
 		}
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -13,9 +13,9 @@
 ## required
 These options are required to run osde2e.
 
-### `UHC_TOKEN`
+### `OCM_TOKEN`
 
-- UHCToken is used to authenticate with UHC.
+- OCMToken is used to authenticate with OCM.
 
 - Type: `string`
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,8 +26,8 @@ type Config struct {
 	// DryRun lets you run osde2e all the way up to the e2e tests then skips them.
 	DryRun bool `env:"DRY_RUN" sect:"tests"`
 
-	// UHCToken is used to authenticate with UHC.
-	UHCToken string `env:"UHC_TOKEN" sect:"required"`
+	// OCMToken is used to authenticate with OCM.
+	OCMToken string `env:"OCM_TOKEN" sect:"required"`
 
 	// ClusterID identifies the cluster. If set at start, an existing cluster is tested.
 	ClusterID string `env:"CLUSTER_ID" sect:"cluster"`


### PR DESCRIPTION
UHC_TOKEN has been renamed to OCM_TOKEN.

Note: There's a duplicate secret in OpenShift CI "OCM_REFRESH_TOKEN" so that once this is checked in, there should be no gap in functionality. Once this is in and a few jobs have run I'll remove UHC_REFRESH_TOKEN.