### PR TITLE
SDCICD-72: Fail osde2e fast if it encounters errors

### DIFF
--- a/common/e2e.go
+++ b/common/e2e.go
@@ -98,14 +98,15 @@ func RunE2ETests(t *testing.T, cfg *config.Config) {
 			}
 		}
 
-		if cfg.DestroyClusterAfterTest {
-			log.Printf("Destroying cluster '%s'...", cfg.ClusterID)
-			if err = OSD.DeleteCluster(cfg.ClusterID); err != nil {
-				t.Errorf("Error deleting cluster: %s", err.Error())
+		if OSD != nil {
+			if cfg.DestroyClusterAfterTest {
+				log.Printf("Destroying cluster '%s'...", cfg.ClusterID)
+				if err = OSD.DeleteCluster(cfg.ClusterID); err != nil {
+					t.Errorf("Error deleting cluster: %s", err.Error())
+				}
+			} else {
+				log.Printf("For debugging, please look for cluster ID %s in environment %s", cfg.ClusterID, cfg.OSDEnv)
 			}
-		} else {
-			log.Printf("For debugging, please look for cluster ID %s in environment %s", cfg.ClusterID, cfg.OSDEnv)
 		}
-
 	}
 }

--- a/pkg/helper/pods.go
+++ b/pkg/helper/pods.go
@@ -1,6 +1,7 @@
 package helper
 
 import (
+	"fmt"
 	"log"
 	"time"
 
@@ -52,7 +53,11 @@ func CheckPodHealth(podClient v1.CoreV1Interface) (bool, error) {
 
 	for _, pod := range list.Items {
 		phase := pod.Status.Phase
+
 		if phase != kubev1.PodRunning && phase != kubev1.PodSucceeded {
+			if phase != kubev1.PodPending {
+				return false, fmt.Errorf("Pod %s errored: %s - %s", pod.GetName(), pod.Status.Reason, pod.Status.Message)
+			}
 			notReady = append(notReady, pod)
 			log.Printf("%s is not ready. Phase: %s, Message: %s, Reason: %s", pod.Name, pod.Status.Phase, pod.Status.Message, pod.Status.Reason)
 		}

--- a/pkg/helper/pods_test.go
+++ b/pkg/helper/pods_test.go
@@ -28,31 +28,32 @@ func pod(name, namespace string, phase v1.PodPhase) *v1.Pod {
 }
 func TestCheckPodHealth(t *testing.T) {
 	var tests = []struct {
-		description string
-		expected    bool
-		objs        []runtime.Object
+		description   string
+		expectedState bool
+		expectedError bool
+		objs          []runtime.Object
 	}{
-		{"no pods", false, nil},
-		{"single pod failed", false, []runtime.Object{pod("a", "a", v1.PodFailed)}},
-		{"one pod good one pod bad same namespace", false, []runtime.Object{pod("a", "a", v1.PodFailed), pod("b", "a", v1.PodRunning)}},
-		{"one pod good one pod bad diff namespace", false, []runtime.Object{pod("a", "a", v1.PodFailed), pod("b", "b", v1.PodRunning)}},
-		{"single pod running", true, []runtime.Object{pod("a", "a", v1.PodRunning)}},
-		{"single pod succeeded", true, []runtime.Object{pod("a", "a", v1.PodSucceeded)}},
-		{"two succeeded pods diff namespace", true, []runtime.Object{pod("a", "a", v1.PodSucceeded), pod("b", "b", v1.PodSucceeded)}},
-		{"two running pods diff namespace", true, []runtime.Object{pod("a", "a", v1.PodRunning), pod("b", "b", v1.PodRunning)}},
+		{"no pods", false, false, nil},
+		{"single pod failed", false, true, []runtime.Object{pod("a", "a", v1.PodFailed)}},
+		{"one pod good one pod bad same namespace", false, true, []runtime.Object{pod("a", "a", v1.PodFailed), pod("b", "a", v1.PodRunning)}},
+		{"one pod good one pod pending same namespace", false, false, []runtime.Object{pod("a", "a", v1.PodPending), pod("b", "a", v1.PodRunning)}},
+		{"one pod good one pod bad diff namespace", false, true, []runtime.Object{pod("a", "a", v1.PodFailed), pod("b", "b", v1.PodRunning)}},
+		{"single pod running", true, false, []runtime.Object{pod("a", "a", v1.PodRunning)}},
+		{"single pod succeeded", true, false, []runtime.Object{pod("a", "a", v1.PodSucceeded)}},
+		{"two succeeded pods diff namespace", true, false, []runtime.Object{pod("a", "a", v1.PodSucceeded), pod("b", "b", v1.PodSucceeded)}},
+		{"two running pods diff namespace", true, false, []runtime.Object{pod("a", "a", v1.PodRunning), pod("b", "b", v1.PodRunning)}},
 	}
 
 	for _, test := range tests {
 		kubeClient := kubernetes.NewSimpleClientset(test.objs...)
 		state, err := CheckPodHealth(kubeClient.CoreV1())
 
-		if err != nil {
-			t.Errorf("Unexpected error: %s", err)
-			return
+		if state != test.expectedState {
+			t.Errorf("%v: Expected state doesn't match returned value (%v, %v)", test.description, test.expectedState, state)
 		}
 
-		if state != test.expected {
-			t.Errorf("%v: Expected value doesn't match returned value (%v, %v)", test.description, test.expected, state)
+		if (err != nil && test.expectedError == false) || (err == nil && test.expectedError == true) {
+			t.Errorf("%v: Expected error doesn't match returned value (%v, %v)", test.description, test.expectedError, err)
 		}
 	}
 }


### PR DESCRIPTION
Currently if a cluster encounters an error while starting up (job or pod fails or OOMs) `PollClusterHealth` will continue until we hit the 45min timeout.

This change will fail an osde2e run if `PollClusterHealth` returns an error five times in a row. 

Along with that logic:
- I added tests to cover the checking of the error response as well as the ready boolean. 
- If you ran osde2e against an ad-hoc cluster, it would still attempt to "delete" the cluster even though the OSD bits weren't initialized. So I added a check to skip that.