### PR TITLE
Fix prometheus gather flake

### DIFF
--- a/test/state/prometheus.go
+++ b/test/state/prometheus.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// cmd to collect prometheus data
-	promCollectCmd = "oc exec -n openshift-monitoring prometheus-k8s-0 -- tar cvzf - -C /prometheus ."
+	promCollectCmd = "oc exec -n openshift-monitoring prometheus-k8s-0 -c prometheus -- tar cvzO -C /prometheus ."
 )
 
 var _ = ginkgo.Describe("Cluster state", func() {
@@ -20,7 +20,10 @@ var _ = ginkgo.Describe("Cluster state", func() {
 	prometheusTimeoutInSeconds := 900
 	ginkgo.It("should include Prometheus data", func() {
 		// setup runner
-		cmd := promCollectCmd + " >" + runner.DefaultRunner.OutputDir + "/prometheus.tar.gz"
+		// this command is has specific code to capture and suppress an exit code of
+		// 1 as tar 1.26 will exit 1 if files change while the tar is running, as is
+		// common for a running prometheus instance
+		cmd := promCollectCmd + " >" + runner.DefaultRunner.OutputDir + "/prometheus.tar.gz ; err=$? ; if (( $err != 1 )) ; then exit $err ; fi"
 		r := h.Runner(cmd)
 		r.Name = "collect-prometheus"
 


### PR DESCRIPTION
The prometheus state gather test will sometimes flake and fail if one of the files on disk is modified while the tar is running. If tar detects this has happened, it will [exit 1](http://man7.org/linux/man-pages/man1/tar.1.html#RETURN_VALUE) causing the job pod to fail.

I can't find a way to modify this behaviour in tar 1.26 (the `--ignore-failed-read` flag doesn't work as expected). Use a bash pipe through to some if logic to prevent this from failing.