### PR TITLE
SDCICD-92 - Re-enable post-upgrade workload tests

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -89,4 +89,7 @@ type Config struct {
 
 	// OperatorSkip is a comma-delimited list of operator names to ignore health checks from. ex. "insights,telemetry"
 	OperatorSkip string `env:"OPERATOR_SKIP" sect:"tests" default:"insights"`
+
+	// InstalledWorkloads is an internal variable used to track currently installed workloads in this test run.
+	InstalledWorkloads map[string]string
 }

--- a/pkg/helper/helper.go
+++ b/pkg/helper/helper.go
@@ -2,6 +2,7 @@
 package helper
 
 import (
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	projectv1 "github.com/openshift/api/project/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -24,7 +26,7 @@ func New() *H {
 	helper := &H{
 		Config: config.Cfg,
 	}
-	helper.installedWorkloads = make(map[string]bool)
+	
 	ginkgo.BeforeEach(helper.Setup)
 	ginkgo.AfterEach(helper.Cleanup)
 	return helper
@@ -36,14 +38,18 @@ type H struct {
 	*config.Config
 
 	// internal
-	restConfig         *rest.Config
-	proj               *projectv1.Project
-	installedWorkloads map[string]bool
+	restConfig *rest.Config
+	proj       *projectv1.Project
 }
 
 // SetupNoProj configures a *rest.Config using the embedded kubeconfig
 func (h *H) SetupNoProj() {
 	var err error
+	
+	if len(h.InstalledWorkloads) < 1 {
+		h.InstalledWorkloads = make(map[string]string)
+	}
+
 	h.restConfig, err = clientcmd.RESTConfigFromKubeConfig(h.Kubeconfig)
 	Expect(err).ShouldNot(HaveOccurred(), "failed to configure client")
 }
@@ -53,6 +59,11 @@ func (h *H) Setup() {
 	var err error
 	h.restConfig, err = clientcmd.RESTConfigFromKubeConfig(h.Kubeconfig)
 	Expect(err).ShouldNot(HaveOccurred(), "failed to configure client")
+
+	if len(h.InstalledWorkloads) < 1 {
+		h.InstalledWorkloads = make(map[string]string)
+	}
+
 
 	// setup project to run tests
 	suffix := randomStr(5)
@@ -74,24 +85,46 @@ func (h *H) Cleanup() {
 	h.proj = nil
 }
 
+// SetRestConfig
+
+// CreateProject returns the project being used for testing.
+func (h *H) CreateProject(name string) {
+	proj, err := h.createProject(name)
+	Expect(err).To(BeNil(), "error creating project")
+	h.proj = proj
+}
+
 // CurrentProject returns the project being used for testing.
 func (h *H) CurrentProject() string {
 	Expect(h.proj).NotTo(BeNil(), "no project is currently set")
 	return h.proj.Name
 }
 
+// SetProjectByName gets a project by name and sets it for the h.proj attribute
+func (h *H) SetProjectByName(projectName string) error {
+	proj, err := h.Project().ProjectV1().Projects().Get(projectName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get project '%s': %v", projectName, err)
+	}
+	h.proj = proj
+	return nil
+}
+
 // GetWorkloads returns a list of workloads this osde2e run has installed
-func (h *H) GetWorkloads() map[string]bool {
-	return h.installedWorkloads
+func (h *H) GetWorkloads() map[string]string {
+	return h.InstalledWorkloads
 }
 
 // GetWorkload takes a workload name and returns true or false depending on if it's installed
-func (h *H) GetWorkload(name string) bool {
-	_, ok := h.installedWorkloads[name]
-	return ok
+func (h *H) GetWorkload(name string) (string, bool) {
+	if val, ok := h.InstalledWorkloads[name]; ok {
+		return val, true
+	}
+
+	return "", false
 }
 
 // AddWorkload uniquely appends a workload to the workloads list
-func (h *H) AddWorkload(name string) {
-	h.installedWorkloads[name] = true
+func (h *H) AddWorkload(name, project string) {
+	h.InstalledWorkloads[name] = project
 }


### PR DESCRIPTION
This tracks and cleans up installed workloads. Whenever invoking the helper, it automatically creates a new project. In this case, we want to be able to recover which project a helper should have, based on the workload. 

So we now track installed workloads within the Config struct, and there are a bunch of added getter/setter functions as part of the helper to let us influence the Project lifecycle for a `helper` instance. 

Lastly, if we run this against an external/non-OSD cluster, we need to clean up everything invasive OSDe2e did during a run.

One thing that became apparent is that the helper may need to be refactored in the future, but it's not urgent.