### PR TITLE
SDCICD-54. Metrics are now exported in prometheus exposition format.

### DIFF
--- a/common/metrics.go
+++ b/common/metrics.go
@@ -1,0 +1,237 @@
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/onsi/ginkgo/reporters"
+	"github.com/openshift/osde2e/pkg/config"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/expfmt"
+)
+
+const (
+	addonMetadataFile         string = "addon-metrics.json"
+	prometheusFileNamePattern string = "%s.%s.metrics.prom"
+
+	cicdPrefix string = "cicd_"
+
+	jUnitMetricName    string = cicdPrefix + "jUnitResult"
+	metadataMetricName string = cicdPrefix + "metadata"
+	addonMetricName    string = cicdPrefix + "addon_metadata"
+)
+
+var junitFileRegex *regexp.Regexp
+
+// Metrics is the metrics object which can parse jUnit and JSON metadata and produce Prometheus metrics.
+type Metrics struct {
+	metricRegistry   *prometheus.Registry
+	jUnitGatherer    *prometheus.GaugeVec
+	metadataGatherer *prometheus.GaugeVec
+	addonGatherer    *prometheus.GaugeVec
+	cfg              *config.Config
+}
+
+// NewMetrics creates a new metrics object using the given config object.
+func NewMetrics(cfg *config.Config) *Metrics {
+	// Set up Prometheus metrics registry and gatherers
+	metricRegistry := prometheus.NewRegistry()
+	jUnitGatherer := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: jUnitMetricName,
+		},
+		[]string{"install_version", "upgrade_version", "environment", "phase", "suite", "testname", "result"},
+	)
+	metadataGatherer := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: metadataMetricName,
+		},
+		[]string{"install_version", "upgrade_version", "environment", "metadata_name"},
+	)
+	addonGatherer := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: addonMetricName,
+		},
+		[]string{"install_version", "upgrade_version", "environment", "metadata_name"},
+	)
+	metricRegistry.MustRegister(jUnitGatherer)
+	metricRegistry.MustRegister(metadataGatherer)
+	metricRegistry.MustRegister(addonGatherer)
+
+	return &Metrics{
+		metricRegistry:   metricRegistry,
+		jUnitGatherer:    jUnitGatherer,
+		metadataGatherer: metadataGatherer,
+		addonGatherer:    addonGatherer,
+		cfg:              cfg,
+	}
+}
+
+func init() {
+	junitFileRegex = regexp.MustCompile("^junit.*\\.xml$")
+}
+
+// WritePrometheusFile collects data and writes it out in the prometheus export file format (https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md)
+// Returns the prometheus file name.
+func (m *Metrics) WritePrometheusFile(reportDir string) (string, error) {
+	files, err := ioutil.ReadDir(reportDir)
+	if err != nil {
+		return "", err
+	}
+
+	for _, file := range files {
+		if file != nil {
+			// This directory name is the name of the current phase we're in, so record it and iterate through these results
+			if file.IsDir() {
+				phase := file.Name()
+				phaseDir := filepath.Join(reportDir, phase)
+				phaseFiles, err := ioutil.ReadDir(phaseDir)
+				if err != nil {
+					return "", err
+				}
+
+				for _, phaseFile := range phaseFiles {
+					// Process the jUnit XML result files
+					if junitFileRegex.MatchString(phaseFile.Name()) {
+						// TODO: The addon metric prefix should reference the addon job being run to further avoid collision
+						m.processJUnitXMLFile(phase, filepath.Join(phaseDir, phaseFile.Name()))
+					}
+				}
+			} else if file.Name() == CustomMetadataFile {
+				m.processJSONFile(m.metadataGatherer, filepath.Join(reportDir, file.Name()))
+			} else if file.Name() == addonMetadataFile {
+				m.processJSONFile(m.addonGatherer, filepath.Join(reportDir, file.Name()))
+			}
+		}
+	}
+
+	prometheusFileName := fmt.Sprintf(prometheusFileNamePattern, m.cfg.ClusterID, m.cfg.JobName)
+	output, err := m.registryToExpositionFormat()
+
+	if err != nil {
+		return "", err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(reportDir, prometheusFileName), output, os.FileMode(0644))
+	if err != nil {
+		return "", err
+	}
+
+	return prometheusFileName, nil
+}
+
+// jUnit file processing
+
+// processJUnitXMLFile will add results to the prometheusOutput that look like:
+//
+// cicd_jUnitResult {environment="prod", install_version="install-version", result="passed|failed|skipped", phase="currentphase", suite="suitename",
+//                   testname="testname", upgrade_version="upgrade-version"} testLength
+func (m *Metrics) processJUnitXMLFile(phase string, junitFile string) (err error) {
+	data, err := ioutil.ReadFile(junitFile)
+	if err != nil {
+		return err
+	}
+
+	// Use Ginkgo's JUnitTestSuite to unmarshal the JUnit XML file
+	var testSuite reporters.JUnitTestSuite
+
+	if err = xml.Unmarshal(data, &testSuite); err != nil {
+		return err
+	}
+
+	for _, testcase := range testSuite.TestCases {
+		var result string
+		if testcase.FailureMessage != nil {
+			result = "failed"
+		} else if testcase.Skipped != nil {
+			result = "skipped"
+		} else {
+			result = "passed"
+		}
+
+		m.jUnitGatherer.WithLabelValues(m.cfg.ClusterVersion, m.cfg.UpgradeReleaseName, m.cfg.OSDEnv, phase, testSuite.Name, testcase.Name, result).Add(testcase.Time)
+	}
+
+	return nil
+}
+
+// JSON file processing
+
+// processJSONFile takes a JSON file and converts it into prometheus metrics of the general format:
+//
+// cicd_[addon_]metadata{environment="prod", install_version="install-version",
+//                       metadata_name="full.path.to.field.separated.by.periiod", upgrade_version="upgrade-version"} userAssignedValue
+//
+// Notes: Only numerical values or strings that look like numerical values will be captured. This is because
+//        Prometheus can only have numerical metric values and capturing strings through the use of labels is
+//        of questionable value.
+func (m *Metrics) processJSONFile(gatherer *prometheus.GaugeVec, jsonFile string) (err error) {
+	data, err := ioutil.ReadFile(jsonFile)
+	if err != nil {
+		return err
+	}
+
+	var jsonOutput interface{}
+
+	if err = json.Unmarshal(data, &jsonOutput); err != nil {
+		return err
+	}
+
+	m.jsonToPrometheusOutput(gatherer, jsonOutput.(map[string]interface{}), []string{})
+
+	return nil
+}
+
+// jsonToPrometheusOutput will take the JSON and write it into the gauge vector.
+func (m *Metrics) jsonToPrometheusOutput(gatherer *prometheus.GaugeVec, jsonOutput map[string]interface{}, context []string) {
+	for k, v := range jsonOutput {
+		fullContext := append(context, k)
+		switch jsonObject := v.(type) {
+		case map[string]interface{}:
+			m.jsonToPrometheusOutput(gatherer, jsonObject, fullContext)
+		default:
+			metadataName := strings.Join(fullContext, ".")
+
+			// Due to current limitations in the Spyglass metadata lens, all fields in a metadata
+			// object need to be strings to display properly. Rather than look for float64 types, we'll
+			// try to parse the float out of the JSON value. That way, if the number is in a string object
+			// we'll still be able to use it numerically instead of shoving it into the label as we'd
+			// otherwise have to do.
+			stringValue := fmt.Sprintf("%v", jsonObject)
+
+			// We're only concerned with tracking float values in Prometheus as they're the only thing we can measure
+			if floatValue, err := strconv.ParseFloat(stringValue, 64); err == nil {
+				gatherer.WithLabelValues(m.cfg.ClusterVersion, m.cfg.UpgradeReleaseName, m.cfg.OSDEnv, metadataName).Add(floatValue)
+			}
+		}
+	}
+}
+
+// Generic Prometheus export file building functions
+
+// registryToExpositionFormat takes all of the gathered metrics and writes them out in the exposition format
+func (m *Metrics) registryToExpositionFormat() ([]byte, error) {
+	buf := &bytes.Buffer{}
+	encoder := expfmt.NewEncoder(buf, expfmt.FmtText)
+	metricFamilies, err := m.metricRegistry.Gather()
+
+	if err != nil {
+		return []byte{}, fmt.Errorf("error while gathering metrics: %v", err)
+	}
+
+	for _, metricFamily := range metricFamilies {
+		if err := encoder.Encode(metricFamily); err != nil {
+			return []byte{}, fmt.Errorf("error encoding metric family: %v", err)
+		}
+	}
+
+	return buf.Bytes(), nil
+}

--- a/common/metrics_test.go
+++ b/common/metrics_test.go
@@ -1,0 +1,415 @@
+package common
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openshift/osde2e/pkg/config"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestProcessJUnitXMLFile(t *testing.T) {
+	config.Cfg.ClusterVersion = "install-version"
+	config.Cfg.UpgradeReleaseName = "upgrade-version"
+	tests := []struct {
+		testName       string
+		phase          string
+		fileContents   string
+		expectedOutput string
+	}{
+		{
+			testName: "regular parsing",
+			phase:    "install",
+			fileContents: `<testsuite name="test suite" time="6">
+	<testcase name="test 1" time="1" />
+	<testcase name="test 2" time="2" />
+	<testcase name="test 3" time="3">
+		<failure type="blah">
+			failure text
+		</failure>
+	</testcase>
+	<testcase name="test 4" time="4">
+		<skipped>
+			blah
+		</skipped>
+	</testcase>
+</testsuite>`,
+			expectedOutput: `cicd_jUnitResult{environment="prod",install_version="install-version",phase="install",result="passed",suite="test suite",testname="test 1",upgrade_version="upgrade-version"} 1
+cicd_jUnitResult{environment="prod",install_version="install-version",phase="install",result="passed",suite="test suite",testname="test 2",upgrade_version="upgrade-version"} 2
+cicd_jUnitResult{environment="prod",install_version="install-version",phase="install",result="failed",suite="test suite",testname="test 3",upgrade_version="upgrade-version"} 3
+cicd_jUnitResult{environment="prod",install_version="install-version",phase="install",result="skipped",suite="test suite",testname="test 4",upgrade_version="upgrade-version"} 4
+`,
+		},
+		{
+			testName: "parsing with complicated attribute values",
+			phase:    "install",
+			fileContents: `<testsuite name="test &quot;suite&quot;" time="6">
+	<testcase name="test \1" time="1" />
+	<testcase name="test 2" time="2" />
+	<testcase name="test 3
+newline" time="3">
+		<failure type="blah">
+			failure text
+		</failure>
+	</testcase>
+</testsuite>`,
+			expectedOutput: `cicd_jUnitResult{environment="prod",install_version="install-version",phase="install",result="passed",suite="test \"suite\"",testname="test \\1",upgrade_version="upgrade-version"} 1
+cicd_jUnitResult{environment="prod",install_version="install-version",phase="install",result="passed",suite="test \"suite\"",testname="test 2",upgrade_version="upgrade-version"} 2
+cicd_jUnitResult{environment="prod",install_version="install-version",phase="install",result="failed",suite="test \"suite\"",testname="test 3\nnewline",upgrade_version="upgrade-version"} 3
+`,
+		},
+	}
+
+	tmpDir, err := ioutil.TempDir("", "")
+
+	if err != nil {
+		t.Errorf("error creating temporary directory: %v", err)
+	}
+
+	defer os.RemoveAll(tmpDir)
+
+	for _, test := range tests {
+		m := NewMetrics(config.Cfg)
+		tmpFile, err := ioutil.TempFile(tmpDir, "*")
+
+		if err != nil {
+			t.Errorf("error writing temporary file: %v", err)
+		}
+
+		tmpFile.WriteString(test.fileContents)
+		tmpFile.Close()
+
+		err = m.processJUnitXMLFile(test.phase, tmpFile.Name())
+
+		if err != nil {
+			t.Errorf("error while processing junit file: %v", err)
+		}
+
+		output, err := m.registryToExpositionFormat()
+		if err != nil {
+			t.Errorf("error convering registry to exposition format: %v", err)
+		}
+
+		if err = arraysHaveSameElements(strings.Split(string(output), "\n"), strings.Split(test.expectedOutput, "\n")); err != nil {
+			t.Errorf("%s\nOutput:\n---\n%s\n---\ndoes not match expected output (disregarding order):\n---\n%s\n---\n%v\n", test.testName, output, test.expectedOutput, err)
+		}
+	}
+}
+
+func TestProcessJSONFile(t *testing.T) {
+	config.Cfg.ClusterVersion = "install-version"
+	config.Cfg.UpgradeReleaseName = "upgrade-version"
+
+	tests := []struct {
+		testName         string
+		useAddonGatherer bool
+		fileContents     string
+		expectedOutput   string
+	}{
+		{
+			testName:         "regular parsing with custom metadata",
+			useAddonGatherer: false,
+			fileContents: `{
+	"test1": "value1",
+	"test2": 6,
+	"nested field": {
+		"another-level": {
+			"test3": "value2"
+		}
+	},
+	"another-nested field": {
+		"another-level": {
+			"test4": "7"
+		}
+	}
+}`,
+			expectedOutput: `cicd_metadata{environment="prod",install_version="install-version",metadata_name="test2",upgrade_version="upgrade-version"} 6
+cicd_metadata{environment="prod",install_version="install-version",metadata_name="another-nested field.another-level.test4",upgrade_version="upgrade-version"} 7
+`,
+		},
+		{
+			testName:         "regular parsing with addon metadata",
+			useAddonGatherer: true,
+			fileContents: `{
+	"test1***?": "value1",
+	"test2": 6,
+	"nested field": {
+		"another-level": {
+			"test3": "value2"
+		}
+	},
+	"another-nested field": {
+		"another-level": {
+			"test4": "7"
+		}
+	}
+}`,
+			expectedOutput: `cicd_addon_metadata{environment="prod",install_version="install-version",metadata_name="test2",upgrade_version="upgrade-version"} 6
+cicd_addon_metadata{environment="prod",install_version="install-version",metadata_name="another-nested field.another-level.test4",upgrade_version="upgrade-version"} 7
+`,
+		},
+	}
+
+	tmpDir, err := ioutil.TempDir("", "")
+
+	if err != nil {
+		t.Errorf("error creating temporary directory: %v", err)
+	}
+
+	defer os.RemoveAll(tmpDir)
+
+	for _, test := range tests {
+		m := NewMetrics(config.Cfg)
+		tmpFile, err := ioutil.TempFile(tmpDir, "*")
+
+		if err != nil {
+			t.Errorf("error writing temporary file: %v", err)
+		}
+
+		tmpFile.WriteString(test.fileContents)
+		tmpFile.Close()
+
+		var gatherer *prometheus.GaugeVec
+		if test.useAddonGatherer {
+			gatherer = m.addonGatherer
+		} else {
+			gatherer = m.metadataGatherer
+		}
+		err = m.processJSONFile(gatherer, tmpFile.Name())
+
+		if err != nil {
+			t.Errorf("error while processing JSON file: %v", err)
+		}
+
+		output, err := m.registryToExpositionFormat()
+		if err != nil {
+			t.Errorf("error convering registry to exposition format: %v", err)
+		}
+
+		err = arraysHaveSameElements(strings.Split(string(output), "\n"), strings.Split(test.expectedOutput, "\n"))
+		if err != nil {
+			t.Errorf("%s\nOutput:\n---\n%s\n---\ndoes not match expected output (disregarding order):\n---\n%s\n---\n%v", test.testName, output, test.expectedOutput, err)
+		}
+	}
+}
+
+func TestWritePrometheusFile(t *testing.T) {
+	config.Cfg.ClusterID = "full-test"
+	config.Cfg.ClusterVersion = "install-version"
+	config.Cfg.UpgradeReleaseName = "upgrade-version"
+	config.Cfg.JobName = "test-job"
+
+	type jUnitFile struct {
+		fileContents string
+		directory    string
+	}
+
+	jUnitFile1Contents := `<testsuite name="test suite 1" time="6">
+	<testcase name="test 1" time="1" />
+	<testcase name="test 2" time="2" />
+	<testcase name="test 3" time="3">
+		<failure type="blah">
+			failure text
+		</failure>
+	</testcase>
+</testsuite>`
+	jUnitFile2Contents := `<testsuite name="test suite 2" time="6">
+	<testcase name="test 1" time="1" />
+	<testcase name="test 2" time="2" />
+	<testcase name="test 3" time="3">
+		<failure type="blah">
+			failure text
+		</failure>
+	</testcase>
+</testsuite>`
+	metadataFileContents := `{
+	"test1": "value1",
+	"test2": 6,
+	"nested": {
+		"another-level": {
+			"test3": "value2"
+		}
+	}
+}`
+	addonMetadataFileContents := metadataFileContents
+
+	jUnitExpectedOutput := `cicd_jUnitResult{environment="prod",install_version="install-version",phase="install",result="passed",suite="test suite 1",testname="test 1",upgrade_version="upgrade-version"} 1
+cicd_jUnitResult{environment="prod",install_version="install-version",phase="install",result="passed",suite="test suite 1",testname="test 2",upgrade_version="upgrade-version"} 2
+cicd_jUnitResult{environment="prod",install_version="install-version",phase="install",result="failed",suite="test suite 1",testname="test 3",upgrade_version="upgrade-version"} 3
+cicd_jUnitResult{environment="prod",install_version="install-version",phase="upgrade",result="passed",suite="test suite 2",testname="test 1",upgrade_version="upgrade-version"} 1
+cicd_jUnitResult{environment="prod",install_version="install-version",phase="upgrade",result="passed",suite="test suite 2",testname="test 2",upgrade_version="upgrade-version"} 2
+cicd_jUnitResult{environment="prod",install_version="install-version",phase="upgrade",result="failed",suite="test suite 2",testname="test 3",upgrade_version="upgrade-version"} 3
+`
+
+	tests := []struct {
+		testName                  string
+		jUnitFiles                []jUnitFile
+		metadataFileContents      string
+		addonMetadataFileContents string
+		expectedOutput            string
+	}{
+		{
+			testName: "regular parsing",
+			jUnitFiles: []jUnitFile{
+				{
+					fileContents: jUnitFile1Contents,
+					directory:    "install",
+				},
+				{
+					fileContents: jUnitFile2Contents,
+					directory:    "upgrade",
+				},
+			},
+			metadataFileContents:      metadataFileContents,
+			addonMetadataFileContents: addonMetadataFileContents,
+			expectedOutput: jUnitExpectedOutput + `cicd_metadata{environment="prod",install_version="install-version",metadata_name="test2",upgrade_version="upgrade-version"} 6
+cicd_addon_metadata{environment="prod",install_version="install-version",metadata_name="test2",upgrade_version="upgrade-version"} 6
+`,
+		},
+		{
+			testName: "no addon metadata",
+			jUnitFiles: []jUnitFile{
+				{
+					fileContents: jUnitFile1Contents,
+					directory:    "install",
+				},
+				{
+					fileContents: jUnitFile2Contents,
+					directory:    "upgrade",
+				},
+			},
+			metadataFileContents:      metadataFileContents,
+			addonMetadataFileContents: "",
+			expectedOutput: jUnitExpectedOutput + `cicd_metadata{environment="prod",install_version="install-version",metadata_name="test2",upgrade_version="upgrade-version"} 6
+`,
+		},
+		{
+			testName: "no addon metadata or regular metadata",
+			jUnitFiles: []jUnitFile{
+				{
+					fileContents: jUnitFile1Contents,
+					directory:    "install",
+				},
+				{
+					fileContents: jUnitFile2Contents,
+					directory:    "upgrade",
+				},
+			},
+			metadataFileContents:      "",
+			addonMetadataFileContents: "",
+			expectedOutput:            jUnitExpectedOutput,
+		},
+	}
+
+	for _, test := range tests {
+		m := NewMetrics(config.Cfg)
+		tmpDir, err := ioutil.TempDir("", "")
+
+		if err != nil {
+			t.Errorf("error creating temporary directory: %v", err)
+		}
+
+		defer os.RemoveAll(tmpDir)
+
+		for _, jUnitFile := range test.jUnitFiles {
+			jUnitDir := filepath.Join(tmpDir, jUnitFile.directory)
+			if _, err := os.Stat(jUnitDir); os.IsNotExist(err) {
+				err := os.Mkdir(jUnitDir, os.FileMode(0755))
+				if err != nil {
+					t.Errorf("error creating jUnit file directory: %v", err)
+				}
+			}
+			tmpFile, err := ioutil.TempFile(jUnitDir, "junit*.xml")
+
+			if err != nil {
+				t.Errorf("error writing junit file: %v", err)
+			}
+			fmt.Printf("Writing file %s\n", tmpFile.Name())
+
+			tmpFile.WriteString(jUnitFile.fileContents)
+			tmpFile.Close()
+		}
+
+		if test.metadataFileContents != "" {
+			err = ioutil.WriteFile(filepath.Join(tmpDir, CustomMetadataFile), []byte(test.metadataFileContents), os.FileMode(0644))
+			if err != nil {
+				t.Errorf("error writing metadata file: %v", err)
+			}
+		}
+
+		if test.addonMetadataFileContents != "" {
+			err = ioutil.WriteFile(filepath.Join(tmpDir, addonMetadataFile), []byte(test.addonMetadataFileContents), os.FileMode(0644))
+			if err != nil {
+				t.Errorf("error writing metadata file: %v", err)
+			}
+		}
+
+		prometheusFile, err := m.WritePrometheusFile(tmpDir)
+
+		if err != nil {
+			t.Errorf("error while processing report directory: %v", err)
+		}
+
+		if prometheusFile != fmt.Sprintf("%s.%s.metrics.prom", config.Cfg.ClusterID, config.Cfg.JobName) {
+			t.Errorf("unexpected prometheus filename: %s", prometheusFile)
+		}
+
+		data, err := ioutil.ReadFile(filepath.Join(tmpDir, prometheusFile))
+
+		if err != nil {
+			t.Errorf("error while reading prometheus file: %v", err)
+		}
+
+		output := string(data)
+		outputLines := strings.Split(output, "\n")
+		expectedLines := strings.Split(test.expectedOutput, "\n")
+
+		err = arraysHaveSameElements(outputLines, expectedLines)
+		if err != nil {
+			t.Errorf("%s\nOutput:\n---\n%s\n---\ndoes not match expected output (disregarding order):\n---\n%s\n---\n%v", test.testName, output, test.expectedOutput, err)
+		}
+	}
+}
+
+func lengthWithoutComments(array []string) int {
+	length := 0
+	for _, line := range array {
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		length++
+	}
+	return length
+}
+
+func arraysHaveSameElements(array1 []string, array2 []string) error {
+	array1Length := lengthWithoutComments(array1)
+	array2Length := lengthWithoutComments(array2)
+
+	if array1Length != array2Length {
+		return fmt.Errorf("arrays don't have the same number of elements (%d and %d)", array1Length, array2Length)
+	}
+
+	for _, array1Item := range array1 {
+		if strings.HasPrefix(array1Item, "#") {
+			continue
+		}
+
+		found := false
+		for _, array2Item := range array2 {
+			if array1Item == array2Item {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("couldn't find line %s in both arrays", array1Item)
+		}
+	}
+
+	return nil
+}

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -46,6 +46,12 @@ These options are required to run osde2e.
 
 - Type: `string`
 
+### `JOB_NAME`
+
+- JobName is the name of the job that is running osde2e.
+
+- Type: `string`
+
 ### `OPERATOR_SKIP`
 
 - OperatorSkip is a comma-delimited list of operator names to ignore health checks from. ex. "insights,telemetry"

--- a/go.mod
+++ b/go.mod
@@ -13,14 +13,14 @@ require (
 	github.com/openshift/api v0.0.0-20190530131937-dafd2647cb03
 	github.com/openshift/client-go v0.0.0-20190806162413-e9678e3b850d
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190926160646-a61144936680
-	github.com/prometheus/common v0.4.1 // indirect
+	github.com/prometheus/client_golang v0.9.3
+	github.com/prometheus/common v0.4.1
 	github.com/prometheus/procfs v0.0.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
 	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.2.4 // indirect
 	k8s.io/api v0.0.0-20191004102349-159aefb8556b
 	k8s.io/apimachinery v0.0.0-20191004074956-c5d2f014d689

--- a/go.sum
+++ b/go.sum
@@ -267,6 +267,7 @@ github.com/prometheus/common v0.0.0-20190104105734-b1c43a6df3ae/go.mod h1:TNfzLD
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.1 h1:K0MGApIoQvMw27RTdJkPbr3JZ7DNbtxQNyi5STVM6Kw=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
+github.com/prometheus/common v0.7.0 h1:L+1lyG48J1zAQXA3RBX/nG/B3gjlHq0zTt2tlbJLyCY=
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,6 +29,9 @@ type Config struct {
 	// OCMToken is used to authenticate with OCM.
 	OCMToken string `env:"OCM_TOKEN" sect:"required"`
 
+	// JobName is the name of the job that is running osde2e.
+	JobName string `env:"JOB_NAME" sect:"tests"`
+
 	// ClusterID identifies the cluster. If set at start, an existing cluster is tested.
 	ClusterID string `env:"CLUSTER_ID" sect:"cluster"`
 
@@ -95,4 +98,7 @@ type Config struct {
 
 	// InstalledWorkloads is an internal variable used to track currently installed workloads in this test run.
 	InstalledWorkloads map[string]string
+
+	// Phase is an internal variable used to track the current set of tests being run (install, upgrade).
+	Phase string
 }

--- a/pkg/helper/runner.go
+++ b/pkg/helper/runner.go
@@ -28,7 +28,7 @@ func (h *H) Runner(cmd string) *runner.Runner {
 // WriteResults dumps runner results into the ReportDir.
 func (h *H) WriteResults(results map[string][]byte) {
 	for filename, data := range results {
-		dst := filepath.Join(h.ReportDir, filename)
+		dst := filepath.Join(h.ReportDir, h.Phase, filename)
 		err := ioutil.WriteFile(dst, data, os.ModePerm)
 		Expect(err).NotTo(HaveOccurred())
 	}


### PR DESCRIPTION
Metrics are now written to a Prometheus file in the report directory.

Several things are done here:

* All jUnit test results stored in an XML file are written out in the
following format:
```
cicd_jUnitResult{environment="int|stage|prod", install_version="install-version", phase="install|upgrade", result="passed|failed|skipped", suite="test suite", testname="test name", upgrade_version="upgrade-version"} 1.2345
```
This is the environment, install and upgrade versions, pass/fail/skipped, what phase (tests pre or post upgrade), the name of the suite, and the name of the test.
* Custom metadata and addon metadata (preliminary support) will be
  written out in the following format:
```
cicd_metadata{environment="int|stage|prod", install_version="install-version", metadata_name="path.to.metadata.in.json", upgrade_version="upgrade-version"} 1.2345
```
  Only numerical data will be captured and recorded from internal/addon metrics,
  as we can't really reason on other data in prometheus.