### PR TITLE
SDCICD-101. Get cluster name for existing clusters.

### DIFF
--- a/common/setup.go
+++ b/common/setup.go
@@ -78,8 +78,23 @@ func setupCluster(cfg *config.Config) (err error) {
 		}
 	} else {
 		log.Printf("CLUSTER_ID of '%s' was provided, skipping cluster creation and using it instead", cfg.ClusterID)
+
+		if cfg.ClusterName == "" {
+			cluster, err := OSD.GetCluster(cfg.ClusterID)
+			if err != nil {
+				return fmt.Errorf("could not retrieve cluster information from OCM: %v", err)
+			}
+
+			if cluster.Name() == "" {
+				return fmt.Errorf("cluster name from OCM is empty, and this shouldn't be possible")
+			}
+
+			cfg.ClusterName = cluster.Name()
+			log.Printf("CLUSTER_NAME not provided, retrieved %s from OCM.", cfg.ClusterName)
+		}
 	}
 
+	metadata.Instance.ClusterName = cfg.ClusterName
 	metadata.Instance.ClusterID = cfg.ClusterID
 
 	if err = OSD.WaitForClusterReady(cfg); err != nil {


### PR DESCRIPTION
If a cluster ID is provided, the cluster name was not being properly
set. It will now be retrieved from OCM if the cluster name has not
otherwise been provided. Additionally, the cluster name is now recorded
in the custom prow metadata.