### PR TITLE
SDCICD-56. Makefile improvements, prow script dependency management.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 PKG := github.com/openshift/osde2e
 E2E_PKG := $(PKG)/suites/e2e
 SCALE_PKG := $(PKG)/suites/scale
+DOC_PKG := $(PKG)/cmd/osde2e-docs
 
 DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
@@ -11,13 +12,13 @@ IMAGE_TAG := $(shell git rev-parse --short=7 HEAD)
 
 CONTAINER_ENGINE ?= docker
 
-check: cmd/osde2e-docs
-	go run $(PKG)/$< --check
-	CGO_ENABLED=0 go test -v ./cmd/... ./pkg/...
+check: $(DIR)/cmd/osde2e-docs
+	go run $(DOC_PKG) --check
+	CGO_ENABLED=0 go test -v $(PKG)/cmd/... $(PKG)/pkg/...
 	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint && \
-    golangci-lint run -c .golang-ci.yml ./... 
+	golangci-lint run -c "$(DIR)/.golang-ci.yml" "$(DIR)/..."
 
-generate: docs/Options.md
+generate: $(DIR)/docs/Options.md
 
 build-image:
 	$(CONTAINER_ENGINE) build -t "$(IMAGE_NAME):$(IMAGE_TAG)" .
@@ -58,5 +59,5 @@ test-docker:
 		-e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) \
 		$(IMAGE_NAME):$(IMAGE_TAG)
 
-docs/Options.md: cmd/osde2e-docs pkg/config/config.go
-	go run $(PKG)/$<
+$(DIR)/docs/Options.md: $(DIR)/cmd/osde2e-docs $(DIR)/pkg/config/config.go
+	go run $(DOC_PKG)

--- a/ci/prow_pr_check.sh
+++ b/ci/prow_pr_check.sh
@@ -2,6 +2,8 @@
 
 set -o pipefail
 
+"$(dirname "$0")/prow_setup.sh"
+
 {
     make check
 } 2>&1 | tee -a $REPORT_DIR/test_output.log

--- a/ci/prow_run_tests.sh
+++ b/ci/prow_run_tests.sh
@@ -2,6 +2,8 @@
 
 set -o pipefail
 
+"$(dirname "$0")/prow_setup.sh"
+
 {
     function exit_if_file_missing {
         FILE_DESCRIPTION="$1"

--- a/ci/prow_setup.sh
+++ b/ci/prow_setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Install the dependencies
+(cd "$(dirname "$0")/.."; go get -u github.com/Masterminds/glide && glide install --strip-vendor)
+
+# Ensure the report directory exists
+mkdir -p "$REPORT_DIR"


### PR DESCRIPTION
The Makefile has been modified to be less reliant on the current working
directory.

Additionally, dependencies for prow scripts are now managed in our own
ci scripts, reducing the need to make modifications to the
openshift/release repository in order to make dependency system changes.