### PR TITLE
SDCICD-83 - Support job configuration by optional YAML file

### DIFF
--- a/.osde2e.yaml
+++ b/.osde2e.yaml
@@ -1,1 +1,0 @@
-dryRun: true

--- a/.osde2e.yaml
+++ b/.osde2e.yaml
@@ -1,0 +1,1 @@
+dryRun: true

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ ifndef $(GOPATH)
     export GOPATH
 endif
 
-check: cmd/osde2e-docs
-	go run $(DOC_PKG) --check
+check:
 	CGO_ENABLED=0 go test -v $(PKG)/cmd/... $(PKG)/pkg/...
 	
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.21.0
@@ -41,7 +40,7 @@ build:
 	CGO_ENABLED=0 go test ./suites/scale -v -c -o ./out/osde2e-scale
 
 test:
-	go test $(E2E_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h
+	go test $(E2E_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h 
 
 test-scale:
 	go test $(SCALE_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)"  -test.timeout 8h -test.run TestScale

--- a/common/e2e.go
+++ b/common/e2e.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo"
+	ginkgoConfig "github.com/onsi/ginkgo/config"
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/onsi/gomega"
 
@@ -34,6 +35,8 @@ var OSD *osd.OSD
 func RunE2ETests(t *testing.T, cfg *config.Config) {
 	var err error
 	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgoConfig.GinkgoConfig.SkipString = cfg.Tests.GinkgoSkip
+	ginkgoConfig.GinkgoConfig.FocusString = cfg.Tests.GinkgoFocus
 
 	// set defaults
 	if cfg.Suffix == "" {
@@ -47,17 +50,17 @@ func RunE2ETests(t *testing.T, cfg *config.Config) {
 	}
 
 	// setup OSD unless Kubeconfig is present
-	if len(cfg.Kubeconfig) > 0 {
+	if len(cfg.Kubeconfig.Path) > 0 {
 		log.Print("Found an existing Kubeconfig!")
 	} else {
-		if OSD, err = osd.New(cfg.OCMToken, cfg.OSDEnv, cfg.DebugOSD); err != nil {
+		if OSD, err = osd.New(cfg.OCM.Token, cfg.OCM.Env, cfg.OCM.Debug); err != nil {
 			t.Fatalf("could not setup OSD: %v", err)
 		}
 
-		metadata.Instance.Environment = cfg.OSDEnv
+		metadata.Instance.Environment = cfg.OCM.Env
 
 		// check that enough quota exists for this test if creating cluster
-		if len(cfg.ClusterID) == 0 {
+		if len(cfg.Cluster.ID) == 0 {
 			if enoughQuota, err := OSD.CheckQuota(cfg); err != nil {
 				log.Printf("Failed to check if enough quota is available: %v", err)
 			} else if !enoughQuota {
@@ -82,8 +85,8 @@ func RunE2ETests(t *testing.T, cfg *config.Config) {
 		log.Println("Running e2e tests...")
 		ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "OSD e2e suite", []ginkgo.Reporter{reporter})
 		// upgrade cluster if requested
-		if cfg.UpgradeImage != "" || cfg.UpgradeReleaseStream != "" {
-			if cfg.Kubeconfig != nil {
+		if cfg.Upgrade.Image != "" || cfg.Upgrade.ReleaseStream != "" {
+			if cfg.Kubeconfig.Contents != nil {
 				if err = upgrade.RunUpgrade(cfg, OSD); err != nil {
 					t.Errorf("Error performing upgrade: %s", err.Error())
 				}
@@ -102,13 +105,13 @@ func RunE2ETests(t *testing.T, cfg *config.Config) {
 		}
 
 		if OSD != nil {
-			if cfg.DestroyClusterAfterTest {
-				log.Printf("Destroying cluster '%s'...", cfg.ClusterID)
-				if err = OSD.DeleteCluster(cfg.ClusterID); err != nil {
+			if cfg.Cluster.DestroyAfterTest {
+				log.Printf("Destroying cluster '%s'...", cfg.Cluster.ID)
+				if err = OSD.DeleteCluster(cfg.Cluster.ID); err != nil {
 					t.Errorf("Error deleting cluster: %s", err.Error())
 				}
 			} else {
-				log.Printf("For debugging, please look for cluster ID %s in environment %s", cfg.ClusterID, cfg.OSDEnv)
+				log.Printf("For debugging, please look for cluster ID %s in environment %s", cfg.Cluster.ID, cfg.OCM.Env)
 			}
 		} else {
 			// If we run against an arbitrary cluster and not a ci-specific cluster

--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,9 @@ require (
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
 	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 // indirect
+	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.2.4 // indirect
+	gopkg.in/yaml.v2 v2.2.4
 	k8s.io/api v0.0.0-20191004102349-159aefb8556b
 	k8s.io/apimachinery v0.0.0-20191004074956-c5d2f014d689
 	k8s.io/client-go v11.0.1-0.20191029005444-8e4128053008+incompatible

--- a/go.mod
+++ b/go.mod
@@ -22,8 +22,6 @@ require (
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
 	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 // indirect
-	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
-	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.2.4
 	k8s.io/api v0.0.0-20191004102349-159aefb8556b
 	k8s.io/apimachinery v0.0.0-20191004074956-c5d2f014d689

--- a/go.mod
+++ b/go.mod
@@ -22,13 +22,9 @@ require (
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 // indirect
 	golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456 // indirect
-<<<<<<< HEAD
 	google.golang.org/genproto v0.0.0-20181016170114-94acd270e44e // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.2.4
-=======
-	gopkg.in/yaml.v2 v2.2.4 // indirect
->>>>>>> 494a949ba526ce323bd513717fe9b8f0ae4ec2ed
 	k8s.io/api v0.0.0-20191004102349-159aefb8556b
 	k8s.io/apimachinery v0.0.0-20191004074956-c5d2f014d689
 	k8s.io/client-go v11.0.1-0.20191029005444-8e4128053008+incompatible

--- a/go.sum
+++ b/go.sum
@@ -271,7 +271,6 @@ github.com/prometheus/common v0.0.0-20190104105734-b1c43a6df3ae/go.mod h1:TNfzLD
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.1 h1:K0MGApIoQvMw27RTdJkPbr3JZ7DNbtxQNyi5STVM6Kw=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
-github.com/prometheus/common v0.7.0 h1:L+1lyG48J1zAQXA3RBX/nG/B3gjlHq0zTt2tlbJLyCY=
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,82 +17,110 @@ var Cfg = new(Config)
 
 // Config dictates the behavior of cluster tests.
 type Config struct {
+	Upgrade UpgradeConfig `yaml:"upgrade"`
+
+	Kubeconfig KubeConfig `yaml:"kubeconfig"`
+
+	Tests TestConfig `yaml:"tests"`
+
+	Cluster ClusterConfig `yaml:"cluster"`
+
+	OCM OCMConfig `yaml:"ocm"`
+
 	// ReportDir is the location JUnit XML results are written.
-	ReportDir string `env:"REPORT_DIR" sect:"tests"`
+	ReportDir string `json:"report_dir,omitempty" env:"REPORT_DIR" sect:"tests" yaml:"reportDir"`
 
 	// Suffix is used at the end of test names to identify them.
-	Suffix string `env:"SUFFIX" sect:"tests"`
+	Suffix string `json:"suffix,omitempty" env:"SUFFIX" sect:"tests" yaml:"suffix"`
 
 	// DryRun lets you run osde2e all the way up to the e2e tests then skips them.
-	DryRun bool `env:"DRY_RUN" sect:"tests"`
-
-	// OCMToken is used to authenticate with OCM.
-	OCMToken string `env:"OCM_TOKEN" sect:"required"`
-
-	// ClusterID identifies the cluster. If set at start, an existing cluster is tested.
-	ClusterID string `env:"CLUSTER_ID" sect:"cluster"`
-
-	// ClusterName is the name of the cluster being created.
-	ClusterName string `env:"CLUSTER_NAME" sect:"cluster"`
-
-	// ClusterVersion is the version of the cluster being deployed.
-	ClusterVersion string `env:"CLUSTER_VERSION" sect:"version"`
-
-	// MajorTarget is the major version to target. If specified, it is used in version selection.
-	MajorTarget int64 `env:"MAJOR_TARGET" sect:"version"`
-
-	// MinorTarget is the minor version to target. If specified, it is used in version selection.
-	MinorTarget int64 `env:"MINOR_TARGET" sect:"version"`
-
-	// PollingTimeout is how long (in mimutes) to wait for an object to be created
-	// before failing the test.
-	PollingTimeout int64 `env:"POLLING_TIMEOUT" sect:"tests" default:"30"`
-
-	// MultiAZ deploys a cluster across multiple availability zones.
-	MultiAZ bool `env:"MULTI_AZ" sect:"cluster" default:"false"`
-
-	// DestroyClusterAfterTest set to false if you want OCM to clean up the cluster itself after the test completes.
-	DestroyClusterAfterTest bool `env:"DESTROY_CLUSTER" sect:"cluster" default:"true"`
-
-	// Kubeconfig is used to access a cluster.
-	Kubeconfig []byte `env:"TEST_KUBECONFIG" sect:"cluster"`
-
-	// ClusterExpiryInMinutes is how long before a cluster expires and is deleted by OSD.
-	ClusterExpiryInMinutes int64 `env:"CLUSTER_EXPIRY_IN_MINUTES" sect:"cluster" default:"210"`
-
-	// AfterTestClusterWait is how long to keep a cluster around after tests have run.
-	AfterTestClusterWait int64 `env:"AFTER_TEST_CLUSTER_WAIT" sect:"environment" default:"60"`
-
-	// ClusterUpTimeout is how long to wait before failing a cluster launch.
-	ClusterUpTimeout int64 `env:"CLUSTER_UP_TIMEOUT" sect:"environment" default:"135"`
-
-	// OSDEnv is the OpenShift Dedicated environment used to provision clusters.
-	OSDEnv string `env:"OSD_ENV" sect:"environment" default:"prod"`
-
-	// DebugOSD shows debug level messages when enabled.
-	DebugOSD bool `env:"DEBUG_OSD" sect:"environment" default:"false"`
-
-	// GinkgoSkip is a regex passed to Ginkgo that skips any test suites matching the regex. ex. "Operator"
-	GinkgoSkip string `env:"GINKGO_SKIP" sect:"tests"`
-
-	// GinkgoFocus is a regex passed to Ginkgo that focus on any test suites matching the regex. ex. "Operator"
-	GinkgoFocus string `env:"GINKGO_FOCUS" sect:"tests"`
-
-	// CleanRuns is the number of times the test-version is run before skipping.
-	CleanRuns int `env:"CLEAN_RUNS" sect:"tests"`
-
-	// UpgradeReleaseStream used to retrieve latest release images. If set, it will be used to perform an upgrade.
-	UpgradeReleaseStream string `env:"UPGRADE_RELEASE_STREAM" sect:"upgrade"`
-
-	// UpgradeReleaseName is the name of the release in a release stream. UpgradeReleaseStream must be set.
-	UpgradeReleaseName string `env:"UPGRADE_RELEASE_NAME" sect:"upgrade"`
-
-	// UpgradeImage is the release image a cluster is upgraded to. If set, it overrides the release stream and upgrades.
-	UpgradeImage string `env:"UPGRADE_IMAGE" sect:"upgrade"`
-
-	// OperatorSkip is a comma-delimited list of operator names to ignore health checks from. ex. "insights,telemetry"
-	OperatorSkip string `env:"OPERATOR_SKIP" sect:"tests" default:"insights"`
+	DryRun bool `json:"dry_run,omitempty" env:"DRY_RUN" sect:"tests"  yaml:"dryRun"`
 
 	// InstalledWorkloads is an internal variable used to track currently installed workloads in this test run.
 	InstalledWorkloads map[string]string
+}
+
+// KubeConfig stores information required to talk to the Kube API
+type KubeConfig struct {
+	// Contents is the actual contents of a valid Kubeconfig
+	Contents []byte `yaml:"contents"`
+
+	// Path is the filepath of an existing Kubeconfig
+	Path string `env:"TEST_KUBECONFIG" sect:"cluster" yaml:"path"`
+}
+
+// OCMConfig contains connect info for the OCM API
+type OCMConfig struct {
+	// Token is used to authenticate with OCM.
+	Token string `json:"ocm_token" env:"OCM_TOKEN" sect:"required" yaml:"token"`
+
+	// Env is the OpenShift Dedicated environment used to provision clusters.
+	Env string `env:"OSD_ENV" sect:"environment" default:"prod" yaml:"env"`
+
+	// Debug shows debug level messages when enabled.
+	Debug bool `env:"DEBUG_OSD" sect:"environment" default:"false" yaml:"debug"`
+}
+
+// UpgradeConfig stores information required to perform OSDe2e upgrade testing
+type UpgradeConfig struct {
+	// MajorTarget is the major version to target. If specified, it is used in version selection.
+	MajorTarget int64 `env:"MAJOR_TARGET" sect:"version" yaml:"majorTarget"`
+
+	// MinorTarget is the minor version to target. If specified, it is used in version selection.
+	MinorTarget int64 `env:"MINOR_TARGET" sect:"version" yaml:"minorTarget"`
+
+	// ReleaseStream used to retrieve latest release images. If set, it will be used to perform an upgrade.
+	ReleaseStream string `env:"UPGRADE_RELEASE_STREAM" sect:"upgrade" yaml:"releaseStream"`
+
+	// ReleaseName is the name of the release in a release stream. UpgradeReleaseStream must be set.
+	ReleaseName string `env:"UPGRADE_RELEASE_NAME" sect:"upgrade" yaml:"releaseName"`
+
+	// Image is the release image a cluster is upgraded to. If set, it overrides the release stream and upgrades.
+	Image string `env:"UPGRADE_IMAGE" sect:"upgrade" yaml:"image"`
+}
+
+// ClusterConfig contains config information pertaining to an OSD cluster
+type ClusterConfig struct {
+	// ID identifies the cluster. If set at start, an existing cluster is tested.
+	ID string `json:"cluster_id,omitempty" env:"CLUSTER_ID" sect:"cluster" yaml:"id"`
+
+	// Name is the name of the cluster being created.
+	Name string `json:"cluster_name,omitempty" env:"CLUSTER_NAME" sect:"cluster" yaml:"name"`
+
+	// Version is the version of the cluster being deployed.
+	Version string `json:"cluster_version,omitempty" env:"CLUSTER_VERSION" sect:"version"  yaml:"version"`
+
+	// MultiAZ deploys a cluster across multiple availability zones.
+	MultiAZ bool `env:"MULTI_AZ" sect:"cluster" default:"false" yaml:"multiAZ"`
+
+	// DestroyAfterTest set to false if you want OCM to clean up the cluster itself after the test completes.
+	DestroyAfterTest bool `env:"DESTROY_CLUSTER" sect:"cluster" default:"true" yaml:"destroyAfterTest"`
+
+	// ExpiryInMinutes is how long before a cluster expires and is deleted by OSD.
+	ExpiryInMinutes int64 `env:"CLUSTER_EXPIRY_IN_MINUTES" sect:"cluster" default:"210" yaml:"expiryInMinutes"`
+
+	// AfterTestWait is how long to keep a cluster around after tests have run.
+	AfterTestWait int64 `env:"AFTER_TEST_CLUSTER_WAIT" sect:"environment" default:"60" yaml:"afterTestWait"`
+
+	// InstallTimeout is how long to wait before failing a cluster launch.
+	InstallTimeout int64 `env:"CLUSTER_UP_TIMEOUT" sect:"environment" default:"135" yaml:"installTimeout"`
+}
+
+// TestConfig changes the behavior of how and what tests are run.
+type TestConfig struct {
+	// PollingTimeout is how long (in mimutes) to wait for an object to be created
+	// before failing the test.
+	PollingTimeout int64 `env:"POLLING_TIMEOUT" sect:"tests" default:"30" yaml:"pollingTimeout"`
+
+	// GinkgoSkip is a regex passed to Ginkgo that skips any test suites matching the regex. ex. "Operator"
+	GinkgoSkip string `env:"GINKGO_SKIP" sect:"tests" yaml:"ginkgoSkip"`
+
+	// GinkgoFocus is a regex passed to Ginkgo that focus on any test suites matching the regex. ex. "Operator"
+	GinkgoFocus string `env:"GINKGO_FOCUS" sect:"tests" yaml:"focus"`
+
+	// CleanRuns is the number of times the test-version is run before skipping.
+	CleanRuns int `env:"CLEAN_RUNS" sect:"tests" yaml:"cleanRuns"`
+
+	// OperatorSkip is a comma-delimited list of operator names to ignore health checks from. ex. "insights,telemetry"
+	OperatorSkip string `env:"OPERATOR_SKIP" sect:"tests" default:"insights" yaml:"ginkgoFocus"`
 }

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -1,73 +1,137 @@
 package config
 
 import (
+	"flag"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
+
+	"gopkg.in/yaml.v2"
 )
 
 func init() {
-	if err := Cfg.LoadFromEnv(); err != nil {
-		log.Fatal("error loading config from environment: ", err)
+	if err := Cfg.LoadFromYAML(); err != nil {
+		log.Printf("Could not load YAML config: %s", err.Error())
+		log.Print("Defaulting to environment variables for config")
+		if err := Cfg.LoadFromEnv(); err != nil {
+			log.Fatal("error loading config values: ", err)
+		}
 	}
+}
+
+// Load loads things
+func (c *Config) Load(v reflect.Value, source string) error {
+	var setValue string
+	var ok bool
+	for i := 0; i < v.Type().NumField(); i++ {
+		f := v.Type().Field(i)
+
+		if f.Type.Kind() == reflect.Struct {
+			c.Load(v.FieldByIndex(f.Index), source)
+		} else {
+			if source == "default" {
+				if setValue, ok = f.Tag.Lookup(DefaultTag); !ok {
+					continue
+				}
+			}
+			if source == "env" {
+				if env, ok := f.Tag.Lookup(EnvVarTag); ok {
+					if setValue = os.Getenv(env); setValue == "" {
+						continue
+					}
+				}
+			}
+
+			field := v.Field(i)
+			if err := processValueFromString(f, field, setValue); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// LoadDefaults takes default values from the annotations in the types
+// file and assigns them to the appropriate config option
+func (c *Config) LoadDefaults() error {
+	v := reflect.ValueOf(c).Elem()
+	c.Load(v, "default")
+	return nil
+}
+
+// LoadFromYAML accepts file info and attempts to unmarshal the file into the
+// config.
+func (c *Config) LoadFromYAML() error {
+	var data []byte
+	var err error
+	var dir, path, name string
+
+	flag.StringVar(&name, "e2e-config", ".osde2e.yaml", "Config file for osde2e")
+
+	flag.Parse()
+
+	if err := c.LoadDefaults(); err != nil {
+		return err
+	}
+
+	if dir, err = os.Getwd(); err != nil {
+		log.Fatalf("Unable to get CWD: %s", err.Error())
+	}
+	// TODO: This needs to change once we stop branching out execution the way we do it currently
+	// It's fragile
+	if path, err = filepath.Abs(filepath.Join(dir, "../../", name)); err != nil {
+		return err
+	}
+
+	path = filepath.Clean(path)
+
+	if data, err = ioutil.ReadFile(path); err != nil {
+		return err
+	}
+
+	if err = yaml.Unmarshal(data, c); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // LoadFromEnv sets values from environment variables specified in `env` tags.
 func (c *Config) LoadFromEnv() error {
-	v := reflect.ValueOf(c).Elem()
-	for i := 0; i < v.Type().NumField(); i++ {
-		f := v.Type().Field(i)
-		if defaultValue, ok := f.Tag.Lookup(DefaultTag); ok {
-			field := v.Field(i)
-			switch f.Type.Kind() {
-			case reflect.String:
-				field.SetString(defaultValue)
-			case reflect.Bool:
-				if newBool, err := strconv.ParseBool(defaultValue); err == nil {
-					field.SetBool(newBool)
-				} else {
-					return fmt.Errorf("error parsing bool value for field %s: %v", f.Name, err)
-				}
-			case reflect.Slice:
-				field.SetBytes([]byte(defaultValue))
-			case reflect.Int:
-				fallthrough
-			case reflect.Int64:
-				if num, err := strconv.ParseInt(defaultValue, 10, 0); err == nil {
-					field.SetInt(num)
-				} else {
-					return fmt.Errorf("error parsing int value for field %s: %v", f.Name, err)
-				}
-			}
-		}
-		if env, ok := f.Tag.Lookup(EnvVarTag); ok {
-			if envVal := os.Getenv(env); len(envVal) > 0 {
-				field := v.Field(i)
-				switch f.Type.Kind() {
-				case reflect.String:
-					field.SetString(envVal)
-				case reflect.Bool:
-					if newBool, err := strconv.ParseBool(envVal); err == nil {
-						field.SetBool(newBool)
-					} else {
-						return fmt.Errorf("error parsing bool value for field %s: %v", f.Name, err)
-					}
-				case reflect.Slice:
-					field.SetBytes([]byte(envVal))
-				case reflect.Int:
-					fallthrough
-				case reflect.Int64:
-					if num, err := strconv.ParseInt(envVal, 10, 0); err == nil {
-						field.SetInt(num)
-					} else {
-						return fmt.Errorf("error parsing int value for field %s: %v", f.Name, err)
-					}
-				}
-			}
-		}
+	if err := c.LoadDefaults(); err != nil {
+		return err
 	}
 
+	v := reflect.ValueOf(c).Elem()
+	c.Load(v, "env")
+
+	return nil
+}
+
+func processValueFromString(f reflect.StructField, field reflect.Value, value string) error {
+	switch f.Type.Kind() {
+	case reflect.String:
+		field.SetString(value)
+	case reflect.Bool:
+		if newBool, err := strconv.ParseBool(value); err == nil {
+			field.SetBool(newBool)
+		} else {
+			return fmt.Errorf("error parsing bool value for field %s: %v", f.Name, err)
+		}
+	case reflect.Slice:
+		field.SetBytes([]byte(value))
+	case reflect.Int:
+		fallthrough
+	case reflect.Int64:
+		if num, err := strconv.ParseInt(value, 10, 0); err == nil {
+			field.SetInt(num)
+		} else {
+			return fmt.Errorf("error parsing int value for field %s: %v", f.Name, err)
+		}
+	}
 	return nil
 }

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -14,20 +13,9 @@ import (
 )
 
 func init() {
-	var name string
-
-	flag.StringVar(&name, "e2e-config", ".osde2e.yaml", "Config file for osde2e")
-
-	if flag.Parsed() {
-		log.Fatal("Flag has been parsed.")
-	}
-
-	if err := Cfg.LoadFromYAML(name); err != nil {
-		log.Printf("Could not load YAML config: %s", err.Error())
-		log.Print("Defaulting to environment variables for config")
-		if err := Cfg.LoadFromEnv(); err != nil {
-			log.Fatal("error loading config values: ", err)
-		}
+	log.Print("Defaulting to environment variables for config")
+	if err := Cfg.LoadFromEnv(); err != nil {
+		log.Fatal("error loading config values: ", err)
 	}
 }
 

--- a/pkg/config/load.go
+++ b/pkg/config/load.go
@@ -14,7 +14,15 @@ import (
 )
 
 func init() {
-	if err := Cfg.LoadFromYAML(); err != nil {
+	var name string
+
+	flag.StringVar(&name, "e2e-config", ".osde2e.yaml", "Config file for osde2e")
+
+	if flag.Parsed() {
+		log.Fatal("Flag has been parsed.")
+	}
+
+	if err := Cfg.LoadFromYAML(name); err != nil {
 		log.Printf("Could not load YAML config: %s", err.Error())
 		log.Print("Defaulting to environment variables for config")
 		if err := Cfg.LoadFromEnv(); err != nil {
@@ -65,14 +73,10 @@ func (c *Config) LoadDefaults() error {
 
 // LoadFromYAML accepts file info and attempts to unmarshal the file into the
 // config.
-func (c *Config) LoadFromYAML() error {
+func (c *Config) LoadFromYAML(name string) error {
 	var data []byte
 	var err error
-	var dir, path, name string
-
-	flag.StringVar(&name, "e2e-config", ".osde2e.yaml", "Config file for osde2e")
-
-	flag.Parse()
+	var dir, path string
 
 	if err := c.LoadDefaults(); err != nil {
 		return err

--- a/pkg/helper/helper.go
+++ b/pkg/helper/helper.go
@@ -26,7 +26,7 @@ func New() *H {
 	helper := &H{
 		Config: config.Cfg,
 	}
-	
+
 	ginkgo.BeforeEach(helper.Setup)
 	ginkgo.AfterEach(helper.Cleanup)
 	return helper
@@ -45,25 +45,24 @@ type H struct {
 // SetupNoProj configures a *rest.Config using the embedded kubeconfig
 func (h *H) SetupNoProj() {
 	var err error
-	
+
 	if len(h.InstalledWorkloads) < 1 {
 		h.InstalledWorkloads = make(map[string]string)
 	}
 
-	h.restConfig, err = clientcmd.RESTConfigFromKubeConfig(h.Kubeconfig)
+	h.restConfig, err = clientcmd.RESTConfigFromKubeConfig(h.Kubeconfig.Contents)
 	Expect(err).ShouldNot(HaveOccurred(), "failed to configure client")
 }
 
 // Setup configures a *rest.Config using the embedded kubeconfig then sets up a Project for tests to run in.
 func (h *H) Setup() {
 	var err error
-	h.restConfig, err = clientcmd.RESTConfigFromKubeConfig(h.Kubeconfig)
+	h.restConfig, err = clientcmd.RESTConfigFromKubeConfig(h.Kubeconfig.Contents)
 	Expect(err).ShouldNot(HaveOccurred(), "failed to configure client")
 
 	if len(h.InstalledWorkloads) < 1 {
 		h.InstalledWorkloads = make(map[string]string)
 	}
-
 
 	// setup project to run tests
 	suffix := randomStr(5)

--- a/pkg/helper/operators.go
+++ b/pkg/helper/operators.go
@@ -27,8 +27,8 @@ func CheckOperatorReadiness(cfg *config.Config, configClient configclient.Config
 	}
 
 	operatorSkipList := make(map[string]string)
-	if len(cfg.OperatorSkip) > 0 {
-		operatorSkipVals := strings.Split(cfg.OperatorSkip, ",")
+	if len(cfg.Tests.OperatorSkip) > 0 {
+		operatorSkipVals := strings.Split(cfg.Tests.OperatorSkip, ",")
 		for _, val := range operatorSkipVals {
 			operatorSkipList[val] = ""
 		}

--- a/pkg/helper/operators_test.go
+++ b/pkg/helper/operators_test.go
@@ -91,7 +91,7 @@ func TestCheckOperatorReadiness(t *testing.T) {
 	for _, test := range tests {
 		cfgClient := fakeConfig.NewSimpleClientset(test.objs...)
 		c := config.Config{}
-		c.OperatorSkip = test.skip
+		c.Tests.OperatorSkip = test.skip
 		state, err := CheckOperatorReadiness(&c, cfgClient.ConfigV1())
 
 		if err != nil {

--- a/pkg/osd/quota.go
+++ b/pkg/osd/quota.go
@@ -48,7 +48,7 @@ func (u *OSD) CheckQuota(cfg *config.Config) (bool, error) {
 	quotaList.Each(func(q *accounts.ResourceQuota) bool {
 		if quotaFound = HasQuotaFor(q, cfg, ResourceAWSCluster, machineType); quotaFound {
 			log.Printf("Quota for test config (%s/%s/multiAZ=%t) found: total=%d, remaining: %d",
-				ResourceAWSCluster, machineType, cfg.MultiAZ, q.Allowed(), q.Allowed()-q.Reserved())
+				ResourceAWSCluster, machineType, cfg.Cluster.MultiAZ, q.Allowed(), q.Allowed()-q.Reserved())
 		}
 		return !quotaFound
 	})
@@ -78,7 +78,7 @@ func (u *OSD) CurrentAccountQuota() (*accounts.ResourceQuotaList, error) {
 // HasQuotaFor the desired configuration. If machineT is empty a default will try to be selected.
 func HasQuotaFor(q *accounts.ResourceQuota, cfg *config.Config, resourceType, machineType string) bool {
 	azType := "single"
-	if cfg.MultiAZ {
+	if cfg.Cluster.MultiAZ {
 		azType = "multi"
 	}
 

--- a/pkg/osd/versions.go
+++ b/pkg/osd/versions.go
@@ -71,7 +71,7 @@ func (u *OSD) PreviousVersion(verStr string) (string, error) {
 func (u *OSD) LatestVersion(major, minor int64) (string, error) {
 	suffix := ""
 
-	if config.Cfg.OSDEnv == "int" {
+	if config.Cfg.OCM.Env == "int" {
 		suffix = "nightly"
 	}
 

--- a/pkg/upgrade/releases.go
+++ b/pkg/upgrade/releases.go
@@ -24,7 +24,7 @@ const (
 func LatestRelease(cfg *config.Config, releaseStream string, use_release_controller_for_int bool) (name, pullSpec string, err error) {
 	var resp *http.Response
 	var data []byte
-	if cfg.OSDEnv == "int" && use_release_controller_for_int {
+	if cfg.OCM.Env == "int" && use_release_controller_for_int {
 		log.Printf("Using the release controller.")
 		latestURL := fmt.Sprintf(latestReleaseControllerURLFmt, releaseStream)
 		resp, err = http.Get(latestURL)
@@ -50,7 +50,7 @@ func LatestRelease(cfg *config.Config, releaseStream string, use_release_control
 	log.Printf("Using Cincinnati.")
 
 	// If stage or prod, use Cincinnati instead of the release controller
-	cincinnatiFormattedURL := fmt.Sprintf(cincinnatiURLFmt, osd.Environments.Choose(cfg.OSDEnv), releaseStream)
+	cincinnatiFormattedURL := fmt.Sprintf(cincinnatiURLFmt, osd.Environments.Choose(cfg.OCM.Env), releaseStream)
 
 	var req *http.Request
 

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -42,7 +42,7 @@ func RunUpgrade(cfg *config.Config, OSD *osd.OSD) error {
 	h.SetupNoProj()
 	defer h.Cleanup()
 
-	log.Printf("Upgrading cluster to UPGRADE_IMAGE '%s'", cfg.UpgradeImage)
+	log.Printf("Upgrading cluster to UPGRADE_IMAGE '%s'", cfg.Upgrade.Image)
 	desired, err := TriggerUpgrade(h, cfg)
 	if err != nil {
 		return fmt.Errorf("failed triggering upgrade: %v", err)
@@ -82,8 +82,8 @@ func TriggerUpgrade(h *helper.H, cfg *config.Config) (*configv1.ClusterVersion, 
 
 	// set requested upgrade targets
 	cVersion.Spec.DesiredUpdate = &configv1.Update{
-		Version: strings.Replace(cfg.UpgradeReleaseName, "openshift-v", "", -1),
-		Image:   cfg.UpgradeImage,
+		Version: strings.Replace(cfg.Upgrade.ReleaseName, "openshift-v", "", -1),
+		Image:   cfg.Upgrade.Image,
 		Force:   true,
 	}
 	updatedCV, err := cfgClient.ConfigV1().ClusterVersions().Update(cVersion)

--- a/suites/e2e/e2e_test.go
+++ b/suites/e2e/e2e_test.go
@@ -1,6 +1,7 @@
 package osde2e_test
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/openshift/osde2e/common"
@@ -14,6 +15,17 @@ import (
 	_ "github.com/openshift/osde2e/test/workloads/guestbook"
 )
 
+func init() {
+	testing.Init()
+
+	cfg := config.Cfg
+
+	flag.StringVar(&cfg.File, "e2e-config", ".osde2e.yaml", "Config file for osde2e")
+	flag.Parse()
+
+	cfg.LoadFromYAML(cfg.File)
+
+}
 func TestE2E(t *testing.T) {
 	cfg := config.Cfg
 	common.RunE2ETests(t, cfg)

--- a/suites/scale/scale_test.go
+++ b/suites/scale/scale_test.go
@@ -1,6 +1,7 @@
 package osde2e_scale
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/openshift/osde2e/common"
@@ -9,6 +10,18 @@ import (
 	// import suites to be tested
 	_ "github.com/openshift/osde2e/test/scale"
 )
+
+func init() {
+	testing.Init()
+
+	cfg := config.Cfg
+
+	flag.StringVar(&cfg.File, "e2e-config", ".osde2e.yaml", "Config file for osde2e")
+	flag.Parse()
+
+	cfg.LoadFromYAML(cfg.File)
+
+}
 
 func TestScale(t *testing.T) {
 	cfg := config.Cfg

--- a/test/operators/certman.go
+++ b/test/operators/certman.go
@@ -19,7 +19,7 @@ var _ = ginkgo.Describe("[OSD] Certman Operator", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(secrets.Items)).Should(Equal(1))
 			secretName = secrets.Items[0].Name
-		}, float64(h.PollingTimeout))
+		}, float64(h.Tests.PollingTimeout))
 
 		ginkgo.It("certificate secret should be applied to apiserver object", func() {
 			getOpts := metav1.GetOptions{}
@@ -27,6 +27,6 @@ var _ = ginkgo.Describe("[OSD] Certman Operator", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(apiserver.Spec.ServingCerts.NamedCertificates)).Should(Equal(1))
 			Expect(apiserver.Spec.ServingCerts.NamedCertificates[0].ServingCertificate.Name).Should(Equal(secretName))
-		}, float64(h.PollingTimeout))
+		}, float64(h.Tests.PollingTimeout))
 	})
 })

--- a/test/operators/curator.go
+++ b/test/operators/curator.go
@@ -32,7 +32,7 @@ var _ = ginkgo.Describe("[OSD] Curator Operator", func() {
 				Expect(ok).Should(Equal(true))
 				Expect(registryNamespace).Should(HavePrefix("curated"))
 			}
-		}, float64(h.PollingTimeout))
+		}, float64(h.Tests.PollingTimeout))
 
 	})
 })

--- a/test/operators/dedicatedadmin.go
+++ b/test/operators/dedicatedadmin.go
@@ -72,6 +72,6 @@ var _ = ginkgo.Describe("[OSD] Dedicated Admin Operator", func() {
 				err := pollRoleBinding(h, project.Name, roleBindingName)
 				Expect(err).NotTo(HaveOccurred())
 			}
-		}, float64(h.PollingTimeout))
+		}, float64(h.Tests.PollingTimeout))
 	})
 })

--- a/test/operators/operators.go
+++ b/test/operators/operators.go
@@ -25,7 +25,7 @@ func checkClusterServiceVersion(h *helper.H, namespace, name string) {
 			csvs, err := pollCsvList(h, namespace, name)
 			Expect(err).ToNot(HaveOccurred(), "failed fetching the clusterServiceVersions")
 			Expect(csvs).NotTo(BeNil())
-		}, float64(h.PollingTimeout))
+		}, float64(h.Tests.PollingTimeout))
 	})
 }
 
@@ -36,7 +36,7 @@ func checkConfigMapLockfile(h *helper.H, namespace, operatorLockFile string) {
 			// Wait for lockfile to signal operator is active
 			err := pollLockFile(h, namespace, operatorLockFile)
 			Expect(err).ToNot(HaveOccurred(), "failed fetching the configMap lockfile")
-		}, float64(h.PollingTimeout))
+		}, float64(h.Tests.PollingTimeout))
 	})
 }
 
@@ -47,7 +47,7 @@ func checkDeployment(h *helper.H, namespace string, name string, defaultDesiredR
 			deployment, err := pollDeployment(h, namespace, name)
 			Expect(err).ToNot(HaveOccurred(), "failed fetching deployment")
 			Expect(deployment).NotTo(BeNil(), "deployment is nil")
-		}, float64(h.PollingTimeout))
+		}, float64(h.Tests.PollingTimeout))
 		ginkgo.It("should have all desired replicas ready", func() {
 			deployment, err := pollDeployment(h, namespace, name)
 			Expect(err).ToNot(HaveOccurred(), "failed fetching deployment")
@@ -60,7 +60,7 @@ func checkDeployment(h *helper.H, namespace string, name string, defaultDesiredR
 
 			// Desired replica count should match ready replica count
 			Expect(readyReplicas).To(BeNumerically("==", desiredReplicas), "All desired replicas should be ready.")
-		}, float64(h.PollingTimeout))
+		}, float64(h.Tests.PollingTimeout))
 	})
 }
 
@@ -72,7 +72,7 @@ func checkClusterRoles(h *helper.H, clusterRoles []string) {
 				_, err := h.Kube().RbacV1().ClusterRoles().Get(clusterRoleName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "failed to get clusterRole %v\n", clusterRoleName)
 			}
-		}, float64(h.PollingTimeout))
+		}, float64(h.Tests.PollingTimeout))
 	})
 }
 
@@ -84,7 +84,7 @@ func checkClusterRoleBindings(h *helper.H, clusterRoleBindings []string) {
 				err := pollClusterRoleBinding(h, clusterRoleBindingName)
 				Expect(err).ToNot(HaveOccurred(), "failed to get clusterRoleBinding %v\n", clusterRoleBindingName)
 			}
-		}, float64(h.PollingTimeout))
+		}, float64(h.Tests.PollingTimeout))
 	})
 }
 
@@ -96,7 +96,7 @@ func checkRole(h *helper.H, namespace string, roles []string) {
 				_, err := h.Kube().RbacV1().Roles(namespace).Get(roleName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred(), "failed to get role %v\n", roleName)
 			}
-		}, float64(h.PollingTimeout))
+		}, float64(h.Tests.PollingTimeout))
 	})
 
 }
@@ -109,7 +109,7 @@ func checkRoleBindings(h *helper.H, namespace string, roleBindings []string) {
 				err := pollRoleBinding(h, namespace, roleBindingName)
 				Expect(err).NotTo(HaveOccurred(), "failed to get roleBinding %v\n", roleBindingName)
 			}
-		}, float64(h.PollingTimeout))
+		}, float64(h.Tests.PollingTimeout))
 	})
 }
 func pollClusterRoleBinding(h *helper.H, clusterRoleBindingName string) error {
@@ -123,7 +123,7 @@ func pollClusterRoleBinding(h *helper.H, clusterRoleBindingName string) error {
 	interval := 5
 
 	// convert time.Duration type
-	timeoutDuration := time.Duration(h.PollingTimeout) * time.Minute
+	timeoutDuration := time.Duration(h.Tests.PollingTimeout) * time.Minute
 	intervalDuration := time.Duration(interval) * time.Second
 
 	start := time.Now()
@@ -162,7 +162,7 @@ func pollRoleBinding(h *helper.H, projectName string, roleBindingName string) er
 	interval := 5
 
 	// convert time.Duration type
-	timeoutDuration := time.Duration(h.PollingTimeout) * time.Minute
+	timeoutDuration := time.Duration(h.Tests.PollingTimeout) * time.Minute
 	intervalDuration := time.Duration(interval) * time.Second
 
 	start := time.Now()
@@ -202,7 +202,7 @@ func pollLockFile(h *helper.H, namespace, operatorLockFile string) error {
 	interval := 30
 
 	// convert time.Duration type
-	timeoutDuration := time.Duration(h.PollingTimeout) * time.Minute
+	timeoutDuration := time.Duration(h.Tests.PollingTimeout) * time.Minute
 	intervalDuration := time.Duration(interval) * time.Second
 
 	start := time.Now()
@@ -243,7 +243,7 @@ func pollDeployment(h *helper.H, namespace, deploymentName string) (*appsv1.Depl
 	interval := 5
 
 	// convert time.Duration type
-	timeoutDuration := time.Duration(h.PollingTimeout) * time.Minute
+	timeoutDuration := time.Duration(h.Tests.PollingTimeout) * time.Minute
 	intervalDuration := time.Duration(interval) * time.Second
 
 	start := time.Now()
@@ -285,7 +285,7 @@ func pollCsvList(h *helper.H, namespace, csvDisplayName string) (*operatorv1.Clu
 	interval := 5
 
 	// convert time.Duration type
-	timeoutDuration := time.Duration(h.PollingTimeout) * time.Minute
+	timeoutDuration := time.Duration(h.Tests.PollingTimeout) * time.Minute
 	intervalDuration := time.Duration(interval) * time.Second
 
 	start := time.Now()

--- a/test/operators/prunejob.go
+++ b/test/operators/prunejob.go
@@ -34,7 +34,7 @@ var _ = ginkgo.Describe("[OSD] Prune jobs", func() {
 				Expect(err).NotTo(HaveOccurred())
 				err = waitJobComplete(h, namespace, job.Name)
 				Expect(err).NotTo(HaveOccurred())
-			}, float64(h.PollingTimeout))
+			}, float64(h.Tests.PollingTimeout))
 		}
 
 	})
@@ -67,7 +67,7 @@ func waitJobComplete(h *helper.H, namespace, jobName string) error {
 	interval := 5
 
 	// convert time.Duration type
-	timeoutDuration := time.Duration(h.PollingTimeout) * time.Minute
+	timeoutDuration := time.Duration(h.Tests.PollingTimeout) * time.Minute
 	intervalDuration := time.Duration(interval) * time.Second
 
 	start := time.Now()


### PR DESCRIPTION
This PR restructures the Config package to have embedded structs. This was becoming necessary as the config options grew. In addition, when `osde2e` is run, it can now be supplied a `yaml` file with the config options.

By default, it looks for `./.osde2e.yaml` and if not found, continues on attempting to use environment variables and defaults. You can specify a file by passing `-e2e-config` when running `osde2e`

While a large PR, the majority of changes by and large involve changing various config options across the whole project. 

/assign @meowfaceman 