### PR TITLE
Strip trailing slashes from the push gateway in the metrics-sync script.

### DIFF
--- a/scripts/metrics-sync.sh
+++ b/scripts/metrics-sync.sh
@@ -6,6 +6,8 @@ PROCESSED=processed
 VENV="$(mktemp -d)"
 METRICS_DIR="$(mktemp -d)"
 
+PUSHGATEWAY_URL=${PUSHGATEWAY_URL%/}
+
 # Cleanup the temporary directories
 trap 'rm -rf "$VENV" "$METRICS_DIR"' EXIT
 


### PR DESCRIPTION
The trailing slash at the end of the URL prevents successfuly metrics
pushing to the pushgateway.