### PR TITLE
SDCICD-87. Addon test harness support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,3 @@ out/
 .idea
 *.swp
 *.code-workspace
-
-# Go dependencies
-vendor/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: check generate build-image push-image push-latest test
 
 PKG := github.com/openshift/osde2e
+ADDONS_PKG := $(PKG)/suites/addons
 E2E_PKG := $(PKG)/suites/e2e
 SCALE_PKG := $(PKG)/suites/scale
 DOC_PKG := $(PKG)/cmd/osde2e-docs
@@ -44,6 +45,9 @@ test:
 
 test-scale:
 	go test $(SCALE_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)"  -test.timeout 8h -test.run TestScale
+
+test-addons:
+	go test $(ADDONS_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)"  -test.timeout 8h -test.run TestAddons
 
 test-docker:
 	$(CONTAINER_ENGINE) run \

--- a/cmd/osde2e-docs/main.go
+++ b/cmd/osde2e-docs/main.go
@@ -49,6 +49,9 @@ var (
 			{
 				Name: "metrics",
 			},
+			{
+				Name: "addons",
+			},
 		},
 	}
 )

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	k8s.io/client-go v11.0.1-0.20191029005444-8e4128053008+incompatible
 	k8s.io/klog v1.0.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a // indirect
+	k8s.io/utils v0.0.0-20190712204705-3dccf664f023
 )
 
 replace (

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kubernetes/utils v0.0.0-20191114200735-6ca3b61696b6 h1:GeRsQrKHGL+2/AdeelJTvyQvSX/GTkvlMg0ofwfRsfg=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,8 @@ type Config struct {
 
 	OCM OCMConfig `yaml:"ocm"`
 
+	Addon AddonConfig `yaml:"addon"`
+
 	// Name lets you name the current e2e job run
 	JobName string `json:"job_name" env:"JOB_NAME" sect:"tests" yaml:"jobName"`
 
@@ -112,6 +114,12 @@ type ClusterConfig struct {
 	InstallTimeout int64 `env:"CLUSTER_UP_TIMEOUT" sect:"environment" default:"135" yaml:"installTimeout"`
 }
 
+// AddonConfig options for addon testing
+type AddonConfig struct {
+	// AddonTestHarness is the image that will be run on the cluster and will exercise various addons that are installed.
+	TestHarness string `env:"ADDON_TEST_HARNESS" sect:"addons" yaml:"testHarness"`
+}
+
 // TestConfig changes the behavior of how and what tests are run.
 type TestConfig struct {
 	// PollingTimeout is how long (in mimutes) to wait for an object to be created
@@ -129,6 +137,9 @@ type TestConfig struct {
 
 	// OperatorSkip is a comma-delimited list of operator names to ignore health checks from. ex. "insights,telemetry"
 	OperatorSkip string `env:"OPERATOR_SKIP" sect:"tests" default:"insights" yaml:"ginkgoFocus"`
+
+	// SkipClusterHealthChecks skips the cluster health checks. Useful when developing against a running cluster.
+	SkipClusterHealthChecks bool `env:"SKIP_CLUSTER_HEALTH_CHECKS" sect:"tests" default:"false" yaml:"skipClusterHealthChecks"`
 
 	// UploadMetrics tells osde2e whether to try to upload to the S3 metrics bucket.
 	UploadMetrics bool `env:"UPLOAD_METRICS" sect:"metrics" default:"false" yaml:"uploadMetrics"`

--- a/pkg/helper/helper.go
+++ b/pkg/helper/helper.go
@@ -2,8 +2,10 @@
 package helper
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
+	"text/template"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -126,4 +128,13 @@ func (h *H) GetWorkload(name string) (string, bool) {
 // AddWorkload uniquely appends a workload to the workloads list
 func (h *H) AddWorkload(name, project string) {
 	h.InstalledWorkloads[name] = project
+}
+
+// ConvertTemplateToString takes a template and uses the provided data interface to construct a command string
+func (h *H) ConvertTemplateToString(template *template.Template, data interface{}) (string, error) {
+	var cmd bytes.Buffer
+	if err := template.Execute(&cmd, data); err != nil {
+		return "", fmt.Errorf("failed templating command: %v", err)
+	}
+	return cmd.String(), nil
 }

--- a/pkg/helper/runner.go
+++ b/pkg/helper/runner.go
@@ -10,8 +10,8 @@ import (
 	"github.com/openshift/osde2e/pkg/runner"
 )
 
-// Runner creates an extended test suite runner and configure RBAC for it and runs cmd in it.
-func (h *H) Runner(cmd string) *runner.Runner {
+// RunnerWithNoCommand creates an extended test suite runner and configure RBAC for it.
+func (h *H) RunnerWithNoCommand() *runner.Runner {
 	h.GiveCurrentProjectClusterAdmin()
 	r := runner.DefaultRunner.DeepCopy()
 
@@ -21,6 +21,12 @@ func (h *H) Runner(cmd string) *runner.Runner {
 
 	// setup tests
 	r.Namespace = h.CurrentProject()
+	return r
+}
+
+// Runner creates an extended test suite runner and configure RBAC for it and runs cmd in it.
+func (h *H) Runner(cmd string) *runner.Runner {
+	r := h.RunnerWithNoCommand()
 	r.Cmd = cmd
 	return r
 }

--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -7,7 +7,7 @@ import (
 )
 
 // testCmd configures default Service Account as a kubeconfig, runs openshift-tests, and serves results over HTTP
-const testCmd = `
+const testCmd = `#!/bin/bash
 # setup cluster credentials
 oc config set-cluster {{.Name}} --server={{.Server}} --certificate-authority={{.CA}}
 oc config set-credentials {{.Name}} --token=$(cat {{.TokenFile}})
@@ -18,7 +18,7 @@ oc config use-context {{.Name}}
 mkdir -p {{.OutputDir}}
 
 # run Cmd and preserve it's stdout and stderr
-{{.Cmd}} > >(tee -a {{.OutputDir}}/{{.Name}}-out.txt) 2> >(tee -a {{.OutputDir}}/{{.Name}}-err.txt >&2)
+{ {{.Cmd}} } > >(tee -a {{.OutputDir}}/{{.Name}}-out.txt) 2> >(tee -a {{.OutputDir}}/{{.Name}}-err.txt >&2)
 
 # create a Tarball of OutputDir if requested
 {{$outDir := .OutputDir}}
@@ -36,10 +36,11 @@ var (
 	cmdTemplate = template.Must(template.New("testCmd").Parse(testCmd))
 )
 
-func (r *Runner) Command() (string, error) {
+// Command generates the templated command.
+func (r *Runner) Command() ([]byte, error) {
 	var cmd bytes.Buffer
 	if err := cmdTemplate.Execute(&cmd, r); err != nil {
-		return "", fmt.Errorf("failed templating command: %v", err)
+		return []byte{}, fmt.Errorf("failed templating command: %v", err)
 	}
-	return cmd.String(), nil
+	return cmd.Bytes(), nil
 }

--- a/pkg/runner/imagestream.go
+++ b/pkg/runner/imagestream.go
@@ -15,8 +15,8 @@ const (
 	testImageStreamNamespace = "openshift"
 )
 
-// getLatestImageStreamTag returns the From name of the latest ImageStream tag.
-func (r *Runner) getLatestImageStreamTag() (string, error) {
+// GetLatestImageStreamTag returns the From name of the latest ImageStream tag.
+func (r *Runner) GetLatestImageStreamTag() (string, error) {
 	return r.getImageStreamTag("latest")
 }
 

--- a/pkg/runner/imagestream_test.go
+++ b/pkg/runner/imagestream_test.go
@@ -40,7 +40,7 @@ func TestGetLatestImageStreamTag(t *testing.T) {
 	r.Image = streamClient
 
 	// confirm tag From name
-	if fromName, err := r.getLatestImageStreamTag(); err != nil {
+	if fromName, err := r.GetLatestImageStreamTag(); err != nil {
 		t.Fatalf("encountered error getting tag From name: %v", err)
 	} else if fromName != expectedFromName {
 		t.Fatalf("expected '%s' not '%s'", expectedFromName, fromName)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	// name used in Runner resources
-	defaultName = "openshift-tests"
+	defaultName = "osde2e-runner"
 
 	// directory containing service account credentials
 	serviceAccountDir = "/var/run/secrets/kubernetes.io/serviceaccount"
@@ -30,7 +30,7 @@ var DefaultRunner = &Runner{
 		},
 		RestartPolicy: kubev1.RestartPolicyNever,
 	},
-	OutputDir: "./results",
+	OutputDir: "/test-run-results",
 	AuthConfig: AuthConfig{
 		Name:      "osde2e",
 		Server:    "https://kubernetes.default",
@@ -97,7 +97,7 @@ func (r *Runner) Run(timeoutInSeconds int, stopCh <-chan struct{}) (err error) {
 
 	// set image if imagestream is set
 	if r.ImageName == "" {
-		if r.ImageName, err = r.getLatestImageStreamTag(); err != nil {
+		if r.ImageName, err = r.GetLatestImageStreamTag(); err != nil {
 			return
 		}
 	}
@@ -150,7 +150,7 @@ func (r *Runner) DeepCopy() *Runner {
 // meta returns the ObjectMeta used for Runner resources.
 func (r *Runner) meta() metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		GenerateName: r.Name + "-",
+		Name: r.Name,
 		Labels: map[string]string{
 			"app": r.Name,
 		},

--- a/suites/addons/addons_test.go
+++ b/suites/addons/addons_test.go
@@ -1,0 +1,16 @@
+package osde2e_addons
+
+import (
+	"testing"
+
+	"github.com/openshift/osde2e/common"
+	"github.com/openshift/osde2e/pkg/config"
+
+	// import suites to be tested
+	_ "github.com/openshift/osde2e/test/addons"
+)
+
+func TestAddons(t *testing.T) {
+	cfg := config.Cfg
+	common.RunE2ETests(t, cfg)
+}

--- a/suites/addons/testdata/addon-runner.template
+++ b/suites/addons/testdata/addon-runner.template
@@ -1,0 +1,42 @@
+cat << 'WORKLOAD' > workload.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: addon-tests
+spec:
+  parallelism: 1
+  completions: 1
+  activeDeadlineSeconds: {{.Timeout}}
+  backoffLimit: 0
+  template:
+    metadata:
+      name: addon-test
+    spec:
+      containers:
+      - name: addon-tests
+        image: quay.io/miwilson/addons-osde2e-testing
+        args: [--output-dir, {{.OutputDir}}]
+        volumeMounts:
+        - mountPath: /test-run-results
+          name: test-output
+      - name: push-results
+        image: {{.PushResultsContainer}}
+        command: [/bin/sh, -c]
+        args:
+        - while ! oc get pod $POD_NAME -o jsonpath='{.status.containerStatuses[?(@.name=="addon-tests")].state}' | grep -q terminated; do sleep 1; done; oc rsync {{.OutputDir}}/. addon-tests:{{.OutputDir}}
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        volumeMounts:
+        - mountPath: {{.OutputDir}}
+          name: test-output
+      volumes:
+      - name: test-output
+        emptyDir: {}
+      restartPolicy: Never
+WORKLOAD
+
+oc apply -f workload.yaml
+while oc get job/addon-tests -o=jsonpath='{.status}' | grep -q active; do sleep 1; done

--- a/test/addons/addon_test_harness.go
+++ b/test/addons/addon_test_harness.go
@@ -1,0 +1,67 @@
+package addons
+
+import (
+	"fmt"
+	"io/ioutil"
+	"text/template"
+
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/osde2e/pkg/helper"
+	"github.com/openshift/osde2e/pkg/runner"
+)
+
+var addonTestTemplate *template.Template
+
+func init() {
+	data, err := ioutil.ReadFile("testdata/addon-runner.template")
+	if err != nil {
+		panic(fmt.Sprintf("unable to read addon runner template: %v", err))
+	}
+
+	addonTestTemplate = template.Must(template.New("addon-test-runner").Parse(string(data)))
+
+}
+
+var _ = ginkgo.Describe("Addon Test Harness", func() {
+	defer ginkgo.GinkgoRecover()
+	h := helper.New()
+
+	addonTimeoutInSeconds := 3600
+	ginkgo.It("should run until completion", func() {
+		// configure tests
+		// setup runner
+		r := h.RunnerWithNoCommand()
+
+		latestImageStream, err := r.GetLatestImageStreamTag()
+		Expect(err).NotTo(HaveOccurred())
+		addonTestCommand, err := h.ConvertTemplateToString(addonTestTemplate, struct {
+			Timeout              int
+			Image                string
+			OutputDir            string
+			PushResultsContainer string
+		}{
+			Timeout:              addonTimeoutInSeconds,
+			Image:                h.Addon.TestHarness,
+			OutputDir:            runner.DefaultRunner.OutputDir,
+			PushResultsContainer: latestImageStream,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		r.Name = "addon-tests"
+		r.Cmd = addonTestCommand
+
+		// run tests
+		stopCh := make(chan struct{})
+		err = r.Run(addonTimeoutInSeconds, stopCh)
+		Expect(err).NotTo(HaveOccurred())
+
+		// get results
+		results, err := r.RetrieveResults()
+		Expect(err).NotTo(HaveOccurred())
+
+		// write results
+		h.WriteResults(results)
+	}, float64(addonTimeoutInSeconds+30))
+})

--- a/test/openshift/openshift.go
+++ b/test/openshift/openshift.go
@@ -32,6 +32,8 @@ var _ = ginkgo.Describe("OpenShift E2E", func() {
 		// setup runner
 		r := h.Runner(cmd)
 
+		r.Name = "openshift-tests"
+
 		// run tests
 		stopCh := make(chan struct{})
 		err := r.Run(e2eTimeoutInSeconds, stopCh)

--- a/vendor/k8s.io/utils/pointer/OWNERS
+++ b/vendor/k8s.io/utils/pointer/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- apelisse
+- stewart-yu
+- thockin
+reviewers:
+- apelisse
+- stewart-yu
+- thockin

--- a/vendor/k8s.io/utils/pointer/pointer.go
+++ b/vendor/k8s.io/utils/pointer/pointer.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pointer
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// AllPtrFieldsNil tests whether all pointer fields in a struct are nil.  This is useful when,
+// for example, an API struct is handled by plugins which need to distinguish
+// "no plugin accepted this spec" from "this spec is empty".
+//
+// This function is only valid for structs and pointers to structs.  Any other
+// type will cause a panic.  Passing a typed nil pointer will return true.
+func AllPtrFieldsNil(obj interface{}) bool {
+	v := reflect.ValueOf(obj)
+	if !v.IsValid() {
+		panic(fmt.Sprintf("reflect.ValueOf() produced a non-valid Value for %#v", obj))
+	}
+	if v.Kind() == reflect.Ptr {
+		if v.IsNil() {
+			return true
+		}
+		v = v.Elem()
+	}
+	for i := 0; i < v.NumField(); i++ {
+		if v.Field(i).Kind() == reflect.Ptr && !v.Field(i).IsNil() {
+			return false
+		}
+	}
+	return true
+}
+
+// Int32Ptr returns a pointer to an int32
+func Int32Ptr(i int32) *int32 {
+	return &i
+}
+
+// Int64Ptr returns a pointer to an int64
+func Int64Ptr(i int64) *int64 {
+	return &i
+}
+
+// Int32PtrDerefOr dereference the int32 ptr and returns it if not nil,
+// else returns def.
+func Int32PtrDerefOr(ptr *int32, def int32) int32 {
+	if ptr != nil {
+		return *ptr
+	}
+	return def
+}
+
+// BoolPtr returns a pointer to a bool
+func BoolPtr(b bool) *bool {
+	return &b
+}
+
+// StringPtr returns a pointer to the passed string.
+func StringPtr(s string) *string {
+	return &s
+}
+
+// Float32Ptr returns a pointer to the passed float32.
+func Float32Ptr(i float32) *float32 {
+	return &i
+}
+
+// Float64Ptr returns a pointer to the passed float64.
+func Float64Ptr(i float64) *float64 {
+	return &i
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -424,5 +424,6 @@ k8s.io/klog
 k8s.io/kube-openapi/pkg/util/proto
 # k8s.io/utils v0.0.0-20190712204705-3dccf664f023
 k8s.io/utils/integer
+k8s.io/utils/pointer
 # sigs.k8s.io/yaml v1.1.0 => sigs.k8s.io/yaml v1.1.0
 sigs.k8s.io/yaml


### PR DESCRIPTION
Addon test harnesses can now be supplied to osde2e. This will allow for
addon authors to test against OSD clusters. Results from addons will be
collected by osde2e for later analysis.