### PR TITLE
SDCICD-87. Fix command rework bug for single line commands.

### DIFF
--- a/pkg/runner/command.go
+++ b/pkg/runner/command.go
@@ -18,7 +18,9 @@ oc config use-context {{.Name}}
 mkdir -p {{.OutputDir}}
 
 # run Cmd and preserve it's stdout and stderr
-{ {{.Cmd}} } > >(tee -a {{.OutputDir}}/{{.Name}}-out.txt) 2> >(tee -a {{.OutputDir}}/{{.Name}}-err.txt >&2)
+{
+{{.Cmd}}
+} > >(tee -a {{.OutputDir}}/{{.Name}}-out.txt) 2> >(tee -a {{.OutputDir}}/{{.Name}}-err.txt >&2)
 
 # create a Tarball of OutputDir if requested
 {{$outDir := .OutputDir}}


### PR DESCRIPTION
Single line commands didn't work with the command rework before due to
the command provided to the helper seeming to require a newline at the
end of it.