### PR TITLE
SDCICD-87. Make sure runners run as root.

### DIFF
--- a/pkg/runner/pod.go
+++ b/pkg/runner/pod.go
@@ -58,6 +58,9 @@ var DefaultContainer = kubev1.Container{
 		},
 		PeriodSeconds: 7,
 	},
+	SecurityContext: &kubev1.SecurityContext{
+		RunAsUser: pointer.Int64Ptr(0),
+	},
 }
 
 var payloadVolumeMounts = []kubev1.VolumeMount{


### PR DESCRIPTION
Runners will ensure that they will run as the root user for a container
so that the necessary directory /test-run-results can be created.