### PR TITLE
SDCICD-108. Counter event support.

### DIFF
--- a/common/e2e_test.go
+++ b/common/e2e_test.go
@@ -1,0 +1,59 @@
+package common
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/openshift/osde2e/pkg/config"
+	"github.com/openshift/osde2e/pkg/events"
+)
+
+func TestNoHiveLogs(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Errorf("failed to create temporary directory: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if resetEvents() != nil {
+		t.Errorf("list of events is not empty on start: %v", err)
+	}
+
+	cfg := config.Cfg
+	cfg.ReportDir = tmpDir
+
+	checkBeforeMetricsGeneration(cfg)
+	if !reflect.DeepEqual(events.GetListOfEvents(), []string{string(events.NoHiveLogs)}) {
+		t.Errorf("the NoHiveLogs event was not detected")
+	}
+
+	// Make sure the events are clear again
+	if resetEvents() != nil {
+		t.Errorf("list of events is not empty during second hive log check: %v", err)
+	}
+
+	_, err = os.Create(filepath.Join(tmpDir, hiveLog))
+	if err != nil {
+		t.Errorf("error creating dummy hive log: %v", err)
+	}
+
+	checkBeforeMetricsGeneration(cfg)
+
+	if !reflect.DeepEqual(events.GetListOfEvents(), []string{}) {
+		t.Errorf("the NoHiveLogs event should not have been detected")
+	}
+}
+
+func resetEvents() error {
+	events.Instance.Events = map[string]bool{}
+
+	if !reflect.DeepEqual(events.GetListOfEvents(), []string{}) {
+		return fmt.Errorf("list of events is not empty on reset")
+	}
+
+	return nil
+}

--- a/pkg/events/event_type.go
+++ b/pkg/events/event_type.go
@@ -1,0 +1,32 @@
+package events
+
+// EventType is the type of event to record
+type EventType string
+
+// This file defines different event types. Please add new types here so that we can easily track them.
+const (
+	// ------ Cluster provisioning events
+
+	// InstallSuccessful when the cluster has successfully provisioned
+	InstallSuccessful EventType = "InstallSuccessful"
+
+	// FailedClusterProvision when the cluster has not been successfully provisioned
+	InstallFailed EventType = "InstallFailed"
+
+	// UpgradeSuccessful when the upgrade was successful
+	UpgradeSuccessful EventType = "UpgradeSuccessful"
+
+	// UpgradeFailed when the upgrade failed
+	UpgradeFailed EventType = "UpgradeFailed"
+
+	// NoHiveLogs when no logs from Hive were collected after a cluster provisioning event
+	NoHiveLogs EventType = "NoHiveLogs"
+
+	// ------ Addon installation events
+
+	// InstallAddonsSuccessful when the addons installed successfully
+	InstallAddonsSuccessful EventType = "InstallAddonsSuccessful"
+
+	// InstallAddonsFailed when the addons failed to install
+	InstallAddonsFailed EventType = "InstallAddonsFailed"
+)

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -1,0 +1,45 @@
+package events
+
+import (
+	"github.com/onsi/gomega"
+)
+
+// Events records individual events that occur during the execution of osde2e
+type Events struct {
+	Events map[string]bool
+}
+
+// Instance is the global Events instance
+var Instance *Events
+
+func init() {
+	Instance = &Events{}
+	Instance.Events = map[string]bool{}
+}
+
+// HandleErrorWithEvents returns a gomega assertion and records events depending on the error state.
+func HandleErrorWithEvents(err error, successEvent EventType, failEvent EventType) gomega.Assertion {
+	if err != nil {
+		RecordEvent(failEvent)
+	}
+	RecordEvent(successEvent)
+	return gomega.Expect(err)
+}
+
+// RecordEvent records the given event in the global events instance
+func RecordEvent(event EventType) {
+	Instance.Events[string(event)] = true
+}
+
+// GetListOfEvents gets the list of events that were registered with the event recorder
+func GetListOfEvents() []string {
+	events := make([]string, len(Instance.Events))
+
+	i := 0
+	for k := range Instance.Events {
+		events[i] = k
+		i++
+	}
+
+	return events
+}

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -1,0 +1,30 @@
+package events
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGetListOfEvents(t *testing.T) {
+	tests := []struct {
+		name           string
+		events         []EventType
+		expectedEvents []string
+	}{
+		{
+			name:           "typical test",
+			events:         []EventType{NoHiveLogs, InstallFailed, UpgradeFailed},
+			expectedEvents: []string{"NoHiveLogs", "InstallFailed", "UpgradeFailed"},
+		},
+	}
+
+	for _, test := range tests {
+		for _, event := range test.events {
+			RecordEvent(event)
+		}
+
+		if !reflect.DeepEqual(GetListOfEvents(), test.expectedEvents) {
+			t.Errorf("The events did not match the expected events for test: %s.", test.name)
+		}
+	}
+}


### PR DESCRIPTION
osde2e can now track counter events. This will allow for tracking the
number of successful/failed events, like cluster provisions, upgrades,
etc. This will be useful for alerting.