### PR TITLE
SDCICD-114. Use osd-4 for default flavor for new clusters.

### DIFF
--- a/pkg/osd/cluster.go
+++ b/pkg/osd/cluster.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// DefaultFlavour is used when no specialized configuration exists.
-	DefaultFlavour = "4"
+	DefaultFlavour = "osd-4"
 )
 
 // LaunchCluster setups an new cluster using the OSD API and returns it's ID.


### PR DESCRIPTION
We should use the osd-4 flavor for clusters now so that we get infra
nodes as part of our clusters.