### PR TITLE
SDCICD-89. General fixes for addon support.

### DIFF
--- a/pkg/osd/cluster.go
+++ b/pkg/osd/cluster.go
@@ -96,27 +96,30 @@ func (u *OSD) ClusterState(clusterID string) (v1.ClusterState, error) {
 // and performs the CRUD operation to trigger addon installation
 func (u *OSD) InstallAddons(cfg *config.Config) (num int, err error) {
 	num = 0
-	clusterClient := u.cluster(cfg.Cluster.ID)
-	for _, addon := range cfg.Addons.IDs {
-		addonResp, err := clusterClient.Addons().Addon(addon).Get().Send()
-		if err != nil {
-			return 0, err
-		}
-		addon := addonResp.Body()
+	// TODO: Uncomment when addon installation is fixed in COM (https://issues.redhat.com/browse/SDA-1757)
+	//addonsClient := u.addons()
+	//clusterClient := u.cluster(cfg.Cluster.ID)
+	//for _, addonID := range cfg.Addons.IDs {
+	//	addonResp, err := addonsClient.Addon(addonID).Get().Send()
+	//	if err != nil {
+	//		return 0, err
+	//	}
+	//	addon := addonResp.Body()
 
-		if addon.Enabled() {
-			aoar, err := clusterClient.Addons().Add().Body(addon).Send()
-			if err != nil {
-				return 0, err
-			}
+	//	if addon.Enabled() {
+	//		addonInstallation, err := v1.NewAddOnInstallation().Addon(v1.NewAddOn().Copy(addon)).Build()
+	//		aoar, err := clusterClient.Addons().Add().Body(addonInstallation).Send()
+	//		if err != nil {
+	//			return 0, err
+	//		}
 
-			if aoar.Error() != nil {
-				return 0, fmt.Errorf("Error (%v) sending request: %v", aoar.Status(), aoar.Error())
-			}
+	//		if aoar.Error() != nil {
+	//			return 0, fmt.Errorf("Error (%v) sending request: %v", aoar.Status(), aoar.Error())
+	//		}
 
-			num++
-		}
-	}
+	//		num++
+	//	}
+	//}
 
 	return num, nil
 }

--- a/pkg/osd/osd.go
+++ b/pkg/osd/osd.go
@@ -67,6 +67,11 @@ func (u *OSD) CurrentAccount() (*accounts.Account, error) {
 	return act.Body(), err
 }
 
+// TODO: Uncomment when SDA-1757 is resolved.
+//func (u *OSD) addons() *clusters.AddOnsClient {
+//	return u.conn.ClustersMgmt().V1().Addons()
+//}
+
 // clusters returns a client used to perform cluster operations.
 func (u *OSD) clusters() *clusters.ClustersClient {
 	return u.conn.ClustersMgmt().V1().Clusters()

--- a/suites/addons/addons_test.go
+++ b/suites/addons/addons_test.go
@@ -1,6 +1,7 @@
 package osde2e_addons
 
 import (
+	"flag"
 	"testing"
 
 	"github.com/openshift/osde2e/common"
@@ -9,6 +10,19 @@ import (
 	// import suites to be tested
 	_ "github.com/openshift/osde2e/test/addons"
 )
+
+func init() {
+	var filename string
+	testing.Init()
+
+	cfg := config.Cfg
+
+	flag.StringVar(&filename, "e2e-config", ".osde2e.yaml", "Config file for osde2e")
+	flag.Parse()
+
+	cfg.LoadFromYAML(filename)
+
+}
 
 func TestAddons(t *testing.T) {
 	cfg := config.Cfg


### PR DESCRIPTION
Though currently blocked by SDA-1757, addon support has had a few fixes
to ensure things work as expected. Namely:

* Proper e2e config parsing.
* Using the general addons endpoint for querying addons as opposed to
  the cluster level one.