### PR TITLE
SDCICD-123. Use cluster image sets for upgrades if specified.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,6 +71,9 @@ type OCMConfig struct {
 
 // UpgradeConfig stores information required to perform OSDe2e upgrade testing
 type UpgradeConfig struct {
+	// UpgradeToCISIfPossible will upgrade to the most recent cluster image set if it's newer than the install version
+	UpgradeToCISIfPossible bool `env:"UPGRADE_TO_CIS_IF_POSSIBLE" sect:"version" default:"false" yaml:"upgradeToCISIfPossible"`
+
 	// MajorTarget is the major version to target. If specified, it is used in version selection.
 	MajorTarget int64 `env:"MAJOR_TARGET" sect:"version" yaml:"majorTarget"`
 

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -6,14 +6,15 @@ import (
 	"os"
 )
 
-// metadata houses the metadata that will be written to the report directory after
+// Metadata houses the metadata that will be written to the report directory after
 type Metadata struct {
 	// Cluster information
-	ClusterID      string `json:"cluster-id"`
-	ClusterName    string `json:"cluster-name"`
-	ClusterVersion string `json:"cluster-version"`
-	Environment    string `json:"environment"`
-	UpgradeVersion string `json:"upgrade-version,omitempty"`
+	ClusterID            string `json:"cluster-id"`
+	ClusterName          string `json:"cluster-name"`
+	ClusterVersion       string `json:"cluster-version"`
+	Environment          string `json:"environment"`
+	UpgradeVersion       string `json:"upgrade-version,omitempty"`
+	UpgradeVersionSource string `json:"upgrade-version-source,omitempty"`
 
 	// Metrics
 	TimeToOCMReportingInstalled float64 `json:"time-to-ocm-reporting-installed,string"`


### PR DESCRIPTION
Cluster image sets can now be used directly for upgrades if specified.