### PR TITLE
e2e test for testing newest Hive with a set of older ClusterImageSets

### DIFF
--- a/common/version.go
+++ b/common/version.go
@@ -96,3 +96,25 @@ func setupUpgradeVersion(cfg *config.Config, osd *osd.OSD) (err error) {
 		cfg.Cluster.Version, cfg.Upgrade.ReleaseName, cfg.Upgrade.ReleaseStream)
 	return
 }
+
+// GetNewestAndOldestVersions returns a list which contains the newest and the oldest non-default versions.
+func GetNewestAndOldestVersions(cfg *config.Config) ([]string, error) {
+	OSD, err := osd.New(cfg.OCM.Token, cfg.OCM.Env, cfg.OCM.Debug)
+	if err != nil {
+		return nil, fmt.Errorf("could not setup OSD: %v", err)
+	}
+
+	versionList, err := OSD.EnabledNoDefaultVersionList()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(versionList) < 2 {
+		return versionList, nil
+	}
+
+	return []string{
+		versionList[0],
+		versionList[len(versionList)-1],
+	}, nil
+}

--- a/common/version.go
+++ b/common/version.go
@@ -97,24 +97,12 @@ func setupUpgradeVersion(cfg *config.Config, osd *osd.OSD) (err error) {
 	return
 }
 
-// GetNewestAndOldestVersions returns a list which contains the newest and the oldest non-default versions.
-func GetNewestAndOldestVersions(cfg *config.Config) ([]string, error) {
+// GetEnabledNoDefaultVersions returns a sorted list of the enabled but not default versions currently offered by OSD
+func GetEnabledNoDefaultVersions(cfg *config.Config) ([]string, error) {
 	OSD, err := osd.New(cfg.OCM.Token, cfg.OCM.Env, cfg.OCM.Debug)
 	if err != nil {
 		return nil, fmt.Errorf("could not setup OSD: %v", err)
 	}
 
-	versionList, err := OSD.EnabledNoDefaultVersionList()
-	if err != nil {
-		return nil, err
-	}
-
-	if len(versionList) < 2 {
-		return versionList, nil
-	}
-
-	return []string{
-		versionList[0],
-		versionList[len(versionList)-1],
-	}, nil
+	return OSD.EnabledNoDefaultVersionList()
 }

--- a/pkg/osd/versions.go
+++ b/pkg/osd/versions.go
@@ -16,6 +16,9 @@ const (
 	// query used to retrieve the current default version.
 	defaultVersionSearch = "default = 't'"
 
+	// query used to retrieve the current enabled version.
+	enabledVersionSearch = "enabled = 't'"
+
 	// VersionPrefix is the string that every OSD version begins with.
 	VersionPrefix = "openshift-"
 
@@ -87,6 +90,30 @@ func (u *OSD) LatestVersion(major, minor int64) (string, error) {
 	// return latest nightly
 	latest := versions[len(versions)-1]
 	return VersionPrefix + latest.Original(), nil
+}
+
+// EnabledNoDefaultVersionList returns a sorted list of the enabled but not default versions currently offered by OSD.
+func (u *OSD) EnabledNoDefaultVersionList() ([]string, error) {
+	semverVersions, err := u.getSemverList(-1, -1, "")
+	if err != nil {
+		return nil, fmt.Errorf("couldn't created sorted version list: %v", err)
+	}
+
+	defaultVersion, err := u.DefaultVersion()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't retrieve the default version: %v", err)
+	}
+
+	var versionList []string
+	for _, sv := range semverVersions {
+		version := VersionPrefix + sv.Original()
+		if strings.Compare(version, defaultVersion) == 0 {
+			continue
+		}
+		versionList = append(versionList, version)
+	}
+
+	return versionList, nil
 }
 
 // getSemverList as sorted semvers containing str for major and minor versions. Negative versions match all.

--- a/pkg/osd/versions.go
+++ b/pkg/osd/versions.go
@@ -16,9 +16,6 @@ const (
 	// query used to retrieve the current default version.
 	defaultVersionSearch = "default = 't'"
 
-	// query used to retrieve the current enabled version.
-	enabledVersionSearch = "enabled = 't'"
-
 	// VersionPrefix is the string that every OSD version begins with.
 	VersionPrefix = "openshift-"
 

--- a/suites/clusterimagesets/latest/imagesets_test.go
+++ b/suites/clusterimagesets/latest/imagesets_test.go
@@ -1,0 +1,47 @@
+package latest
+
+import (
+	"flag"
+	"log"
+	"testing"
+
+	"github.com/openshift/osde2e/common"
+	"github.com/openshift/osde2e/pkg/config"
+	// import suites to be tested
+)
+
+func init() {
+	var filename string
+	testing.Init()
+
+	cfg := config.Cfg
+
+	flag.StringVar(&filename, "e2e-config", ".osde2e.yaml", "Config file for osde2e")
+	flag.Parse()
+
+	cfg.LoadFromYAML(filename)
+
+}
+func TestE2E(t *testing.T) {
+	// force overwriting the attributes to make sure the cluster with the specified cluster will be created.
+	cfg := config.Cfg
+	cfg.Kubeconfig.Path = ""
+	cfg.Cluster.ID = ""
+	cfg.Cluster.Version = ""
+	cfg.Cluster.DestroyAfterTest = true
+
+	versionList, err := common.GetNewestAndOldestVersions(cfg)
+	if err != nil {
+		log.Printf("Failed to do clusterImageSets testing: %+v\n", err)
+	} else {
+		if len(versionList) == 0 {
+			log.Printf("Skip doing clusterImageSets testing: Default version is covered by the regular testing\n")
+		} else if len(versionList) == 1 {
+			log.Printf("Skip doing clusterImageSets testing: The version %s is covered by the oldest version testing\n", versionList[0])
+		} else {
+			log.Printf("Start doing clusterImageSets testing with the specified version %+v\n", versionList[1])
+			cfg.Cluster.Version = versionList[1]
+			common.RunE2ETests(t, cfg)
+		}
+	}
+}

--- a/suites/clusterimagesets/middle/imagesets_test.go
+++ b/suites/clusterimagesets/middle/imagesets_test.go
@@ -1,4 +1,4 @@
-package latest
+package middle
 
 import (
 	"flag"
@@ -23,24 +23,24 @@ func init() {
 
 }
 func TestE2E(t *testing.T) {
-	// force overwriting the attributes to make sure the cluster with the specified cluster will be created.
+	// force overwriting the attributes to make sure the cluster with the specified version will be created.
 	cfg := config.Cfg
 	cfg.Kubeconfig.Path = ""
 	cfg.Cluster.ID = ""
 	cfg.Cluster.Version = ""
 	cfg.Cluster.DestroyAfterTest = true
 
-	versionList, err := common.GetNewestAndOldestVersions(cfg)
+	versionList, err := common.GetEnabledNoDefaultVersions(cfg)
 	if err != nil {
-		log.Printf("Failed to do clusterImageSets testing: %+v\n", err)
+		log.Printf("Abort doing clusterImageSets testing: %+v\n", err)
 	} else {
 		if len(versionList) == 0 {
 			log.Printf("Skip doing clusterImageSets testing: Default version is covered by the regular testing\n")
 		} else if len(versionList) == 1 {
 			log.Printf("Skip doing clusterImageSets testing: The version %s is covered by the oldest version testing\n", versionList[0])
 		} else {
-			log.Printf("Start doing clusterImageSets testing with the specified version %+v\n", versionList[1])
-			cfg.Cluster.Version = versionList[1]
+			log.Printf("Start doing clusterImageSets testing with the specified version %+v\n", versionList[len(versionList)/2])
+			cfg.Cluster.Version = versionList[len(versionList)/2]
 			common.RunE2ETests(t, cfg)
 		}
 	}

--- a/suites/clusterimagesets/oldest/imagesets_test.go
+++ b/suites/clusterimagesets/oldest/imagesets_test.go
@@ -31,7 +31,6 @@ func TestE2E(t *testing.T) {
 	cfg.Cluster.DestroyAfterTest = true
 
 	versionList, err := common.GetEnabledNoDefaultVersions(cfg)
-	versionList = []string{}
 	if err != nil {
 		log.Printf("Failed to do clusterImageSets testing: %+v\n", err)
 	} else {

--- a/suites/clusterimagesets/oldest/imagesets_test.go
+++ b/suites/clusterimagesets/oldest/imagesets_test.go
@@ -23,13 +23,15 @@ func init() {
 
 }
 func TestE2E(t *testing.T) {
-	// force overwriting the attributes to make sure the cluster with the specified cluster will be created.
+	// force overwriting the attributes to make sure the cluster with the specified version will be created.
 	cfg := config.Cfg
 	cfg.Kubeconfig.Path = ""
 	cfg.Cluster.ID = ""
+	cfg.Cluster.Version = ""
 	cfg.Cluster.DestroyAfterTest = true
 
-	versionList, err := common.GetNewestAndOldestVersions(cfg)
+	versionList, err := common.GetEnabledNoDefaultVersions(cfg)
+	versionList = []string{}
 	if err != nil {
 		log.Printf("Failed to do clusterImageSets testing: %+v\n", err)
 	} else {

--- a/suites/clusterimagesets/oldest/imagesets_test.go
+++ b/suites/clusterimagesets/oldest/imagesets_test.go
@@ -1,0 +1,44 @@
+package oldest
+
+import (
+	"flag"
+	"log"
+	"testing"
+
+	"github.com/openshift/osde2e/common"
+	"github.com/openshift/osde2e/pkg/config"
+	// import suites to be tested
+)
+
+func init() {
+	var filename string
+	testing.Init()
+
+	cfg := config.Cfg
+
+	flag.StringVar(&filename, "e2e-config", ".osde2e.yaml", "Config file for osde2e")
+	flag.Parse()
+
+	cfg.LoadFromYAML(filename)
+
+}
+func TestE2E(t *testing.T) {
+	// force overwriting the attributes to make sure the cluster with the specified cluster will be created.
+	cfg := config.Cfg
+	cfg.Kubeconfig.Path = ""
+	cfg.Cluster.ID = ""
+	cfg.Cluster.DestroyAfterTest = true
+
+	versionList, err := common.GetNewestAndOldestVersions(cfg)
+	if err != nil {
+		log.Printf("Failed to do clusterImageSets testing: %+v\n", err)
+	} else {
+		if len(versionList) == 0 {
+			log.Printf("Skip doing clusterImageSets testing: Default version is covered by the regular testing\n")
+		} else {
+			log.Printf("Start doing clusterImageSets testing with the specified version %+v\n", versionList[0])
+			cfg.Cluster.Version = versionList[0]
+			common.RunE2ETests(t, cfg)
+		}
+	}
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/SDCICD-9

Based on the current framework, the cluster will be created once before suite. The only method for me is separating the oldest and newest ClusterImageSets into two suites.  The versions used for testing are not the default version, that means three versions will be covered. 

Certainly, it can be enhanced to test all the versions, but need to think whether it is worth doing. In my opinion, the newest, the oldest, the middle one can cover the most cases.

