### PR TITLE
SDCICD-120: Install stable version on Int before upgrading to nightly

### DIFF
--- a/common/version.go
+++ b/common/version.go
@@ -34,6 +34,8 @@ func ChooseVersions(cfg *config.Config, osd *osd.OSD) (err error) {
 
 // chooses between default version and nightly based on target versions.
 func setupVersion(cfg *config.Config, osd *osd.OSD) (err error) {
+	suffix := ""
+
 	if len(cfg.Cluster.Version) > 0 {
 		return
 	}
@@ -42,8 +44,13 @@ func setupVersion(cfg *config.Config, osd *osd.OSD) (err error) {
 		if cfg.Upgrade.MajorTarget == 0 {
 			cfg.Upgrade.MajorTarget = -1
 		}
+
+		if config.Cfg.OCM.Env == "int" && config.Cfg.Upgrade.ReleaseStream == "" {
+			suffix = "nightly"
+		}
+
 		// look for the latest release and install it for this OSD cluster.
-		if cfg.Cluster.Version, err = osd.LatestVersion(cfg.Upgrade.MajorTarget, cfg.Upgrade.MinorTarget); err == nil {
+		if cfg.Cluster.Version, err = osd.LatestVersion(cfg.Upgrade.MajorTarget, cfg.Upgrade.MinorTarget, suffix); err == nil {
 			log.Printf("CLUSTER_VERSION not set but a TARGET is, running '%s'", cfg.Cluster.Version)
 		}
 	}
@@ -74,7 +81,11 @@ func setupUpgradeVersion(cfg *config.Config, osd *osd.OSD) (err error) {
 	}
 
 	if cfg.Upgrade.UpgradeToCISIfPossible {
-		cisUpgradeVersionString, err := osd.LatestVersion(-1, -1)
+		suffix := ""
+		if config.Cfg.OCM.Env == "int" {
+			suffix = "nightly"
+		}
+		cisUpgradeVersionString, err := osd.LatestVersion(-1, -1, suffix)
 
 		if err != nil {
 			log.Printf("unable to get the most recent version of openshift from OSD: %v", err)

--- a/pkg/osd/versions.go
+++ b/pkg/osd/versions.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/Masterminds/semver"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	"github.com/openshift/osde2e/pkg/config"
 )
 
 const (
@@ -68,13 +67,7 @@ func (u *OSD) PreviousVersion(verStr string) (string, error) {
 }
 
 // LatestVersion gets latest release for major and minor versions. Negative versions match all.
-func (u *OSD) LatestVersion(major, minor int64) (string, error) {
-	suffix := ""
-
-	if config.Cfg.OCM.Env == "int" {
-		suffix = "nightly"
-	}
-
+func (u *OSD) LatestVersion(major, minor int64, suffix string) (string, error) {
 	versions, err := u.getSemverList(major, minor, suffix)
 	if err != nil {
 		return "", fmt.Errorf("couldn't created sorted version list: %v", err)


### PR DESCRIPTION
By default Int will install a nightly rather than a stable version. This is true even in upgrade tests where we want to test a nightly _upgrade_ from a stable base. 

This PR changes the version selection logic to use a stable base if it detects the test will be an upgrade. Tested it locally and seems good. 