### PR TITLE
SDCICD-128: Write to two different metadata.json files

### DIFF
--- a/common/e2e.go
+++ b/common/e2e.go
@@ -111,10 +111,10 @@ func RunE2ETests(t *testing.T, cfg *config.Config) {
 
 		if cfg.ReportDir != "" {
 			if err = metadata.Instance.WriteToJSON(filepath.Join(cfg.ReportDir, CustomMetadataFile)); err != nil {
-				t.Errorf("error while writing custom metadata: %v", err)
+				t.Errorf("error while writing the custom metadata: %v", err)
 			}
 			if err = metadata.Instance.WriteToJSON(filepath.Join(cfg.ReportDir, MetadataFile)); err != nil {
-				t.Errorf("error while writing metadata: %v", err)
+				t.Errorf("error while writing the metadata: %v", err)
 			}
 
 			checkBeforeMetricsGeneration(cfg)

--- a/common/e2e.go
+++ b/common/e2e.go
@@ -31,6 +31,7 @@ import (
 const (
 	// CustomMetadataFile is the name of the custom metadata file generated for spyglass visualization.
 	CustomMetadataFile string = "custom-prow-metadata.json"
+	MetadataFile       string = "metadata.json"
 
 	// hiveLog is the name of the hive log file.
 	hiveLog string = "hive-log.txt"
@@ -110,6 +111,9 @@ func RunE2ETests(t *testing.T, cfg *config.Config) {
 
 		if cfg.ReportDir != "" {
 			if err = metadata.Instance.WriteToJSON(filepath.Join(cfg.ReportDir, CustomMetadataFile)); err != nil {
+				t.Errorf("error while writing custom metadata: %v", err)
+			}
+			if err = metadata.Instance.WriteToJSON(filepath.Join(cfg.ReportDir, MetadataFile)); err != nil {
 				t.Errorf("error while writing metadata: %v", err)
 			}
 

--- a/pkg/events/events_test.go
+++ b/pkg/events/events_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"log"
 	"reflect"
 	"testing"
 )
@@ -23,6 +24,7 @@ func TestGetListOfEvents(t *testing.T) {
 			RecordEvent(event)
 		}
 
+		log.Printf("Events:\n%v\n%v", GetListOfEvents(), test.expectedEvents)
 		if !reflect.DeepEqual(GetListOfEvents(), test.expectedEvents) {
 			t.Errorf("The events did not match the expected events for test: %s.", test.name)
 		}


### PR DESCRIPTION
Groundwork required before Prow Jobs PR. We need to write to `metadata.json` as well as `custom-prow-metadata.json`

This will allow a smooth transition to vanilla Prow jobs. 

/assign @meowfaceman 