### PR TITLE
SDCICD-85. Updates for addon test harness work.

### DIFF
--- a/common/e2e.go
+++ b/common/e2e.go
@@ -29,10 +29,6 @@ import (
 )
 
 const (
-	// CustomMetadataFile is the name of the custom metadata file generated for spyglass visualization.
-	CustomMetadataFile string = "custom-prow-metadata.json"
-	MetadataFile       string = "metadata.json"
-
 	// hiveLog is the name of the hive log file.
 	hiveLog string = "hive-log.txt"
 )
@@ -110,11 +106,8 @@ func RunE2ETests(t *testing.T, cfg *config.Config) {
 		}
 
 		if cfg.ReportDir != "" {
-			if err = metadata.Instance.WriteToJSON(filepath.Join(cfg.ReportDir, CustomMetadataFile)); err != nil {
+			if err = metadata.Instance.WriteToJSON(cfg.ReportDir); err != nil {
 				t.Errorf("error while writing the custom metadata: %v", err)
-			}
-			if err = metadata.Instance.WriteToJSON(filepath.Join(cfg.ReportDir, MetadataFile)); err != nil {
-				t.Errorf("error while writing the metadata: %v", err)
 			}
 
 			checkBeforeMetricsGeneration(cfg)

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -4,6 +4,18 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+)
+
+const (
+	// CustomMetadataFile is the name of the custom metadata file generated for spyglass visualization.
+	CustomMetadataFile string = "custom-prow-metadata.json"
+
+	// MetadataFile is the name of the custom metadata file generated for spyglass visualization.
+	MetadataFile string = "metadata.json"
+
+	// AddonMetadataFile he name of the addon metadata file
+	AddonMetadataFile string = "addon-metadata.json"
 )
 
 // Metadata houses the metadata that will be written to the report directory after
@@ -29,13 +41,64 @@ func init() {
 }
 
 // WriteToJSON will marshall the metadata struct and write it into the given file.
-func (m *Metadata) WriteToJSON(outputFilename string) (err error) {
+func (m *Metadata) WriteToJSON(reportDir string) (err error) {
 	var data []byte
 	if data, err = json.Marshal(m); err != nil {
 		return err
 	}
 
-	if err = ioutil.WriteFile(outputFilename, data, os.FileMode(0644)); err != nil {
+	files, err := ioutil.ReadDir(reportDir)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		if file != nil {
+			// This directory name is the name of the current phase we're in, so record it and iterate through these results
+			if file.IsDir() {
+				phase := file.Name()
+				phaseDir := filepath.Join(reportDir, phase)
+				phaseFiles, err := ioutil.ReadDir(phaseDir)
+				if err != nil {
+					return err
+				}
+
+				for _, phaseFile := range phaseFiles {
+					// Process the jUnit XML result files
+					if phaseFile.Name() == AddonMetadataFile {
+						// Unmarshal raw metadata to map
+						var rawMetadataJSON = map[string]interface{}{}
+						if err := json.Unmarshal(data, &rawMetadataJSON); err != nil {
+							return err
+						}
+
+						// Unmarshal addon metadata to map
+						addonData, err := ioutil.ReadFile(filepath.Join(phaseDir, phaseFile.Name()))
+						if err != nil {
+							return err
+						}
+
+						var rawAddonMetadataJSON = map[string]interface{}{}
+						if err := json.Unmarshal(addonData, &rawAddonMetadataJSON); err != nil {
+							return err
+						}
+
+						rawMetadataJSON["addon."+phase] = rawAddonMetadataJSON
+
+						if data, err = json.Marshal(rawMetadataJSON); err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if err = ioutil.WriteFile(filepath.Join(reportDir, CustomMetadataFile), data, os.FileMode(0644)); err != nil {
+		return err
+	}
+
+	if err = ioutil.WriteFile(filepath.Join(reportDir, MetadataFile), data, os.FileMode(0644)); err != nil {
 		return err
 	}
 

--- a/pkg/metadata/metadata_test.go
+++ b/pkg/metadata/metadata_test.go
@@ -73,13 +73,12 @@ func writeAndTestMetadata(m *Metadata, expected map[string]interface{}) (err err
 
 	defer os.RemoveAll(tempDir)
 
-	outputFilename := filepath.Join(tempDir, "test.json")
-	if err = m.WriteToJSON(outputFilename); err != nil {
+	if err = m.WriteToJSON(tempDir); err != nil {
 		return err
 	}
 
 	var data []byte
-	if data, err = ioutil.ReadFile(outputFilename); err != nil {
+	if data, err = ioutil.ReadFile(filepath.Join(tempDir, MetadataFile)); err != nil {
 		return err
 	}
 

--- a/suites/addons/testdata/addon-runner.template
+++ b/suites/addons/testdata/addon-runner.template
@@ -14,8 +14,7 @@ spec:
     spec:
       containers:
       - name: addon-tests
-        image: quay.io/miwilson/addons-osde2e-testing
-        args: [--output-dir, {{.OutputDir}}]
+        image: {{.Image}}
         volumeMounts:
         - mountPath: /test-run-results
           name: test-output


### PR DESCRIPTION
Addon test harnesses were not being properly supplied to the addon
runner template, so this has been corrected. Additionally, addon
metadata is now added to the general metadata object for Spyglass
metadata display. Finally, addon prometheus data will recognize phases
now.
