### PR TITLE
Remove outdated rolebinding

### DIFF
--- a/test/operators/managedvelero.go
+++ b/test/operators/managedvelero.go
@@ -29,7 +29,4 @@ var _ = ginkgo.Describe("[OSD] Managed Velero Operator", func() {
 	checkRoleBindings(h,
 		operatorNamespace,
 		[]string{"managed-velero-operator"})
-	checkRoleBindings(h,
-		"kube-system",
-		[]string{"managed-velero-operator-cluster-config-v1-reader"})
 })


### PR DESCRIPTION
The role and rolebinding for reading cluster-config-v1
is outdated and has been removed from managed-velero-operator.

https://github.com/openshift/managed-velero-operator/pull/35

This commit removes the test that looks for that rolebinding.