### PR TITLE
SDCICD-157. Skip upgrades if the versions are identical.

### DIFF
--- a/common/e2e.go
+++ b/common/e2e.go
@@ -74,6 +74,11 @@ func RunE2ETests(t *testing.T) {
 		if err = ChooseVersions(OSD); err != nil {
 			t.Fatalf("failed to configure versions: %v", err)
 		}
+
+		if state.Upgrade.UpgradeVersionEqualToInstallVersion {
+			log.Printf("Install version and upgrade version are the same. Skipping tests.")
+			return
+		}
 	}
 
 	// setup reporter

--- a/common/version.go
+++ b/common/version.go
@@ -117,13 +117,15 @@ func setupUpgradeVersion(osd *osd.OSD) (err error) {
 		}
 
 		// If the available cluster image set makes sense, then we'll just use that
-		if cisUpgradeVersion.GreaterThan(clusterVersion) {
+		if !cisUpgradeVersion.LessThan(clusterVersion) {
 			log.Printf("Using cluster image set.")
 			state.Upgrade.ReleaseName = cisUpgradeVersionString
 			metadata.Instance.SetUpgradeVersionSource("cluster image set")
+			state.Upgrade.UpgradeVersionEqualToInstallVersion = cisUpgradeVersion.Equal(clusterVersion)
 			log.Printf("Selecting version '%s' to be able to upgrade to '%s'", state.Cluster.Version, state.Upgrade.ReleaseName)
 			return nil
 		}
+
 		if state.Upgrade.ReleaseName != "" {
 			log.Printf("The most recent cluster image set is equal to the default. Falling back to upgrading with Cincinnati.")
 		} else {

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -44,4 +44,7 @@ type UpgradeState struct {
 
 	// Image is the release image a cluster is upgraded to. If set, it overrides the release stream and upgrades.
 	Image string `env:"UPGRADE_IMAGE" sect:"upgrade" yaml:"image"`
+
+	// UpgradeVersionEqualToInstallVersion is true if the install version and upgrade versions are the same.
+	UpgradeVersionEqualToInstallVersion bool
 }


### PR DESCRIPTION
If the upgrade version and install version matches, we should skip the
upgrade.