### PR TITLE
SDCICD-158. Increase health check window.

### DIFF
--- a/pkg/osd/cluster.go
+++ b/pkg/osd/cluster.go
@@ -22,7 +22,7 @@ const (
 	DefaultFlavour = "osd-4"
 
 	// cleanRunWindow is the number of checks made to determine if a cluster is ready.
-	cleanRunWindow = 10
+	cleanRunWindow = 20
 
 	// errorWindow is the number of checks made to determine if a cluster has truly failed.
 	errorWindow = 5


### PR DESCRIPTION
This effecitvely makes the health check window require 10 minutes of
good health instead of 5. This will hopefully allow for OSD operators to
have more time to set up properly and reduce flakes in our builds.