### PR TITLE
SDCICD-160: Add a wait loop to certman tests

### DIFF
--- a/test/operators/certman.go
+++ b/test/operators/certman.go
@@ -1,30 +1,57 @@
 package operators
 
 import (
+	"time"
+
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	osv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/osde2e/pkg/config"
 	"github.com/openshift/osde2e/pkg/helper"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 var _ = ginkgo.Describe("[OSD] Certman Operator", func() {
 	h := helper.New()
 	ginkgo.Context("certificate secret should be applied when cluster installed", func() {
 		var secretName string
+		var secrets *v1.SecretList
+		var err error
+		var apiserver *osv1.APIServer
+
 		ginkgo.It("certificate secret exist under openshift-config namespace", func() {
-			listOpts := metav1.ListOptions{
-				LabelSelector: "certificate_request",
-			}
-			secrets, err := h.Kube().CoreV1().Secrets("openshift-config").List(listOpts)
+			wait.PollImmediate(30*time.Second, 15*time.Minute, func() (bool, error) {
+				listOpts := metav1.ListOptions{
+					LabelSelector: "certificate_request",
+				}
+				secrets, err = h.Kube().CoreV1().Secrets("openshift-config").List(listOpts)
+				if err != nil {
+					return false, err
+				}
+				if len(secrets.Items) < 1 {
+					return false, nil
+				}
+				secretName = secrets.Items[0].Name
+				return true, nil
+			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(secrets.Items)).Should(Equal(1))
-			secretName = secrets.Items[0].Name
 		}, float64(config.Instance.Tests.PollingTimeout))
 
 		ginkgo.It("certificate secret should be applied to apiserver object", func() {
-			getOpts := metav1.GetOptions{}
-			apiserver, err := h.Cfg().ConfigV1().APIServers().Get("cluster", getOpts)
+			wait.PollImmediate(30*time.Second, 15*time.Minute, func() (bool, error) {
+				getOpts := metav1.GetOptions{}
+				apiserver, err = h.Cfg().ConfigV1().APIServers().Get("cluster", getOpts)
+				if err != nil {
+					return false, err
+				}
+				if len(apiserver.Spec.ServingCerts.NamedCertificates) < 1 {
+					return false, nil
+				}
+				return true, nil
+			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(apiserver.Spec.ServingCerts.NamedCertificates)).Should(Equal(1))
 			Expect(apiserver.Spec.ServingCerts.NamedCertificates[0].ServingCertificate.Name).Should(Equal(secretName))


### PR DESCRIPTION
Instead of failing immediately, we should give the certman operator a minimum of 15 minutes to provision certs per the [docs](https://github.com/openshift/certman-operator#how-the-certman-operator-works)

