### PR TITLE
SDCICD-161. Fix cluster image set upgrade logic.

### DIFF
--- a/common/e2e.go
+++ b/common/e2e.go
@@ -93,7 +93,7 @@ func RunE2ETests(t *testing.T) {
 		runTestsInPhase(t, "install", "OSD e2e suite")
 
 		// upgrade cluster if requested
-		if state.Upgrade.Image != "" || cfg.Upgrade.ReleaseStream != "" {
+		if state.Upgrade.Image != "" || state.Upgrade.ReleaseName != "" {
 			if state.Kubeconfig.Contents != nil {
 				if err = upgrade.RunUpgrade(OSD); err != nil {
 					events.RecordEvent(events.UpgradeFailed)


### PR DESCRIPTION
Cluster image set upgrades were not behaving as expected due to the
logic surrounding whether to run an upgrade and upgrade tests. It now
simply tests if the release name has been set.