### PR TITLE
Add test to verify volume expansion

### DIFF
--- a/test/verify/storage.go
+++ b/test/verify/storage.go
@@ -1,0 +1,25 @@
+package verify
+
+import (
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/osde2e/pkg/helper"
+)
+
+var _ = ginkgo.Describe("Storage", func() {
+	h := helper.New()
+
+	ginkgo.It("should be able to be expanded", func() {
+		scList, err := h.Kube().StorageV1().StorageClasses().List(metav1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred(), "couldn't list StorageClasses")
+		Expect(scList).NotTo(BeNil())
+
+		for _, sc := range scList.Items {
+			Expect(*sc.AllowVolumeExpansion).To(BeTrue())
+		}
+
+	}, 300)
+})


### PR DESCRIPTION
Adding a test to verify volume expansion is set correctly as per: https://issues.redhat.com/browse/OSD-2390

During an upgrade [a bug](.https://bugzilla.redhat.com/show_bug.cgi?id=1751641) was introduced where `AllowVolumeExpansion` was unset. This test verifies this value is true on all StorageClasses.