### PR TITLE
SDCICD-171. Use composable configs instead of separate exeuction paths.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,7 @@
 .PHONY: check generate build-image push-image push-latest test
 
 PKG := github.com/openshift/osde2e
-ADDONS_PKG := $(PKG)/suites/addons
-E2E_PKG := $(PKG)/suites/e2e
-SCALE_PKG := $(PKG)/suites/scale
 DOC_PKG := $(PKG)/cmd/osde2e-docs
-MIDDLE_IMAGESETS_PKG := $(PKG)/suites/middleclusterimageset
-OLDEST_IMAGESETS_PKG := $(PKG)/suites/oldestclusterimageset
 
 DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
@@ -43,19 +38,19 @@ build:
 	CGO_ENABLED=0 go test ./suites/scale -v -c -o ./out/osde2e-scale
 
 test:
-	go test $(E2E_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -e2e-config=$(E2ECONFIG)
+	go test -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -configs=e2e-suite -custom-config=$(CUSTOM_CONFIG)
 
 test-scale:
-	go test $(SCALE_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)"  -test.timeout 8h -test.run TestScale -e2e-config=$(E2ECONFIG)
+	go test -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -configs=scale-suite -custom-config=$(CUSTOM_CONFIG)
 
 test-addons:
-	go test $(ADDONS_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)"  -test.timeout 8h -test.run TestAddons -e2e-config=$(E2ECONFIG)
+	go test -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -configs=addon-suite -custom-config=$(CUSTOM_CONFIG)
 
 test-middle-imageset:
-	go test $(MIDDLE_IMAGESETS_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -test.run TestMiddleImageSet -e2e-config=$(E2ECONFIG)
+	go test -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -configs=e2e-suite,use-middle-version -custom-config=$(CUSTOM_CONFIG)
 
 test-oldest-imageset:
-	go test $(OLDEST_IMAGESETS_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)"  -test.timeout 8h -test.run TestOldestImageSet -e2e-config=$(E2ECONFIG)
+	go test -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -configs=e2e-suite,use-oldest-version -custom-config=$(CUSTOM_CONFIG)
 
 test-docker:
 	$(CONTAINER_ENGINE) run \

--- a/common/version.go
+++ b/common/version.go
@@ -42,8 +42,8 @@ func setupVersion(osd *osd.OSD) (err error) {
 	state := state.Instance
 	suffix := ""
 
-	if len(state.Cluster.Version) == 0 && (cfg.Upgrade.MajorTarget != 0 || cfg.Upgrade.MinorTarget != 0) {
-		majorTarget := cfg.Upgrade.MajorTarget
+	if len(state.Cluster.Version) == 0 && (cfg.Cluster.MajorTarget != 0 || cfg.Cluster.MinorTarget != 0) {
+		majorTarget := cfg.Cluster.MajorTarget
 		// don't require major to be set
 		if majorTarget == 0 {
 			majorTarget = -1
@@ -54,7 +54,7 @@ func setupVersion(osd *osd.OSD) (err error) {
 		}
 
 		// look for the latest release and install it for this OSD cluster.
-		if state.Cluster.Version, err = osd.LatestVersion(majorTarget, cfg.Upgrade.MinorTarget, suffix); err == nil {
+		if state.Cluster.Version, err = osd.LatestVersion(majorTarget, cfg.Cluster.MinorTarget, suffix); err == nil {
 			log.Printf("CLUSTER_VERSION not set but a TARGET is, running '%s'", state.Cluster.Version)
 		}
 	}
@@ -62,9 +62,15 @@ func setupVersion(osd *osd.OSD) (err error) {
 	if len(state.Cluster.Version) == 0 {
 		var err error
 		var versionType string
-		if cfg.Upgrade.UseLatestVersionForInstall {
+		if cfg.Cluster.UseLatestVersionForInstall {
 			state.Cluster.Version, err = osd.LatestVersion(-1, -1, "")
 			versionType = "latest version"
+		} else if cfg.Cluster.UseMiddleClusterImageSetForInstall {
+			state.Cluster.Version, err = osd.MiddleVersion()
+			versionType = "middle version"
+		} else if cfg.Cluster.UseOldestClusterImageSetForInstall {
+			state.Cluster.Version, err = osd.OldestVersion()
+			versionType = "oldest version"
 		} else {
 			state.Cluster.Version, err = osd.DefaultVersion()
 			versionType = "current default"

--- a/configs/addon-suite.yaml
+++ b/configs/addon-suite.yaml
@@ -1,0 +1,3 @@
+tests:
+  testsToRun:
+  - '[Suite: addons]'

--- a/configs/conformance-suite.yaml
+++ b/configs/conformance-suite.yaml
@@ -1,0 +1,3 @@
+tests:
+  testsToRun:
+  - '[Suite: conformance]'

--- a/configs/dry-run.yaml
+++ b/configs/dry-run.yaml
@@ -1,0 +1,1 @@
+dryRun: true

--- a/configs/e2e-suite.yaml
+++ b/configs/e2e-suite.yaml
@@ -1,0 +1,4 @@
+tests:
+  testsToRun:
+  - '[Suite: e2e]'
+  - '[Suite: operators]'

--- a/configs/int.yaml
+++ b/configs/int.yaml
@@ -1,0 +1,2 @@
+ocm:
+  env: int

--- a/configs/prod.yaml
+++ b/configs/prod.yaml
@@ -1,0 +1,2 @@
+ocm:
+  env: prod

--- a/configs/scale-suite.yaml
+++ b/configs/scale-suite.yaml
@@ -1,0 +1,3 @@
+tests:
+  testsToRun:
+  - '[Suite: scale]'

--- a/configs/skip-health-checks.yaml
+++ b/configs/skip-health-checks.yaml
@@ -1,0 +1,2 @@
+tests:
+  skipClusterHealthChecks: true

--- a/configs/stage.yaml
+++ b/configs/stage.yaml
@@ -1,0 +1,2 @@
+ocm:
+  env: stage

--- a/configs/use-middle-version.yaml
+++ b/configs/use-middle-version.yaml
@@ -1,0 +1,2 @@
+cluster:
+  useMiddleClusterVersionForInstall: true

--- a/configs/use-oldest-version.yaml
+++ b/configs/use-oldest-version.yaml
@@ -1,0 +1,2 @@
+cluster:
+  useOldestClusterVersionForInstall: true

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -1,4 +1,4 @@
-package osde2e_test
+package osde2e
 
 import (
 	"testing"
@@ -6,8 +6,10 @@ import (
 	"github.com/openshift/osde2e/common"
 
 	// import suites to be tested
+	_ "github.com/openshift/osde2e/test/addons"
 	_ "github.com/openshift/osde2e/test/openshift"
 	_ "github.com/openshift/osde2e/test/operators"
+	_ "github.com/openshift/osde2e/test/scale"
 	_ "github.com/openshift/osde2e/test/state"
 	_ "github.com/openshift/osde2e/test/verify"
 	_ "github.com/openshift/osde2e/test/workloads/guestbook"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,15 +58,6 @@ type UpgradeConfig struct {
 	// UpgradeToCISIfPossible will upgrade to the most recent cluster image set if it's newer than the install version
 	UpgradeToCISIfPossible bool `env:"UPGRADE_TO_CIS_IF_POSSIBLE" sect:"version" default:"false" yaml:"upgradeToCISIfPossible"`
 
-	// UseLatestVersionForInstall will select the latest cluster image set available for a fresh install.
-	UseLatestVersionForInstall bool `env:"USE_LATEST_VERSION_FOR_INSTALL" sect:"version" default:"false" yaml:"useLatestVersionForInstall"`
-
-	// MajorTarget is the major version to target. If specified, it is used in version selection.
-	MajorTarget int64 `env:"MAJOR_TARGET" sect:"version" yaml:"majorTarget"`
-
-	// MinorTarget is the minor version to target. If specified, it is used in version selection.
-	MinorTarget int64 `env:"MINOR_TARGET" sect:"version" yaml:"minorTarget"`
-
 	// ReleaseStream used to retrieve latest release images. If set, it will be used to perform an upgrade.
 	ReleaseStream string `env:"UPGRADE_RELEASE_STREAM" sect:"upgrade" yaml:"releaseStream"`
 }
@@ -76,8 +67,8 @@ type ClusterConfig struct {
 	// MultiAZ deploys a cluster across multiple availability zones.
 	MultiAZ bool `env:"MULTI_AZ" sect:"cluster" default:"false" yaml:"multiAZ"`
 
-	// DestroyClusterAfterTest set to false if you want to keep the cluster after the test completes.
-	DestroyAfterTest bool `env:"DESTROY_CLUSTER" sect:"cluster" default:"true" yaml:"destroyAfterTest"`
+	// DestroyClusterAfterTest set to true if you want to the cluster to be explicitly deleted after the test.
+	DestroyAfterTest bool `env:"DESTROY_CLUSTER" sect:"cluster" default:"false" yaml:"destroyAfterTest"`
 
 	// ExpiryInMinutes is how long before a cluster expires and is deleted by OSD.
 	ExpiryInMinutes int64 `env:"CLUSTER_EXPIRY_IN_MINUTES" sect:"cluster" default:"210" yaml:"expiryInMinutes"`
@@ -87,6 +78,21 @@ type ClusterConfig struct {
 
 	// InstallTimeout is how long to wait before failing a cluster launch.
 	InstallTimeout int64 `env:"CLUSTER_UP_TIMEOUT" sect:"environment" default:"135" yaml:"installTimeout"`
+
+	// UseLatestVersionForInstall will select the latest cluster image set available for a fresh install.
+	UseLatestVersionForInstall bool `env:"USE_LATEST_VERSION_FOR_INSTALL" sect:"version" default:"false" yaml:"useLatestVersionForInstall"`
+
+	// UseMiddleClusterImageSetForInstall will select the cluster image set that is in the middle of the list of ordered cluster versions known to OCM.
+	UseMiddleClusterImageSetForInstall bool `env:"USE_MIDDLE_CLUSTER_IMAGE_SET_FOR_INSTALL" sect:"version" default:"false" yaml:"useMiddleClusterVersionForInstall"`
+
+	// UseOldestClusterImageSetForInstall will select the cluster image set that is in the end of the list of ordered cluster versions known to OCM.
+	UseOldestClusterImageSetForInstall bool `env:"USE_OLDEST_CLUSTER_IMAGE_SET_FOR_INSTALL" sect:"version" default:"false" yaml:"useOldestClusterVersionForInstall"`
+
+	// MajorTarget is the major version to target. If specified, it is used in version selection.
+	MajorTarget int64 `env:"MAJOR_TARGET" sect:"version" yaml:"majorTarget"`
+
+	// MinorTarget is the minor version to target. If specified, it is used in version selection.
+	MinorTarget int64 `env:"MINOR_TARGET" sect:"version" yaml:"minorTarget"`
 }
 
 // AddonConfig options for addon testing
@@ -108,6 +114,12 @@ type TestConfig struct {
 
 	// GinkgoFocus is a regex passed to Ginkgo that focus on any test suites matching the regex. ex. "Operator"
 	GinkgoFocus string `env:"GINKGO_FOCUS" sect:"tests" yaml:"focus"`
+
+	// TestsToRun is a list of files which should be executed as part of a test suite
+	TestsToRun []string `env:"TESTS_TO_RUN" sect:"tests" yaml:"testsToRun"`
+
+	// SuppressSkipNotifications suppresses the notifications of skipped tests
+	SuppressSkipNotifications bool `env:"SUPPRESS_SKIP_NOTIFICATIONS" sect:"tests" default:"true" yaml:"suppressSkipNotifications"`
 
 	// CleanRuns is the number of times the test-version is run before skipping.
 	CleanRuns int `env:"CLEAN_RUNS" sect:"tests" yaml:"cleanRuns"`

--- a/pkg/osd/versions.go
+++ b/pkg/osd/versions.go
@@ -82,6 +82,34 @@ func (u *OSD) LatestVersion(major, minor int64, suffix string) (string, error) {
 	return VersionPrefix + latest.Original(), nil
 }
 
+// MiddleVersion gets the middle version in the ordered list of cluster image sets known to OCM.
+func (u *OSD) MiddleVersion() (string, error) {
+	versionList, err := u.EnabledNoDefaultVersionList()
+	if err != nil {
+		return "", err
+	}
+
+	if len(versionList) <= 1 {
+		return "", fmt.Errorf("there are not enough versions known to OCM to select a middle version")
+	}
+
+	return versionList[len(versionList)/2], nil
+}
+
+// OldestVersion gets the middle version in the ordered list of cluster image sets known to OCM.
+func (u *OSD) OldestVersion() (string, error) {
+	versionList, err := u.EnabledNoDefaultVersionList()
+	if err != nil {
+		return "", err
+	}
+
+	if len(versionList) <= 1 {
+		return "", fmt.Errorf("there are not enough versions known to OCM to select an oldest version")
+	}
+
+	return versionList[0], nil
+}
+
 // EnabledNoDefaultVersionList returns a sorted list of the enabled but not default versions currently offered by OSD.
 func (u *OSD) EnabledNoDefaultVersionList() ([]string, error) {
 	semverVersions, err := u.getSemverList(-1, -1, "")

--- a/test/addons/addon_test_harness.go
+++ b/test/addons/addon_test_harness.go
@@ -36,14 +36,14 @@ func init() {
 
 }
 
-var _ = ginkgo.Describe("Addon Test Harness", func() {
+var _ = ginkgo.Describe("[Suite: addons] Addon Test Harness", func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 
 	for _, harness := range config.Instance.Addons.TestHarnesses {
 		if harness != "" {
 			addonTimeoutInSeconds := 3600
-			ginkgo.It("should run until completion", func() {
+			ginkgo.It(harness+" should run until completion", func() {
 				// configure tests
 				// setup runner
 				r := h.RunnerWithNoCommand()

--- a/test/openshift/openshift.go
+++ b/test/openshift/openshift.go
@@ -19,7 +19,7 @@ var DefaultE2EConfig = E2EConfig{
 	},
 }
 
-var _ = ginkgo.Describe("OpenShift E2E", func() {
+var _ = ginkgo.Describe("[Suite: conformance] OpenShift E2E", func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/test/operators/certman.go
+++ b/test/operators/certman.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-var _ = ginkgo.Describe("[OSD] Certman Operator", func() {
+var _ = ginkgo.Describe("[Suite: operators] [OSD] Certman Operator", func() {
 	h := helper.New()
 	ginkgo.Context("certificate secret should be applied when cluster installed", func() {
 		var secretName string

--- a/test/operators/configurealertmanager.go
+++ b/test/operators/configurealertmanager.go
@@ -5,7 +5,7 @@ import (
 	"github.com/openshift/osde2e/pkg/helper"
 )
 
-var _ = ginkgo.Describe("[OSD] Configure AlertManager Operator", func() {
+var _ = ginkgo.Describe("[Suite: operators] [OSD] Configure AlertManager Operator", func() {
 	var operatorName = "configure-alertmanager-operator"
 	var operatorNamespace string = "openshift-monitoring"
 	var operatorLockFile string = "configure-alertmanager-operator-lock"

--- a/test/operators/curator.go
+++ b/test/operators/curator.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var _ = ginkgo.Describe("[OSD] Curator Operator", func() {
+var _ = ginkgo.Describe("[Suite: operators] [OSD] Curator Operator", func() {
 	h := helper.New()
 	ginkgo.Context("operator source should be curated", func() {
 

--- a/test/operators/managedvelero.go
+++ b/test/operators/managedvelero.go
@@ -5,7 +5,7 @@ import (
 	"github.com/openshift/osde2e/pkg/helper"
 )
 
-var _ = ginkgo.Describe("[OSD] Managed Velero Operator", func() {
+var _ = ginkgo.Describe("[Suite: operators] [OSD] Managed Velero Operator", func() {
 	var operatorName = "managed-velero-operator"
 	var operatorNamespace string = "openshift-velero"
 	var operatorLockFile string = "managed-velero-operator-lock"

--- a/test/operators/prunejob.go
+++ b/test/operators/prunejob.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
-var _ = ginkgo.Describe("[OSD] Prune jobs", func() {
+var _ = ginkgo.Describe("[Suite: operators] [OSD] Prune jobs", func() {
 	h := helper.New()
 	ginkgo.Context("pruner jobs should works", func() {
 		namespace := "openshift-sre-pruning"

--- a/test/scale/nodevertical.go
+++ b/test/scale/nodevertical.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/osde2e/pkg/helper"
 )
 
-var _ = ginkgo.Describe("Scaling", func() {
+var _ = ginkgo.Describe("[Suite: scale] Scaling", func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/test/state/mustgather.go
+++ b/test/state/mustgather.go
@@ -13,7 +13,7 @@ var (
 	mustGatherCmd = "oc adm must-gather --dest-dir=" + runner.DefaultRunner.OutputDir
 )
 
-var _ = ginkgo.Describe("Cluster state", func() {
+var _ = ginkgo.Describe("[Suite: e2e] Cluster state", func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/test/state/prometheus.go
+++ b/test/state/prometheus.go
@@ -13,7 +13,7 @@ const (
 	promCollectCmd = "oc exec -n openshift-monitoring prometheus-k8s-0 -c prometheus -- tar cvzO -C /prometheus ."
 )
 
-var _ = ginkgo.Describe("Cluster state", func() {
+var _ = ginkgo.Describe("[Suite: e2e] Cluster state", func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/test/state/state.go
+++ b/test/state/state.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openshift/osde2e/pkg/helper"
 )
 
-var _ = ginkgo.Describe("Cluster state", func() {
+var _ = ginkgo.Describe("[Suite: e2e] Cluster state", func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/test/verify/imagestreams.go
+++ b/test/verify/imagestreams.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift/osde2e/pkg/helper"
 )
 
-var _ = ginkgo.Describe("ImageStreams", func() {
+var _ = ginkgo.Describe("[Suite: e2e] ImageStreams", func() {
 	h := helper.New()
 
 	ginkgo.It("should exist in the cluster", func() {

--- a/test/verify/pods.go
+++ b/test/verify/pods.go
@@ -8,14 +8,14 @@ import (
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/osde2e/pkg/helper"
 )
 
-var _ = ginkgo.Describe("Pods", func() {
+var _ = ginkgo.Describe("[Suite: e2e] Pods", func() {
 	h := helper.New()
 
 	ginkgo.It("should be Running or Succeeded", func() {

--- a/test/verify/projects.go
+++ b/test/verify/projects.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/osde2e/pkg/helper"
 )
 
-var _ = ginkgo.Describe("Projects", func() {
+var _ = ginkgo.Describe("[Suite: e2e] Projects", func() {
 	h := helper.New()
 
 	ginkgo.It("Empty Project should be created", func() {

--- a/test/verify/routes.go
+++ b/test/verify/routes.go
@@ -8,7 +8,7 @@ import (
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/openshift/api/route/v1"
+	v1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/osde2e/pkg/helper"
@@ -19,7 +19,7 @@ const (
 	consoleLabel     = "console"
 )
 
-var _ = ginkgo.Describe("Routes", func() {
+var _ = ginkgo.Describe("[Suite: e2e] Routes", func() {
 	h := helper.New()
 
 	ginkgo.It("should be created for Console", func() {

--- a/test/verify/storage.go
+++ b/test/verify/storage.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift/osde2e/pkg/helper"
 )
 
-var _ = ginkgo.Describe("Storage", func() {
+var _ = ginkgo.Describe("[Suite: e2e] Storage", func() {
 	h := helper.New()
 
 	ginkgo.It("should be able to be expanded", func() {

--- a/test/workloads/guestbook/guestbook.go
+++ b/test/workloads/guestbook/guestbook.go
@@ -19,7 +19,7 @@ var testDir = "/artifacts/workloads/e2e/guestbook"
 // Use the base folder name for the workload name. Make it easy!
 var workloadName = filepath.Base(testDir)
 
-var _ = ginkgo.Describe("Workload ("+workloadName+")", func() {
+var _ = ginkgo.Describe("[Suite: e2e] Workload ("+workloadName+")", func() {
 	defer ginkgo.GinkgoRecover()
 	// setup helper
 	h := &helper.H{


### PR DESCRIPTION
Rather than use separate exeuction paths, osde2e now has composable
configs using multiple baked in config objects.

Users can now specify CONFIGS=config1,config2,config3 and osde2e will
attempt to load those configs from the new /configs directory in the
repository. Users can still specify environment variables and can still
use a custom yaml config. The custom yaml config now uses the config
option setting -custom-config rather than -e2e-config.

Additionally, the config and state objects have been lightly refactored
and the middle/oldest cluster image set object has been migrated into
the version.go code.