### PR TITLE
Add PagerDuty e2e test and fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN go mod download
 
 # compile test binary
 COPY . .
+RUN go mod vendor
 RUN make check
 RUN make build
 

--- a/test/operators/pagerduty.go
+++ b/test/operators/pagerduty.go
@@ -1,0 +1,16 @@
+package operators
+
+import (
+	"github.com/onsi/ginkgo"
+	"github.com/openshift/osde2e/pkg/helper"
+)
+
+var _ = ginkgo.Describe("[OSD] Pagerduty Operator", func() {
+	h := helper.New()
+	var secrets = []string{
+		"pd-secret",
+	}
+	var namespace string = "openshift-monitoring"
+	// Check if pd-secret exists under openshift-monitoring ns
+	checkSecrets(h, namespace, secrets)
+})

--- a/test/operators/pagerduty.go
+++ b/test/operators/pagerduty.go
@@ -5,7 +5,7 @@ import (
 	"github.com/openshift/osde2e/pkg/helper"
 )
 
-var _ = ginkgo.Describe("[OSD] Pagerduty Operator", func() {
+var _ = ginkgo.Describe("[Suite: operators] [OSD] Pagerduty Operator", func() {
 	h := helper.New()
 	var secrets = []string{
 		"pd-secret",


### PR DESCRIPTION
Testing if the secrets exist in the target cluster after installation.
Also added `RUN go mod vendor` in the `dockerfile` to fix the image build which was failing.