### PR TITLE
Added DeadMansSnitch operator test case

### DIFF
--- a/test/operators/deadmanssnitch.go
+++ b/test/operators/deadmanssnitch.go
@@ -1,0 +1,17 @@
+package operators
+
+import (
+	"github.com/onsi/ginkgo"
+	"github.com/openshift/osde2e/pkg/helper"
+)
+
+var _ = ginkgo.Describe("[Suite: operators] [OSD] DeadMansSnitch Operator", func() {
+
+	var namespace = "openshift-monitoring"
+	var secrets = []string{
+		"dms-secret",
+	}
+
+	h := helper.New()
+	checkSecrets(h, namespace, secrets)
+})


### PR DESCRIPTION
OSD-2455 concerns the validation of the behaviour of the Hive deadmanssnitch operator to successfully install a secret on a target OSD cluster. This PR adds a test case to verify that the DeadMansSnitch secret has been successfully installed on the target cluster.