### PR TITLE
SDCICD-159: Start generating metrics based on logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,19 +39,19 @@ build:
 	CGO_ENABLED=0 go test ./suites/scale -v -c -o ./out/osde2e-scale
 
 test:
-	go test $(RUNNER_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -configs=e2e-suite -custom-config=$(CUSTOM_CONFIG)
+	go test $(RUNNER_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -configs=e2e-suite,log-metrics -custom-config=$(CUSTOM_CONFIG)
 
 test-scale:
-	go test $(RUNNER_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -configs=scale-suite -custom-config=$(CUSTOM_CONFIG)
+	go test $(RUNNER_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -configs=scale-suite,log-metrics -custom-config=$(CUSTOM_CONFIG)
 
 test-addons:
-	go test $(RUNNER_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -configs=addon-suite -custom-config=$(CUSTOM_CONFIG)
+	go test $(RUNNER_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -configs=addon-suite,log-metrics -custom-config=$(CUSTOM_CONFIG)
 
 test-middle-imageset:
-	go test $(RUNNER_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -configs=e2e-suite,use-middle-version -custom-config=$(CUSTOM_CONFIG)
+	go test $(RUNNER_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -configs=e2e-suite,use-middle-version,log-metrics -custom-config=$(CUSTOM_CONFIG)
 
 test-oldest-imageset:
-	go test $(RUNNER_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -configs=e2e-suite,use-oldest-version -custom-config=$(CUSTOM_CONFIG)
+	go test $(RUNNER_PKG) -test.v -ginkgo.skip="$(GINKGO_SKIP)" -ginkgo.focus="$(GINKGO_FOCUS)" -test.timeout 8h -configs=e2e-suite,use-oldest-version,log-metrics -custom-config=$(CUSTOM_CONFIG)
 
 test-docker:
 	$(CONTAINER_ENGINE) run \

--- a/configs/log-metrics.yaml
+++ b/configs/log-metrics.yaml
@@ -1,0 +1,6 @@
+logMetrics:
+  cluster-mgmt-500: "CLUSTERS-MGMT-500"
+  access-token-500: "can't get access token: token response status is: 500 Internal Server Error"
+  eof: "EOF"
+  cluster-pending: "Cluster is not ready, current status 'pending'"
+  host-dns-lookup: "dial tcp: lookup api\\.ci-cluster.* no such host occurred"

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -223,13 +223,15 @@ func runTestsInPhase(t *testing.T, phase string, description string) bool {
 	}
 
 	for _, file := range files {
+		//log.Printf("Parsing log metrics in %s", filepath.Join(cfg.ReportDir, file.Name()))
 		if logFileRegex.MatchString(file.Name()) {
 			data, err := ioutil.ReadFile(filepath.Join(cfg.ReportDir, file.Name()))
 			if err != nil {
 				t.Fatalf("error opening log file %s: %s", file.Name(), err.Error())
 			}
 			for name, matchRegex := range logMetricsRegexs {
-				matches := matchRegex.Find(data)
+				matches := matchRegex.FindAll(data, -1)
+				//log.Printf("-- Found %d matches for %s", len(matches), name)
 				metadata.Instance.IncrementLogMetric(name, len(matches))
 			}
 		}


### PR DESCRIPTION
Starting metric generation using five basic but frequently-occurring errors observed.

One note: These metrics do not need to be negative or error metrics: We can generate positive metrics, or whatever we want. 