### PR TITLE
SDCICD-182. Make sure the out directory is created before building.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ push-latest:
 	@$(CONTAINER_ENGINE) --config=$(DOCKER_CONF) push "$(IMAGE_NAME):latest"
 
 build:
+	mkdir -p "$(OUT_DIR)"
 	go build -o "$(OUT_DIR)" "$(DIR)cmd/..."
 
 test: build


### PR DESCRIPTION
The out directory is now created when building the osde2e binary.