### PR TITLE
SDCICD-20. Fix failing scale tests.

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -107,7 +107,7 @@ type AddonConfig struct {
 
 // ScaleConfig options for scale testing
 type ScaleConfig struct {
-	WorkloadsRepository string `env:"WORKLOADS_REPO" sect:"scale" default:"https://github.com/openshift-scale/workloads.git" yaml:"workloadsRepository"`
+	WorkloadsRepository string `env:"WORKLOADS_REPO" sect:"scale" default:"https://github.com/openshift-scale/workloads" yaml:"workloadsRepository"`
 
 	WorkloadsRepositoryBranch string `env:"WORKLOADS_REPO_BRANCH" sect:"scale" default:"master" yaml:"workloadsRepositoryBranch"`
 

--- a/pkg/e2e/scale/scale.go
+++ b/pkg/e2e/scale/scale.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"sync"
 	"text/template"
 
 	"github.com/markbates/pkger"
@@ -25,18 +26,11 @@ const (
 )
 
 var (
-	// scaleRepos are the default repos cloned with scale tests.
-	scaleRepos = runner.Repos{
-		{
-			Name:      "workloads",
-			URL:       config.Instance.Scale.WorkloadsRepository,
-			MountPath: WorkloadsPath,
-			Branch:    config.Instance.Scale.WorkloadsRepositoryBranch,
-		},
-	}
-
 	scaleRunnerCmdTpl *template.Template
 )
+
+var once sync.Once = sync.Once{}
+var scaleRepos runner.Repos
 
 type scaleRunnerConfig struct {
 	Name             string
@@ -66,6 +60,18 @@ func init() {
 
 // Runner returns a runner with a base config for scale tests.
 func (sCfg scaleRunnerConfig) Runner(h *helper.H) *runner.Runner {
+	once.Do(func() {
+		// scaleRepos are the default repos cloned with scale tests.
+		scaleRepos = runner.Repos{
+			{
+				Name:      "workloads",
+				URL:       config.Instance.Scale.WorkloadsRepository,
+				MountPath: WorkloadsPath,
+				Branch:    config.Instance.Scale.WorkloadsRepositoryBranch,
+			},
+		}
+	})
+
 	// template command from config
 	sCfg.Name = "scale-" + sCfg.Name
 	sCfg.WorkloadsPath = WorkloadsPath


### PR DESCRIPTION
Scale tests were failing because the execution order of configuration
value loading has changed, making the init() call in scale.go execute
prior to loading any configuration values. This has been fixed.