### PR TITLE
SDCICD-173. Bugfixes for the gate-report.sh script.

### DIFF
--- a/scripts/gate-report.sh
+++ b/scripts/gate-report.sh
@@ -33,8 +33,10 @@ if ! aws s3 ls s3://$METRICS_BUCKET 2>&1 > /dev/null ; then
 	exit 1
 fi
 
-REPORT_FILE="$REPORT_DIR/$ENVIRONMENT-$VERSION-report.json"
+REPORT_FILE="$ENVIRONMENT-$VERSION-report.json"
 
-osde2e gate -output "$REPORT_FILE" "$ENVIRONMENT" "$VERSION"
+set +e
+osde2e gate-report -output "$REPORT_DIR/$REPORT_FILE" "$ENVIRONMENT" "$VERSION"
+set -e
 
-aws s3 cp "$REPORT_FILE" "s3://$METRICS_BUCKET/$GATE_REPORT/$REPORT_FILE"
+aws s3 cp "$REPORT_DIR/$REPORT_FILE" "s3://$METRICS_BUCKET/$GATE_REPORT/$REPORT_FILE"


### PR DESCRIPTION
The report name for the generated gate report was interpolated
incorrectly. Additionally, if a report that was not viable was
generated, it would fail the report generation, which was not intended.