### PR TITLE
SDCICD-194. Exit gracefully for middle/oldest imageset tests.

### DIFF
--- a/pkg/common/osd/versions.go
+++ b/pkg/common/osd/versions.go
@@ -82,32 +82,32 @@ func (u *OSD) LatestVersion(major, minor int64, suffix string) (string, error) {
 	return VersionPrefix + latest.Original(), nil
 }
 
-// MiddleVersion gets the middle version in the ordered list of cluster image sets known to OCM.
-func (u *OSD) MiddleVersion() (string, error) {
+// MiddleVersion gets the middle version in the ordered list of cluster image sets known to OCM. It will also return true if there were enough versions to select from.
+func (u *OSD) MiddleVersion() (string, bool, error) {
 	versionList, err := u.EnabledNoDefaultVersionList()
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
 	if len(versionList) <= 1 {
-		return "", fmt.Errorf("there are not enough versions known to OCM to select a middle version")
+		return "", false, nil
 	}
 
-	return versionList[len(versionList)/2], nil
+	return versionList[len(versionList)/2], true, nil
 }
 
-// OldestVersion gets the middle version in the ordered list of cluster image sets known to OCM.
-func (u *OSD) OldestVersion() (string, error) {
+// OldestVersion gets the middle version in the ordered list of cluster image sets known to OCM. It will also return true if there were enough versions to select from.
+func (u *OSD) OldestVersion() (string, bool, error) {
 	versionList, err := u.EnabledNoDefaultVersionList()
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
 	if len(versionList) <= 1 {
-		return "", fmt.Errorf("there are not enough versions known to OCM to select an oldest version")
+		return "", false, nil
 	}
 
-	return versionList[0], nil
+	return versionList[0], true, nil
 }
 
 // EnabledNoDefaultVersionList returns a sorted list of the enabled but not default versions currently offered by OSD.

--- a/pkg/common/state/state.go
+++ b/pkg/common/state/state.go
@@ -29,6 +29,9 @@ type ClusterState struct {
 
 	// Version is the version of the cluster being deployed.
 	Version string `json:"cluster_version,omitempty" env:"CLUSTER_VERSION" sect:"version"  yaml:"version"`
+
+	// EnoughVersionsForOldestOrMiddleTest is true if there were enough versions for an older/middle test.
+	EnoughVersionsForOldestOrMiddleTest bool `default:"true"`
 }
 
 // KubeconfigState stores information required to talk to the Kube API

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -89,6 +89,11 @@ func runGinkgoTests() error {
 			return fmt.Errorf("failed to configure versions: %v", err)
 		}
 
+		if !state.Cluster.EnoughVersionsForOldestOrMiddleTest {
+			log.Printf("There were not enough available cluster image sets to choose and oldest or middle cluster image set to test against. Skipping tests.")
+			return nil
+		}
+
 		if state.Upgrade.UpgradeVersionEqualToInstallVersion {
 			log.Printf("Install version and upgrade version are the same. Skipping tests.")
 			return nil

--- a/pkg/e2e/version.go
+++ b/pkg/e2e/version.go
@@ -67,10 +67,10 @@ func setupVersion(osd *osd.OSD) (err error) {
 			state.Cluster.Version, err = osd.LatestVersion(-1, -1, "")
 			versionType = "latest version"
 		} else if cfg.Cluster.UseMiddleClusterImageSetForInstall {
-			state.Cluster.Version, err = osd.MiddleVersion()
+			state.Cluster.Version, state.Cluster.EnoughVersionsForOldestOrMiddleTest, err = osd.MiddleVersion()
 			versionType = "middle version"
 		} else if cfg.Cluster.UseOldestClusterImageSetForInstall {
-			state.Cluster.Version, err = osd.OldestVersion()
+			state.Cluster.Version, state.Cluster.EnoughVersionsForOldestOrMiddleTest, err = osd.OldestVersion()
 			versionType = "oldest version"
 		} else {
 			state.Cluster.Version, err = osd.DefaultVersion()
@@ -78,7 +78,11 @@ func setupVersion(osd *osd.OSD) (err error) {
 		}
 
 		if err == nil {
-			log.Printf("CLUSTER_VERSION not set, using the %s '%s'", versionType, state.Cluster.Version)
+			if state.Cluster.EnoughVersionsForOldestOrMiddleTest {
+				log.Printf("CLUSTER_VERSION not set, using the %s '%s'", versionType, state.Cluster.Version)
+			} else {
+				log.Printf("Unable to get the %s.", versionType)
+			}
 		} else {
 			return fmt.Errorf("Error finding default cluster version: %v", err)
 		}


### PR DESCRIPTION
If a version cannot be found for the middle/oldest imageset test, we
should exit gracefully instead of failing.