### PR TITLE
SDCICD-174. Scripts should always grab the most recent image.

### DIFF
--- a/scripts/gate-report-analysis.sh
+++ b/scripts/gate-report-analysis.sh
@@ -36,4 +36,5 @@ REPORT_FILE="$ENVIRONMENT-$VERSION-report.json"
 
 aws s3 cp "s3://$METRICS_BUCKET/$GATE_REPORT/$REPORT_FILE" "$REPORT_DIR/$REPORT_FILE"
 
+docker pull quay.io/app-sre/osde2e
 docker run -v "$REPORT_DIR:/report-input" quay.io/app-sre/osde2e gate-report-analysis "/report-input/$REPORT_FILE"

--- a/scripts/gate-report.sh
+++ b/scripts/gate-report.sh
@@ -33,6 +33,7 @@ fi
 
 REPORT_FILE="$ENVIRONMENT-$VERSION-report.json"
 
+docker pull quay.io/app-sre/osde2e
 docker run -e PROMETHEUS_ADDRESS -e PROMETHEUS_BEARER_TOKEN -v "$REPORT_DIR:/report-output" quay.io/app-sre/osde2e gate-report -output "/report-output/$REPORT_FILE" "$ENVIRONMENT" "$VERSION"
 
 aws s3 cp "$REPORT_DIR/$REPORT_FILE" "s3://$METRICS_BUCKET/$GATE_REPORT/$REPORT_FILE"


### PR DESCRIPTION
The scripts will now always grab the most recent docker image before
running the docker run command.