### PR TITLE
SDCICD-204. Use candidate-x.y channel for rcs.

### DIFF
--- a/pkg/common/upgrade/upgrade.go
+++ b/pkg/common/upgrade/upgrade.go
@@ -120,7 +120,11 @@ func TriggerUpgrade(h *helper.H) (*configv1.ClusterVersion, error) {
 
 		if upgradeVersionParsed.GreaterThan(installVersionParsed) {
 			// Upgrade the channel
-			cVersion.Spec.Channel = fmt.Sprintf("fast-%d.%d", upgradeVersionParsed.Major(), upgradeVersionParsed.Minor())
+			if strings.HasPrefix(upgradeVersionParsed.Prerelease(), "rc") {
+				cVersion.Spec.Channel = fmt.Sprintf("candidate-%d.%d", upgradeVersionParsed.Major(), upgradeVersionParsed.Minor())
+			} else {
+				cVersion.Spec.Channel = fmt.Sprintf("fast-%d.%d", upgradeVersionParsed.Major(), upgradeVersionParsed.Minor())
+			}
 			cVersion, err = cfgClient.ConfigV1().ClusterVersions().Update(cVersion)
 			if err != nil {
 				return cVersion, fmt.Errorf("couldn't update desired release channel: %v", err)


### PR DESCRIPTION
Release candidates should use the candidate-x.y channel instead of the
fast-x.y channel.