### PR TITLE
SDCICD-206. Filter upgrade version CISes if they're not in Cincinnati.

### DIFF
--- a/pkg/common/upgrade/upgrade.go
+++ b/pkg/common/upgrade/upgrade.go
@@ -119,6 +119,7 @@ func TriggerUpgrade(h *helper.H) (*configv1.ClusterVersion, error) {
 		installVersionParsed := semver.MustParse(installVersion)
 
 		if upgradeVersionParsed.GreaterThan(installVersionParsed) {
+			cVersion.Spec.Channel = VersionToChannel(upgradeVersionParsed)
 			// Upgrade the channel
 			if strings.HasPrefix(upgradeVersionParsed.Prerelease(), "rc") {
 				cVersion.Spec.Channel = fmt.Sprintf("candidate-%d.%d", upgradeVersionParsed.Major(), upgradeVersionParsed.Minor())


### PR DESCRIPTION
If cluster image sets are not present in Cincinnati, then they will now
be filtered out of electable upgrade versions if trying to use cluster
immge sets.

Additionally, upgrading clusters via Cincinnati has now been excised
since we no longer do that directly. We only use cluster image sets or
the release controller.