### PR TITLE
SDCICD-209. Reduce number of samples needed in generate_report.

### DIFF
--- a/pkg/gate/generate_report.go
+++ b/pkg/gate/generate_report.go
@@ -137,7 +137,7 @@ func generateVersionsAndFailures(matrixResults model.Matrix) ([]string, []string
 
 	failureArray := []string{}
 	for testname, failureCount := range failures {
-		if failureCount > (config.Instance.Gate.NumberOfSamplesNecessary - 1) {
+		if failureCount >= (config.Instance.Gate.NumberOfSamplesNecessary - 1) {
 			failureArray = append(failureArray, testname)
 		}
 	}


### PR DESCRIPTION
generate_report had the number of samples required to generate a
"non-viable" OCP gate too high by one. This has been corrected.