### PR TITLE
SDCICD-210. Use fixed operator versions to test upgrades.

### DIFF
--- a/pkg/e2e/operators/configurealertmanager.go
+++ b/pkg/e2e/operators/configurealertmanager.go
@@ -3,8 +3,8 @@ package operators
 import (
 	"github.com/onsi/ginkgo"
 	"github.com/openshift/osde2e/pkg/common/helper"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	operatorv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = ginkgo.Describe("[Suite: operators] [OSD] Configure AlertManager Operator", func() {
@@ -42,16 +42,19 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Configure AlertManager Operato
 })
 
 var _ = ginkgo.Describe("[Suite: operators] [OSD] Upgrade Configure AlertManager Operator", func() {
-	checkUpgrade(helper.New(), &operatorv1.Subscription{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "configure-alertmanager-operator",
-			Namespace: "openshift-monitoring",
+	checkUpgrade(helper.New(),
+		&operatorv1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "configure-alertmanager-operator",
+				Namespace: "openshift-monitoring",
+			},
+			Spec: &operatorv1.SubscriptionSpec{
+				Package:                "configure-alertmanager-operator",
+				Channel:                getChannel(),
+				CatalogSourceNamespace: "openshift-monitoring",
+				CatalogSource:          "configure-alertmanager-operator-registry",
+			},
 		},
-		Spec: &operatorv1.SubscriptionSpec{
-			Package: "configure-alertmanager-operator",
-			Channel: getChannel(),
-			CatalogSourceNamespace: "openshift-monitoring",
-			CatalogSource: "configure-alertmanager-operator-registry",
-		},
-	})
+		"configure-alertmanager-operator.v0.1.116-0b1cafc",
+	)
 })

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -2,6 +2,7 @@ package operators
 
 import (
 	"fmt"
+
 	"github.com/onsi/ginkgo"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -40,18 +41,21 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Dedicated Admins SubjectPermis
 })
 
 var _ = ginkgo.Describe("[Suite: operators] [OSD] Upgrade RBAC Permissions Operator", func() {
-	checkUpgrade(helper.New(), &operatorv1.Subscription{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "rbac-permissions-operator",
-			Namespace: "openshift-rbac-permissions",
+	checkUpgrade(helper.New(),
+		&operatorv1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rbac-permissions-operator",
+				Namespace: "openshift-rbac-permissions",
+			},
+			Spec: &operatorv1.SubscriptionSpec{
+				Package:                "rbac-permissions-operator",
+				Channel:                getChannel(),
+				CatalogSourceNamespace: "openshift-rbac-permissions",
+				CatalogSource:          "openshift-rbac-permissions",
+			},
 		},
-		Spec: &operatorv1.SubscriptionSpec{
-			Package:                "rbac-permissions-operator",
-			Channel:                getChannel(),
-			CatalogSourceNamespace: "openshift-rbac-permissions",
-			CatalogSource:          "openshift-rbac-permissions",
-		},
-	})
+		"rbac-permissions-operator.v0.1.95-0d5723c",
+	)
 })
 
 func checkSubjectPermissions(h *helper.H, spName string) {

--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -33,16 +33,19 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Splunk Forwarder Operator", fu
 })
 
 var _ = ginkgo.Describe("[Suite: operators] [OSD] Upgrade Splunk Forwarder Operator", func() {
-	checkUpgrade(helper.New(), &operatorv1.Subscription{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "openshift-splunk-forwarder-operator",
-			Namespace: "openshift-splunk-forwarder-operator",
+	checkUpgrade(helper.New(),
+		&operatorv1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "openshift-splunk-forwarder-operator",
+				Namespace: "openshift-splunk-forwarder-operator",
+			},
+			Spec: &operatorv1.SubscriptionSpec{
+				Package:                "openshift-splunk-forwarder-operator",
+				Channel:                getChannel(),
+				CatalogSourceNamespace: "openshift-splunk-forwarder-operator",
+				CatalogSource:          "splunk-forwarder-operator-catalog",
+			},
 		},
-		Spec: &operatorv1.SubscriptionSpec{
-			Package: "openshift-splunk-forwarder-operator",
-			Channel: getChannel(),
-			CatalogSourceNamespace: "openshift-splunk-forwarder-operator",
-			CatalogSource: "splunk-forwarder-operator-catalog",
-		},
-	})
+		"splunk-forwarder-operator.v0.1.95-1d7f20a",
+	)
 })


### PR DESCRIPTION
Fixed operator versions are now being used to test upgrades due the OLM
change where the `Replaces` field is no longer being used.