### PR TITLE
SDCICD-212. Use AppsV1 instead of ExtensionV1beta1 for daemonset check.

### DIFF
--- a/pkg/common/osd/versions.go
+++ b/pkg/common/osd/versions.go
@@ -22,6 +22,11 @@ const (
 	PageSize = 100
 )
 
+var (
+	// Version440 represents Openshift version 4.4.0 and above
+	Version440 = semver.MustParse("4.4.0-rc.0")
+)
+
 // Use for the semver list filter to include all results.
 func noFilter(_ *semver.Version) bool {
 	return true
@@ -180,7 +185,7 @@ func (u *OSD) getSemverList(major, minor int64, str string, filter func(*semver.
 
 		// parse versions, filter for major+minor nightlies, then sort
 		resp.Items().Each(func(v *v1.Version) bool {
-			if version, err := u.OpenshiftVersionToSemver(v.ID()); err != nil {
+			if version, err := OpenshiftVersionToSemver(v.ID()); err != nil {
 				log.Printf("could not parse version '%s': %v", v.ID(), err)
 			} else if version.Major() != major && major >= 0 {
 				return true
@@ -204,7 +209,7 @@ func (u *OSD) getSemverList(major, minor int64, str string, filter func(*semver.
 }
 
 // OpenshiftVersionToSemver converts an OpenShift version to a semver string which can then be used for comparisons.
-func (u *OSD) OpenshiftVersionToSemver(openshiftVersion string) (*semver.Version, error) {
+func OpenshiftVersionToSemver(openshiftVersion string) (*semver.Version, error) {
 	name := strings.TrimPrefix(openshiftVersion, VersionPrefix)
 	return semver.NewVersion(name)
 }

--- a/pkg/e2e/setup.go
+++ b/pkg/e2e/setup.go
@@ -115,19 +115,16 @@ func setupCluster() (err error) {
 	} else {
 		log.Printf("CLUSTER_ID of '%s' was provided, skipping cluster creation and using it instead", state.Cluster.ID)
 
-		if state.Cluster.Name == "" {
-			cluster, err := OSD.GetCluster(state.Cluster.ID)
-			if err != nil {
-				return fmt.Errorf("could not retrieve cluster information from OCM: %v", err)
-			}
-
-			if cluster.Name() == "" {
-				return fmt.Errorf("cluster name from OCM is empty, and this shouldn't be possible")
-			}
-
-			state.Cluster.Name = cluster.Name()
-			log.Printf("CLUSTER_NAME not provided, retrieved %s from OCM.", state.Cluster.Name)
+		cluster, err := OSD.GetCluster(state.Cluster.ID)
+		if err != nil {
+			return fmt.Errorf("could not retrieve cluster information from OCM: %v", err)
 		}
+
+		state.Cluster.Name = cluster.Name()
+		log.Printf("CLUSTER_NAME set to %s from OCM.", state.Cluster.Name)
+
+		state.Cluster.Version = cluster.Version().ID()
+		log.Printf("CLUSTER_VERSION set to %s from OCM.", state.Cluster.Version)
 	}
 
 	metadata.Instance.SetClusterName(state.Cluster.Name)


### PR DESCRIPTION
The daemonset check in prom_exporters uses the ExtensionV1beta1 API. In
Openshift 4.4.0+, this check should now use the AppsV1 API instead.