### PR TITLE
SDCICD-210. Remove operator upgrade tests.

### DIFF
--- a/pkg/e2e/operators/configurealertmanager.go
+++ b/pkg/e2e/operators/configurealertmanager.go
@@ -41,7 +41,7 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Configure AlertManager Operato
 	checkRoleBindings(h, operatorNamespace, roleBindings)
 })
 
-var _ = ginkgo.Describe("[Suite: operators] [OSD] Upgrade Configure AlertManager Operator", func() {
+var _ = ginkgo.PDescribe("[Suite: operators] [OSD] Upgrade Configure AlertManager Operator", func() {
 	checkUpgrade(helper.New(),
 		&operatorv1.Subscription{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -40,7 +40,7 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Dedicated Admins SubjectPermis
 	checkSubjectPermissions(h, "dedicated-admins")
 })
 
-var _ = ginkgo.Describe("[Suite: operators] [OSD] Upgrade RBAC Permissions Operator", func() {
+var _ = ginkgo.PDescribe("[Suite: operators] [OSD] Upgrade RBAC Permissions Operator", func() {
 	checkUpgrade(helper.New(),
 		&operatorv1.Subscription{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -32,7 +32,7 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Splunk Forwarder Operator", fu
 	checkClusterRoles(h, clusterRoles)
 })
 
-var _ = ginkgo.Describe("[Suite: operators] [OSD] Upgrade Splunk Forwarder Operator", func() {
+var _ = ginkgo.PDescribe("[Suite: operators] [OSD] Upgrade Splunk Forwarder Operator", func() {
 	checkUpgrade(helper.New(),
 		&operatorv1.Subscription{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
At the moment, it looks like Openshift 4.4 doesn't really have a good
way of returning the previous available version of an operator. We can
use a fixed version rather than try to detect a previously available
version, but it looks like these upgrades take >20 minutes per, and we
have a max limit of 4 hours per test run.

At the moment, we're going to just have to remove these tests until we
figure out a better approach that's compatible with Openshift 4.4.

cc @sedroche 