### PR TITLE
SDCICD-211. Remove prometheus-exporter-machine-api checks.

### DIFF
--- a/pkg/e2e/verify/prom_exporters.go
+++ b/pkg/e2e/verify/prom_exporters.go
@@ -18,7 +18,6 @@ var _ = ginkgo.Describe("[Suite: e2e] [OSD] Prometheus Exporters", func() {
 	var services = []string{
 		"sre-ebs-iops-reporter",
 		"sre-dns-latency-exporter",
-		"sre-machine-api-status-exporter",
 		"sre-stuck-ebs-vols",
 	}
 
@@ -26,7 +25,6 @@ var _ = ginkgo.Describe("[Suite: e2e] [OSD] Prometheus Exporters", func() {
 		"sre-dns-latency-exporter-code",
 		"sre-stuck-ebs-vols-code",
 		"sre-ebs-iops-reporter-code",
-		"sre-machine-api-status-exporter-code",
 	}
 
 	var secrets = []string{
@@ -38,7 +36,6 @@ var _ = ginkgo.Describe("[Suite: e2e] [OSD] Prometheus Exporters", func() {
 		"sre-dns-latency-exporter",
 		"sre-ebs-iops-reporter",
 		"sre-stuck-ebs-vols",
-		"sre-machine-api-status-exporter",
 	}
 
 	var daemonSets = []string{


### PR DESCRIPTION
The machine-api prometheus exporter checks are no longer necessary as
the machine-api exporters are being removed.