### PR TITLE
OSD-2132 Introducing tests for Customer Perspective Testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build:
 	go build -o "$(OUT_DIR)" "$(DIR)cmd/..."
 
 test: build
-	"$(OSDE2E)" test -configs=e2e-suite,log-metrics -custom-config=$(CUSTOM_CONFIG)
+	"$(OSDE2E)" test -configs=e2e-suite,app-build-suite,log-metrics -custom-config=$(CUSTOM_CONFIG)
 
 test-scale: build
 	"$(OSDE2E)" test -configs=scale-nodes-and-pods-suite,log-metrics -custom-config=$(CUSTOM_CONFIG)

--- a/configs/app-build-suite.yaml
+++ b/configs/app-build-suite.yaml
@@ -1,0 +1,3 @@
+tests:
+  testsToRun:
+  - '[Suite: app-builds]'

--- a/pkg/e2e/openshift/app_builds.go
+++ b/pkg/e2e/openshift/app_builds.go
@@ -1,0 +1,126 @@
+// Package openshift runs the OpenShift extended test suite.
+package openshift
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/runner"
+	kubev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// BuildE2EConfig is the base configuration for the E2E run.
+var BuildE2EConfig = E2EConfig{
+	TestCmd: "run",
+	Suite:   "openshift/image-ecosystem",
+	Env: []string{
+		"DELETE_NAMESPACE=false",
+	},
+	Flags: []string{
+		"--include-success",
+		"--junit-dir=" + runner.DefaultRunner.OutputDir,
+	},
+}
+
+var testApplications = []string{
+	"cakephp-mysql",
+	"nodejs-mongodb",
+	"django-psql",
+	"rails-postgresql",
+}
+
+var _ = ginkgo.Describe("[Suite: app-builds] OpenShift Application Build E2E", func() {
+	defer ginkgo.GinkgoRecover()
+
+	h := helper.New()
+
+	e2eTimeoutInSeconds := 3600
+	ginkgo.It("should get created in the cluster", func() {
+
+		namespacesExist := false
+		for _, application := range testApplications {
+			_, err := findAppNamespace(h, application)
+			if err == nil {
+				namespacesExist = true
+				break
+			}
+		}
+
+		if namespacesExist {
+
+			// The job namespaces are present, indicating that the test has run once
+			// In this case, just verify the healthy state of the applications
+
+			log.Printf("Existing applications detected, will verify rather than build.")
+			for _, applicationName := range testApplications {
+				appNamespace, err := findAppNamespace(h, applicationName)
+				Expect(err).NotTo(HaveOccurred())
+
+				list, err := h.Kube().CoreV1().Pods(appNamespace).List(metav1.ListOptions{
+					FieldSelector: fmt.Sprintf("status.phase=%s", kubev1.PodFailed),
+				})
+				Expect(err).NotTo(HaveOccurred(), "couldn't list Pods")
+				Expect(list).NotTo(BeNil())
+				Expect(list.Items).Should(HaveLen(0), "'%d' Pods are 'Failed'", len(list.Items))
+
+			}
+
+		} else {
+
+			// The applications do not exist, so test the successful build of them.
+			// configure tests
+			cfg := BuildE2EConfig
+			// Add run flags for the testing apps
+			cfg.Flags = append(cfg.Flags, "--run \"Building ("+strings.Join(testApplications, "|")+") app\"")
+
+			cmd := cfg.Cmd()
+
+			// setup runner
+			r := h.Runner(cmd)
+
+			r.Name = "openshift-tests"
+
+			// run tests
+			stopCh := make(chan struct{})
+			err := r.Run(e2eTimeoutInSeconds, stopCh)
+			Expect(err).NotTo(HaveOccurred())
+
+			// get results
+			results, err := r.RetrieveResults()
+			Expect(err).NotTo(HaveOccurred())
+
+			// write results
+			h.WriteResults(results)
+		}
+
+	}, float64(e2eTimeoutInSeconds+30))
+
+})
+
+func findAppNamespace(h *helper.H, appName string) (string, error) {
+
+	namespaceRegex := regexp.MustCompile("e2e-test-" + appName + "-repo-test-\\w+")
+	namespaceList, err := h.Project().ProjectV1().Projects().List(metav1.ListOptions{})
+	//h.Kube().CoreV1().Namespaces().List()
+	if err != nil {
+		err = fmt.Errorf("failed to fetch namespaces")
+	}
+
+	foundNamespace := ""
+	for _, namespace := range namespaceList.Items {
+		if namespaceRegex.MatchString(namespace.Name) {
+			foundNamespace = namespace.Name
+		}
+	}
+	if foundNamespace == "" {
+		err = fmt.Errorf("no matching namespace found for %s", appName)
+	}
+
+	return foundNamespace, err
+}

--- a/pkg/e2e/openshift/config.go
+++ b/pkg/e2e/openshift/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 const testCmd = `
-{{printTests .TestNames}} | openshift-tests {{.TestCmd}} {{selectTests .Suite .TestNames}} {{unwrap .Flags}}
+{{printTests .TestNames}} | {{unwrap .Env}} openshift-tests {{.TestCmd}} {{selectTests .Suite .TestNames}} {{unwrap .Flags}}
 `
 
 var (
@@ -24,6 +24,10 @@ var (
 
 // E2EConfig defines the behavior of the extended test suite.
 type E2EConfig struct {
+
+	// Env defines any environment variable settings in name=value pairs to control the test process
+	Env []string
+
 	// TestCmd determines which suite the runner executes.
 	TestCmd string
 


### PR DESCRIPTION
This commit introduces tests from the OpenShift image-ecosystem
suite to verify the ability to build and host S2I applications.

Refs [OSD-2132](https://issues.redhat.com/browse/OSD-2132)