### PR TITLE
SDCICD-212. Use semver constraint instead of version comparison.

### DIFF
--- a/pkg/common/osd/versions.go
+++ b/pkg/common/osd/versions.go
@@ -24,8 +24,17 @@ const (
 
 var (
 	// Version440 represents Openshift version 4.4.0 and above
-	Version440 = semver.MustParse("4.4.0-rc.0")
+	Version440 *semver.Constraints
 )
+
+func init() {
+	var err error
+	Version440, err = semver.NewConstraint(">= 4.4.0-0")
+
+	if err != nil {
+		panic(err)
+	}
+}
 
 // Use for the semver list filter to include all results.
 func noFilter(_ *semver.Version) bool {

--- a/pkg/common/osd/versions_test.go
+++ b/pkg/common/osd/versions_test.go
@@ -1,0 +1,37 @@
+package osd
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver"
+)
+
+func TestVersion440Constraint(t *testing.T) {
+	tests := []struct {
+		Name           string
+		Version        string
+		ExpectedResult bool
+	}{
+		{
+			Name:           "4.3.0 test",
+			Version:        "4.3.0",
+			ExpectedResult: false,
+		},
+		{
+			Name:           "4.4.0 test",
+			Version:        "4.4.0",
+			ExpectedResult: true,
+		},
+		{
+			Name:           "4.4.0-rc.0 test",
+			Version:        "4.4.0-rc.0",
+			ExpectedResult: true,
+		},
+	}
+
+	for _, test := range tests {
+		if Version440.Check(semver.MustParse(test.Version)) != test.ExpectedResult {
+			t.Errorf("test %s did not produce the expected result: %t", test.Name, test.ExpectedResult)
+		}
+	}
+}

--- a/pkg/e2e/verify/prom_exporters.go
+++ b/pkg/e2e/verify/prom_exporters.go
@@ -74,7 +74,7 @@ var _ = ginkgo.Describe("[Suite: e2e] [OSD] Prometheus Exporters", func() {
 
 		for _, daemonSetName := range daemonSets {
 			// Use appv1 for clusters 4.4.0 or later
-			if !currentClusterVersion.LessThan(osd.Version440) {
+			if osd.Version440.Check(currentClusterVersion) {
 				daemonSet, err := h.Kube().AppsV1().DaemonSets(namespace).Get(daemonSetName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred(), "failed to get daemonset %v\n", daemonSetName)
 				Expect(daemonSet.Status.DesiredNumberScheduled).Should(Equal(daemonSet.Status.CurrentNumberScheduled),


### PR DESCRIPTION
Semver constraints are now being used instead of version comparison for
checking for DaemonSets. This will be clearer. Additionally, the
constraint has been updated to properly accommodate prereleases.

https://github.com/Masterminds/semver#working-with-prerelease-versions