### PR TITLE
Set operator upgrades to automatic after first manual test refs OSD-3141

### DIFF
--- a/pkg/e2e/operators/configurealertmanager.go
+++ b/pkg/e2e/operators/configurealertmanager.go
@@ -41,7 +41,7 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Configure AlertManager Operato
 	checkRoleBindings(h, operatorNamespace, roleBindings)
 })
 
-var _ = ginkgo.PDescribe("[Suite: operators] [OSD] Upgrade Configure AlertManager Operator", func() {
+var _ = ginkgo.Describe("[Suite: operators] [OSD] Upgrade Configure AlertManager Operator", func() {
 	checkUpgrade(helper.New(),
 		&operatorv1.Subscription{
 			ObjectMeta: metav1.ObjectMeta{
@@ -55,6 +55,6 @@ var _ = ginkgo.PDescribe("[Suite: operators] [OSD] Upgrade Configure AlertManage
 				CatalogSource:          "configure-alertmanager-operator-registry",
 			},
 		},
-		"configure-alertmanager-operator.v0.1.116-0b1cafc",
+		"configure-alertmanager-operator.v0.1.121-361b817",
 	)
 })

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -54,7 +54,7 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Upgrade RBAC Permissions Opera
 				CatalogSource:          "openshift-rbac-permissions",
 			},
 		},
-		"rbac-permissions-operator.v0.1.95-0d5723c",
+		"rbac-permissions-operator.v0.1.81-ce6731c",
 	)
 })
 

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -40,7 +40,7 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Dedicated Admins SubjectPermis
 	checkSubjectPermissions(h, "dedicated-admins")
 })
 
-var _ = ginkgo.PDescribe("[Suite: operators] [OSD] Upgrade RBAC Permissions Operator", func() {
+var _ = ginkgo.Describe("[Suite: operators] [OSD] Upgrade RBAC Permissions Operator", func() {
 	checkUpgrade(helper.New(),
 		&operatorv1.Subscription{
 			ObjectMeta: metav1.ObjectMeta{
@@ -54,7 +54,7 @@ var _ = ginkgo.PDescribe("[Suite: operators] [OSD] Upgrade RBAC Permissions Oper
 				CatalogSource:          "openshift-rbac-permissions",
 			},
 		},
-		"rbac-permissions-operator.v0.1.81-ce6731c",
+		"rbac-permissions-operator.v0.1.95-0d5723c",
 	)
 })
 

--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -46,6 +46,6 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Upgrade Splunk Forwarder Opera
 				CatalogSource:          "splunk-forwarder-operator-catalog",
 			},
 		},
-		"splunk-forwarder-operator.v0.1.95-1d7f20a",
+		"splunk-forwarder-operator.v0.1.91-aaa0027",
 	)
 })

--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -32,7 +32,7 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Splunk Forwarder Operator", fu
 	checkClusterRoles(h, clusterRoles)
 })
 
-var _ = ginkgo.PDescribe("[Suite: operators] [OSD] Upgrade Splunk Forwarder Operator", func() {
+var _ = ginkgo.Describe("[Suite: operators] [OSD] Upgrade Splunk Forwarder Operator", func() {
 	checkUpgrade(helper.New(),
 		&operatorv1.Subscription{
 			ObjectMeta: metav1.ObjectMeta{
@@ -46,6 +46,6 @@ var _ = ginkgo.PDescribe("[Suite: operators] [OSD] Upgrade Splunk Forwarder Oper
 				CatalogSource:          "splunk-forwarder-operator-catalog",
 			},
 		},
-		"splunk-forwarder-operator.v0.1.91-aaa0027",
+		"splunk-forwarder-operator.v0.1.95-1d7f20a",
 	)
 })


### PR DESCRIPTION
This fixes an issue identified in OSD-3141 / SDCICD-210 whereby
once the static previousCSV version got two hops out of date
the test would fail. The fix sets the operator subscription
installplan to automatic once a first manual upgrade hop
has successfully been undertaken.

Additionally the previousCSVs for affected operators have been
updated to the most recent N-1 version.