### PR TITLE
SDCICD-215. Stick with one test suite for now.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ build:
 	go build -o "$(OUT_DIR)" "$(DIR)cmd/..."
 
 test: build
-	"$(OSDE2E)" test -configs=e2e-suite,app-build-suite,log-metrics -custom-config=$(CUSTOM_CONFIG)
+	"$(OSDE2E)" test -configs=e2e-suite,log-metrics -custom-config=$(CUSTOM_CONFIG)
 
 test-scale: build
 	"$(OSDE2E)" test -configs=scale-nodes-and-pods-suite,log-metrics -custom-config=$(CUSTOM_CONFIG)

--- a/configs/app-build-suite.yaml
+++ b/configs/app-build-suite.yaml
@@ -1,3 +1,0 @@
-tests:
-  testsToRun:
-  - '[Suite: app-builds]'

--- a/configs/e2e-suite.yaml
+++ b/configs/e2e-suite.yaml
@@ -3,3 +3,4 @@ tests:
   - '[Suite: e2e]'
   - '[Suite: operators]'
   - '[Suite: service-definition]'
+  - '[Suite: app-builds]'


### PR DESCRIPTION
Due to limitations in the way we parse files, we need to stick with one
e2e suite for now. We'll follow on to see if we can merge YAML files
together and parse.