### PR TITLE
Extend the poll timeout for CSV on operator upgrade checks.

### DIFF
--- a/pkg/e2e/operators/operators.go
+++ b/pkg/e2e/operators/operators.go
@@ -161,7 +161,7 @@ func approveInstallPlan(h *helper.H, ip *operatorv1.InstallPlan) error {
 }
 
 func ensureCSVIsInstalled(h *helper.H, csvName string, namespace string) error {
-	err := wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
+	err := wait.PollImmediate(5*time.Second, 15*time.Minute, func() (bool, error) {
 		csv, err := h.Operator().OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(csvName, metav1.GetOptions{})
 		if err != nil && !kerror.IsNotFound(err) {
 			return false, err


### PR DESCRIPTION
When testing in staging environments, the number of hops that can potentially be made to upgrade an operator up to the latest version can sometimes exceed the previous polling timeout of 5 minutes. This increases the timeout to 15 minutes which should be a generous enough period to allow an operator
to get back to the latest version.

Refs OSD-3141