### PR TITLE
Removing app builds cakephp-mysql and nodejs-mongodb

### DIFF
--- a/pkg/e2e/openshift/app_builds.go
+++ b/pkg/e2e/openshift/app_builds.go
@@ -29,10 +29,11 @@ var BuildE2EConfig = E2EConfig{
 }
 
 var testApplications = []string{
-	"cakephp-mysql",
-	"nodejs-mongodb",
 	"django-psql",
 	"rails-postgresql",
+	// The following applications rely on an imagestream not present until at least v4.3.5
+	// "cakephp-mysql",
+	// "nodejs-mongodb",
 }
 
 var _ = ginkgo.Describe("[Suite: app-builds] OpenShift Application Build E2E", func() {


### PR DESCRIPTION
cakephp-mysql and nodejs-mongodb are failing to build on clusters v4.3.0 and older as the required imagestreams are not present. removing the builds until we are on later versions.

Some background info on this is available [at this Jira link](https://issues.redhat.com/browse/OSD-2132?focusedCommentId=14004073&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14004073).

refs OSD-2132