### PR TITLE
OSD-2132 Add Redmine workload

### DIFF
--- a/assets/workloads/e2e/redmine/mysql-deployment.yaml
+++ b/assets/workloads/e2e/redmine/mysql-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+kind: Deployment
+metadata:
+  name: redmine-mysql
+  labels:
+    app: redmine
+spec:
+  selector:
+    matchLabels:
+      app: redmine
+      tier: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: redmine
+        tier: mysql
+    spec:
+      containers:
+        - image: mysql:5.6
+          name: mysql
+          env:
+            - name: MYSQL_DATABASE
+              value: redmine
+            - name: MYSQL_USER
+              value: redmine
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-pass
+                  key: password
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-root-pass
+                  key: password
+          ports:
+            - containerPort: 3306
+              name: mysql
+          volumeMounts:
+            - name: mysql-persistent-storage
+              mountPath: /var/lib/mysql
+      volumes:
+        - name: mysql-persistent-storage
+          persistentVolumeClaim:
+            claimName: mysql-pv-claim

--- a/assets/workloads/e2e/redmine/mysql-pvc.yaml
+++ b/assets/workloads/e2e/redmine/mysql-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pv-claim
+  labels:
+    app: redmine
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/assets/workloads/e2e/redmine/mysql-root-secret.yaml
+++ b/assets/workloads/e2e/redmine/mysql-root-secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-root-pass
+data:
+  password: Tm90aGluZ1RvU2VlSGVyZQ==
+type: Opaque

--- a/assets/workloads/e2e/redmine/mysql-secret.yaml
+++ b/assets/workloads/e2e/redmine/mysql-secret.yaml
@@ -1,0 +1,7 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: mysql-pass
+data:
+  password: T25lVHdvRm91clRocmVl
+type: Opaque

--- a/assets/workloads/e2e/redmine/mysql-service.yaml
+++ b/assets/workloads/e2e/redmine/mysql-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redmine-mysql
+  labels:
+    app: redmine
+spec:
+  ports:
+    - port: 3306
+  selector:
+    app: redmine
+    tier: mysql
+  clusterIP: None

--- a/assets/workloads/e2e/redmine/redmine-deployment.yaml
+++ b/assets/workloads/e2e/redmine/redmine-deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redmine
+  labels:
+    app: redmine
+spec:
+  selector:
+    matchLabels:
+      app: redmine
+      tier: frontend
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: redmine
+        tier: frontend
+    spec:
+      containers:
+        - image: redmine:4.1.0
+          name: redmine
+          env:
+            - name: REDMINE_DB_MYSQL
+              value: redmine-mysql
+            - name: REDMINE_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-pass
+                  key: password
+            - name: REDMINE_DB_USERNAME
+              value: redmine
+          ports:
+            - containerPort: 3000
+              name: redmine
+          volumeMounts:
+            - name: redmine-persistent-storage
+              mountPath: /usr/src/redmine/files
+      volumes:
+        - name: redmine-persistent-storage
+          persistentVolumeClaim:
+            claimName: redmine-pv-claim

--- a/assets/workloads/e2e/redmine/redmine-pvc.yaml
+++ b/assets/workloads/e2e/redmine/redmine-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redmine-pv-claim
+  labels:
+    app: redmine
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/assets/workloads/e2e/redmine/redmine-service.yaml
+++ b/assets/workloads/e2e/redmine/redmine-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redmine-frontend
+  labels:
+    app: redmine
+spec:
+  ports:
+    - port: 3000
+  selector:
+    app: redmine
+    tier: frontend
+  clusterIP: None

--- a/cmd/osde2e/test/test.go
+++ b/cmd/osde2e/test/test.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/openshift/osde2e/pkg/e2e/state"
 	_ "github.com/openshift/osde2e/pkg/e2e/verify"
 	_ "github.com/openshift/osde2e/pkg/e2e/workloads/guestbook"
+	_ "github.com/openshift/osde2e/pkg/e2e/workloads/redmine"
 )
 
 // Command is the command for running end to end tests on OSD clusters

--- a/pkg/common/helper/workloads.go
+++ b/pkg/common/helper/workloads.go
@@ -150,6 +150,35 @@ func CreateRuntimeObject(obj runtime.Object, ns string, kube kubernetes.Interfac
 			return nil, err
 		}
 		return newObj, nil
+	case "PersistentVolume":
+		if _, ok = obj.(*corev1.PersistentVolume); !ok {
+			return nil, fmt.Errorf("Error casting object to PersistentVolume")
+		}
+
+		if newObj, err = kube.CoreV1().PersistentVolumes().Create(obj.(*corev1.PersistentVolume)); err != nil {
+			return nil, err
+		}
+		return newObj, nil
+	case "PersistentVolumeClaim":
+		if _, ok = obj.(*corev1.PersistentVolumeClaim); !ok {
+			return nil, fmt.Errorf("Error casting object to PersistentVolumeClaim")
+		}
+
+		if newObj, err = kube.CoreV1().PersistentVolumeClaims(ns).Create(obj.(*corev1.PersistentVolumeClaim)); err != nil {
+			return nil, err
+		}
+		return newObj, nil
+
+	case "Secret":
+		if _, ok = obj.(*corev1.Secret); !ok {
+			return nil, fmt.Errorf("Error casting object to Secret")
+		}
+
+		if newObj, err = kube.CoreV1().Secrets(ns).Create(obj.(*corev1.Secret)); err != nil {
+			return nil, err
+		}
+		return newObj, nil
+
 	default:
 		return nil, fmt.Errorf("Unable to handle object type %s", obj.GetObjectKind().GroupVersionKind().Kind)
 	}

--- a/pkg/e2e/workloads/redmine/redmine.go
+++ b/pkg/e2e/workloads/redmine/redmine.go
@@ -1,0 +1,96 @@
+package workloads
+
+import (
+	"fmt"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"log"
+	"path/filepath"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/osde2e/pkg/common/helper"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// Specify where the YAML definitions are for the workloads.
+var testDir = "/assets/workloads/e2e/redmine"
+
+// Use the base folder name for the workload name. Make it easy!
+var workloadName = filepath.Base(testDir)
+
+var _ = ginkgo.Describe("[Suite: e2e] Workload ("+workloadName+")", func() {
+	defer ginkgo.GinkgoRecover()
+	// setup helper
+	h := helper.New()
+
+	ginkgo.It("should get created in the cluster", func() {
+		// Does this workload exist? If so, this must be a repeat run.
+		// In this case we should assume the workload has had a valid run once already
+		// And simply run another test validating the workload.
+		if _, ok := h.GetWorkload(workloadName); ok {
+			// Run the workload test
+			doTest(h)
+
+		} else {
+			// Create all K8s objects that are within the testDir
+			objects, err := helper.ApplyYamlInFolder(testDir, h.CurrentProject(), h.Kube())
+			Expect(err).NotTo(HaveOccurred(), "couldn't apply k8s yaml")
+
+			// Log how many objects have been created
+			log.Printf("%v objects created", len(objects))
+
+			// Give the cluster a second to churn before checking
+			time.Sleep(3 * time.Second)
+
+			// Wait for all pods to come up healthy
+			err = wait.PollImmediate(15*time.Second, 5*time.Minute, func() (bool, error) {
+				// This is pretty basic. Are all the pods up? Cool.
+				if check, err := helper.CheckPodHealth(h.Kube().CoreV1()); !check || err != nil {
+					return false, nil
+				}
+				return true, nil
+			})
+			Expect(err).NotTo(HaveOccurred(), "objects not created in a timely manner")
+			// Run the test
+			doTest(h)
+
+			// If success, add the workload to the list of installed workloads
+			h.AddWorkload(workloadName, h.CurrentProject())
+		}
+
+	})
+})
+
+func doTest(h *helper.H) {
+
+	// duration in seconds between polls
+	interval := 5
+
+	// convert time.Duration type
+	timeoutDuration := time.Duration(config.Instance.Tests.PollingTimeout) * time.Minute
+	intervalDuration := time.Duration(interval) * time.Second
+
+	start := time.Now()
+
+Loop:
+	for {
+		_, err := h.Kube().CoreV1().Services(h.CurrentProject()).ProxyGet("http", "redmine-frontend", "3000", "/", nil).DoRaw()
+		elapsed := time.Since(start)
+
+		switch {
+		case err == nil:
+			// Success
+			break Loop
+		default:
+			if elapsed < timeoutDuration {
+				log.Printf("Waiting %v for application to load", (timeoutDuration - elapsed))
+				time.Sleep(intervalDuration)
+			} else {
+				err = fmt.Errorf("Failed to check service before timeout")
+				break Loop
+			}
+		}
+	}
+}

--- a/pkg/e2e/workloads/redmine/redmine.go
+++ b/pkg/e2e/workloads/redmine/redmine.go
@@ -65,6 +65,9 @@ var _ = ginkgo.Describe("[Suite: e2e] Workload ("+workloadName+")", func() {
 
 func doTest(h *helper.H) {
 
+	// track if error occurs
+	var err error
+
 	// duration in seconds between polls
 	interval := 5
 
@@ -73,10 +76,10 @@ func doTest(h *helper.H) {
 	intervalDuration := time.Duration(interval) * time.Second
 
 	start := time.Now()
-
+	
 Loop:
 	for {
-		_, err := h.Kube().CoreV1().Services(h.CurrentProject()).ProxyGet("http", "redmine-frontend", "3000", "/", nil).DoRaw()
+		_, err = h.Kube().CoreV1().Services(h.CurrentProject()).ProxyGet("http", "redmine-frontend", "3000", "/", nil).DoRaw()
 		elapsed := time.Since(start)
 
 		switch {
@@ -88,9 +91,11 @@ Loop:
 				log.Printf("Waiting %v for application to load", (timeoutDuration - elapsed))
 				time.Sleep(intervalDuration)
 			} else {
-				err = fmt.Errorf("Failed to check service before timeout")
+				err = fmt.Errorf("failed to check service before timeout")
 				break Loop
 			}
 		}
 	}
+
+	Expect(err).NotTo(HaveOccurred(), "unable to access front end of app")
 }


### PR DESCRIPTION
In support of OSD-2132 to improve customer app testing, this PR adds a new workload to build and host the Redmine web application via a Kubernetes deployment, using persistent storage for both the backend MySQL database service and the frontend web service, and secrets to manage the database credentials.

An initial validation method has been written to check that the service is responding. The deployment should complete within several minutes.

It has been successfully tested on staging and prod CI clusters so far.

If accepted as an additional workload, more sophisticated validation will be added as part of OSD-2132.

Thank you! :)