### PR TITLE
Fix ginkgo panic on helper cleanup failure.

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -160,11 +160,16 @@ func runGinkgoTests() error {
 		}
 	}
 
-	// We need to clean up our helper tests manually.
-	h := &helper.H{
-		State: state,
-	}
-	h.Cleanup()
+	func() {
+		defer ginkgo.GinkgoRecover()
+		// We need to clean up our helper tests manually.
+		if !cfg.DryRun {
+			h := &helper.H{
+				State: state,
+			}
+			h.Cleanup()
+		}
+	}()
 
 	if !testsPassed || !upgradeTestsPassed {
 		return fmt.Errorf("please inspect logs for more details")


### PR DESCRIPTION
When the helper fails to clean up, ginkgo will panic. This will fix that
panic, as well as prevent the cleanup from running during a dry run.