### PR TITLE
Ensure alert scraper test runs as cluster-admin

### DIFF
--- a/pkg/e2e/state/alerts.go
+++ b/pkg/e2e/state/alerts.go
@@ -42,6 +42,7 @@ func init() {
 var _ = ginkgo.Describe("[Suite: e2e] Cluster state", func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
+	h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
 
 	alertsTimeoutInSeconds := 900
 	ginkgo.It("should have no alerts", func() {


### PR DESCRIPTION
Due to the previous RBAC/SA PRs, if a test requires elevated permissions we need to explicitly specify it. 