### PR TITLE
SDCICD-214. Enable dynamic version selection for fresh installs.

### DIFF
--- a/configs/one-release-from-prod-default.yaml
+++ b/configs/one-release-from-prod-default.yaml
@@ -1,0 +1,2 @@
+cluster:
+  nextReleaseAfterProdDefault: 1

--- a/configs/two-releases-from-prod-default.yaml
+++ b/configs/two-releases-from-prod-default.yaml
@@ -1,0 +1,2 @@
+cluster:
+  nextReleaseAfterProdDefault: 2

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -99,6 +99,9 @@ type ClusterConfig struct {
 	// UseOldestClusterImageSetForInstall will select the cluster image set that is in the end of the list of ordered cluster versions known to OCM.
 	UseOldestClusterImageSetForInstall bool `env:"USE_OLDEST_CLUSTER_IMAGE_SET_FOR_INSTALL" sect:"version" default:"false" yaml:"useOldestClusterVersionForInstall"`
 
+	// NextReleaseAfterProdDefault will select the cluster image set that the given number of releases away from the the production default.
+	NextReleaseAfterProdDefault int `env:"NEXT_RELEASE_AFTER_PROD_DEFAULT" sect:"version" default:"0" yaml:"nextReleaseAfterProdDefault"`
+
 	// MajorTarget is the major version to target. If specified, it is used in version selection.
 	MajorTarget int64 `env:"MAJOR_TARGET" sect:"version" yaml:"majorTarget"`
 

--- a/pkg/common/osd/versions_test.go
+++ b/pkg/common/osd/versions_test.go
@@ -35,3 +35,75 @@ func TestVersion440Constraint(t *testing.T) {
 		}
 	}
 }
+
+func TestNextReleaseAfterGivenVersionFromVersionList(t *testing.T) {
+	tests := []struct {
+		Name                     string
+		GivenVersion             *semver.Version
+		VersionList              []string
+		ReleasesFromGivenVersion int
+		ExpectedVersion          string
+	}{
+		{
+			Name:                     "no nightly, distance 1 (4.3.0)",
+			GivenVersion:             semver.MustParse("4.3.0"),
+			VersionList:              []string{"4.3.0", "4.3.1", "4.4.0", "4.4.2", "4.5.0", "4.5.5", "4.6.1"},
+			ReleasesFromGivenVersion: 1,
+			ExpectedVersion:          "4.4.2",
+		},
+		{
+			Name:                     "no nightly, distance 1, given version doesn't exist in version list (4.4.1)",
+			GivenVersion:             semver.MustParse("4.4.1"),
+			VersionList:              []string{"4.3.0", "4.3.1", "4.4.0", "4.4.2", "4.5.0", "4.5.5", "4.6.1"},
+			ReleasesFromGivenVersion: 1,
+			ExpectedVersion:          "4.5.5",
+		},
+		{
+			Name:                     "no nightly, distance 2 (4.3.0)",
+			GivenVersion:             semver.MustParse("4.3.0"),
+			VersionList:              []string{"4.3.0", "4.3.1", "4.4.0", "4.4.2", "4.5.0", "4.5.5", "4.6.1"},
+			ReleasesFromGivenVersion: 2,
+			ExpectedVersion:          "4.5.5",
+		},
+		{
+			Name:                     "rc should be selected, distance 1 (4.3.0)",
+			GivenVersion:             semver.MustParse("4.3.0"),
+			VersionList:              []string{"4.3.0", "4.3.1", "4.4.0", "4.4.2", "4.4.3-rc.0", "4.5.0"},
+			ReleasesFromGivenVersion: 1,
+			ExpectedVersion:          "4.4.3-rc.0",
+		},
+		{
+			Name:                     "rc should be skipped, distance 1 (4.3.0)",
+			GivenVersion:             semver.MustParse("4.3.0"),
+			VersionList:              []string{"4.3.0", "4.3.1", "4.4.0", "4.4.2", "4.4.3-rc.0", "4.4.3", "4.5.0"},
+			ReleasesFromGivenVersion: 1,
+			ExpectedVersion:          "4.4.3",
+		},
+		{
+			Name:                     "nightly should be selected, distance 1 (4.3.0)",
+			GivenVersion:             semver.MustParse("4.3.0"),
+			VersionList:              []string{"4.3.0", "4.3.1", "4.4.0-0.nightly-1", "4.4.0", "4.4.2", "4.4.3-rc.0", "4.4.3", "4.5.0"},
+			ReleasesFromGivenVersion: 1,
+			ExpectedVersion:          "4.4.0-0.nightly-1",
+		},
+		{
+			Name:                     "second nightly should be selected, distance 1 (4.3.0)",
+			GivenVersion:             semver.MustParse("4.3.0"),
+			VersionList:              []string{"4.3.0", "4.3.1", "4.4.0-0.nightly-1", "4.4.0-0.nightly-2", "4.4.0", "4.4.2", "4.4.3-rc.0", "4.4.3", "4.5.0"},
+			ReleasesFromGivenVersion: 1,
+			ExpectedVersion:          "4.4.0-0.nightly-2",
+		},
+	}
+
+	for _, test := range tests {
+		selectedVersion, err := nextReleaseAfterGivenVersionFromVersionList(test.GivenVersion, test.VersionList, test.ReleasesFromGivenVersion)
+
+		if err != nil {
+			t.Errorf("error selecting version from list: %v", err)
+		}
+
+		if selectedVersion != test.ExpectedVersion {
+			t.Errorf("test %s did not produce the expected result: %s, got %s instead", test.Name, test.ExpectedVersion, selectedVersion)
+		}
+	}
+}

--- a/pkg/e2e/version.go
+++ b/pkg/e2e/version.go
@@ -84,6 +84,9 @@ func setupVersion(osdClient *osd.OSD) (err error) {
 		} else if cfg.Cluster.UseOldestClusterImageSetForInstall {
 			state.Cluster.Version, state.Cluster.EnoughVersionsForOldestOrMiddleTest, err = osdClient.OldestVersion()
 			versionType = "oldest version"
+		} else if cfg.Cluster.NextReleaseAfterProdDefault > 0 {
+			state.Cluster.Version, err = osdClient.NextReleaseAfterProdDefault(cfg.Cluster.NextReleaseAfterProdDefault)
+			versionType = "next y version after prod"
 		} else {
 			state.Cluster.Version, err = osdClient.DefaultVersion()
 			versionType = "current default"


### PR DESCRIPTION
Fresh installs now can be specified as a delta from the production
default value. As an example:

- Prod default: 4.3, delta 1 == 4.4.0-nightly.
- Prod default: 4.3, delta 2 == 4.5.0-nightly.
- Prod default: 4.4, delta 1 == 4.5.0-nightly.
- Prod default, 4.4, delta 2 == 4.6.0-nightly.

There needs to be a follow on to support upgrades in the same way, but
this will get us half of the way there.