### PR TITLE
SDCICD-214. Enable dynamic version selection for upgrades.

### DIFF
--- a/configs/nightly-release-for-prod-default.yaml
+++ b/configs/nightly-release-for-prod-default.yaml
@@ -1,0 +1,2 @@
+cluster:
+  nextReleaseAfterProdDefault: 0

--- a/configs/upgrade-nightly-release-for-prod-default.yaml
+++ b/configs/upgrade-nightly-release-for-prod-default.yaml
@@ -1,0 +1,2 @@
+upgrade:
+  nextReleaseAfterProdDefaultForUpgrade: 0

--- a/configs/upgrade-one-release-from-prod-default.yaml
+++ b/configs/upgrade-one-release-from-prod-default.yaml
@@ -1,0 +1,2 @@
+upgrade:
+  nextReleaseAfterProdDefaultForUpgrade: 1

--- a/configs/upgrade-two-releases-from-prod-default.yaml
+++ b/configs/upgrade-two-releases-from-prod-default.yaml
@@ -1,0 +1,2 @@
+upgrade:
+  nextReleaseAfterProdDefaultForUpgrade: 2

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -69,6 +69,9 @@ type UpgradeConfig struct {
 	// UpgradeToCISIfPossible will upgrade to the most recent cluster image set if it's newer than the install version
 	UpgradeToCISIfPossible bool `env:"UPGRADE_TO_CIS_IF_POSSIBLE" sect:"version" default:"false" yaml:"upgradeToCISIfPossible"`
 
+	// NextReleaseAfterProdDefault will select the cluster image set that the given number of releases away from the the production default.
+	NextReleaseAfterProdDefaultForUpgrade int `env:"NEXT_RELEASE_AFTER_PROD_DEFAULT_FOR_UPGRADE" sect:"version" default:"-1" yaml:"nextReleaseAfterProdDefaultForUpgrade"`
+
 	// ReleaseStream used to retrieve latest release images. If set, it will be used to perform an upgrade.
 	ReleaseStream string `env:"UPGRADE_RELEASE_STREAM" sect:"upgrade" yaml:"releaseStream"`
 }
@@ -100,7 +103,7 @@ type ClusterConfig struct {
 	UseOldestClusterImageSetForInstall bool `env:"USE_OLDEST_CLUSTER_IMAGE_SET_FOR_INSTALL" sect:"version" default:"false" yaml:"useOldestClusterVersionForInstall"`
 
 	// NextReleaseAfterProdDefault will select the cluster image set that the given number of releases away from the the production default.
-	NextReleaseAfterProdDefault int `env:"NEXT_RELEASE_AFTER_PROD_DEFAULT" sect:"version" default:"0" yaml:"nextReleaseAfterProdDefault"`
+	NextReleaseAfterProdDefault int `env:"NEXT_RELEASE_AFTER_PROD_DEFAULT" sect:"version" default:"-1" yaml:"nextReleaseAfterProdDefault"`
 
 	// MajorTarget is the major version to target. If specified, it is used in version selection.
 	MajorTarget int64 `env:"MAJOR_TARGET" sect:"version" yaml:"majorTarget"`

--- a/pkg/common/upgrade/releases.go
+++ b/pkg/common/upgrade/releases.go
@@ -115,7 +115,7 @@ func IsVersionInCincinnati(version *semver.Version) (bool, error) {
 }
 
 // LatestReleaseFromReleaseController retrieves latest release information for given releaseStream on the release controller.
-func LatestReleaseFromReleaseController(releaseStream string, useReleaseControllerForInt bool) (name, pullSpec string, err error) {
+func LatestReleaseFromReleaseController(releaseStream string) (name, pullSpec string, err error) {
 	var resp *http.Response
 	var data []byte
 


### PR DESCRIPTION
Dynamic version selection is now enabled for integration upgrades. Like
dynamic version selection for fresh installs, this allows you to specify
a distance from the current prod default to determine what version of
OCP to upgrade to. This currently only really works for integration, and
it's doubtful this will be expanded unless necessary.

Additionally, the original logic has been modified to support a 0 value
for next release, allowing for the nightly in the current major/minor
version line for the default version in production.