### PR TITLE
SDCICD-198 - Create junit.xml based on observed log metrics

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -264,6 +264,25 @@ func runTestsInPhase(phase string, description string) bool {
 		}
 	}
 
+	logMetricTestSuite := reporters.JUnitTestSuite{
+		Name: "Log Metrics",
+	}
+	for name, value := range metadata.Instance.LogMetrics {
+		logMetricTestSuite.TestCases = append(logMetricTestSuite.TestCases, reporters.JUnitTestCase{
+			ClassName: "Log Metrics",
+			Name:      fmt.Sprintf("[Log Metrics] %s", name),
+			Time:      float64(value),
+		})
+	}
+
+	data, err := xml.Marshal(&logMetricTestSuite)
+
+	err = ioutil.WriteFile(filepath.Join(phaseDirectory, "junit_logmetrics.xml"), data, 0644)
+	if err != nil {
+		log.Printf("error writing to junit file: %s", err.Error())
+		return false
+	}
+
 	return ginkgoPassed
 }
 


### PR DESCRIPTION
This creates a separate junit.xml with the contents of log-metrics. This will, in effect, render the work done to generate the log-metrics prom file redundant/obsolete, which is fine. 

The count of observed metrics has been put in the "time" field 