### PR TITLE
Bugfix: Grant cluster-admin to addon tests

### DIFF
--- a/pkg/e2e/addons/addon_test_harness.go
+++ b/pkg/e2e/addons/addon_test_harness.go
@@ -42,6 +42,8 @@ var _ = ginkgo.Describe("[Suite: addons] Addon Test Harness", func() {
 
 	addonTimeoutInSeconds := 3600
 	ginkgo.It("should run until completion", func() {
+		// We don't know what a test harness may need so let's give them everything.
+		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
 		for _, harness := range config.Instance.Addons.TestHarnesses {
 			// configure tests
 			// setup runner


### PR DESCRIPTION
See here: https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/7909/rehearse-7909-periodic-ci-openshift-osde2e-addon-codeready-operator-stage/14/artifacts/install/addon-tests-err.txt