### PR TITLE
SDCICD-235. Use -1 as a default for pass rates.

### DIFF
--- a/pkg/common/metadata/metadata.go
+++ b/pkg/common/metadata/metadata.go
@@ -47,6 +47,8 @@ var Instance *Metadata
 
 func init() {
 	Instance = &Metadata{}
+	Instance.InstallPhasePassRate = -1.0
+	Instance.UpgradePhasePassRate = -1.0
 	Instance.LogMetrics = make(map[string]int)
 }
 


### PR DESCRIPTION
-1 should be used as a default for pass rates so that we can filter out
non-existent values.