### PR TITLE
SDCICD-237. Cincinnati aware version selection for upgrades.

### DIFF
--- a/configs/only-upgrade-to-z-releases.yaml
+++ b/configs/only-upgrade-to-z-releases.yaml
@@ -1,0 +1,2 @@
+upgrade:
+  onlyUpgradeToZReleases: true

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -107,10 +107,13 @@ type OCMConfig struct {
 // UpgradeConfig stores information required to perform OSDe2e upgrade testing
 type UpgradeConfig struct {
 	// UpgradeToCISIfPossible will upgrade to the most recent cluster image set if it's newer than the install version
-	UpgradeToCISIfPossible bool `env:"UPGRADE_TO_CIS_IF_POSSIBLE" sect:"version" default:"false" yaml:"upgradeToCISIfPossible"`
+	UpgradeToCISIfPossible bool `env:"UPGRADE_TO_CIS_IF_POSSIBLE" sect:"upgrade" default:"false" yaml:"upgradeToCISIfPossible"`
+
+	// OnlyUpgradeToZReleases will restrict upgrades to selecting Z releases on stage/prod.
+	OnlyUpgradeToZReleases bool `env:"ONLY_UPGRADE_TO_Z_RELEASES" sect:"upgrade" default:"false" yaml:"onlyUpgradeToZReleases"`
 
 	// NextReleaseAfterProdDefault will select the cluster image set that the given number of releases away from the the production default.
-	NextReleaseAfterProdDefaultForUpgrade int `env:"NEXT_RELEASE_AFTER_PROD_DEFAULT_FOR_UPGRADE" sect:"version" default:"-1" yaml:"nextReleaseAfterProdDefaultForUpgrade"`
+	NextReleaseAfterProdDefaultForUpgrade int `env:"NEXT_RELEASE_AFTER_PROD_DEFAULT_FOR_UPGRADE" sect:"upgrade" default:"-1" yaml:"nextReleaseAfterProdDefaultForUpgrade"`
 
 	// ReleaseStream used to retrieve latest release images. If set, it will be used to perform an upgrade.
 	ReleaseStream string `env:"UPGRADE_RELEASE_STREAM" sect:"upgrade" yaml:"releaseStream"`

--- a/pkg/common/osd/versions.go
+++ b/pkg/common/osd/versions.go
@@ -22,6 +22,9 @@ const (
 
 	// PageSize is the number of results to get per page from the cluster versions endpoint
 	PageSize = 100
+
+	// NoVersionFound is the value placed into a version string when no valid Cincinnati version can be selected.
+	NoVersionFound = "NoVersionFound"
 )
 
 var (
@@ -136,7 +139,7 @@ func (u *OSD) LatestVersionWithFilter(filter func(*semver.Version) bool) (string
 	}
 
 	if len(versions) == 0 {
-		return "", fmt.Errorf("no versions available after applying filter")
+		return NoVersionFound, nil
 	}
 
 	latest := versions[len(versions)-1]

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -91,6 +91,11 @@ func runGinkgoTests() error {
 			return nil
 		}
 
+		if state.Upgrade.ReleaseName == osd.NoVersionFound {
+			log.Printf("No valid versions were found. Skipping tests.")
+			return nil
+		}
+
 		// check that enough quota exists for this test if creating cluster
 		if len(state.Cluster.ID) == 0 {
 			if cfg.DryRun {


### PR DESCRIPTION
Upgrades can now be restricted to only Z releases, not just the latest
version in the OCM versions endpoint.

Stage will now use fast/candidate channels and production will use
stable. Additionally, we will not attempt to select a version if no
edges exist in Cincinnati for the proposed upgrade.