### PR TITLE
SDCICD-229: Attempt to retry failed tests 3 times

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -63,6 +63,7 @@ func runGinkgoTests() error {
 	ginkgoConfig.GinkgoConfig.SkipString = cfg.Tests.GinkgoSkip
 	ginkgoConfig.GinkgoConfig.FocusString = cfg.Tests.GinkgoFocus
 	ginkgoConfig.GinkgoConfig.DryRun = cfg.DryRun
+	ginkgoConfig.GinkgoConfig.FlakeAttempts = 3
 
 	state := state.Instance
 


### PR DESCRIPTION
Sets the ginkgo flag to retry a failed test 3 times.

Per Ginkgo, if there's one success it deems the test a success. 