### PR TITLE
SDCICD-242. Don't test AWS specific prom exporters on GCP.

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -17,8 +17,6 @@ type Config struct {
 
 	Tests TestConfig `yaml:"tests"`
 
-	CloudProvider CloudProviderConfig `yaml:"cloudProvider"`
-
 	Cluster ClusterConfig `yaml:"cluster"`
 
 	OCM OCMConfig `yaml:"ocm"`
@@ -117,15 +115,6 @@ type UpgradeConfig struct {
 
 	// ReleaseStream used to retrieve latest release images. If set, it will be used to perform an upgrade.
 	ReleaseStream string `env:"UPGRADE_RELEASE_STREAM" sect:"upgrade" yaml:"releaseStream"`
-}
-
-// CloudProviderConfig contains config information pertaining to which cloud provider to use for cluster provisioning.
-type CloudProviderConfig struct {
-	// CloudProviderID is the cloud provider ID to use to provision the cluster.
-	CloudProviderID string `env:"CLOUD_PROVIDER_ID" sect:"cloudProvider" default:"aws" yaml:"providerId"`
-
-	// Region is the cloud provider region to use to provision the cluster.
-	Region string `env:"CLOUD_PROVIDER_REGION" sect:"cloudProvider" default:"us-east-1" yaml:"region"`
 }
 
 // ClusterConfig contains config information pertaining to an OSD cluster

--- a/pkg/common/osd/cluster.go
+++ b/pkg/common/osd/cluster.go
@@ -44,12 +44,12 @@ func (u *OSD) LaunchCluster() (string, error) {
 		Flavour(v1.NewFlavour().
 			ID(flavourID)).
 		Region(v1.NewCloudRegion().
-			ID(cfg.CloudProvider.Region)).
+			ID(state.CloudProvider.Region)).
 		MultiAZ(cfg.Cluster.MultiAZ).
 		Version(v1.NewVersion().
 			ID(state.Cluster.Version)).
 		CloudProvider(v1.NewCloudProvider().
-			ID(cfg.CloudProvider.CloudProviderID)).
+			ID(state.CloudProvider.CloudProviderID)).
 		ExpirationTimestamp(expiration)
 
 	if cfg.Cluster.MultiAZ {

--- a/pkg/common/osd/quota.go
+++ b/pkg/common/osd/quota.go
@@ -8,6 +8,7 @@ import (
 	accounts "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 
 	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/state"
 )
 
 const (
@@ -41,7 +42,7 @@ func (u *OSD) CheckQuota() (bool, error) {
 	machineType := ""
 
 	quotaFound := false
-	resourceClusterType := fmt.Sprintf(ResourceClusterFmt, config.Instance.CloudProvider.CloudProviderID)
+	resourceClusterType := fmt.Sprintf(ResourceClusterFmt, state.Instance.CloudProvider.CloudProviderID)
 	for _, q := range quotaList.Slice() {
 		if quotaFound = HasQuotaFor(q, resourceClusterType, machineType); quotaFound {
 			log.Printf("Quota for test config (%s/%s/multiAZ=%t) found: total=%d, remaining: %d",

--- a/pkg/common/state/state.go
+++ b/pkg/common/state/state.go
@@ -8,6 +8,8 @@ var Instance = new(State)
 type State struct {
 	Cluster ClusterState `yaml:"cluster"`
 
+	CloudProvider CloudProviderState `yaml:"cloudProvider"`
+
 	Kubeconfig KubeconfigState `yaml:"kubeconfig"`
 
 	Upgrade UpgradeState `yaml:"upgrade"`
@@ -20,6 +22,15 @@ type State struct {
 
 	// Project is both the project and SA automatically created to house all objects created during an osde2e-run
 	Project string
+}
+
+// CloudProviderState contains state information pertaining to which cloud provider to use for cluster provisioning.
+type CloudProviderState struct {
+	// CloudProviderID is the cloud provider ID to use to provision the cluster.
+	CloudProviderID string `env:"CLOUD_PROVIDER_ID" sect:"cloudProvider" default:"aws" yaml:"providerId"`
+
+	// Region is the cloud provider region to use to provision the cluster.
+	Region string `env:"CLOUD_PROVIDER_REGION" sect:"cloudProvider" default:"us-east-1" yaml:"region"`
 }
 
 // ClusterState contains state information about the active cluster.

--- a/pkg/e2e/setup.go
+++ b/pkg/e2e/setup.go
@@ -121,6 +121,12 @@ func setupCluster() (err error) {
 
 		state.Cluster.Version = cluster.Version().ID()
 		log.Printf("CLUSTER_VERSION set to %s from OCM.", state.Cluster.Version)
+
+		state.CloudProvider.CloudProviderID = cluster.CloudProvider().ID()
+		log.Printf("CLOUD_PROVIDER_ID set to %s from OCM.", state.CloudProvider.CloudProviderID)
+
+		state.CloudProvider.Region = cluster.Region().ID()
+		log.Printf("CLOUD_PROVIDER_REGION set to %s from OCM.", state.CloudProvider.Region)
 	}
 
 	metadata.Instance.SetClusterName(state.Cluster.Name)

--- a/pkg/e2e/verify/prom_exporters.go
+++ b/pkg/e2e/verify/prom_exporters.go
@@ -11,68 +11,122 @@ import (
 	"github.com/openshift/osde2e/pkg/common/state"
 )
 
-var _ = ginkgo.Describe("[Suite: e2e] [OSD] Prometheus Exporters", func() {
+const (
+	// all represents all environments
+	all = "all"
 
-	var namespace = "openshift-monitoring"
+	// aws represents tests to be run on AWS environments
+	aws = "aws"
+)
 
-	var services = []string{
-		"sre-ebs-iops-reporter",
+var namespace = "openshift-monitoring"
+
+var services = map[string][]string{
+	all: []string{
 		"sre-dns-latency-exporter",
+	},
+	aws: []string{
+		"sre-ebs-iops-reporter",
 		"sre-stuck-ebs-vols",
-	}
+	},
+}
 
-	var configMaps = []string{
+var configMaps = map[string][]string{
+	all: []string{
 		"sre-dns-latency-exporter-code",
+	},
+	aws: []string{
 		"sre-stuck-ebs-vols-code",
 		"sre-ebs-iops-reporter-code",
-	}
+	},
+}
 
-	var secrets = []string{
+var secrets = map[string][]string{
+	aws: []string{
 		"sre-ebs-iops-reporter-aws-credentials",
 		"sre-stuck-ebs-vols-aws-credentials",
-	}
+	},
+}
 
-	var roleBindings = []string{
+var roleBindings = map[string][]string{
+	all: []string{
 		"sre-dns-latency-exporter",
+	},
+	aws: []string{
 		"sre-ebs-iops-reporter",
 		"sre-stuck-ebs-vols",
-	}
+	},
+}
 
-	var daemonSets = []string{
+var daemonSets = map[string][]string{
+	all: []string{
 		"sre-dns-latency-exporter",
-	}
+	},
+}
+
+var _ = ginkgo.Describe("[Suite: e2e] [OSD] Prometheus Exporters", func() {
 
 	h := helper.New()
 
 	ginkgo.It("should exist and be running in the cluster", func() {
+
+		envs := []string{all, state.Instance.CloudProvider.CloudProviderID}
 
 		// Expect project to exist
 		_, err := h.Project().ProjectV1().Projects().Get(namespace, metav1.GetOptions{})
 		Expect(err).ShouldNot(HaveOccurred(), "project should have been created")
 
 		// Ensure presence of config maps
-		for _, configMapName := range configMaps {
-			_, err = h.Kube().CoreV1().ConfigMaps(namespace).Get(configMapName, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred(), "failed to get config map %v\n", configMapName)
-		}
+		checkConfigMaps(h, envs...)
 
 		// Ensure presence of secrets
-		for _, secretName := range secrets {
-			_, err = h.Kube().CoreV1().Secrets(namespace).Get(secretName, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred(), "failed to get secret %v\n", secretName)
-		}
+		checkSecrets(h, envs...)
 
 		// Ensure presence of rolebindings
-		for _, roleBindingName := range roleBindings {
-			_, err = h.Kube().RbacV1().RoleBindings(namespace).Get(roleBindingName, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred(), "failed to get role binding %v\n", roleBindingName)
-		}
+		checkRoleBindings(h, envs...)
 
 		// Ensure daemonsets are present and satisfied
-		currentClusterVersion, err := osd.OpenshiftVersionToSemver(state.Instance.Cluster.Version)
-		Expect(err).NotTo(HaveOccurred(), "error parsing cluster version %s", state.Instance.Cluster.Version)
+		checkDaemonSets(h, envs...)
 
-		for _, daemonSetName := range daemonSets {
+		// Ensure services are present
+		checkServices(h, envs...)
+	}, 300)
+
+})
+
+func checkConfigMaps(h *helper.H, providers ...string) {
+	for _, provider := range providers {
+		for _, configMapName := range configMaps[provider] {
+			_, err := h.Kube().CoreV1().ConfigMaps(namespace).Get(configMapName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "failed to get config map %v\n", configMapName)
+		}
+	}
+}
+
+func checkSecrets(h *helper.H, providers ...string) {
+	for _, provider := range providers {
+		for _, secretName := range secrets[provider] {
+			_, err := h.Kube().CoreV1().Secrets(namespace).Get(secretName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "failed to get secret %v\n", secretName)
+		}
+	}
+}
+
+func checkRoleBindings(h *helper.H, providers ...string) {
+	for _, provider := range providers {
+		for _, roleBindingName := range roleBindings[provider] {
+			_, err := h.Kube().RbacV1().RoleBindings(namespace).Get(roleBindingName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "failed to get role binding %v\n", roleBindingName)
+		}
+	}
+}
+
+func checkDaemonSets(h *helper.H, providers ...string) {
+	currentClusterVersion, err := osd.OpenshiftVersionToSemver(state.Instance.Cluster.Version)
+	Expect(err).NotTo(HaveOccurred(), "error parsing cluster version %s", state.Instance.Cluster.Version)
+
+	for _, provider := range providers {
+		for _, daemonSetName := range daemonSets[provider] {
 			// Use appv1 for clusters 4.4.0 or later
 			if osd.Version440.Check(currentClusterVersion) {
 				daemonSet, err := h.Kube().AppsV1().DaemonSets(namespace).Get(daemonSetName, metav1.GetOptions{})
@@ -86,9 +140,12 @@ var _ = ginkgo.Describe("[Suite: e2e] [OSD] Prometheus Exporters", func() {
 					"daemonset desired count should match currently running")
 			}
 		}
+	}
+}
 
-		// Ensure services are present
-		for _, serviceName := range services {
+func checkServices(h *helper.H, providers ...string) {
+	for _, provider := range providers {
+		for _, serviceName := range services[provider] {
 			service, err := h.Kube().CoreV1().Services(namespace).Get(serviceName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred(), "failed to get service %v\n", serviceName)
 			Expect(service.Spec.ClusterIP).Should(Not(BeNil()),
@@ -96,6 +153,5 @@ var _ = ginkgo.Describe("[Suite: e2e] [OSD] Prometheus Exporters", func() {
 			Expect(service.Spec.Ports).Should(Not(BeEmpty()),
 				"failed to get service cluster ports for %v\n", serviceName)
 		}
-	}, 300)
-
-})
+	}
+}


### PR DESCRIPTION
GCP clusters will no longer test AWS specific prom exporters.
Additionally, cloud provider configuration has been moved to the state
object, as it can now be populated by osde2e when given a cluster ID.