### PR TITLE
SDCICD-249. Make scale tests run as privileged workloads.

### DIFF
--- a/pkg/e2e/scale/scale.go
+++ b/pkg/e2e/scale/scale.go
@@ -91,6 +91,9 @@ func (sCfg scaleRunnerConfig) Runner(h *helper.H) *runner.Runner {
 	runner.PodSpec.Containers[0].Env = append(runner.PodSpec.Containers[0].Env, kubev1.EnvVar{
 		Name:  "PBENCH_SERVER",
 		Value: config.Instance.Scale.PbenchServer,
+	}, kubev1.EnvVar{
+		Name:  "WORKLOAD_JOB_PRIVILEGED",
+		Value: "true",
 	})
 
 	return runner


### PR DESCRIPTION
The scale tests now run as privileged workloads, which should solve some
of the issues with the jobs running on GCP.