### PR TITLE
SDCICD-253. Append random string to pods.

### DIFF
--- a/pkg/common/runner/runner.go
+++ b/pkg/common/runner/runner.go
@@ -2,10 +2,12 @@
 package runner
 
 import (
+	"fmt"
 	"log"
 	"os"
 
 	image "github.com/openshift/client-go/image/clientset/versioned"
+	"github.com/openshift/osde2e/pkg/common/util"
 	kubev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kube "k8s.io/client-go/kubernetes"
@@ -138,7 +140,7 @@ func (r *Runner) DeepCopy() *Runner {
 // meta returns the ObjectMeta used for Runner resources.
 func (r *Runner) meta() metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Name: r.Name,
+		Name: fmt.Sprintf("%s-%s", r.Name, util.RandomStr(5)),
 		Labels: map[string]string{
 			"app": r.Name,
 		},


### PR DESCRIPTION
Now that runner pods all share a namespace, we now append a 5 character
long random string to the end of pod names to make sure it's unique.