### PR TITLE
SDCICD-254: Tune log metrics further

### DIFF
--- a/configs/log-metrics.yaml
+++ b/configs/log-metrics.yaml
@@ -9,13 +9,13 @@ logMetrics:
   lowThreshold: -1
 - name: eof
   regex: "EOF"
-  highThreshold: 1
+  highThreshold: 6
   lowThreshold: -1
 - name: cluster-pending
   regex: "Cluster is not ready, current status 'pending'"
-  highThreshold: 6
+  highThreshold: 20
   lowThreshold: -1
 - name: host-dns-lookup
-  regex: "dial tcp: lookup api\\.ci-cluster.* no such host occurred"
+  regex: "no such host"
   highThreshold: 1
   lowThreshold: -1


### PR DESCRIPTION
- Setting EOFs to a high threshold of 6 assuming several instances are acceptable
- Changing "Pending" instances to be up to 20 from GCP observations
- Updating DNS log metric to be more generic / match other errors observed