### PR TITLE
SDCICD-256: Zero out log metrics at every phase

### DIFF
--- a/pkg/common/metadata/metadata.go
+++ b/pkg/common/metadata/metadata.go
@@ -128,6 +128,13 @@ func (m *Metadata) SetPassRate(currentPhase string, passRate float64) {
 	}
 }
 
+// ResetLogMetrics zeroes out old results to be used before a new run.
+func (m *Metadata) ResetLogMetrics() {
+	for metric := range m.LogMetrics {
+		m.LogMetrics[metric] = 0
+	}
+}
+
 // IncrementLogMetric adds a supplied number to a log metric or sets the metric to
 // the value if it doesn't exist already
 func (m *Metadata) IncrementLogMetric(metric string, value int) {

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -369,6 +369,9 @@ func runTestsInPhase(phase string, description string) bool {
 		}
 	}
 
+	// Ensure all log metrics are zeroed out before running again
+	metadata.Instance.ResetLogMetrics()
+
 	logMetricTestSuite := reporters.JUnitTestSuite{
 		Name: "Log Metrics",
 	}


### PR DESCRIPTION
Previously, log metrics from the install phase would then be duplicated during the upgrade phase: This is not ideal. Now we zero out the metrics between phases.

Of note: Two metadata files, and thus, logMetric entries, will still be created: One for Install, one for Upgrade.

I'm not 100% sure whether this should occur long-term, but it could provide interesting data being able to diff log metrics between phases. 

