### PR TITLE
SDCICD-257. Add in missing certFound flag set.

### DIFF
--- a/pkg/common/osd/healthchecks/certs.go
+++ b/pkg/common/osd/healthchecks/certs.go
@@ -41,6 +41,7 @@ func CheckCerts(secretClient v1.CoreV1Interface) (bool, error) {
 	}
 
 	if !certCheck.certFound {
+		certCheck.certFound = true
 		metadata.Instance.SetTimeToCertificateIssued(time.Since(certCheck.startTime).Seconds())
 	}
 


### PR DESCRIPTION
The certFound flag was not set, which led to longer than expected cert
issued times.