### PR TITLE
SDCICD-269: Run upgrade testing regardless of install phase results

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -118,24 +118,20 @@ func runGinkgoTests() error {
 	testsPassed := runTestsInPhase(phase.InstallPhase, "OSD e2e suite")
 	upgradeTestsPassed := true
 
-	if testsPassed {
-		// upgrade cluster if requested
-		if state.Upgrade.Image != "" || state.Upgrade.ReleaseName != "" {
-			if state.Kubeconfig.Contents != nil {
-				if err = upgrade.RunUpgrade(OSD); err != nil {
-					events.RecordEvent(events.UpgradeFailed)
-					return fmt.Errorf("error performing upgrade: %v", err)
-				}
-				events.RecordEvent(events.UpgradeSuccessful)
-
-				log.Println("Running e2e tests POST-UPGRADE...")
-				upgradeTestsPassed = runTestsInPhase(phase.UpgradePhase, "OSD e2e suite post-upgrade")
-			} else {
-				log.Println("No Kubeconfig found from initial cluster setup. Unable to run upgrade.")
+	// upgrade cluster if requested
+	if state.Upgrade.Image != "" || state.Upgrade.ReleaseName != "" {
+		if state.Kubeconfig.Contents != nil {
+			if err = upgrade.RunUpgrade(OSD); err != nil {
+				events.RecordEvent(events.UpgradeFailed)
+				return fmt.Errorf("error performing upgrade: %v", err)
 			}
+			events.RecordEvent(events.UpgradeSuccessful)
+
+			log.Println("Running e2e tests POST-UPGRADE...")
+			upgradeTestsPassed = runTestsInPhase(phase.UpgradePhase, "OSD e2e suite post-upgrade")
+		} else {
+			log.Println("No Kubeconfig found from initial cluster setup. Unable to run upgrade.")
 		}
-	} else {
-		log.Print("Install tests did not pass. Skipping upgrade tests.")
 	}
 
 	if cfg.ReportDir != "" {


### PR DESCRIPTION
An idealistic behavior that in retrospect was a mistake.

This will ensure we have some form of upgrade-signal regardless of the results of install-phase testing. 

/assign @meowfaceman 