### PR TITLE
SDCICD-264. Use state instead of of last termination state.

### DIFF
--- a/pkg/common/runner/service.go
+++ b/pkg/common/runner/service.go
@@ -70,7 +70,7 @@ func (r *Runner) waitForCompletion(podName string, timeoutInSeconds int) error {
 			var err *multierror.Error
 			for _, containerStatus := range pod.Status.ContainerStatuses {
 				if containerStatus.State.Terminated != nil {
-					if containerStatus.LastTerminationState.Terminated.ExitCode != 0 {
+					if containerStatus.State.Terminated.ExitCode != 0 {
 						multierror.Append(fmt.Errorf("container %s failed, please refer to artifacts for results", containerStatus.Name))
 					}
 				}


### PR DESCRIPTION
LastTerminationState can have a null terminated object apparently -- we
should use the raw state when checking the termination state instead of
using the LastTerminationState.