### PR TITLE
SDCICD-222: Add nodeLabel permission check to informing suite

### DIFF
--- a/pkg/e2e/osd/nodelabels.go
+++ b/pkg/e2e/osd/nodelabels.go
@@ -1,0 +1,31 @@
+package osd
+
+import (
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/helper"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = ginkgo.Describe("[Suite: informing] [OSD] NodeLabels", func() {
+	ginkgo.Context("Modifying nodeLabels is not allowed", func() {
+		// setup helper
+		h := helper.New()
+		ginkgo.It("node-label cannot be added", func() {
+			// Set it to a wildcard dedicated-admin
+			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-cluster")
+
+			nodes, err := h.Kube().CoreV1().Nodes().List(metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(nodes.Items)).Should(BeNumerically(">", 0))
+
+			node := nodes.Items[0]
+
+			node.Labels["osde2e"] = "touched by osde2e"
+
+			_, err = h.Kube().CoreV1().Nodes().Update(&node)
+			Expect(err).To(HaveOccurred())
+		}, float64(config.Instance.Tests.PollingTimeout))
+	})
+})


### PR DESCRIPTION
This test verifies that dedicated-admins cannot update nodeLabels in an OSD cluster. 