### PR TITLE
Fix MkdirAll so that it creates the directory and not the filename.

### DIFF
--- a/pkg/common/helper/runner.go
+++ b/pkg/common/helper/runner.go
@@ -37,7 +37,7 @@ func (h *H) Runner(cmd string) *runner.Runner {
 func (h *H) WriteResults(results map[string][]byte) {
 	for filename, data := range results {
 		dst := filepath.Join(config.Instance.ReportDir, h.Phase, filename)
-		err := os.MkdirAll(filepath.Base(dst), os.FileMode(0755))
+		err := os.MkdirAll(filepath.Dir(dst), os.FileMode(0755))
 		Expect(err).NotTo(HaveOccurred())
 		err = ioutil.WriteFile(dst, data, os.ModePerm)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
After discovering my very polluted cwd, I realized that I thought
`filename.Base` was the same as `filename.Dir`. Don't ask me how.
Anyway, it's fixed.