### PR TITLE
SDCICD-274. Prevent cluster panic if err occurs in wait.

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -35,7 +35,7 @@ func WaitForClusterReady(provisioner spi.Provisioner, clusterID string) error {
 	ocmReady := false
 	if !cfg.Tests.SkipClusterHealthChecks {
 		return wait.PollImmediate(30*time.Second, time.Duration(cfg.Cluster.InstallTimeout)*time.Minute, func() (bool, error) {
-			if cluster, err := provisioner.GetCluster(clusterID); cluster.State() == spi.ClusterStateReady {
+			if cluster, err := provisioner.GetCluster(clusterID); err != nil && cluster.State() == spi.ClusterStateReady {
 				// This is the first time that we've entered this section, so we'll consider this the time until OCM has said the cluster is ready
 				if !ocmReady {
 					ocmReady = true

--- a/pkg/e2e/version.go
+++ b/pkg/e2e/version.go
@@ -196,7 +196,9 @@ func setupUpgradeVersion() (err error) {
 		numFilteredVersions := len(filteredVersionList)
 
 		if numFilteredVersions == 0 {
-			return fmt.Errorf("no edges found for install version %s", state.Cluster.Version)
+			log.Printf("no edges found for install version %s", state.Cluster.Version)
+			state.Upgrade.ReleaseName = NoVersionFound
+			return nil
 		}
 
 		cisUpgradeVersionString := util.SemverToOpenshiftVersion(filteredVersionList[len(filteredVersionList)-1])


### PR DESCRIPTION
During the cluster health wait, if an error occurs when hitting the
provisioner API, an NPE can be hit because the err isn't being checked.

Additionally, when no upgrade candidates are found, the job doesn't
fail, but just fails gracefully (again).
