### PR TITLE
Fix scale tests.

### DIFF
--- a/pkg/common/runner/service.go
+++ b/pkg/common/runner/service.go
@@ -77,7 +77,7 @@ func (r *Runner) waitForCompletion(podName string, timeoutInSeconds int) error {
 					}
 				}
 			}
-			return len(err.Errors) == 0, err.ErrorOrNil()
+			return err == nil, err.ErrorOrNil()
 		} else if pod.Status.Phase == kubev1.PodPending {
 			pendingCount++
 			if pendingCount > podPendingTimeout {


### PR DESCRIPTION
Looks like the scale tests are failing because err.Errors in service.go
doesn't always get populated. Looks like we can just replace this with a
nil check instead.