### PR TITLE
SDCICD-273: Fix arg order for generatediff

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -416,7 +416,7 @@ func runTestsInPhase(phase string, description string) bool {
 			}
 
 			if cfg.JobName != "" && cfg.JobID > 0 {
-				diff, err := debug.GenerateDiff(cfg.BaseJobURL, dependencies, phase, cfg.JobName, cfg.JobID)
+				diff, err := debug.GenerateDiff(cfg.BaseJobURL, phase, dependencies, cfg.JobName, cfg.JobID)
 				if err != nil {
 					log.Printf("Error generating diff: %s", err.Error())
 				} else {


### PR DESCRIPTION
Flubbed the order of the args for GenerateDiff