### PR TITLE
SDCICD-273: Have GenerateDiff output directly to the log rather than return a string

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -415,13 +415,11 @@ func runTestsInPhase(phase string, description string) bool {
 				err = ioutil.WriteFile(filepath.Join(phaseDirectory, "dependencies.txt"), []byte(dependencies), 0644)
 			}
 
+			log.Println("Dependency changes:")
 			if cfg.JobName != "" && cfg.JobID > 0 {
-				diff, err := debug.GenerateDiff(cfg.BaseJobURL, phase, dependencies, cfg.JobName, cfg.JobID)
+				err := debug.GenerateDiff(cfg.BaseJobURL, phase, dependencies, cfg.JobName, cfg.JobID)
 				if err != nil {
 					log.Printf("Error generating diff: %s", err.Error())
-				} else {
-					log.Println("Dependency changes:")
-					log.Println(diff)
 				}
 			} else {
 				log.Println("Not run in prow, skipping dependency diff")


### PR DESCRIPTION
It's entirely possible aurora is outputting an incorrect color type because it's being concatted and then output. 

Since we aren't doing anything else with the generated diff, we'll just have the GenerateDiff function handle logging out the results per-line. 