### PR TITLE
SDCICD-283. Select versions prior to default version.

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -156,6 +156,9 @@ type ClusterConfig struct {
 	// UseOldestClusterImageSetForInstall will select the cluster image set that is in the end of the list of ordered cluster versions known to OCM.
 	UseOldestClusterImageSetForInstall bool `env:"USE_OLDEST_CLUSTER_IMAGE_SET_FOR_INSTALL" sect:"version" default:"false" yaml:"useOldestClusterVersionForInstall"`
 
+	// PreviousReleaseFromDefault will select the clsuter image set that is the given number of releases before the current default.
+	PreviousReleaseFromDefault int `env:"PREVIOUS_RELEASE_FROM_DEFAULT" sect:"version" default:"0" yaml:"previousReleaseFromDefault"`
+
 	// NextReleaseAfterProdDefault will select the cluster image set that the given number of releases away from the the production default.
 	NextReleaseAfterProdDefault int `env:"NEXT_RELEASE_AFTER_PROD_DEFAULT" sect:"version" default:"-1" yaml:"nextReleaseAfterProdDefault"`
 

--- a/pkg/common/state/state.go
+++ b/pkg/common/state/state.go
@@ -46,6 +46,9 @@ type ClusterState struct {
 
 	// EnoughVersionsForOldestOrMiddleTest is true if there were enough versions for an older/middle test.
 	EnoughVersionsForOldestOrMiddleTest bool `default:"true"`
+
+	// PreviousVersionFromDefaultFound is true if a previous version from default was found.
+	PreviousVersionFromDefaultFound bool `default:"true"`
 }
 
 // KubeconfigState stores information required to talk to the Kube API

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -88,6 +88,11 @@ func runGinkgoTests() error {
 			return nil
 		}
 
+		if !state.Cluster.PreviousVersionFromDefaultFound {
+			log.Printf("No previous version from default found with the given arguments.")
+			return nil
+		}
+
 		if state.Upgrade.UpgradeVersionEqualToInstallVersion {
 			log.Printf("Install version and upgrade version are the same. Skipping tests.")
 			return nil


### PR DESCRIPTION
A test can be configured to run N versions prior to the default version.
Since production will soon support running multiple installation
versions on production, this will be necessary to ensure that we have
automated tests for all versions trying to upgrade to the current
default.