### PR TITLE
OSD-3551. Disable curator operator tests for Openshift version <4.2.0.

### DIFF
--- a/pkg/common/cluster/healthchecks/clusterversionoperator.go
+++ b/pkg/common/cluster/healthchecks/clusterversionoperator.go
@@ -3,17 +3,23 @@ package healthchecks
 import (
 	"log"
 
+	v1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+// GetClusterVersionObject wlil get the cluster version object for the cluster.
+func GetClusterVersionObject(configClient configclient.ConfigV1Interface) (*v1.ClusterVersion, error) {
+	getOpts := metav1.GetOptions{}
+	return configClient.ClusterVersions().Get("version", getOpts)
+}
 
 // CheckCVOReadiness attempts to look at the state of the ClusterVersionOperator and returns true if things are healthy.
 func CheckCVOReadiness(configClient configclient.ConfigV1Interface) (bool, error) {
 	success := true
 	log.Print("Checking that CVO says the cluster is healthy...")
 
-	getOpts := metav1.GetOptions{}
-	cvInfo, err := configClient.ClusterVersions().Get("version", getOpts)
+	cvInfo, err := GetClusterVersionObject(configClient)
 	if err != nil {
 		return false, nil
 	}

--- a/pkg/common/util/versionutil.go
+++ b/pkg/common/util/versionutil.go
@@ -5,12 +5,21 @@ import (
 )
 
 var (
+	// Version420 represents Openshift version 4.2.0 and above
+	Version420 *semver.Constraints
+
 	// Version440 represents Openshift version 4.4.0 and above
 	Version440 *semver.Constraints
 )
 
 func init() {
 	var err error
+
+	Version420, err = semver.NewConstraint(">= 4.2.0-0")
+	if err != nil {
+		panic(err)
+	}
+
 	Version440, err = semver.NewConstraint(">= 4.4.0-0")
 
 	if err != nil {

--- a/pkg/common/util/versionutil_test.go
+++ b/pkg/common/util/versionutil_test.go
@@ -1,0 +1,77 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver"
+)
+
+func TestVersion420(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Version  *semver.Version
+		Expected bool
+	}{
+		{
+			Name:     "passes constraint",
+			Version:  semver.MustParse("4.2.1"),
+			Expected: true,
+		},
+		{
+			Name:     "rc passes constraint",
+			Version:  semver.MustParse("4.2.1-rc.0"),
+			Expected: true,
+		},
+		{
+			Name:     "fails constraint",
+			Version:  semver.MustParse("4.1.9"),
+			Expected: false,
+		},
+		{
+			Name:     "rc fails constraint",
+			Version:  semver.MustParse("4.1.9-rc.0"),
+			Expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		if Version420.Check(test.Version) != test.Expected {
+			t.Errorf("test %s did not produce the expected result (%t) when using version %v", test.Name, test.Expected, test.Version)
+		}
+	}
+}
+
+func TestVersion440(t *testing.T) {
+	tests := []struct {
+		Name     string
+		Version  *semver.Version
+		Expected bool
+	}{
+		{
+			Name:     "passes constraint",
+			Version:  semver.MustParse("4.4.1"),
+			Expected: true,
+		},
+		{
+			Name:     "rc passes constraint",
+			Version:  semver.MustParse("4.4.1-rc.0"),
+			Expected: true,
+		},
+		{
+			Name:     "fails constraint",
+			Version:  semver.MustParse("4.3.9"),
+			Expected: false,
+		},
+		{
+			Name:     "rc fails constraint",
+			Version:  semver.MustParse("4.3.9-rc.0"),
+			Expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		if Version440.Check(test.Version) != test.Expected {
+			t.Errorf("test %s did not produce the expected result (%t) when using version %v", test.Name, test.Expected, test.Version)
+		}
+	}
+}

--- a/pkg/e2e/verify/prom_exporters.go
+++ b/pkg/e2e/verify/prom_exporters.go
@@ -6,7 +6,9 @@ import (
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/osde2e/pkg/common/cluster"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	clusterProviders "github.com/openshift/osde2e/pkg/common/providers"
 	"github.com/openshift/osde2e/pkg/common/state"
 	"github.com/openshift/osde2e/pkg/common/util"
 )
@@ -122,8 +124,10 @@ func checkRoleBindings(h *helper.H, providers ...string) {
 }
 
 func checkDaemonSets(h *helper.H, providers ...string) {
-	currentClusterVersion, err := util.OpenshiftVersionToSemver(state.Instance.Cluster.Version)
-	Expect(err).NotTo(HaveOccurred(), "error parsing cluster version %s", state.Instance.Cluster.Version)
+	provider, err := clusterProviders.ClusterProvider()
+	Expect(err).NotTo(HaveOccurred(), "error getting cluster provider")
+	currentClusterVersion, err := cluster.GetClusterVersion(provider, state.Instance.Cluster.ID)
+	Expect(err).NotTo(HaveOccurred(), "error getting cluster version %s", state.Instance.Cluster.Version)
 
 	for _, provider := range providers {
 		for _, daemonSetName := range daemonSets[provider] {


### PR DESCRIPTION
The curator operator tests don't work for clusters under version 4.2.0
at least. The curator operator is being removed, but in the meanwhile,
we'll just disable these tests since they don't work for the 4.1.x line.
If they don't work for the 4.2.x line, we'll deal with that when we come
to it.