### PR TITLE
SDCICD-??? Check for cluster state before attempting dependency gather

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -52,6 +52,7 @@ func GetClusterVersion(provider spi.Provider, clusterID string) (*semver.Version
 // WaitForClusterReady blocks until the cluster is ready for testing.
 func WaitForClusterReady(provider spi.Provider, clusterID string) error {
 	cfg := config.Instance
+	state := state.Instance
 
 	log.Printf("Waiting %v minutes for cluster '%s' to be ready...\n", cfg.Cluster.InstallTimeout, clusterID)
 	cleanRuns := 0
@@ -62,7 +63,9 @@ func WaitForClusterReady(provider spi.Provider, clusterID string) error {
 	ocmReady := false
 	if !cfg.Tests.SkipClusterHealthChecks {
 		return wait.PollImmediate(30*time.Second, time.Duration(cfg.Cluster.InstallTimeout)*time.Minute, func() (bool, error) {
-			if cluster, err := provider.GetCluster(clusterID); err == nil && cluster.State() == spi.ClusterStateReady {
+			cluster, err := provider.GetCluster(clusterID)
+			state.Cluster.State = cluster.State()
+			if err == nil && cluster.State() == spi.ClusterStateReady {
 				// This is the first time that we've entered this section, so we'll consider this the time until OCM has said the cluster is ready
 				if !ocmReady {
 					ocmReady = true

--- a/pkg/common/state/state.go
+++ b/pkg/common/state/state.go
@@ -1,6 +1,8 @@
 // Package state provides common state across osde2e
 package state
 
+import "github.com/openshift/osde2e/pkg/common/spi"
+
 // Instance is the global state for osde2e runs
 var Instance = new(State)
 
@@ -49,6 +51,9 @@ type ClusterState struct {
 
 	// PreviousVersionFromDefaultFound is true if a previous version from default was found.
 	PreviousVersionFromDefaultFound bool `default:"true"`
+
+	// State is the cluster state observed by OCM.
+	State spi.ClusterState `json:"cluster_state,omitempty" yaml:"state"`
 }
 
 // KubeconfigState stores information required to talk to the Kube API

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -406,7 +406,7 @@ func runTestsInPhase(phase string, description string) bool {
 		return false
 	}
 
-	if !cfg.DryRun {
+	if !cfg.DryRun && state.Cluster.State == spi.ClusterStateReady {
 		h := helper.NewOutsideGinkgo()
 		dependencies, err := debug.GenerateDependencies(h.Kube())
 		if err != nil {


### PR DESCRIPTION
This creates a state variable that updates during cluster-readiness-check.

If the cluster state is not "Installed" it assumes that dependencies cannot get gathered. 