### PR TITLE
SDCICD-313. Move log metrics reset before the calculation.

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -357,6 +357,9 @@ func runTestsInPhase(phase string, description string) bool {
 		return false
 	}
 
+	// Ensure all log metrics are zeroed out before running again
+	metadata.Instance.ResetLogMetrics()
+
 	for _, file := range files {
 		if logFileRegex.MatchString(file.Name()) {
 			data, err := ioutil.ReadFile(filepath.Join(cfg.ReportDir, file.Name()))
@@ -369,9 +372,6 @@ func runTestsInPhase(phase string, description string) bool {
 			}
 		}
 	}
-
-	// Ensure all log metrics are zeroed out before running again
-	metadata.Instance.ResetLogMetrics()
 
 	logMetricTestSuite := reporters.JUnitTestSuite{
 		Name: "Log Metrics",


### PR DESCRIPTION
It looks like the log metrics reset was inadvertently directly after
collecting the log metrics, which was causing all log metrics to be zero
all the time. This has been moved.