### PR TITLE
SDCICD-283. Fix version NPE.

### DIFF
--- a/pkg/e2e/version.go
+++ b/pkg/e2e/version.go
@@ -188,6 +188,11 @@ func setupUpgradeVersion() error {
 		return err
 	}
 
+	if clusterVersion == nil {
+		log.Printf("no install version found, skipping upgrade")
+		return nil
+	}
+
 	versionList, err := provider.Versions()
 
 	if err != nil {


### PR DESCRIPTION
If the install version can't be found while trying to perform an
upgrade, we'll get a null pointer exception. This fixes that problem.