### PR TITLE
SDCICD-289: Change error handling depending on whether helper is in ginkgo or not.

### DIFF
--- a/pkg/common/upgrade/upgrade.go
+++ b/pkg/common/upgrade/upgrade.go
@@ -46,6 +46,9 @@ func RunUpgrade(provider spi.Provider) error {
 
 	// setup helper
 	h := helper.NewOutsideGinkgo()
+	if h == nil {
+		return fmt.Errorf("Unable to generate helper outside ginkgo")
+	}
 
 	if h.Upgrade.Image != "" {
 		log.Printf("Upgrading cluster to UPGRADE_IMAGE '%s'", h.Upgrade.Image)

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -83,22 +83,17 @@ func runGinkgoTests() error {
 			return fmt.Errorf("failed to configure versions: %v", err)
 		}
 
-		if !state.Cluster.EnoughVersionsForOldestOrMiddleTest {
+		switch {
+		case !state.Cluster.EnoughVersionsForOldestOrMiddleTest:
 			log.Printf("There were not enough available cluster image sets to choose and oldest or middle cluster image set to test against. Skipping tests.")
 			return nil
-		}
-
-		if !state.Cluster.PreviousVersionFromDefaultFound {
+		case !state.Cluster.PreviousVersionFromDefaultFound:
 			log.Printf("No previous version from default found with the given arguments.")
 			return nil
-		}
-
-		if state.Upgrade.UpgradeVersionEqualToInstallVersion {
+		case state.Upgrade.UpgradeVersionEqualToInstallVersion:
 			log.Printf("Install version and upgrade version are the same. Skipping tests.")
 			return nil
-		}
-
-		if state.Upgrade.ReleaseName == NoVersionFound {
+		case state.Upgrade.ReleaseName == NoVersionFound:
 			log.Printf("No valid upgrade versions were found. Skipping tests.")
 			return nil
 		}
@@ -177,7 +172,12 @@ func runGinkgoTests() error {
 	if !cfg.DryRun {
 		h := helper.NewOutsideGinkgo()
 
+		if h == nil {
+			return fmt.Errorf("Unable to generate helper object for cleanup")
+		}
+
 		cleanupAfterE2E(h)
+
 	}
 
 	if !testsPassed || !upgradeTestsPassed {
@@ -411,22 +411,21 @@ func runTestsInPhase(phase string, description string) bool {
 
 	if !cfg.DryRun && state.Cluster.State == spi.ClusterStateReady {
 		h := helper.NewOutsideGinkgo()
+		if h == nil {
+			log.Println("Unable to generate helper outside of ginkgo")
+			return ginkgoPassed
+		}
 		dependencies, err := debug.GenerateDependencies(h.Kube())
 		if err != nil {
 			log.Printf("Error generating dependencies: %s", err.Error())
 		} else {
-			if len(dependencies) > 0 {
-				err = ioutil.WriteFile(filepath.Join(phaseDirectory, "dependencies.txt"), []byte(dependencies), 0644)
+			if err = ioutil.WriteFile(filepath.Join(phaseDirectory, "dependencies.txt"), []byte(dependencies), 0644); err != nil {
+				log.Printf("Error writing dependencies.txt: %s", err.Error())
 			}
 
-			log.Println("Dependency changes:")
-			if cfg.JobName != "" && cfg.JobID > 0 {
-				err := debug.GenerateDiff(cfg.BaseJobURL, phase, dependencies, cfg.JobName, cfg.JobID)
-				if err != nil {
-					log.Printf("Error generating diff: %s", err.Error())
-				}
-			} else {
-				log.Println("Not run in prow, skipping dependency diff")
+			err := debug.GenerateDiff(cfg.BaseJobURL, phase, dependencies, cfg.JobName, cfg.JobID)
+			if err != nil {
+				log.Printf("Error generating diff: %s", err.Error())
 			}
 
 		}


### PR DESCRIPTION
Whenever helper.OutsideGinkgo is called, we should ensure helper is aware that it may not have some of the ginkgo error handling properties.

Also while running checks against this change, I had to refactor a couple things in order to get under `gocyclo`'s (seemingly arbitrary) check. 

Now, it will always attempt to generate a diff (regardless of if you're in Prow or not) and return an error if it fails (which seems fine for this case.)