### PR TITLE
SDCICD-315. Restore cluster properties with Prow specific logic.

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	JobName string `json:"job_name" env:"JOB_NAME" sect:"tests" yaml:"jobName"`
 
 	// JobID is the ID designated by prow for this run
-	JobID int `json:"job_id" env:"BUILD_NUMBER" sect:"tests" yaml:"jobID"`
+	JobID int `json:"job_id" env:"BUILD_NUMBER" sect:"tests" default:"-1" yaml:"jobID"`
 
 	// BaseJobURL is the root location for all job artifacts
 	// For example, https://storage.googleapis.com/origin-ci-test/logs/osde2e-prod-gcp-e2e-next/61/build-log.txt would be


### PR DESCRIPTION
It looks like, on prow, user.Current() fails. Now, if a BUILD_NUMBER is
detected, it's assumed we're running on prow. This should prevent
failures when running on prow.