### PR TITLE
SDCICD-321. Ignore the MetricsClientSendFailingSRE alert in int.

### DIFF
--- a/pkg/e2e/state/alerts_test.go
+++ b/pkg/e2e/state/alerts_test.go
@@ -1,0 +1,150 @@
+package state
+
+import "testing"
+
+func TestFindCriticalAlerts(t *testing.T) {
+	tests := []struct {
+		Name        string
+		Results     []result
+		Provider    string
+		Environment string
+		Expected    bool
+	}{
+		{
+			Name: "found critical",
+			Results: []result{
+				{
+					Metric: metric{
+						AlertName: "alert1",
+						Severity:  "info",
+					},
+				},
+				{
+					Metric: metric{
+						AlertName: "alert2",
+						Severity:  "warning",
+					},
+				},
+				{
+					Metric: metric{
+						AlertName: "alert3",
+						Severity:  "critical",
+					},
+				},
+			},
+			Provider:    "ocm",
+			Environment: "prod",
+			Expected:    true,
+		},
+		{
+			Name: "no critical",
+			Results: []result{
+				{
+					Metric: metric{
+						AlertName: "alert1",
+						Severity:  "info",
+					},
+				},
+				{
+					Metric: metric{
+						AlertName: "alert2",
+						Severity:  "warning",
+					},
+				},
+				{
+					Metric: metric{
+						AlertName: "alert3",
+						Severity:  "warning",
+					},
+				},
+			},
+			Provider:    "ocm",
+			Environment: "prod",
+			Expected:    false,
+		},
+		{
+			Name: "ignored critical",
+			Results: []result{
+				{
+					Metric: metric{
+						AlertName: "alert1",
+						Severity:  "info",
+					},
+				},
+				{
+					Metric: metric{
+						AlertName: "alert2",
+						Severity:  "warning",
+					},
+				},
+				{
+					Metric: metric{
+						AlertName: "MetricsClientSendFailingSRE",
+						Severity:  "critical",
+					},
+				},
+			},
+			Provider:    "ocm",
+			Environment: "int",
+			Expected:    false,
+		},
+		{
+			Name: "found critical ignored in other environment",
+			Results: []result{
+				{
+					Metric: metric{
+						AlertName: "alert1",
+						Severity:  "info",
+					},
+				},
+				{
+					Metric: metric{
+						AlertName: "alert2",
+						Severity:  "warning",
+					},
+				},
+				{
+					Metric: metric{
+						AlertName: "MetricsClientSendFailingSRE",
+						Severity:  "critical",
+					},
+				},
+			},
+			Provider:    "ocm",
+			Environment: "prod",
+			Expected:    true,
+		},
+		{
+			Name: "found critical ignored in other provider",
+			Results: []result{
+				{
+					Metric: metric{
+						AlertName: "alert1",
+						Severity:  "info",
+					},
+				},
+				{
+					Metric: metric{
+						AlertName: "alert2",
+						Severity:  "warning",
+					},
+				},
+				{
+					Metric: metric{
+						AlertName: "MetricsClientSendFailingSRE",
+						Severity:  "critical",
+					},
+				},
+			},
+			Provider:    "other-provider",
+			Environment: "int",
+			Expected:    true,
+		},
+	}
+
+	for _, test := range tests {
+		if findCriticalAlerts(test.Results, test.Provider, test.Environment) != test.Expected {
+			t.Errorf("Test %s did not produce expected result (%t) for finding critical alerts", test.Name, test.Expected)
+		}
+	}
+}


### PR DESCRIPTION
In integration, this alert fires with every test (OSD-3300). This is a
known problem, but does not otherwise effect the quality of an OSD
cluster in integration. We should ignore this alert for now until
OSD-3300 is fixed.