### PR TITLE
SDCICD-311. Refactor version selection logic.

### DIFF
--- a/pkg/common/util/versionutil.go
+++ b/pkg/common/util/versionutil.go
@@ -5,6 +5,9 @@ import (
 )
 
 var (
+	// NoVersionFound when no version can be found.
+	NoVersionFound = "NoVersionFound"
+
 	// Version420 represents Openshift version 4.2.0 and above
 	Version420 *semver.Constraints
 

--- a/pkg/common/versions/common/utils.go
+++ b/pkg/common/versions/common/utils.go
@@ -1,0 +1,94 @@
+package common
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/spi"
+)
+
+// NextReleaseAfterGivenVersionFromVersionList will attempt to look for the next valid X.Y stream release, given a delta (releaseFromGivenVersion)
+// Example In/Out
+// In: 4.3.12, [4.3.13, 4.4.0, 4.5.0], 2
+// Out: 4.5.0, nil
+func NextReleaseAfterGivenVersionFromVersionList(givenVersion *semver.Version, versionList []*spi.Version, releasesFromGivenVersion int) (*semver.Version, error) {
+	versionBuckets := map[string]*semver.Version{}
+
+	// Assemble a map that lists a release (x.y.0) to its latest version, with nightlies taking precedence over all else
+	for _, version := range versionList {
+		versionSemver := version.Version()
+		majorMinor := createMajorMinorStringFromSemver(versionSemver)
+
+		if _, ok := versionBuckets[majorMinor]; !ok {
+			versionBuckets[majorMinor] = versionSemver
+		} else {
+			currentGreatestVersion := versionBuckets[majorMinor]
+			versionIsNightly := strings.Contains(versionSemver.Prerelease(), "nightly")
+			currentIsNightly := strings.Contains(currentGreatestVersion.Prerelease(), "nightly")
+
+			// Make sure nightlies take precedence over other versions
+			if versionIsNightly && !currentIsNightly {
+				versionBuckets[majorMinor] = versionSemver
+			} else if currentIsNightly && !versionIsNightly {
+				continue
+			} else if currentGreatestVersion.LessThan(versionSemver) {
+				versionBuckets[majorMinor] = versionSemver
+			}
+		}
+	}
+
+	// Parse all major minor versions (x.y.0) into semver versions and place them in an array.
+	// This is done explicitly so that we can utilize the semver library's sorting capability.
+	majorMinorList := []*semver.Version{}
+	for k := range versionBuckets {
+		parsedMajorMinor, err := semver.NewVersion(k)
+		if err != nil {
+			return nil, err
+		}
+
+		majorMinorList = append(majorMinorList, parsedMajorMinor)
+	}
+
+	sort.Sort(semver.Collection(majorMinorList))
+
+	// Now that the list is sorted, we want to locate the major minor of the given version in the list.
+	givenMajorMinor, err := semver.NewVersion(createMajorMinorStringFromSemver(givenVersion))
+
+	if err != nil {
+		return nil, err
+	}
+
+	indexOfGivenMajorMinor := -1
+	for i, majorMinor := range majorMinorList {
+		if majorMinor.Equal(givenMajorMinor) {
+			indexOfGivenMajorMinor = i
+			break
+		}
+	}
+
+	if indexOfGivenMajorMinor == -1 {
+		return nil, fmt.Errorf("unable to find given version from list of available versions")
+	}
+
+	// Next, we'll go the given version distance ahead of the given version. We want to do it this way instead of guessing
+	// the next minor release so that we can handle major releases in the future, In other words, if the Openshift
+	// 4.y line stops at 4.13, we'll still be able to pick 5.0 if it's the next release after 4.13.
+	nextMajorMinorIndex := indexOfGivenMajorMinor + releasesFromGivenVersion
+
+	if len(majorMinorList) <= nextMajorMinorIndex {
+		return nil, fmt.Errorf("there is no eligible next release from the list of available versions")
+	}
+	nextMajorMinor := createMajorMinorStringFromSemver(majorMinorList[nextMajorMinorIndex])
+
+	if _, ok := versionBuckets[nextMajorMinor]; !ok {
+		return nil, fmt.Errorf("no major/minor version found for %s", nextMajorMinor)
+	}
+
+	return versionBuckets[nextMajorMinor], nil
+}
+
+func createMajorMinorStringFromSemver(version *semver.Version) string {
+	return fmt.Sprintf("%d.%d", version.Major(), version.Minor())
+}

--- a/pkg/common/versions/common/utils_test.go
+++ b/pkg/common/versions/common/utils_test.go
@@ -1,4 +1,4 @@
-package e2e
+package common
 
 import (
 	"testing"
@@ -73,7 +73,7 @@ func TestNextReleaseAfterGivenVersionFromVersionList(t *testing.T) {
 				Version(semver.MustParse(version)).
 				Build())
 		}
-		selectedVersion, err := nextReleaseAfterGivenVersionFromVersionList(test.GivenVersion, versions, test.ReleasesFromGivenVersion)
+		selectedVersion, err := NextReleaseAfterGivenVersionFromVersionList(test.GivenVersion, versions, test.ReleasesFromGivenVersion)
 
 		if err != nil {
 			t.Errorf("error selecting version from list: %v", err)

--- a/pkg/common/versions/installselectors/default_version.go
+++ b/pkg/common/versions/installselectors/default_version.go
@@ -1,0 +1,25 @@
+package installselectors
+
+import (
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/spi"
+)
+
+func init() {
+	registerSelector(defaultVersion{})
+}
+
+// DefaultVersion is the fallback selector.
+type defaultVersion struct{}
+
+func (d defaultVersion) ShouldUse() bool {
+	return true
+}
+
+func (d defaultVersion) Priority() int {
+	return 0
+}
+
+func (d defaultVersion) SelectVersion(versionList *spi.VersionList) (*semver.Version, string, error) {
+	return versionList.Default(), "current default", nil
+}

--- a/pkg/common/versions/installselectors/interface.go
+++ b/pkg/common/versions/installselectors/interface.go
@@ -1,0 +1,19 @@
+package installselectors
+
+import (
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/spi"
+)
+
+// Interface is the interface for version selection implementations for installs.
+type Interface interface {
+	// ShouldUse will return true if the version selector should be used.
+	ShouldUse() bool
+
+	// Priority is the integer priority for the selector. The higher the integer,
+	// the higher the priority. 0 is the minimum.
+	Priority() int
+
+	// SelectVersion will select a version to install.
+	SelectVersion(versionList *spi.VersionList) (*semver.Version, string, error)
+}

--- a/pkg/common/versions/installselectors/latest_version_selector.go
+++ b/pkg/common/versions/installselectors/latest_version_selector.go
@@ -1,0 +1,36 @@
+package installselectors
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/spi"
+)
+
+func init() {
+	registerSelector(latestVersion{})
+}
+
+// LatestVersion will always select the latest version of openshift.
+type latestVersion struct{}
+
+func (l latestVersion) ShouldUse() bool {
+	return config.Instance.Cluster.UseLatestVersionForInstall
+}
+
+func (l latestVersion) Priority() int {
+	return 70
+}
+
+func (l latestVersion) SelectVersion(versionList *spi.VersionList) (*semver.Version, string, error) {
+	availableVersions := versionList.AvailableVersions()
+	numVersions := len(availableVersions)
+	versionType := "latest version"
+
+	if numVersions == 0 {
+		return nil, versionType, fmt.Errorf("not enough versions to select the latest version")
+	}
+
+	return availableVersions[len(availableVersions)-1].Version(), versionType, nil
+}

--- a/pkg/common/versions/installselectors/middle_cluster_image_set.go
+++ b/pkg/common/versions/installselectors/middle_cluster_image_set.go
@@ -1,0 +1,38 @@
+package installselectors
+
+import (
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/spi"
+	"github.com/openshift/osde2e/pkg/common/state"
+)
+
+func init() {
+	registerSelector(middleClusterImageSet{})
+}
+
+// MiddleClusterImageSet will use the image in the middle of the available versions.
+type middleClusterImageSet struct{}
+
+func (m middleClusterImageSet) ShouldUse() bool {
+	return config.Instance.Cluster.UseMiddleClusterImageSetForInstall
+}
+
+func (m middleClusterImageSet) Priority() int {
+	return 60
+}
+
+func (m middleClusterImageSet) SelectVersion(versionList *spi.VersionList) (*semver.Version, string, error) {
+	versionsWithoutDefault := removeDefaultVersion(versionList.AvailableVersions())
+	numVersions := len(versionsWithoutDefault)
+	versionType := "middle version"
+
+	// We don't want to fail entirely if there aren't enough versions. It's valid and perhaps even expected
+	// that we d on't have enough versions for a middle cluster image set.
+	if numVersions < 2 {
+		state.Instance.Cluster.EnoughVersionsForOldestOrMiddleTest = false
+		return nil, versionType, nil
+	}
+
+	return versionsWithoutDefault[numVersions/2].Version(), versionType, nil
+}

--- a/pkg/common/versions/installselectors/next_version_after_prod_default.go
+++ b/pkg/common/versions/installselectors/next_version_after_prod_default.go
@@ -1,0 +1,32 @@
+package installselectors
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/spi"
+	"github.com/openshift/osde2e/pkg/common/versions/common"
+)
+
+func init() {
+	registerSelector(nextVersionAfterProdDefault{})
+}
+
+// nextVersionAfterProdDefault will select a version that is N releases from the current production default.
+type nextVersionAfterProdDefault struct{}
+
+func (n nextVersionAfterProdDefault) ShouldUse() bool {
+	return config.Instance.Cluster.NextReleaseAfterProdDefault > -1
+}
+
+func (n nextVersionAfterProdDefault) Priority() int {
+	return 40
+}
+
+func (n nextVersionAfterProdDefault) SelectVersion(versionList *spi.VersionList) (*semver.Version, string, error) {
+	numReleasesAfterProdDefault := config.Instance.Cluster.NextReleaseAfterProdDefault
+	defaultVersion := versionList.Default()
+	selectedVersion, err := common.NextReleaseAfterGivenVersionFromVersionList(defaultVersion, versionList.AvailableVersions(), numReleasesAfterProdDefault)
+	return selectedVersion, fmt.Sprintf("%d release(s) from the default version in prod", numReleasesAfterProdDefault), err
+}

--- a/pkg/common/versions/installselectors/oldest_cluster_image_set.go
+++ b/pkg/common/versions/installselectors/oldest_cluster_image_set.go
@@ -1,0 +1,38 @@
+package installselectors
+
+import (
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/spi"
+	"github.com/openshift/osde2e/pkg/common/state"
+)
+
+func init() {
+	registerSelector(oldestClusterImageSet{})
+}
+
+// oldestClusterImageSet will use the oldest image from the list of available versions.
+type oldestClusterImageSet struct{}
+
+func (o oldestClusterImageSet) ShouldUse() bool {
+	return config.Instance.Cluster.UseOldestClusterImageSetForInstall
+}
+
+func (o oldestClusterImageSet) Priority() int {
+	return 60
+}
+
+func (o oldestClusterImageSet) SelectVersion(versionList *spi.VersionList) (*semver.Version, string, error) {
+	versionsWithoutDefault := removeDefaultVersion(versionList.AvailableVersions())
+	numVersions := len(versionsWithoutDefault)
+	versionType := "oldest version"
+
+	// We don't want to fail entirely if there aren't enough versions. It's valid and perhaps even expected
+	// that we d on't have enough versions for a middle cluster image set.
+	if numVersions < 2 {
+		state.Instance.Cluster.EnoughVersionsForOldestOrMiddleTest = false
+		return nil, versionType, nil
+	}
+
+	return versionsWithoutDefault[0].Version(), versionType, nil
+}

--- a/pkg/common/versions/installselectors/previous_release_from_default.go
+++ b/pkg/common/versions/installselectors/previous_release_from_default.go
@@ -1,0 +1,58 @@
+package installselectors
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/spi"
+	"github.com/openshift/osde2e/pkg/common/state"
+)
+
+func init() {
+	registerSelector(previousReleaseFromDefault{})
+}
+
+// previousReleaseFromDefault is the selector which will
+type previousReleaseFromDefault struct{}
+
+func (p previousReleaseFromDefault) ShouldUse() bool {
+	return config.Instance.Cluster.PreviousReleaseFromDefault > 0
+}
+
+func (p previousReleaseFromDefault) Priority() int {
+	return 50
+}
+
+func (p previousReleaseFromDefault) SelectVersion(versionList *spi.VersionList) (*semver.Version, string, error) {
+	availableVersions := versionList.AvailableVersions()
+	defaultIndex := findDefaultVersionIndex(availableVersions)
+	numReleasesFromDefault := config.Instance.Cluster.PreviousReleaseFromDefault
+	versionType := fmt.Sprintf("version %d releases prior to the default", numReleasesFromDefault)
+
+	if defaultIndex < 0 {
+		log.Printf("unable to find default version in avaialable version list")
+		state.Instance.Cluster.PreviousVersionFromDefaultFound = false
+	}
+
+	targetIndex := defaultIndex - numReleasesFromDefault
+
+	if targetIndex < 0 {
+		log.Printf("not enough enabled versions to go back %d releases", numReleasesFromDefault)
+		state.Instance.Cluster.PreviousVersionFromDefaultFound = false
+		return nil, versionType, nil
+	}
+
+	return availableVersions[targetIndex].Version(), versionType, nil
+}
+
+func findDefaultVersionIndex(versions []*spi.Version) int {
+	for index, version := range versions {
+		if version.Default() {
+			return index
+		}
+	}
+
+	return -1
+}

--- a/pkg/common/versions/installselectors/registry.go
+++ b/pkg/common/versions/installselectors/registry.go
@@ -1,0 +1,19 @@
+package installselectors
+
+// registry is the install version selector registry.
+type registry struct {
+	selectors []Interface
+}
+
+var globalSelectorRegistry registry = registry{
+	selectors: []Interface{},
+}
+
+// GetVersionSelectors will return the registered version selectors for initial cluster installation.
+func GetVersionSelectors() []Interface {
+	return globalSelectorRegistry.selectors
+}
+
+func registerSelector(i Interface) {
+	globalSelectorRegistry.selectors = append(globalSelectorRegistry.selectors, i)
+}

--- a/pkg/common/versions/installselectors/utils.go
+++ b/pkg/common/versions/installselectors/utils.go
@@ -1,0 +1,15 @@
+package installselectors
+
+import "github.com/openshift/osde2e/pkg/common/spi"
+
+func removeDefaultVersion(versions []*spi.Version) []*spi.Version {
+	versionsWithoutDefault := []*spi.Version{}
+
+	for _, version := range versions {
+		if !version.Default() {
+			versionsWithoutDefault = append(versionsWithoutDefault, version)
+		}
+	}
+
+	return versionsWithoutDefault
+}

--- a/pkg/common/versions/upgradeselectors/cincinnati_version.go
+++ b/pkg/common/versions/upgradeselectors/cincinnati_version.go
@@ -1,4 +1,4 @@
-package upgrade
+package upgradeselectors
 
 import (
 	"encoding/json"
@@ -6,23 +6,78 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"strings"
 	"sync"
 
 	"github.com/Masterminds/semver"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/metadata"
-	"github.com/openshift/osde2e/pkg/common/providers"
+	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/state"
+	"github.com/openshift/osde2e/pkg/common/upgrade"
 	"github.com/openshift/osde2e/pkg/common/util"
 )
 
 const (
-	// format string for release stream latest from release controller
-	latestReleaseControllerURLFmt = "https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/%s/latest"
 	// format string for Cincinnati releases
 	cincinnatiURLFmt = "https://api.openshift.com/api/upgrades_info/v1/graph?channel=%s&arch=amd64"
 )
+
+func init() {
+	registerSelector(cincinnatiUpgrade{})
+}
+
+// cincinnatiUpgrade will select an upgrade target based on Cincinnaati.
+type cincinnatiUpgrade struct{}
+
+func (c cincinnatiUpgrade) ShouldUse(upgradeSource spi.UpgradeSource) bool {
+	return upgradeSource == spi.CincinnatiSource && config.Instance.Upgrade.UpgradeToCISIfPossible
+}
+
+func (c cincinnatiUpgrade) Priority() int {
+	return 40
+}
+
+func (c cincinnatiUpgrade) SelectVersion(installVersion *semver.Version, versionList *spi.VersionList) (string, string, error) {
+	state := state.Instance
+
+	var filteredVersionList = []*semver.Version{}
+	for _, version := range versionList.AvailableVersions() {
+		if filterOnCincinnati(installVersion, version.Version()) {
+			filteredVersionList = append(filteredVersionList, version.Version())
+		}
+	}
+
+	numResults := len(filteredVersionList)
+	if numResults == 0 {
+		state.Upgrade.ReleaseName = util.NoVersionFound
+		metadata.Instance.SetUpgradeVersionSource("none")
+		return "", "", nil
+	}
+
+	cisUpgradeVersion := filteredVersionList[numResults-1]
+
+	releaseName := ""
+	// If the available cluster image set makes sense, then we'll just use that
+	if !cisUpgradeVersion.LessThan(installVersion) {
+		log.Printf("Using cluster image set.")
+		releaseName = util.SemverToOpenshiftVersion(cisUpgradeVersion)
+		metadata.Instance.SetUpgradeVersionSource("cluster image set")
+		state.Upgrade.UpgradeVersionEqualToInstallVersion = cisUpgradeVersion.Equal(installVersion)
+	}
+
+	return releaseName, "", nil
+}
+
+func filterOnCincinnati(installVersion *semver.Version, upgradeVersion *semver.Version) bool {
+	versionInCincinnati, err := doesEdgeExistInCincinnati(installVersion, upgradeVersion)
+
+	if err != nil {
+		log.Printf("error while trying to filter on version in Cincinnati: %v", err)
+		return false
+	}
+
+	return versionInCincinnati
+}
 
 type smallCincinnatiCache struct {
 	Cache map[string]smallCincinnatiCacheObject
@@ -111,9 +166,9 @@ var cache *smallCincinnatiCache = &smallCincinnatiCache{
 	mutex: sync.Mutex{},
 }
 
-// DoesEdgeExistInCincinnati returns true if the version can be found in Cincinnati and the edge from the install version to the upgrade version exists.
-func DoesEdgeExistInCincinnati(installVersion, upgradeVersion *semver.Version) (bool, error) {
-	channel, err := VersionToChannel(upgradeVersion)
+// doesEdgeExistInCincinnati returns true if the version can be found in Cincinnati and the edge from the install version to the upgrade version exists.
+func doesEdgeExistInCincinnati(installVersion, upgradeVersion *semver.Version) (bool, error) {
+	channel, err := upgrade.VersionToChannel(upgradeVersion)
 	if err != nil {
 		return false, fmt.Errorf("error getting channel from provided version: %v", err)
 	}
@@ -156,78 +211,6 @@ func DoesEdgeExistInCincinnati(installVersion, upgradeVersion *semver.Version) (
 	}
 
 	return false, nil
-}
-
-// LatestReleaseFromReleaseController retrieves latest release information for given releaseStream on the release controller.
-func LatestReleaseFromReleaseController(releaseStream string) (name, pullSpec string, err error) {
-	var resp *http.Response
-	var data []byte
-
-	latestURL := fmt.Sprintf(latestReleaseControllerURLFmt, releaseStream)
-	resp, err = http.Get(latestURL)
-	if err != nil {
-		err = fmt.Errorf("failed to get latest for stream '%s': %v", releaseStream, err)
-		return
-	}
-
-	data, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		err = fmt.Errorf("failed reading body: %v", err)
-		return
-	}
-
-	latest := latestAccepted{}
-	if err = json.Unmarshal(data, &latest); err != nil {
-		return "", "", fmt.Errorf("error decoding body of '%s': %v", data, err)
-	}
-
-	metadata.Instance.SetUpgradeVersionSource("release controller")
-
-	return ensureReleasePrefix(latest.Name), latest.PullSpec, nil
-}
-
-// VersionToChannel creates a Cincinnati channel version out of an OpenShift version.
-// If the config.Instance.Upgrade.OnlyUpgradeToZReleases flag is set, this will use the install version
-// in the global state object to determine the channel.
-// The provider will be queried for the appropriate Cincinnati channel  to use unless a prelease version
-// is being used, in which case the candidate channel will be used.
-func VersionToChannel(version *semver.Version) (string, error) {
-	useVersion := version
-	if config.Instance.Upgrade.OnlyUpgradeToZReleases {
-		var err error
-		useVersion, err = util.OpenshiftVersionToSemver(state.Instance.Cluster.Version)
-
-		if err != nil {
-			panic("cluster version stored in state object is invalid")
-		}
-	}
-
-	if strings.HasPrefix(useVersion.Prerelease(), "rc") {
-		return fmt.Sprintf("candidate-%d.%d", useVersion.Major(), useVersion.Minor()), nil
-	}
-
-	provider, err := providers.ClusterProvider()
-
-	if err != nil {
-		return "", fmt.Errorf("unable to get provider: %s", err)
-	}
-
-	return fmt.Sprintf("%s-%d.%d", provider.CincinnatiChannel(), useVersion.Major(), useVersion.Minor()), nil
-}
-
-func ensureReleasePrefix(release string) string {
-	if len(release) > 0 && !strings.Contains(release, "openshift-v") {
-		log.Printf("Version %s didn't have prefix. Adding....", release)
-		release = "openshift-v" + release
-	}
-	return release
-}
-
-// latestAccepted information from release controller.
-type latestAccepted struct {
-	Name        string `json:"name"`
-	PullSpec    string `json:"pullSpec"`
-	DownloadURL string `json:"downloadURL"`
 }
 
 type cincinnatiReleaseNodes struct {

--- a/pkg/common/versions/upgradeselectors/interface.go
+++ b/pkg/common/versions/upgradeselectors/interface.go
@@ -1,0 +1,20 @@
+package upgradeselectors
+
+import (
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/spi"
+)
+
+// Interface is the interface for version selection implementations for upgrades.
+type Interface interface {
+	// ShouldUse will return true if the version selector should be used.
+	ShouldUse(upgradeSource spi.UpgradeSource) bool
+
+	// Priority is the integer priority for the selector. The higher the integer,
+	// the higher the priority. 0 is the minimum.
+	Priority() int
+
+	// SelectVersion will select a version to upgrade. This will be populated as a release name and an image.
+	// If the image is blank, OpenShift will use Cincinnati to attempt to upgrade.
+	SelectVersion(installVersion *semver.Version, versionList *spi.VersionList) (string, string, error)
+}

--- a/pkg/common/versions/upgradeselectors/registry.go
+++ b/pkg/common/versions/upgradeselectors/registry.go
@@ -1,0 +1,19 @@
+package upgradeselectors
+
+// registry is the upgrade version selector registry.
+type registry struct {
+	selectors []Interface
+}
+
+var globalSelectorRegistry registry = registry{
+	selectors: []Interface{},
+}
+
+// GetVersionSelectors will return the registered version selectors for cluster upgrades.
+func GetVersionSelectors() []Interface {
+	return globalSelectorRegistry.selectors
+}
+
+func registerSelector(u Interface) {
+	globalSelectorRegistry.selectors = append(globalSelectorRegistry.selectors, u)
+}

--- a/pkg/common/versions/upgradeselectors/release_controller_version.go
+++ b/pkg/common/versions/upgradeselectors/release_controller_version.go
@@ -1,0 +1,106 @@
+package upgradeselectors
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/metadata"
+	"github.com/openshift/osde2e/pkg/common/spi"
+	"github.com/openshift/osde2e/pkg/common/util"
+	"github.com/openshift/osde2e/pkg/common/versions/common"
+)
+
+const (
+	// format string for release stream latest from release controller
+	latestReleaseControllerURLFmt = "https://openshift-release.svc.ci.openshift.org/api/v1/releasestream/%s/latest"
+)
+
+func init() {
+	registerSelector(releaseControllerUpgrade{})
+}
+
+// releaseControllerUpgrade will select an upgrade target based on the ReleaseController.
+type releaseControllerUpgrade struct{}
+
+func (r releaseControllerUpgrade) ShouldUse(upgradeSource spi.UpgradeSource) bool {
+	return upgradeSource == spi.ReleaseControllerSource && config.Instance.Upgrade.NextReleaseAfterProdDefaultForUpgrade > -1
+}
+
+func (r releaseControllerUpgrade) Priority() int {
+	return 40
+}
+
+func (r releaseControllerUpgrade) SelectVersion(installVersion *semver.Version, versionList *spi.VersionList) (string, string, error) {
+	cfg := config.Instance
+
+	// If we're using the release controller, we're trying to do relative version selection.
+	// We'll confirm this in case things change in the future and just proceed with that assumption.
+	nextVersion, err := common.NextReleaseAfterGivenVersionFromVersionList(versionList.Default(), versionList.AvailableVersions(), cfg.Upgrade.NextReleaseAfterProdDefaultForUpgrade)
+
+	if err != nil {
+		return "", "", fmt.Errorf("error determining next version to upgrade to: %v", err)
+	}
+
+	releaseStream := fmt.Sprintf("%d.%d.0-0.nightly", nextVersion.Major(), nextVersion.Minor())
+
+	return latestReleaseFromReleaseController(releaseStream)
+}
+
+// latestAccepted information from release controller.
+type latestAccepted struct {
+	Name        string `json:"name"`
+	PullSpec    string `json:"pullSpec"`
+	DownloadURL string `json:"downloadURL"`
+}
+
+// latestReleaseFromReleaseController retrieves latest release information for given releaseStream on the release controller.
+func latestReleaseFromReleaseController(releaseStream string) (name, pullSpec string, err error) {
+	var resp *http.Response
+	var data []byte
+
+	latestURL := fmt.Sprintf(latestReleaseControllerURLFmt, releaseStream)
+	resp, err = http.Get(latestURL)
+	if err != nil {
+		err = fmt.Errorf("failed to get latest for stream '%s': %v", releaseStream, err)
+		return
+	}
+
+	data, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		err = fmt.Errorf("failed reading body: %v", err)
+		return
+	}
+
+	latest := latestAccepted{}
+	if err = json.Unmarshal(data, &latest); err != nil {
+		return "", "", fmt.Errorf("error decoding body of '%s': %v", data, err)
+	}
+
+	metadata.Instance.SetUpgradeVersionSource("release controller")
+
+	if latest.Name == "" {
+		return util.NoVersionFound, "", nil
+	}
+
+	releaseName := ensureReleasePrefix(latest.Name)
+
+	if releaseStream == "" {
+		return util.NoVersionFound, "", nil
+	}
+
+	return releaseName, latest.PullSpec, err
+}
+
+func ensureReleasePrefix(release string) string {
+	if len(release) > 0 && !strings.Contains(release, "openshift-v") {
+		log.Printf("Version %s didn't have prefix. Adding....", release)
+		release = "openshift-v" + release
+	}
+	return release
+}

--- a/pkg/common/versions/version_selector.go
+++ b/pkg/common/versions/version_selector.go
@@ -1,0 +1,63 @@
+package versions
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/spi"
+	"github.com/openshift/osde2e/pkg/common/util"
+	"github.com/openshift/osde2e/pkg/common/versions/installselectors"
+	"github.com/openshift/osde2e/pkg/common/versions/upgradeselectors"
+)
+
+// GetVersionForInstall will get a version based upon available configuration options.
+func GetVersionForInstall(versionList *spi.VersionList) (*semver.Version, string, error) {
+	var selectedVersionSelector installselectors.Interface = nil
+
+	curPriority := math.MinInt32
+
+	versionSelectors := installselectors.GetVersionSelectors()
+
+	for _, versionSelector := range versionSelectors {
+		if versionSelector.ShouldUse() && versionSelector.Priority() > curPriority {
+			selectedVersionSelector = versionSelector
+			curPriority = versionSelector.Priority()
+		}
+	}
+
+	if selectedVersionSelector == nil {
+		return nil, "", fmt.Errorf("unable to find an install version selector")
+	}
+
+	return selectedVersionSelector.SelectVersion(versionList)
+}
+
+// GetVersionForUpgrade will get a version based upon available configuration options.
+func GetVersionForUpgrade(installVersion *semver.Version, versionList *spi.VersionList, upgradeSource spi.UpgradeSource) (string, string, error) {
+	var selectedVersionSelector upgradeselectors.Interface = nil
+
+	curPriority := math.MinInt32
+
+	versionSelectors := upgradeselectors.GetVersionSelectors()
+
+	for _, versionSelector := range versionSelectors {
+		if versionSelector.ShouldUse(upgradeSource) && versionSelector.Priority() > curPriority {
+			selectedVersionSelector = versionSelector
+			curPriority = versionSelector.Priority()
+		}
+	}
+
+	// If no version selector has been found for an upgrade, assume that an upgrade is not being asked for.
+	if selectedVersionSelector == nil {
+		return "", "", nil
+	}
+
+	releaseName, image, err := selectedVersionSelector.SelectVersion(installVersion, versionList)
+
+	if releaseName == "" && err == nil {
+		return util.NoVersionFound, "", nil
+	}
+
+	return releaseName, image, err
+}

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -31,6 +31,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/state"
 	"github.com/openshift/osde2e/pkg/common/upgrade"
+	"github.com/openshift/osde2e/pkg/common/util"
 	"github.com/openshift/osde2e/pkg/debug"
 )
 
@@ -93,7 +94,7 @@ func runGinkgoTests() error {
 		case state.Upgrade.UpgradeVersionEqualToInstallVersion:
 			log.Printf("Install version and upgrade version are the same. Skipping tests.")
 			return nil
-		case state.Upgrade.ReleaseName == NoVersionFound:
+		case state.Upgrade.ReleaseName == util.NoVersionFound:
 			log.Printf("No valid upgrade versions were found. Skipping tests.")
 			return nil
 		}

--- a/pkg/e2e/version.go
+++ b/pkg/e2e/version.go
@@ -4,55 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"sort"
-	"strings"
 
 	"github.com/Masterminds/semver"
-	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/metadata"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/state"
-	"github.com/openshift/osde2e/pkg/common/upgrade"
 	"github.com/openshift/osde2e/pkg/common/util"
+	"github.com/openshift/osde2e/pkg/common/versions"
 )
-
-const (
-	// NoVersionFound when no version can be found.
-	NoVersionFound = "NoVersionFound"
-)
-
-func filterOnCincinnati(installVersion *semver.Version, upgradeVersion *semver.Version) bool {
-	versionInCincinnati, err := upgrade.DoesEdgeExistInCincinnati(installVersion, upgradeVersion)
-
-	if err != nil {
-		log.Printf("error while trying to filter on version in Cincinnati: %v", err)
-		return false
-	}
-
-	return versionInCincinnati
-}
-
-func removeDefaultVersion(versions []*spi.Version) []*spi.Version {
-	versionsWithoutDefault := []*spi.Version{}
-
-	for _, version := range versions {
-		if !version.Default() {
-			versionsWithoutDefault = append(versionsWithoutDefault, version)
-		}
-	}
-
-	return versionsWithoutDefault
-}
-
-func findDefaultVersionIndex(versions []*spi.Version) int {
-	for index, version := range versions {
-		if version.Default() {
-			return index
-		}
-	}
-
-	return -1
-}
 
 // ChooseVersions sets versions in cfg if not set based on defaults and upgrade options.
 // If a release stream is set for an upgrade the previous available version is used and it's image is used for upgrade.
@@ -62,10 +21,24 @@ func ChooseVersions() (err error) {
 	// when defined, use set version
 	if provider == nil {
 		err = errors.New("osd must be setup when upgrading with release stream")
-	} else if shouldUpgrade() {
-		err = setupUpgradeVersion()
 	} else {
-		_, err = setupVersion()
+		versionList, err := provider.Versions()
+
+		if err != nil {
+			return fmt.Errorf("error getting versions: %v", err)
+		}
+
+		clusterVersion, err := setupVersion(versionList)
+
+		if err != nil {
+			return fmt.Errorf("error while selecting install version: %v", err)
+		}
+
+		err = setupUpgradeVersion(clusterVersion, versionList)
+
+		if err != nil {
+			return fmt.Errorf("error while selecting upgrade version: %v", err)
+		}
 	}
 
 	// Set the versions in metadata. If upgrade hasn't been chosen, it should still be omitted from the end result.
@@ -75,22 +48,10 @@ func ChooseVersions() (err error) {
 	return err
 }
 
-// shouldUpgrade determines if this test run should attempt an upgrade.
-func shouldUpgrade() bool {
-	cfg := config.Instance
-	state := state.Instance
-
-	return state.Upgrade.Image == "" &&
-		(cfg.Upgrade.ReleaseStream != "" ||
-			cfg.Upgrade.UpgradeToCISIfPossible ||
-			cfg.Upgrade.NextReleaseAfterProdDefaultForUpgrade > -1)
-}
-
 // chooses between default version and nightly based on target versions.
-func setupVersion() (*semver.Version, error) {
+func setupVersion(versionList *spi.VersionList) (*semver.Version, error) {
 	var selectedVersion *semver.Version
 
-	cfg := config.Instance
 	state := state.Instance
 
 	versionType := "user supplied version"
@@ -98,62 +59,7 @@ func setupVersion() (*semver.Version, error) {
 	if len(state.Cluster.Version) == 0 {
 		var err error
 
-		versionList, err := provider.Versions()
-
-		if err != nil {
-			return nil, fmt.Errorf("error getting versions: %v", err)
-		}
-
-		availableVersions := versionList.AvailableVersions()
-
-		if cfg.Cluster.UseLatestVersionForInstall {
-			selectedVersion = availableVersions[len(availableVersions)-1].Version()
-			versionType = "latest version"
-		} else if cfg.Cluster.UseMiddleClusterImageSetForInstall {
-			versionsWithoutDefault := removeDefaultVersion(availableVersions)
-			numVersions := len(versionsWithoutDefault)
-			if numVersions < 2 {
-				state.Cluster.EnoughVersionsForOldestOrMiddleTest = false
-			} else {
-				selectedVersion = versionsWithoutDefault[numVersions/2].Version()
-			}
-			versionType = "middle version"
-		} else if cfg.Cluster.UseOldestClusterImageSetForInstall {
-			versionsWithoutDefault := removeDefaultVersion(availableVersions)
-			numVersions := len(versionsWithoutDefault)
-			if numVersions < 2 {
-				state.Cluster.EnoughVersionsForOldestOrMiddleTest = false
-			} else {
-				selectedVersion = versionsWithoutDefault[0].Version()
-			}
-			versionType = "oldest version"
-		} else if cfg.Cluster.PreviousReleaseFromDefault > 0 {
-			defaultIndex := findDefaultVersionIndex(availableVersions)
-
-			if defaultIndex < 0 {
-				log.Printf("unable to find default version in avaialable version list")
-				state.Cluster.PreviousVersionFromDefaultFound = false
-			} else {
-
-				targetIndex := defaultIndex - cfg.Cluster.PreviousReleaseFromDefault
-
-				if targetIndex < 0 {
-					log.Printf("not enough enabled versions to go back %d releases", cfg.Cluster.PreviousReleaseFromDefault)
-					state.Cluster.PreviousVersionFromDefaultFound = false
-				} else {
-					selectedVersion = availableVersions[targetIndex].Version()
-					versionType = fmt.Sprintf("version %d releases prior to the default", cfg.Cluster.PreviousReleaseFromDefault)
-				}
-			}
-		} else if cfg.Cluster.NextReleaseAfterProdDefault > -1 {
-			defaultVersion := versionList.Default()
-			selectedVersion, err = nextReleaseAfterGivenVersionFromVersionList(defaultVersion, availableVersions, cfg.Cluster.NextReleaseAfterProdDefault)
-			versionType = fmt.Sprintf("%d release(s) from the default version in prod", cfg.Cluster.NextReleaseAfterProdDefault)
-		} else {
-			selectedVersion = versionList.Default()
-			versionType = "current default"
-		}
-
+		selectedVersion, versionType, err = versions.GetVersionForInstall(versionList)
 		if err == nil {
 			if state.Cluster.EnoughVersionsForOldestOrMiddleTest && state.Cluster.PreviousVersionFromDefaultFound {
 				state.Cluster.Version = util.SemverToOpenshiftVersion(selectedVersion)
@@ -173,186 +79,44 @@ func setupVersion() (*semver.Version, error) {
 		}
 	}
 
-	log.Printf("Using the %s '%s'", versionType, state.Cluster.Version)
+	if selectedVersion == nil {
+		log.Printf("Unable to select a cluster version.")
+	} else {
+		log.Printf("Using the %s '%s'", versionType, state.Cluster.Version)
+	}
 
 	return selectedVersion, nil
 }
 
 // chooses version based on optimal upgrade path
-func setupUpgradeVersion() error {
+func setupUpgradeVersion(clusterVersion *semver.Version, versionList *spi.VersionList) error {
+	var err error
 	state := state.Instance
 
-	// Decide the version to install
-	clusterVersion, err := setupVersion()
-	if err != nil {
-		return err
-	}
-
-	if clusterVersion == nil {
-		log.Printf("no install version found, skipping upgrade")
+	if state.Upgrade.ReleaseName != "" || state.Upgrade.Image != "" {
+		log.Printf("Using user supplied upgrade state.")
 		return nil
 	}
 
-	versionList, err := provider.Versions()
+	if clusterVersion == nil {
+		log.Printf("No install version found, skipping upgrade.")
+		return nil
+	}
+
+	upgradeSource := provider.UpgradeSource()
+	state.Upgrade.ReleaseName, state.Upgrade.Image, err = versions.GetVersionForUpgrade(clusterVersion, versionList, upgradeSource)
 
 	if err != nil {
-		return err
+		return fmt.Errorf("error selecting an upgrade version: %v", err)
 	}
 
-	availableVersions := versionList.AvailableVersions()
-
-	if provider.UpgradeSource() == spi.CincinnatiSource {
-		getCincinnatiUpgradeTarget(clusterVersion, availableVersions)
-	} else {
-		getReleaseControllerUpgradeTarget(versionList)
-	}
-
-	if state.Upgrade.ReleaseName == "" {
-		return fmt.Errorf("failed to find an upgrade target")
+	if state.Upgrade.ReleaseName == "" && state.Upgrade.Image == "" && err == nil {
+		log.Printf("No upgrade selector found. Not selecting an upgrade version.")
+		return nil
 	}
 
 	// set upgrade image
 	log.Printf("Selecting version '%s' to be able to upgrade to '%s' using upgrade source '%s'",
-		state.Cluster.Version, state.Upgrade.ReleaseName, provider.UpgradeSource())
+		state.Cluster.Version, state.Upgrade.ReleaseName, upgradeSource)
 	return nil
-}
-
-func getCincinnatiUpgradeTarget(clusterVersion *semver.Version, availableVersions []*spi.Version) error {
-	state := state.Instance
-
-	var filteredVersionList = []*semver.Version{}
-	for _, version := range availableVersions {
-		if filterOnCincinnati(clusterVersion, version.Version()) {
-			filteredVersionList = append(filteredVersionList, version.Version())
-		}
-	}
-
-	numResults := len(filteredVersionList)
-	if numResults == 0 {
-		state.Upgrade.ReleaseName = NoVersionFound
-		metadata.Instance.SetUpgradeVersionSource("none")
-		return nil
-	}
-
-	cisUpgradeVersion := filteredVersionList[numResults-1]
-
-	// If the available cluster image set makes sense, then we'll just use that
-	if !cisUpgradeVersion.LessThan(clusterVersion) {
-		log.Printf("Using cluster image set.")
-		state.Upgrade.ReleaseName = util.SemverToOpenshiftVersion(cisUpgradeVersion)
-		metadata.Instance.SetUpgradeVersionSource("cluster image set")
-		state.Upgrade.UpgradeVersionEqualToInstallVersion = cisUpgradeVersion.Equal(clusterVersion)
-	}
-
-	return nil
-}
-
-func getReleaseControllerUpgradeTarget(versionList *spi.VersionList) error {
-	cfg := config.Instance
-	state := state.Instance
-
-	if cfg.Upgrade.NextReleaseAfterProdDefaultForUpgrade < 0 {
-		return fmt.Errorf("anything other than relative version selection is currently unsupported")
-	}
-
-	// If we're using the release controller, we're trying to do relative version selection.
-	// We'll confirm this in case things change in the future and just proceed with that assumption.
-	nextVersion, err := nextReleaseAfterGivenVersionFromVersionList(versionList.Default(), versionList.AvailableVersions(), cfg.Upgrade.NextReleaseAfterProdDefaultForUpgrade)
-
-	if err != nil {
-		return fmt.Errorf("error determining next version to upgrade to: %v", err)
-	}
-
-	releaseStream := fmt.Sprintf("%d.%d.0-0.nightly", nextVersion.Major(), nextVersion.Minor())
-
-	state.Upgrade.ReleaseName, state.Upgrade.Image, err = upgrade.LatestReleaseFromReleaseController(releaseStream)
-	if err != nil {
-		return fmt.Errorf("couldn't get latest release from release-controller: %v", err)
-	}
-
-	return nil
-}
-
-// nextReleaseAfterGivenVersionFromVersionList will attempt to look for the next valid X.Y stream release, given a delta (releaseFromGivenVersion)
-// Example In/Out
-// In: 4.3.12, [4.3.13, 4.4.0, 4.5.0], 2
-// Out: 4.5.0, nil
-func nextReleaseAfterGivenVersionFromVersionList(givenVersion *semver.Version, versionList []*spi.Version, releasesFromGivenVersion int) (*semver.Version, error) {
-	versionBuckets := map[string]*semver.Version{}
-
-	// Assemble a map that lists a release (x.y.0) to its latest version, with nightlies taking precedence over all else
-	for _, version := range versionList {
-		versionSemver := version.Version()
-		majorMinor := createMajorMinorStringFromSemver(versionSemver)
-
-		if _, ok := versionBuckets[majorMinor]; !ok {
-			versionBuckets[majorMinor] = versionSemver
-		} else {
-			currentGreatestVersion := versionBuckets[majorMinor]
-			versionIsNightly := strings.Contains(versionSemver.Prerelease(), "nightly")
-			currentIsNightly := strings.Contains(currentGreatestVersion.Prerelease(), "nightly")
-
-			// Make sure nightlies take precedence over other versions
-			if versionIsNightly && !currentIsNightly {
-				versionBuckets[majorMinor] = versionSemver
-			} else if currentIsNightly && !versionIsNightly {
-				continue
-			} else if currentGreatestVersion.LessThan(versionSemver) {
-				versionBuckets[majorMinor] = versionSemver
-			}
-		}
-	}
-
-	// Parse all major minor versions (x.y.0) into semver versions and place them in an array.
-	// This is done explicitly so that we can utilize the semver library's sorting capability.
-	majorMinorList := []*semver.Version{}
-	for k := range versionBuckets {
-		parsedMajorMinor, err := semver.NewVersion(k)
-		if err != nil {
-			return nil, err
-		}
-
-		majorMinorList = append(majorMinorList, parsedMajorMinor)
-	}
-
-	sort.Sort(semver.Collection(majorMinorList))
-
-	// Now that the list is sorted, we want to locate the major minor of the given version in the list.
-	givenMajorMinor, err := semver.NewVersion(createMajorMinorStringFromSemver(givenVersion))
-
-	if err != nil {
-		return nil, err
-	}
-
-	indexOfGivenMajorMinor := -1
-	for i, majorMinor := range majorMinorList {
-		if majorMinor.Equal(givenMajorMinor) {
-			indexOfGivenMajorMinor = i
-			break
-		}
-	}
-
-	if indexOfGivenMajorMinor == -1 {
-		return nil, fmt.Errorf("unable to find given version from list of available versions")
-	}
-
-	// Next, we'll go the given version distance ahead of the given version. We want to do it this way instead of guessing
-	// the next minor release so that we can handle major releases in the future, In other words, if the Openshift
-	// 4.y line stops at 4.13, we'll still be able to pick 5.0 if it's the next release after 4.13.
-	nextMajorMinorIndex := indexOfGivenMajorMinor + releasesFromGivenVersion
-
-	if len(majorMinorList) <= nextMajorMinorIndex {
-		return nil, fmt.Errorf("there is no eligible next release from the list of available versions")
-	}
-	nextMajorMinor := createMajorMinorStringFromSemver(majorMinorList[nextMajorMinorIndex])
-
-	if _, ok := versionBuckets[nextMajorMinor]; !ok {
-		return nil, fmt.Errorf("no major/minor version found for %s", nextMajorMinor)
-	}
-
-	return versionBuckets[nextMajorMinor], nil
-}
-
-func createMajorMinorStringFromSemver(version *semver.Version) string {
-	return fmt.Sprintf("%d.%d", version.Major(), version.Minor())
 }


### PR DESCRIPTION
The version selection logic has been refactored. The version selection
logic is complex, so it's been split out into a number of different
version selectors. These version selectors should be easier to test
independently, which will give us more confidence overall in our version
selection logic.