### PR TITLE
Optimize shellcheck tarball fetch

### DIFF
--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -5,5 +5,7 @@
 
 SCRIPT_DIR="$(dirname "$0")"
 scversion="stable" # or "v0.4.7", or "latest"
-[ ! -d "$SCRIPT_DIR/shellcheck-${scversion?}" ] && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv -C "$SCRIPT_DIR"
+os=$(uname -s)
+arch=$(uname -m)
+[ ! -d "$SCRIPT_DIR/shellcheck-${scversion?}" ] && wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.${os}.${arch}.tar.xz" | tar -xJv -C "$SCRIPT_DIR"
 "$SCRIPT_DIR/shellcheck-${scversion?}/shellcheck" "$@"


### PR DESCRIPTION
Fetch the correct tarball based on the operating system and
architecture.

Fixes #391 

## Reproducer

### Environment Setup

- Macbook
- Fetch the repo using `git clone`
- Run `make check`

### Before this PR

```bash
/Users/drpaneas/gocode/src/github.com/openshift/osde2e/scripts/shellcheck.sh: line 9: /Users/drpaneas/gocode/src/github.com/openshift/osde2e/scripts/shellcheck-stable/shellcheck: cannot execute binary file
make: *** [check] Error 126
```

--> Issue has been reproduced

### After this PR


```bash
x shellcheck-stable/README.txt
x shellcheck-stable/LICENSE.txt
x shellcheck-stable/shellcheck
No files specified.
```

--> Issue is fixed.