### PR TITLE
Fix minor nits in User Validating Webhook and Prom Exporter tests

### DIFF
--- a/pkg/e2e/verify/user_webhook.go
+++ b/pkg/e2e/verify/user_webhook.go
@@ -1,4 +1,4 @@
-package operators
+package verify
 
 import (
 	"github.com/onsi/ginkgo"
@@ -18,8 +18,9 @@ const (
 	CUSTOMER_PROVIDER_NAME = "CUSTOM"
 )
 
-var _ = ginkgo.Describe("[Suite: informing] [OSD] validating webhook", func() {
+var _ = ginkgo.Describe("[Suite: informing] [OSD] user validating webhook", func() {
 	h := helper.New()
+
 	ginkgo.Context("user validating webhook", func() {
 		ginkgo.It("dedicated admins cannot manage redhat users", func() {
 			userName := util.RandomStr(5) + "@redhat.com"


### PR DESCRIPTION
This PR addresses two minor nits:

- The "user validating webhook" test has been moved out of the operators package and into verify (it is not operator related), and renamed to explicitly identify as a user validating webhook test to better distinguish it from other webhook tests.

- The variables in the "prometheus exporter" test have been moved out of package scope and into the test scope. This will help prevent accidental use of the variables in other "verify" package files. 
