### PR TITLE
Add viper config integration on CLI for test subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The `osde2e` command is the root command that executes all functionality within 
 OSDe2e comes with a number of [configs] that can be passed to the `osde2e test` command using the -configs argument. These can be strung together in a comma separated list to create a more complex scenario for testing.
 
 ```
-$ osde2e test -configs prod,e2e-suite,conformance-suite
+$ osde2e test --configs prod,e2e-suite,conformance-suite
 ```
 
 This will create a cluster on production (using the default version) that will run both the end to end suite and the Kubernetes conformance tests.
@@ -61,15 +61,28 @@ These can be combined with the composable configs mentioned in the previous sect
 OCM_TOKEN=$(cat ~/.ocm-token) \
 MAJOR_TARGET=4 \
 MINOR_TARGET=2 \
-osde2e test -configs prod,e2e-suite
+osde2e test --configs prod,e2e-suite
 ``` 
 
 #### Using a custom YAML config
 
-The composable configs consist of a number of small YAML files that can all be loaded together. Rather than use these built in configs, you can also elect to build your own custom YAML file and provide that using the `-custom-config` parameter.
+The composable configs consist of a number of small YAML files that can all be loaded together. Rather than use these built in configs, you can also elect to build your own custom YAML file and provide that using the `--custom-config` parameter.
 
 ```
-osde2e test -custom-config ./osde2e.yaml
+osde2e test --custom-config ./osde2e.yaml
+```
+
+#### Via the command-line
+
+Some configuration settings are also exposed as command-line parameters. A full list can be displayed by providing `--help` after the command.
+
+An example is included below:
+
+```shell
+osde2e test --cluster-id 1ddkj9cr9j908gdlb1q5v6ld4b7ina5m \
+    --provider stage \
+    --skip-health-check \
+    --focus-tests "RBAC Operator"
 ```
 
 ##### Full custom YAML config example
@@ -108,7 +121,7 @@ It is possible to test against non-OSD clusters by specifying a kubeconfig to te
 
 ```
 TEST_KUBECONFIG=~/.kube/config \
-osde2e test -configs prod -custom-config .osde2e.yaml
+osde2e test --configs prod --custom-config .osde2e.yaml
 ```
 *Note: You must skip certain Operator tests that only exist in a hosted OSD instance. This can be skipped by skipping the operators test suite.*
 

--- a/cmd/osde2e/helpers/helpers.go
+++ b/cmd/osde2e/helpers/helpers.go
@@ -1,0 +1,28 @@
+package helpers
+
+import (
+	"github.com/markbates/pkger"
+	"github.com/spf13/cobra"
+	"os"
+	"strings"
+)
+
+func ConfigComplete(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	completeArgs := make([]string, 0)
+	err := pkger.Walk("/configs", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info != nil && (strings.HasSuffix(info.Name(), ".yaml") || strings.HasSuffix(info.Name(), ".yml")) {
+			trimmedName := strings.TrimSuffix(
+				strings.TrimSuffix(info.Name(), ".yaml"),
+				".yml")
+			completeArgs = append(completeArgs, trimmedName)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+	return completeArgs, cobra.ShellCompDirectiveDefault
+}

--- a/cmd/osde2e/test/cmd.go
+++ b/cmd/osde2e/test/cmd.go
@@ -30,15 +30,16 @@ var Cmd = &cobra.Command{
 }
 
 var args struct {
-	configString string
-	customConfig string
-	clusterID string
-	environment string
-	kubeConfig string
+	configString     string
+	customConfig     string
+	clusterID        string
+	environment      string
+	kubeConfig       string
 	destroyAfterTest bool
 	skipHealthChecks bool
-	focusTests string
-	skipTests string
+	mustGather       bool
+	focusTests       string
+	skipTests        string
 }
 
 func init() {
@@ -102,6 +103,12 @@ func init() {
 		"",
 		"Skip any Ginkgo tests whose names match the regular expression.",
 	)
+	pfs.BoolVar(
+		&args.mustGather,
+		"must-gather",
+		false,
+		"Control the Must Gather process at the end of a failed testing run.",
+	)
 
 	viper.BindPFlag(config.Cluster.ID, Cmd.PersistentFlags().Lookup("cluster-id"))
 	viper.BindPFlag(ocmprovider.Env, Cmd.PersistentFlags().Lookup("environment"))
@@ -110,6 +117,7 @@ func init() {
 	viper.BindPFlag(config.Tests.SkipClusterHealthChecks, Cmd.PersistentFlags().Lookup("skip-health-check"))
 	viper.BindPFlag(config.Tests.GinkgoFocus, Cmd.PersistentFlags().Lookup("focus-tests"))
 	viper.BindPFlag(config.Tests.GinkgoSkip, Cmd.PersistentFlags().Lookup("skip-tests"))
+	viper.BindPFlag(config.MustGather, Cmd.PersistentFlags().Lookup("skip-must-gather"))
 }
 
 func run(cmd *cobra.Command, argv []string) error {

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -191,7 +191,10 @@ func runGinkgoTests() error {
 			return fmt.Errorf("error deleting cluster: %s", err.Error())
 		}
 	} else {
-		log.Printf("For debugging, please look for cluster ID %s in environment %s", clusterID, provider.Environment())
+		// When using a local kubeconfig, provider might not be set
+		if provider != nil {
+			log.Printf("For debugging, please look for cluster ID %s in environment %s", clusterID, provider.Environment())
+		}
 	}
 
 	if !dryRun {


### PR DESCRIPTION
This PR integrates the work of #399 and #400 to allow the ability to specify some test-related configuration parameters via the CLI. 

Parameters selected were based on personal preferences of ones I change/use frequently, these can also be viewed via `osde2e test --help`:

- cluster ID
- OCM provider environment
- kube config path
- tests to focus
- tests to skip
- skip health checks
- destroy after test

As an example:
`osde2e test --configs informing-suite --environment int --cluster-id 1ddkj9cr9j908gdlb1q5v6ld4b7ina5m --focus="namespace validating" --skip-health-check`

The README has also been updated to include an example.