### PR TITLE
SDCICD-330: Fail cluster readiness checks more loudly

### DIFF
--- a/pkg/common/cluster/healthchecks/clusterversionoperator.go
+++ b/pkg/common/cluster/healthchecks/clusterversionoperator.go
@@ -21,7 +21,7 @@ func CheckCVOReadiness(configClient configclient.ConfigV1Interface) (bool, error
 
 	cvInfo, err := GetClusterVersionObject(configClient)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 
 	for _, v := range cvInfo.Status.Conditions {

--- a/pkg/common/cluster/healthchecks/clusterversionoperator_test.go
+++ b/pkg/common/cluster/healthchecks/clusterversionoperator_test.go
@@ -72,21 +72,22 @@ func progressingClusterVersion() *configv1.ClusterVersion {
 
 func TestCheckCVOReadiness(t *testing.T) {
 	var tests = []struct {
-		description string
-		expected    bool
-		objs        []runtime.Object
+		description   string
+		expected      bool
+		expectedError bool
+		objs          []runtime.Object
 	}{
-		{"no version", false, nil},
-		{"single version success", true, []runtime.Object{clusterVersion()}},
-		{"single version failure", false, []runtime.Object{unavailableClusterVersion()}},
-		{"single version progressing", false, []runtime.Object{progressingClusterVersion()}},
+		{"no version", false, true, nil},
+		{"single version success", true, false, []runtime.Object{clusterVersion()}},
+		{"single version failure", false, false, []runtime.Object{unavailableClusterVersion()}},
+		{"single version progressing", false, false, []runtime.Object{progressingClusterVersion()}},
 	}
 
 	for _, test := range tests {
 		cfgClient := fakeConfig.NewSimpleClientset(test.objs...)
 		state, err := CheckCVOReadiness(cfgClient.ConfigV1())
 
-		if err != nil {
+		if err != nil && !test.expectedError {
 			t.Errorf("Unexpected error: %s", err)
 			return
 		}

--- a/pkg/common/cluster/healthchecks/nodes.go
+++ b/pkg/common/cluster/healthchecks/nodes.go
@@ -20,8 +20,7 @@ func CheckNodeHealth(nodeClient v1.CoreV1Interface) (bool, error) {
 	}
 
 	if len(list.Items) == 0 {
-		log.Printf("Zero nodes found...?")
-		return false, nil
+		return false, fmt.Errorf("no nodes found")
 	}
 
 	for _, node := range list.Items {

--- a/pkg/common/cluster/healthchecks/operators.go
+++ b/pkg/common/cluster/healthchecks/operators.go
@@ -23,8 +23,7 @@ func CheckOperatorReadiness(configClient configclient.ConfigV1Interface) (bool, 
 	}
 
 	if len(list.Items) == 0 {
-		log.Printf("No operators found...?")
-		return false, nil
+		return false, fmt.Errorf("no operators were found")
 	}
 
 	// Load the list of operators we want to ignore and skip.

--- a/pkg/common/cluster/healthchecks/pods.go
+++ b/pkg/common/cluster/healthchecks/pods.go
@@ -22,7 +22,7 @@ func CheckPodHealth(podClient v1.CoreV1Interface) (bool, error) {
 	}
 
 	if len(list.Items) == 0 {
-		return false, nil
+		return false, fmt.Errorf("pod list is empty. this should NOT happen")
 	}
 
 	for _, pod := range list.Items {

--- a/pkg/common/cluster/healthchecks/pods_test.go
+++ b/pkg/common/cluster/healthchecks/pods_test.go
@@ -33,7 +33,7 @@ func TestCheckPodHealth(t *testing.T) {
 		expectedError bool
 		objs          []runtime.Object
 	}{
-		{"no pods", false, false, nil},
+		{"no pods", false, true, nil},
 		{"single pod failed", false, true, []runtime.Object{pod("a", "a", v1.PodFailed)}},
 		{"one pod good one pod bad same namespace", false, true, []runtime.Object{pod("a", "a", v1.PodFailed), pod("b", "a", v1.PodRunning)}},
 		{"one pod good one pod pending same namespace", false, false, []runtime.Object{pod("a", "a", v1.PodPending), pod("b", "a", v1.PodRunning)}},


### PR DESCRIPTION
Upon review, there were a couple conditions where a cluster readiness check would fail silently or incorrectly.

This makes certain conditions return errors that should be visible during the readiness check.

/assign @meowfaceman 
/cc @cblecker 