### PR TITLE
Start test for aws-efs-operator

### DIFF
--- a/configs/wip-suite.yaml
+++ b/configs/wip-suite.yaml
@@ -1,0 +1,3 @@
+tests:
+  testsToRun:
+    - '[Suite: wip]'

--- a/pkg/e2e/operators/awsefs.go
+++ b/pkg/e2e/operators/awsefs.go
@@ -1,0 +1,42 @@
+package operators
+
+import (
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/helper"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const sharedVolumeCRDName = "sharedvolumes.aws-efs.managed.openshift.io"
+
+var _ = ginkgo.Describe("[Suite: wip] [OSD] AWS EFS Operator", func() {
+	h := helper.New()
+
+	ginkgo.Context("Sniff", func() {
+		ginkgo.FIt("SharedVolume CRD exists", func() {
+			crd, err := h.Dynamic().Resource(
+				schema.GroupVersionResource{
+					Group:    "apiextensions.k8s.io",
+					Resource: "customresourcedefinitions",
+					Version:  "v1",
+				},
+			).Get(sharedVolumeCRDName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(crd.GetName()).Should(Equal(sharedVolumeCRDName))
+		})
+
+		ginkgo.FIt("No SharedVolume resources exist", func() {
+			sharedVolumes, err := h.Dynamic().Resource(
+				schema.GroupVersionResource{
+					Group:    "aws-efs.managed.openshift.io",
+					Resource: "sharedvolumes",
+					Version:  "v1alpha1",
+				},
+			).List(metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(sharedVolumes.Items)).Should(Equal(0))
+
+		})
+	})
+})


### PR DESCRIPTION
This won't be ready for primetime until
[all](https://github.com/openshift/aws-efs-operator/pull/4)
[the](https://github.com/openshift/release/pull/9355)
[things](https://gitlab.cee.redhat.com/service/app-interface/merge_requests/4924)
and more have merged.

For now, run this as:

```shell
$ export OCM_TOKEN=...
$ export CLUSTER_ID=...
$ osde2e test --configs stage,skip-health-checks --custom-config configs/wip-suite.yaml
```