### PR TITLE
Bumping previousCSV values for operator upgrade tests

### DIFF
--- a/pkg/e2e/operators/configurealertmanager.go
+++ b/pkg/e2e/operators/configurealertmanager.go
@@ -41,6 +41,6 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Configure AlertManager Operato
 
 var _ = ginkgo.Describe("[Suite: informing] [OSD] Upgrade Configure AlertManager Operator", func() {
 	checkUpgrade(helper.New(), "openshift-monitoring", "configure-alertmanager-operator",
-		"configure-alertmanager-operator.v0.1.121-361b817",
+		"configure-alertmanager-operator.v0.1.171-dba3c73",
 	)
 })

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -42,7 +42,7 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Dedicated Admins SubjectPermis
 
 var _ = ginkgo.Describe("[Suite: informing] [OSD] Upgrade RBAC Permissions Operator", func() {
 	checkUpgrade(helper.New(), "openshift-rbac-permissions", "rbac-permissions-operator",
-		"rbac-permissions-operator.v0.1.81-ce6731c",
+		"rbac-permissions-operator.v0.1.97-68cf185",
 	)
 })
 

--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -32,6 +32,6 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Splunk Forwarder Operator", fu
 
 var _ = ginkgo.Describe("[Suite: informing] [OSD] Upgrade Splunk Forwarder Operator", func() {
 	checkUpgrade(helper.New(), "openshift-splunk-forwarder-operator", "openshift-splunk-forwarder-operator",
-		"splunk-forwarder-operator.v0.1.91-aaa0027",
+		"splunk-forwarder-operator.v0.1.157-3dca592",
 	)
 })


### PR DESCRIPTION
This PR bumps the previousCSV values used for operator upgrade tests in the RBAC, Configure-Alertmanager and Splunk-forwarder operators. This should hopefully reduce the timeouts being observed during these tests due to the number of version-hops needed to get back to the latest CSV.

Refs: #413 where this was most recently observed.