### PR TITLE
SDCICD-297. Alter metrics AWS parsing to support MOA pipelines.

### DIFF
--- a/ci/prow_run_tests.sh
+++ b/ci/prow_run_tests.sh
@@ -25,9 +25,14 @@ set -o pipefail
 
     # Extract the secrets
     extract_secret_from_dirs OCM_TOKEN "$SECRETS" ocm-refresh-token "OCM token file"
-    extract_secret_from_dirs AWS_ACCESS_KEY_ID "$SECRETS" aws-access-key "AWS access key file"
-    extract_secret_from_dirs AWS_SECRET_ACCESS_KEY "$SECRETS" aws-secret-access-key "AWS secret access key file"
-    extract_secret_from_dirs AWS_REGION "$SECRETS" aws-region "AWS region file"
+    extract_secret_from_dirs METRICS_AWS_ACCESS_KEY_ID "$SECRETS" metrics-aws-access-key "metrics AWS access key file"
+    extract_secret_from_dirs METRICS_AWS_SECRET_ACCESS_KEY "$SECRETS" metrics-aws-secret-access-key "metrics AWS secret access key file"
+    extract_secret_from_dirs METRICS_AWS_REGION "$SECRETS" metrics-aws-region "metrics AWS region file"
+
+    # For the moment, MOA specific credentials must be loaded into the environment.
+    extract_secret_from_dirs AWS_ACCESS_KEY_ID "$SECRETS" moa-aws-access-key "MOA AWS access key file" false
+    extract_secret_from_dirs AWS_SECRET_ACCESS_KEY "$SECRETS" moa-aws-secret-access-key "MOA AWS secret access key file" false
+    extract_secret_from_dirs AWS_REGION "$SECRETS" moa-aws-region "MOA AWS region file" false
 
     # We explicitly want to make sure we're always uploading metrics from prow jobs.
     export UPLOAD_METRICS=true

--- a/ci/prow_setup.sh
+++ b/ci/prow_setup.sh
@@ -6,6 +6,7 @@ function extract_secret_from_dirs {
     DIRECTORIES="$2"
     FILE_NAME="$3"
     FILE_DESCRIPTION="$4"
+    SHOULD_FAIL_IF_NOT_FOUND="${5:-true}"
 
     IFS=',' read -ra SECRET_DIR_ARRAY <<< "$DIRECTORIES"
     for SECRET_DIR in "${SECRET_DIR_ARRAY[@]}"; do
@@ -16,8 +17,12 @@ function extract_secret_from_dirs {
     done
 
     if [ -z "${!VAR_NAME}" ]; then
-        echo "Required $FILE_DESCRIPTION does not exist or has no value."
-        exit 3
+        if [ "$SHOULD_FAIL_IF_NOT_FOUND" = "true" ]; then
+            echo "Required $FILE_DESCRIPTION does not exist or has no value."
+            exit 3
+        else
+            echo "$FILE_DESCRIPTION not found, but not required."
+        fi
     fi
 }
 

--- a/pkg/common/aws/s3.go
+++ b/pkg/common/aws/s3.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"net/url"
 	"strings"
 
@@ -63,6 +64,8 @@ func WriteToS3(outputKey string, data []byte) error {
 		Key:    aws.String(key),
 		Body:   reader,
 	})
+
+	log.Printf("Uploaded to %s", outputKey)
 
 	return err
 }

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -477,6 +477,5 @@ func uploadFileToMetricsBucket(filename string) error {
 		return err
 	}
 
-	aws.WriteToS3(aws.CreateS3URL(viper.GetString(config.Tests.MetricsBucket), "incoming", filepath.Base(filename)), data)
-	return err
+	return aws.WriteToS3(aws.CreateS3URL(viper.GetString(config.Tests.MetricsBucket), "incoming", filepath.Base(filename)), data)
 }


### PR DESCRIPTION
At the moment, MOA can only be provisioned using AWS environment
variables. This alters things such that metrics now uses static AWS
credentials as opposed to using environment variables to make room for
MOA's use of the AWS environment variables.

Note: The various MOA/Metrics secrets are already in place in origin CI.