### PR TITLE
OSD-3680 Add route monitoring during upgrades

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,14 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/adamliesko/retry v0.0.0-20200123222335-86c8baac277d
 	github.com/aws/aws-sdk-go v1.29.17
+	github.com/c2h5oh/datasize v0.0.0-20200112174442-28bbd4740fee // indirect
 	github.com/code-ready/crc v1.10.0
 	github.com/emicklei/go-restful v2.9.6+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-github/v31 v31.0.0
 	github.com/google/uuid v1.1.1
 	github.com/hashicorp/go-multierror v1.1.0
+	github.com/influxdata/tdigest v0.0.1 // indirect
 	github.com/kylelemons/godebug v1.1.0
 	github.com/markbates/pkger v0.16.0
 	github.com/onsi/ginkgo v1.12.0
@@ -27,6 +29,8 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
+	github.com/tsenart/go-tsz v0.0.0-20180814235614-0bd30b3df1c3 // indirect
+	github.com/tsenart/vegeta v12.7.0+incompatible
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	k8s.io/api v0.0.0-20191004102349-159aefb8556b
 	k8s.io/apimachinery v0.18.2

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bugsnag/bugsnag-go v1.5.1/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
 github.com/bugsnag/panicwrap v1.2.0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/c2h5oh/datasize v0.0.0-20200112174442-28bbd4740fee h1:BnPxIde0gjtTnc9Er7cxvBk8DHLWhEux0SxayC8dP6I=
+github.com/c2h5oh/datasize v0.0.0-20200112174442-28bbd4740fee/go.mod h1:S/7n9copUssQ56c7aAgHqftWO4LTf4xY6CGWt8Bc+3M=
 github.com/cavaliercoder/grab v2.0.0+incompatible h1:wZHbBQx56+Yxjx2TCGDcenhh3cJn7cCLMfkEPmySTSE=
 github.com/cavaliercoder/grab v2.0.0+incompatible/go.mod h1:tTBkfNqSBfuMmMBFaO2phgyhdYhiZQ/+iXCZDzcDsMI=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
@@ -267,6 +269,8 @@ github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
 github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/influxdata/tdigest v0.0.1 h1:XpFptwYmnEKUqmkcDjrzffswZ3nvNeevbUSLPP/ZzIY=
+github.com/influxdata/tdigest v0.0.1/go.mod h1:Z0kXnxzbTC2qrx4NaIzYkE1k66+6oEDQTvL95hQFh5Y=
 github.com/intel-go/cpuid v0.0.0-20181003105527-1a4a6f06a1c6/go.mod h1:RmeVYf9XrPRbRc3XIx0gLYA8qOFvNoPOfaEZduRlEp4=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
@@ -308,6 +312,7 @@ github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzR
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
+github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63 h1:nTT4s92Dgz2HlrB2NaMgvlfqHH39OgMhA7z3PK7PGD4=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/markbates/pkger v0.16.0 h1:bZGAXW80/vi6ORfJCDVQhT8/9raoPdGAhvFd9Yq0LMA=
 github.com/markbates/pkger v0.16.0/go.mod h1:0JoVlrol20BSywW79rN3kdFFsE5xYM+rSCQDXbLhiuI=
@@ -485,6 +490,10 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20171017195756-830351dc03c6/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/tsenart/go-tsz v0.0.0-20180814235614-0bd30b3df1c3 h1:pcQGQzTwCg//7FgVywqge1sW9Yf8VMsMdG58MI5kd8s=
+github.com/tsenart/go-tsz v0.0.0-20180814235614-0bd30b3df1c3/go.mod h1:SWZznP1z5Ki7hDT2ioqiFKEse8K9tU2OUvaRI0NeGQo=
+github.com/tsenart/vegeta v12.7.0+incompatible h1:sGlrv11EMxQoKOlDuMWR23UdL90LE5VlhKw/6PWkZmU=
+github.com/tsenart/vegeta v12.7.0+incompatible/go.mod h1:Smz/ZWfhKRcyDDChZkG3CyTHdj87lHzio/HOCkbndXM=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181022190402-e5e69e061d4f/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
@@ -523,6 +532,7 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -618,6 +628,7 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181011152555-a398e557df60/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -648,7 +659,9 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gonum.org/v1/gonum v0.0.0-20181121035319-3f7ecaa7e8ca/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/gonum v0.0.0-20190710053202-4340aa3071a0/go.mod h1:03dgh78c4UvU1WksguQ/lvJQXbezKQGJSrwwRq5MraQ=
+gonum.org/v1/netlib v0.0.0-20181029234149-ec6d1f5cefe6/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 gonum.org/v1/netlib v0.0.0-20190313105609-8cb42192e0e0/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -64,6 +64,9 @@ var Upgrade = struct {
 
 	// UpgradeVersionEqualToInstallVersion is true if the install version and upgrade versions are the same.
 	UpgradeVersionEqualToInstallVersion string
+
+	// MonitorRoutesDuringUpgrade will monitor the availability of routes whilst an upgrade takes place
+	MonitorRoutesDuringUpgrade string
 }{
 	UpgradeToCISIfPossible:                "upgrade.upgradeToCISIfPossible",
 	OnlyUpgradeToZReleases:                "upgrade.onlyUpgradeToZReleases",
@@ -72,6 +75,7 @@ var Upgrade = struct {
 	ReleaseName:                           "upgrade.releaseName",
 	Image:                                 "upgrade.image",
 	UpgradeVersionEqualToInstallVersion:   "upgrade.upgradeVersionEqualToInstallVersion",
+	MonitorRoutesDuringUpgrade:            "upgrade.monitorRoutesDuringUpgrade",
 }
 
 // Kubeconfig config keys.
@@ -325,6 +329,9 @@ func init() {
 	viper.BindEnv(Upgrade.Image, "UPGRADE_IMAGE")
 
 	viper.SetDefault(Upgrade.UpgradeVersionEqualToInstallVersion, false)
+
+	viper.BindEnv(Upgrade.MonitorRoutesDuringUpgrade, "UPGRADE_MONITOR_ROUTES")
+	viper.SetDefault(Upgrade.MonitorRoutesDuringUpgrade, true)
 
 	// ----- Kubeconfig -----
 	viper.BindEnv(Kubeconfig.Path, "TEST_KUBECONFIG")

--- a/pkg/common/metadata/metadata.go
+++ b/pkg/common/metadata/metadata.go
@@ -32,14 +32,17 @@ type Metadata struct {
 	UpgradeVersionSource string `json:"upgrade-version-source,omitempty"`
 
 	// Metrics
-	TimeToOCMReportingInstalled float64        `json:"time-to-ocm-reporting-installed,string"`
-	TimeToClusterReady          float64        `json:"time-to-cluster-ready,string"`
-	TimeToUpgradedCluster       float64        `json:"time-to-upgraded-cluster,string"`
-	TimeToUpgradedClusterReady  float64        `json:"time-to-upgraded-cluster-ready,string"`
-	TimeToCertificateIssued     float64        `json:"time-to-certificate-issued,string"`
-	InstallPhasePassRate        float64        `json:"install-phase-pass-rate,string"`
-	UpgradePhasePassRate        float64        `json:"upgrade-phase-pass-rate,string"`
-	LogMetrics                  map[string]int `json:"log-metrics"`
+	TimeToOCMReportingInstalled float64            `json:"time-to-ocm-reporting-installed,string"`
+	TimeToClusterReady          float64            `json:"time-to-cluster-ready,string"`
+	TimeToUpgradedCluster       float64            `json:"time-to-upgraded-cluster,string"`
+	TimeToUpgradedClusterReady  float64            `json:"time-to-upgraded-cluster-ready,string"`
+	TimeToCertificateIssued     float64            `json:"time-to-certificate-issued,string"`
+	InstallPhasePassRate        float64            `json:"install-phase-pass-rate,string"`
+	UpgradePhasePassRate        float64            `json:"upgrade-phase-pass-rate,string"`
+	LogMetrics                  map[string]int     `json:"log-metrics"`
+	RouteLatencies              map[string]float64 `json:"route-latencies"`
+	RouteThroughputs            map[string]float64 `json:"route-throughputs"`
+	RouteAvailabilities         map[string]float64 `json:"route-availabilities"`
 
 	// Internal variables
 	ReportDir string `json:"-"`
@@ -53,6 +56,9 @@ func init() {
 	Instance.InstallPhasePassRate = -1.0
 	Instance.UpgradePhasePassRate = -1.0
 	Instance.LogMetrics = make(map[string]int)
+	Instance.RouteLatencies = make(map[string]float64)
+	Instance.RouteThroughputs = make(map[string]float64)
+	Instance.RouteAvailabilities = make(map[string]float64)
 }
 
 // Next are a bunch of setter functions that allow us
@@ -158,6 +164,27 @@ func (m *Metadata) IncrementLogMetric(metric string, value int) {
 		m.LogMetrics[metric] = value
 	}
 
+	m.WriteToJSON(m.ReportDir)
+}
+
+// SetRouteLatency sets the mean latency for the given route
+// (measured in milliseconds)
+func (m *Metadata) SetRouteLatency(route string, latency float64) {
+	m.RouteLatencies[route] = latency
+	m.WriteToJSON(m.ReportDir)
+}
+
+// SetRouteThroughput sets the throughput for the given route
+// (rate of successful requests per second)
+func (m *Metadata) SetRouteThroughput(route string, throughput float64) {
+	m.RouteThroughputs[route] = throughput
+	m.WriteToJSON(m.ReportDir)
+}
+
+// SetRouteAvailability sets the availability for the given route
+// (ratio of successful requests)
+func (m *Metadata) SetRouteAvailability(route string, availability float64) {
+	m.RouteAvailabilities[route] = availability
 	m.WriteToJSON(m.ReportDir)
 }
 

--- a/pkg/e2e/routemonitors/routemonitors.go
+++ b/pkg/e2e/routemonitors/routemonitors.go
@@ -25,7 +25,6 @@ type RouteMonitors struct {
 	Monitors          map[string]<-chan *vegeta.Result
 	Metrics           map[string]*vegeta.Metrics
 	Plots             map[string]*plot.Plot
-	urls              map[string]string
 	targeters         map[string]vegeta.Targeter
 	attackers         []*vegeta.Attacker
 }
@@ -48,12 +47,14 @@ func Create() (*RouteMonitors, error) {
 	}
 	consoleUrl := fmt.Sprintf("https://%s", consoleRoute.Spec.Host)
 	u, err := url.Parse(consoleUrl)
-	consoleTargeter := vegeta.NewStaticTargeter(vegeta.Target{
-		Method: "GET",
-		URL:    consoleUrl,
-	})
-	targeters[u.Host] = consoleTargeter
-
+	if err == nil {
+		consoleTargeter := vegeta.NewStaticTargeter(vegeta.Target{
+			Method: "GET",
+			URL:    consoleUrl,
+		})
+		targeters[u.Host] = consoleTargeter
+	}
+	
 	// Create a monitor for the oauth URL
 	oauthRoute, err := h.Route().RouteV1().Routes(oauthNamespace).Get(oauthName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/e2e/routemonitors/routemonitors.go
+++ b/pkg/e2e/routemonitors/routemonitors.go
@@ -1,0 +1,209 @@
+package routemonitors
+
+import (
+	"fmt"
+	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/metadata"
+	vegeta "github.com/tsenart/vegeta/lib"
+	"github.com/tsenart/vegeta/lib/plot"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	consoleNamespace = "openshift-console"
+	consoleLabel     = "console"
+	oauthNamespace   = "openshift-authentication"
+	oauthName        = "oauth-openshift"
+)
+
+type RouteMonitors struct {
+	Monitors          map[string]<-chan *vegeta.Result
+	Metrics           map[string]*vegeta.Metrics
+	Plots             map[string]*plot.Plot
+	consoleTargeter   vegeta.Targeter
+	oauthTargeter     vegeta.Targeter
+	apiTargeters      []vegeta.Targeter
+	workloadTargeters []vegeta.Targeter
+	attackers         []*vegeta.Attacker
+}
+
+// Frequency of requests per second (per route)
+const pollFrequency = 3
+const timeoutSeconds = 3 * time.Second
+
+// Detects the available routes in the cluster and initializes monitors for their availability
+func Create() (*RouteMonitors, error) {
+	h := helper.NewOutsideGinkgo()
+
+	// Create a monitor for the web console
+	consoleRoute, err := h.Route().RouteV1().Routes(consoleNamespace).Get(consoleLabel, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve console route %s", consoleLabel)
+	}
+	consoleUrl := fmt.Sprintf("https://%s", consoleRoute.Spec.Host)
+	consoleTargeter := vegeta.NewStaticTargeter(vegeta.Target{
+		Method: "GET",
+		URL:    consoleUrl,
+	})
+
+	// Create a monitor for the oauth URL
+	oauthRoute, err := h.Route().RouteV1().Routes(oauthNamespace).Get(oauthName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve oauth route %s", oauthName)
+	}
+	oauthUrl := fmt.Sprintf("https://%s/healthz", oauthRoute.Spec.Host)
+	oauthTargeter := vegeta.NewStaticTargeter(vegeta.Target{
+		Method: "GET",
+		URL:    oauthUrl,
+	})
+
+	// Create monitors for API Server URLs
+	apiservers, err := h.Cfg().ConfigV1().APIServers().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve list of API servers")
+	}
+	apiTargeters := make([]vegeta.Targeter, 0)
+	for _, apiServer := range apiservers.Items {
+		for _, servingCert := range apiServer.Spec.ServingCerts.NamedCertificates {
+			for _, name := range servingCert.Names {
+				apiUrl := fmt.Sprintf("https://%s:6443/healthz", name)
+				apiTargeters = append(apiTargeters,
+					vegeta.NewStaticTargeter(vegeta.Target{
+						Method: "GET",
+						URL:    apiUrl,
+					}))
+			}
+		}
+	}
+
+	// If we created any routes during workload testing, let's add them too
+	workloadRoutes, err := h.Route().RouteV1().Routes(h.CurrentProject()).List(metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not retrieve list of workload routes")
+	}
+	workloadTargeters := make([]vegeta.Targeter, 0)
+	for _, workloadRoute := range workloadRoutes.Items {
+		workloadUrl := fmt.Sprintf("https://%s", workloadRoute.Spec.Host)
+		workloadTargeters = append(workloadTargeters,
+			vegeta.NewStaticTargeter(vegeta.Target{
+				Method: "GET",
+				URL:    workloadUrl,
+			}))
+	}
+
+	return &RouteMonitors{
+		Monitors:          make(map[string]<-chan *vegeta.Result, 0),
+		Metrics:           make(map[string]*vegeta.Metrics, 0),
+		Plots:             make(map[string]*plot.Plot, 0),
+		consoleTargeter:   consoleTargeter,
+		oauthTargeter:     oauthTargeter,
+		apiTargeters:      apiTargeters,
+		workloadTargeters: workloadTargeters,
+	}, nil
+}
+
+// Sets the RouteMonitors to begin polling the configured routes with traffic
+func (rm *RouteMonitors) Start() {
+	pollRate := vegeta.Rate{Freq: pollFrequency, Per: time.Second}
+	timeout := vegeta.Timeout(timeoutSeconds)
+	consoleAttacker := vegeta.NewAttacker(timeout)
+	oauthAttacker := vegeta.NewAttacker(timeout)
+
+	rm.Monitors["console"] = consoleAttacker.Attack(rm.consoleTargeter, pollRate, 0, "console")
+	rm.Plots["console"] = createPlot("console")
+	rm.Monitors["oauth"] = oauthAttacker.Attack(rm.oauthTargeter, pollRate, 0, "oauth")
+	rm.Plots["oauth"] = createPlot("oauth")
+	for i, apiTargeter := range rm.apiTargeters {
+		apititle := fmt.Sprintf("api-%d", i)
+		apiAttacker := vegeta.NewAttacker(timeout)
+		rm.Monitors[apititle] = apiAttacker.Attack(apiTargeter, pollRate, 0, apititle)
+		rm.Plots[apititle] = createPlot(apititle)
+	}
+	for i, workloadTargeter := range rm.workloadTargeters {
+		workloadTitle := fmt.Sprintf("workload-%d", i)
+		workloadAttacker := vegeta.NewAttacker(timeout)
+		rm.Monitors[workloadTitle] = workloadAttacker.Attack(workloadTargeter, pollRate, 0, workloadTitle)
+		rm.Plots[workloadTitle] = createPlot(workloadTitle)
+	}
+
+	for title, _ := range rm.Monitors {
+		rm.Metrics[title] = &vegeta.Metrics{}
+	}
+}
+
+// Sets the RouteMonitors to cease polling the configured routes with traffic
+func (rm *RouteMonitors) End() {
+	for _, attacker := range rm.attackers {
+		attacker.Stop()
+	}
+	for _, metric := range rm.Metrics {
+		metric.Close()
+	}
+}
+
+// Stores the measured RouteMonitor metrics inside osde2e metadata for DataHub
+func (rm *RouteMonitors) StoreMetadata() {
+	for title, metric := range rm.Metrics {
+		latency := float64(metric.Latencies.Mean / time.Millisecond)
+		if latency < 0 {
+			latency = 0
+		}
+		metadata.Instance.SetRouteLatency(title, latency)
+		metadata.Instance.SetRouteThroughput(title, metric.Throughput)
+		metadata.Instance.SetRouteAvailability(title, metric.Success)
+	}
+}
+
+// Saves the measured RouteMonitor metrics in HDR Histogram reports in the specified base directory
+func (rm *RouteMonitors) SaveReports(baseDir string) error {
+	outputDirectory := filepath.Join(baseDir, "route-monitors")
+	if _, err := os.Stat(outputDirectory); os.IsNotExist(err) {
+		if err := os.Mkdir(outputDirectory, os.FileMode(0755)); err != nil {
+			return fmt.Errorf("error while creating route monitor report directory %s: %v", outputDirectory, err)
+		}
+	}
+	for title, metric := range rm.Metrics {
+		histoPath := filepath.Join(outputDirectory, fmt.Sprintf("%s.histo", title))
+		reporter := vegeta.NewHDRHistogramPlotReporter(metric)
+		out, err := os.Create(histoPath)
+		if err != nil {
+			return fmt.Errorf("error while creating route monitor report: %v", err)
+		}
+		reporter.Report(out)
+		log.Printf("Wrote route monitor histogram: %s\n", histoPath)
+	}
+	return nil
+}
+
+// Saves HTML-formatted latency plots in the specified base directory
+func (rm *RouteMonitors) SavePlots(baseDir string) error {
+	outputDirectory := filepath.Join(baseDir, "route-monitors")
+	if _, err := os.Stat(outputDirectory); os.IsNotExist(err) {
+		if err := os.Mkdir(outputDirectory, os.FileMode(0755)); err != nil {
+			return fmt.Errorf("error while creating route monitor report directory %s: %v", outputDirectory, err)
+		}
+	}
+	for title, pl := range rm.Plots {
+		plotPath := filepath.Join(outputDirectory, fmt.Sprintf("%s.html", title))
+		out, err := os.Create(plotPath)
+		if err != nil {
+			return fmt.Errorf("error while creating route monitor report: %v", err)
+		}
+		pl.WriteTo(out)
+		log.Printf("Wrote route monitor plot: %s\n", plotPath)
+
+	}
+	return nil
+}
+
+// Creates a new plot with the specified title
+func createPlot(title string) *plot.Plot {
+	return plot.New(
+		plot.Title(title),
+		plot.Label(plot.ErrorLabeler),
+	)
+}

--- a/pkg/e2e/workloads/guestbook/guestbook.go
+++ b/pkg/e2e/workloads/guestbook/guestbook.go
@@ -1,6 +1,8 @@
 package workloads
 
 import (
+	v1 "github.com/openshift/api/route/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"log"
 	"path/filepath"
 	"time"
@@ -39,6 +41,22 @@ var _ = ginkgo.Describe("[Suite: e2e] Workload ("+workloadName+")", func() {
 
 			// Log how many objects have been created
 			log.Printf("%v objects created", len(objects))
+
+			// Create an OpenShift route to go with it
+			appRoute := &v1.Route{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "guestbook",
+				},
+				Spec: v1.RouteSpec{
+					To: v1.RouteTargetReference{
+						Name: "frontend",
+					},
+					TLS: &v1.TLSConfig{Termination: "edge"},
+				},
+				Status: v1.RouteStatus{},
+			}
+			_, err = h.Route().RouteV1().Routes(h.CurrentProject()).Create(appRoute)
+			Expect(err).NotTo(HaveOccurred(), "couldn't create application route")
 
 			// Give the cluster a second to churn before checking
 			time.Sleep(3 * time.Second)


### PR DESCRIPTION
**About**

This PR presents a first cut at implementing [OSD-3680](https://issues.redhat.com/browse/OSD-3680) to perform and present 
monitoring of important routes during an OpenShift upgrade.

The PR introduces a `RouteMonitors` package which, when used, will automatically detect and monitor the following routes to ensure they continue to respond to HTTP GET requests:
- API servers
- OAuth
- Web Console
- Any OSDE2E workloads with routes

The `redmine` OSDE2E workload has been updated as part of this PR to now create a route that can hence be monitored.

Monitoring of routes is being performed using `vegeta` - this has been added as a new go module dependency.

**Configuration**

The route monitor process can be controlled through the MonitorRoutesDuringUpgrade configuration option (and `UPGRADE_MONITOR_ROUTES` environment variable)

The PR defaults to this option being enabled.

**File Output**

At the completion of a cluster upgrade, the RouteMonitors will persist the following files in the working directory (in a "route-monitors" sub-directory):
 - HDR Histograms of latency (`<route>.hist`)
 - HTML Plots of latency over time (`<route>.html`)

**Metadata**

The following metadata entries are introduced:
* `RouteLatencies` - for each route, stores the mean latency over the upgrade period (milliseconds)
* `RouteThroughputs` - for each route, stores the throughput over the upgrade period (rate of successful requests per second) 
* `RouteAvailabilities` - for each route, stores the availability over the upgrade period (ratio of successful requests)
