### PR TITLE
SDCICD-200. Handle secret gathering within osde2e.

### DIFF
--- a/cmd/osde2e/common/configs.go
+++ b/cmd/osde2e/common/configs.go
@@ -9,10 +9,15 @@ import (
 )
 
 // LoadConfigs loads config objects given the provided list of configs and a custom config
-func LoadConfigs(configString string, customConfig string) error {
+func LoadConfigs(configString string, customConfig string, secretLocationsString string) error {
 	var configs []string
 	if configString != "" {
 		configs = strings.Split(configString, ",")
+	}
+
+	var secretLocations []string
+	if secretLocationsString != "" {
+		secretLocations = strings.Split(secretLocationsString, ",")
 	}
 
 	for _, config := range configs {
@@ -20,7 +25,7 @@ func LoadConfigs(configString string, customConfig string) error {
 	}
 
 	// Load configs
-	if err := load.Configs(configs, customConfig); err != nil {
+	if err := load.Configs(configs, customConfig, secretLocations); err != nil {
 		return fmt.Errorf("error loading config: %v", err)
 	}
 

--- a/cmd/osde2e/query/cmd.go
+++ b/cmd/osde2e/query/cmd.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/spf13/cobra"
 	"log"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/spf13/cobra"
 
 	"github.com/openshift/osde2e/cmd/osde2e/common"
 	"github.com/openshift/osde2e/pkg/common/prometheus"
@@ -24,9 +25,10 @@ var Cmd = &cobra.Command{
 }
 
 var args struct {
-	configString string
-	customConfig string
-	outputFormat string
+	configString    string
+	customConfig    string
+	secretLocations string
+	outputFormat    string
 }
 
 func init() {
@@ -45,6 +47,12 @@ func init() {
 		"Custom config file for osde2e",
 	)
 	flags.StringVar(
+		&args.secretLocations,
+		"secret-locations",
+		"",
+		"A comma separated list of possible secret directory locations for loading secret configs.",
+	)
+	flags.StringVar(
 		&args.outputFormat,
 		"output-format",
 		"-",
@@ -58,7 +66,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) error {
 
-	if err := common.LoadConfigs(args.configString, args.customConfig); err != nil {
+	if err := common.LoadConfigs(args.configString, args.customConfig, args.secretLocations); err != nil {
 		return fmt.Errorf("error loading initial state: %v", err)
 	}
 

--- a/cmd/osde2e/test/cmd.go
+++ b/cmd/osde2e/test/cmd.go
@@ -34,6 +34,7 @@ var Cmd = &cobra.Command{
 var args struct {
 	configString     string
 	customConfig     string
+	secretLocations  string
 	clusterID        string
 	environment      string
 	kubeConfig       string
@@ -58,6 +59,12 @@ func init() {
 		"custom-config",
 		"",
 		"Custom config file for osde2e",
+	)
+	pfs.StringVar(
+		&args.secretLocations,
+		"secret-locations",
+		"",
+		"A comma separated list of possible secret directory locations for loading secret configs.",
 	)
 	pfs.StringVarP(
 		&args.clusterID,
@@ -123,7 +130,7 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) error {
-	if err := common.LoadConfigs(args.configString, args.customConfig); err != nil {
+	if err := common.LoadConfigs(args.configString, args.customConfig, args.secretLocations); err != nil {
 		return fmt.Errorf("error loading initial state: %v", err)
 	}
 
@@ -131,5 +138,5 @@ func run(cmd *cobra.Command, argv []string) error {
 		return nil
 	}
 
-	return fmt.Errorf("Testing failed.")
+	return fmt.Errorf("testing failed")
 }

--- a/cmd/osde2e/weather/cmd.go
+++ b/cmd/osde2e/weather/cmd.go
@@ -2,6 +2,7 @@ package weather
 
 import (
 	"fmt"
+
 	"github.com/openshift/osde2e/cmd/osde2e/common"
 	"github.com/openshift/osde2e/pkg/weather"
 	"github.com/spf13/cobra"
@@ -10,16 +11,17 @@ import (
 var Cmd = &cobra.Command{
 	Use:   "weather-report",
 	Short: "Weather report.",
-	Long: "Produces a report based on osde2e test runs.",
+	Long:  "Produces a report based on osde2e test runs.",
 	Args:  cobra.OnlyValidArgs,
-	RunE: run,
+	RunE:  run,
 }
 
 var args struct {
-	configString string
-	customConfig string
-	output       string
-	outputType   string
+	configString    string
+	customConfig    string
+	secretLocations string
+	output          string
+	outputType      string
 }
 
 func init() {
@@ -36,6 +38,12 @@ func init() {
 		"custom-config",
 		"",
 		"Custom config file for osde2e",
+	)
+	flags.StringVar(
+		&args.secretLocations,
+		"secret-locations",
+		"",
+		"A comma separated list of possible secret directory locations for loading secret configs.",
 	)
 	flags.StringVar(
 		&args.output,
@@ -57,7 +65,7 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) error {
-	if err := common.LoadConfigs(args.configString, args.customConfig); err != nil {
+	if err := common.LoadConfigs(args.configString, args.customConfig, args.secretLocations); err != nil {
 		return fmt.Errorf("error loading initial state: %v", err)
 	}
 

--- a/cmd/osde2e/weather_slack/cmd.go
+++ b/cmd/osde2e/weather_slack/cmd.go
@@ -2,6 +2,7 @@ package weather_slack
 
 import (
 	"fmt"
+
 	"github.com/openshift/osde2e/cmd/osde2e/common"
 	"github.com/openshift/osde2e/pkg/weather"
 	"github.com/spf13/cobra"
@@ -10,14 +11,15 @@ import (
 var Cmd = &cobra.Command{
 	Use:   "weather-report-to-slack",
 	Short: "Weather report to slack.",
-	Long: "Produces a report based on osde2e test runs and sends it to a Slack webhook.",
-	Args: cobra.OnlyValidArgs,
-	RunE: run,
+	Long:  "Produces a report based on osde2e test runs and sends it to a Slack webhook.",
+	Args:  cobra.OnlyValidArgs,
+	RunE:  run,
 }
 
 var args struct {
-	configString string
-	customConfig string
+	configString    string
+	customConfig    string
+	secretLocations string
 }
 
 func init() {
@@ -35,10 +37,16 @@ func init() {
 		"",
 		"Custom config file for osde2e",
 	)
+	flags.StringVar(
+		&args.secretLocations,
+		"secret-locations",
+		"",
+		"A comma separated list of possible secret directory locations for loading secret configs.",
+	)
 }
 
 func run(cmd *cobra.Command, argv []string) error {
-	if err := common.LoadConfigs(args.configString, args.customConfig); err != nil {
+	if err := common.LoadConfigs(args.configString, args.customConfig, args.secretLocations); err != nil {
 		return fmt.Errorf("error loading initial state: %v", err)
 	}
 

--- a/configs/moa.yaml
+++ b/configs/moa.yaml
@@ -1,3 +1,1 @@
-cloudProvider:
-  providerId: moa
-  region: us-east-1
+provider: moa

--- a/pkg/common/aws/session.go
+++ b/pkg/common/aws/session.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/prometheus/common/log"
 	"github.com/spf13/viper"
 )
@@ -31,8 +32,13 @@ var AWSSession awsSession
 
 func init() {
 	viper.BindEnv(metricsAWSAccessKeyID, metricsAWSAccessKeyIDEnv)
+	config.RegisterSecret(metricsAWSAccessKeyID, "metrics-aws-access-key")
+
 	viper.BindEnv(metricsAWSSecretAccessKey, metricsAWSSecretAccessKeyEnv)
+	config.RegisterSecret(metricsAWSSecretAccessKey, "metrics-aws-secret-access-key")
+
 	viper.BindEnv(metricsAWSRegion, metricsAWSRegionEnv)
+	config.RegisterSecret(metricsAWSRegion, "metrics-aws-region")
 }
 
 func (a *awsSession) getSession() (*session.Session, error) {

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -2,6 +2,8 @@
 package config
 
 import (
+	"sync"
+
 	"github.com/spf13/viper"
 )
 
@@ -41,6 +43,10 @@ const (
 	// Project is both the project and SA automatically created to house all objects created during an osde2e-run
 	Project = "project"
 )
+
+// This is a config key to secret file mapping. We will attempt to read in from secret files before loading anything else.
+var keyToSecretMapping = map[string]string{}
+var keyToSecretMappingMutex = sync.Mutex{}
 
 // Upgrade config keys.
 var Upgrade = struct {
@@ -439,4 +445,16 @@ func init() {
 
 	viper.SetDefault(Weather.JobWhitelist, "osde2e-.*-aws-e2e-.*")
 	viper.BindEnv(Weather.JobWhitelist, "JOB_WHITELIST")
+}
+
+// RegisterSecret will register the secret filename that will be used for the corresponding Viper string.
+func RegisterSecret(key string, secretFileName string) {
+	keyToSecretMappingMutex.Lock()
+	keyToSecretMapping[key] = secretFileName
+	keyToSecretMappingMutex.Unlock()
+}
+
+// GetAllSecrets will return Viper config keys and their corresponding secret filenames.
+func GetAllSecrets() map[string]string {
+	return keyToSecretMapping
 }

--- a/pkg/common/load/load.go
+++ b/pkg/common/load/load.go
@@ -2,12 +2,14 @@ package load
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 
 	"github.com/markbates/pkger"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/spf13/viper"
 )
 
@@ -23,7 +25,7 @@ const (
 )
 
 // Configs will populate viper with specified configs.
-func Configs(configs []string, customConfig string) error {
+func Configs(configs []string, customConfig string, secretLocations []string) error {
 	// This used to be complicated, but now we just lean on Viper for everything.
 	// 1. Load pre-canned YAML configs.
 	for _, config := range configs {
@@ -37,6 +39,14 @@ func Configs(configs []string, customConfig string) error {
 		log.Printf("Custom YAML config provided, loading from %s", customConfig)
 		if err := loadYAMLFromFile(customConfig); err != nil {
 			return fmt.Errorf("error loading custom config from YAML: %v", err)
+		}
+	}
+
+	// 3. Secrets. These will override all previous entries.
+	if len(secretLocations) > 0 {
+		secrets := config.GetAllSecrets()
+		for key, secretFilename := range secrets {
+			loadSecretFileIntoKey(key, secretFilename, secretLocations)
 		}
 	}
 
@@ -85,6 +95,26 @@ func loadYAMLFromFile(name string) error {
 
 	if err = viper.MergeConfig(fh); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// loadSecretFileIntoKey will attempt to load the contents of a secret file into the given key.
+// If the secret file doesn't exist, we'll skip this.
+func loadSecretFileIntoKey(key string, filename string, secretLocations []string) error {
+	for _, secretLocation := range secretLocations {
+		fullFilename := filepath.Join(secretLocation, filename)
+		stat, err := os.Stat(fullFilename)
+		if err == nil && !stat.IsDir() {
+			data, err := ioutil.ReadFile(fullFilename)
+			if err != nil {
+				return fmt.Errorf("error loading secret file %s from location %s", filename, secretLocation)
+			}
+			log.Printf("Found secret for key %s.", key)
+			viper.Set(key, string(data))
+			return nil
+		}
 	}
 
 	return nil

--- a/pkg/common/providers/moaprovider/config.go
+++ b/pkg/common/providers/moaprovider/config.go
@@ -1,12 +1,22 @@
 package moaprovider
 
 import (
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/spf13/viper"
 )
 
 const (
 	// Env is the OpenShift Dedicated environment used to provision clusters.
 	Env = "moa.env"
+
+	// AWSAccessKeyID for provisioning clusters.
+	AWSAccessKeyID = "moa.awsAccessKey"
+
+	// AWSSecretAccessKey for provisioning clusters.
+	AWSSecretAccessKey = "moa.awsSecretAccessKey"
+
+	// AWSRegion for provisioning clusters.
+	AWSRegion = "moa.awsRegion"
 
 	// MachineCIDR is the CIDR to use for machines.
 	MachineCIDR = "moa.machineCIDR"
@@ -31,6 +41,15 @@ func init() {
 	// ----- MOA -----
 	viper.SetDefault(Env, "prod")
 	viper.BindEnv(Env, "MOA_ENV")
+
+	viper.BindEnv(AWSAccessKeyID, "MOA_AWS_ACCESS_KEY_ID")
+	config.RegisterSecret(AWSAccessKeyID, "moa-aws-access-key")
+
+	viper.BindEnv(AWSSecretAccessKey, "MOA_AWS_SECRET_ACCESS_KEY")
+	config.RegisterSecret(AWSSecretAccessKey, "moa-aws-secret-access-key")
+
+	viper.BindEnv(AWSRegion, "MOA_AWS_REGION")
+	config.RegisterSecret(AWSRegion, "moa-aws-region")
 
 	viper.BindEnv(MachineCIDR, "MOA_MACHINE_CIDR")
 

--- a/pkg/common/providers/moaprovider/util.go
+++ b/pkg/common/providers/moaprovider/util.go
@@ -1,0 +1,28 @@
+package moaprovider
+
+import (
+	"os"
+	"strings"
+
+	"github.com/spf13/viper"
+)
+
+// At the moment, moactl requires AWS sessions to be set globally. To get around that, we'll use this
+// helper method here so that we can set environment variables and restore them before returning from the function.
+func callAndSetAWSSession(f func()) {
+	var env []string
+	defer func() {
+		os.Clearenv()
+		for _, envVar := range env {
+			keyAndValue := strings.SplitN(envVar, "=", 2)
+			os.Setenv(keyAndValue[0], keyAndValue[1])
+		}
+	}()
+
+	env = os.Environ()
+	os.Setenv("AWS_ACCESS_KEY_ID", viper.GetString(AWSAccessKeyID))
+	os.Setenv("AWS_SECRET_ACCESS_KEY", viper.GetString(AWSSecretAccessKey))
+	os.Setenv("AWS_REGION", viper.GetString(AWSRegion))
+
+	f()
+}

--- a/pkg/common/providers/ocmprovider/config.go
+++ b/pkg/common/providers/ocmprovider/config.go
@@ -1,6 +1,7 @@
 package ocmprovider
 
 import (
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/spf13/viper"
 )
 
@@ -21,6 +22,7 @@ const (
 func init() {
 	// ----- OCM -----
 	viper.BindEnv(Token, "OCM_TOKEN")
+	config.RegisterSecret(Token, "ocm-refresh-token")
 
 	viper.SetDefault(Env, "prod")
 	viper.BindEnv(Env, "OSD_ENV")


### PR DESCRIPTION
Secret gathering is now handled by osde2e. This is the first step in
removing our reliance on scripting glue, which should make our job
definitions simpler.

Some refactoring was done to MOA to ensure that we'd be able to remove
the prow_run_tests.sh script.