### PR TITLE
SDCICD-294: Define per-ginkgo-context alerting mechanism

### DIFF
--- a/cmd/osde2e/alert/cmd.go
+++ b/cmd/osde2e/alert/cmd.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/osde2e/cmd/osde2e/common"
-	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/alert"
 
 	// import suites to be alerted on
 	_ "github.com/openshift/osde2e/pkg/e2e/addons"
@@ -60,7 +60,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("error loading initial state: %v", err)
 	}
 
-	mas := config.GetMetricAlerts()
+	mas := alert.GetMetricAlerts()
 	err := mas.Notify()
 
 	return err

--- a/cmd/osde2e/alert/cmd.go
+++ b/cmd/osde2e/alert/cmd.go
@@ -1,0 +1,67 @@
+package alert
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/osde2e/cmd/osde2e/common"
+	"github.com/openshift/osde2e/pkg/common/config"
+
+	// import suites to be alerted on
+	_ "github.com/openshift/osde2e/pkg/e2e/addons"
+	_ "github.com/openshift/osde2e/pkg/e2e/openshift"
+	_ "github.com/openshift/osde2e/pkg/e2e/operators"
+	_ "github.com/openshift/osde2e/pkg/e2e/osd"
+	_ "github.com/openshift/osde2e/pkg/e2e/scale"
+	_ "github.com/openshift/osde2e/pkg/e2e/state"
+	_ "github.com/openshift/osde2e/pkg/e2e/verify"
+	_ "github.com/openshift/osde2e/pkg/e2e/workloads/guestbook"
+	_ "github.com/openshift/osde2e/pkg/e2e/workloads/redmine"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "alert",
+	Short: "Generates alerts for OSDe2e test owners.",
+	Long:  "Generates alerts for OSDe2e test owners.",
+	Args:  cobra.OnlyValidArgs,
+	RunE:  run,
+}
+
+var args struct {
+	configString string
+	customConfig string
+}
+
+func init() {
+	flags := Cmd.Flags()
+
+	flags.StringVar(
+		&args.configString,
+		"configs",
+		"",
+		"A comma separated list of built in configs to use",
+	)
+	flags.StringVar(
+		&args.customConfig,
+		"custom-config",
+		"",
+		"Custom config file for osde2e",
+	)
+
+	Cmd.RegisterFlagCompletionFunc("output-format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"json", "prom"}, cobra.ShellCompDirectiveDefault
+	})
+}
+
+func run(cmd *cobra.Command, argv []string) error {
+
+	if err := common.LoadConfigs(args.configString, args.customConfig); err != nil {
+		return fmt.Errorf("error loading initial state: %v", err)
+	}
+
+	mas := config.GetMetricAlerts()
+	err := mas.Notify()
+
+	return err
+}

--- a/cmd/osde2e/alert/cmd.go
+++ b/cmd/osde2e/alert/cmd.go
@@ -29,8 +29,9 @@ var Cmd = &cobra.Command{
 }
 
 var args struct {
-	configString string
-	customConfig string
+	configString    string
+	customConfig    string
+	secretLocations string
 }
 
 func init() {
@@ -48,6 +49,12 @@ func init() {
 		"",
 		"Custom config file for osde2e",
 	)
+	flags.StringVar(
+		&args.secretLocations,
+		"secret-locations",
+		"",
+		"A comma separated list of possible secret directory locations for loading secret configs.",
+	)
 
 	Cmd.RegisterFlagCompletionFunc("output-format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json", "prom"}, cobra.ShellCompDirectiveDefault
@@ -56,7 +63,7 @@ func init() {
 
 func run(cmd *cobra.Command, argv []string) error {
 
-	if err := common.LoadConfigs(args.configString, args.customConfig); err != nil {
+	if err := common.LoadConfigs(args.configString, args.customConfig, args.secretLocations); err != nil {
 		return fmt.Errorf("error loading initial state: %v", err)
 	}
 

--- a/cmd/osde2e/main.go
+++ b/cmd/osde2e/main.go
@@ -11,6 +11,7 @@ import (
 	// The root import needs to happen before importing the rest of osde2e, as this is what imports the various assets.
 	_ "github.com/openshift/osde2e"
 
+	"github.com/openshift/osde2e/cmd/osde2e/alert"
 	"github.com/openshift/osde2e/cmd/osde2e/arguments"
 	"github.com/openshift/osde2e/cmd/osde2e/completion"
 	"github.com/openshift/osde2e/cmd/osde2e/query"
@@ -22,8 +23,8 @@ import (
 )
 
 var root = &cobra.Command{
-	Use:  "osde2e",
-	Long: "Command line tool for osde2e.",
+	Use:           "osde2e",
+	Long:          "Command line tool for osde2e.",
 	SilenceErrors: true,
 	SilenceUsage:  true,
 	PersistentPreRun: func(cmd *cobra.Command, argv []string) {
@@ -44,6 +45,7 @@ func init() {
 	root.AddCommand(test.Cmd)
 	root.AddCommand(query.Cmd)
 	root.AddCommand(completion.Cmd)
+	root.AddCommand(alert.Cmd)
 
 }
 
@@ -90,7 +92,7 @@ func selfUpdate() {
 	// Exec with update=false, which will prevent recursive updates.
 	filteredCmdArgs := make([]string, 0)
 	for _, arg := range os.Args {
-		if ! strings.Contains(arg,"-update") {
+		if !strings.Contains(arg, "-update") {
 			filteredCmdArgs = append(filteredCmdArgs, arg)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190926160646-a61144936680
 	github.com/prometheus/client_golang v1.4.1
 	github.com/prometheus/common v0.9.1
-	github.com/slack-go/slack v0.6.3
+	github.com/slack-go/slack v0.6.5
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -215,7 +215,6 @@ github.com/googleapis/gnostic v0.3.0 h1:CcQijm0XKekKjP/YCz28LXVSpgguuB+nCxaSjCe0
 github.com/googleapis/gnostic v0.3.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
@@ -343,8 +342,6 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/munnerz/goautoneg v0.0.0-20190414153302-2ae31c8b6b30/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nlopes/slack v0.6.0 h1:jt0jxVQGhssx1Ib7naAOZEZcGdtIhTzkP0nopK0AsRA=
-github.com/nlopes/slack v0.6.0/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.8.0 h1:VkHVNpR4iVnU8XQR6DBm8BqYjN7CRzw+xKUbVVbbW9w=
@@ -441,8 +438,6 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/slack-go/slack v0.6.3 h1:qU037g8gQ71EuH6S9zYKnvYrEUj0fLFH4HFekFqBoRU=
-github.com/slack-go/slack v0.6.3/go.mod h1:HE4RwNe7YpOg/F0vqo5PwXH3Hki31TplTvKRW9dGGaw=
 github.com/slack-go/slack v0.6.5 h1:IkDKtJ2IROJNoe3d6mW870/NRKvq2fhLB/Q5XmzWk00=
 github.com/slack-go/slack v0.6.5/go.mod h1:FGqNzJBmxIsZURAxh2a8D21AnOVvvXZvGligs4npPUM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=

--- a/go.sum
+++ b/go.sum
@@ -343,6 +343,7 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/munnerz/goautoneg v0.0.0-20190414153302-2ae31c8b6b30/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nlopes/slack v0.6.0 h1:jt0jxVQGhssx1Ib7naAOZEZcGdtIhTzkP0nopK0AsRA=
 github.com/nlopes/slack v0.6.0/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -442,6 +443,8 @@ github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/slack-go/slack v0.6.3 h1:qU037g8gQ71EuH6S9zYKnvYrEUj0fLFH4HFekFqBoRU=
 github.com/slack-go/slack v0.6.3/go.mod h1:HE4RwNe7YpOg/F0vqo5PwXH3Hki31TplTvKRW9dGGaw=
+github.com/slack-go/slack v0.6.5 h1:IkDKtJ2IROJNoe3d6mW870/NRKvq2fhLB/Q5XmzWk00=
+github.com/slack-go/slack v0.6.5/go.mod h1:FGqNzJBmxIsZURAxh2a8D21AnOVvvXZvGligs4npPUM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=

--- a/pkg/common/alert/alert.go
+++ b/pkg/common/alert/alert.go
@@ -24,7 +24,6 @@ var once = sync.Once{}
 
 var metricAlerts = MetricAlerts{}
 var slackChannelCache = make(map[string]slack.Channel)
-var slackUserCache = make(map[string]slack.User)
 
 // GetMetricAlerts will return the log metrics.
 func GetMetricAlerts() MetricAlerts {

--- a/pkg/common/alert/alert.go
+++ b/pkg/common/alert/alert.go
@@ -9,8 +9,7 @@ import (
 	"time"
 
 	"github.com/openshift/osde2e/pkg/common/config"
-	osde2eProm "github.com/openshift/osde2e/pkg/common/prometheus"
-	"github.com/prometheus/client_golang/api"
+	"github.com/openshift/osde2e/pkg/common/prometheus"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	"github.com/slack-go/slack"
@@ -76,18 +75,13 @@ type MetricAlert struct {
 
 // Notify prepares and then iterates through MetricAlerts to generate notifications
 func (mas MetricAlerts) Notify() error {
-	client, err := api.NewClient(api.Config{
-		Address:      viper.GetString(config.Prometheus.Address),
-		RoundTripper: osde2eProm.WeatherRoundTripper,
-	})
-
+	client, err := prometheus.CreateClient()
 	if err != nil {
 		return fmt.Errorf("unable to create Prometheus client: %v", err)
 	}
 
 	promAPI := v1.NewAPI(client)
 	for _, ma := range mas {
-		log.Printf("%v", ma)
 		if err := ma.Check(promAPI); err != nil {
 			return err
 		}

--- a/pkg/common/config/alerts.go
+++ b/pkg/common/config/alerts.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"log"
+
+	"github.com/spf13/viper"
+)
+
+// MetricAlerts is an array of LogMetric types with an easier lookup method
+type MetricAlerts []MetricAlert
+
+// once is already declared in log_metrics
+
+var metricAlerts = MetricAlerts{}
+
+// GetMetricAlerts will return the log metrics.
+func GetMetricAlerts() MetricAlerts {
+	once.Do(func() {
+		viper.Set("metricAlerts", metricAlerts)
+	})
+
+	tmp := viper.Get("metricAlerts")
+	ma, ok := tmp.(MetricAlerts)
+	if !ok {
+		log.Println("Error casting metricAlerts from Viper")
+	}
+
+	return ma
+}
+
+// AddAlert adds an alert to an existing MetricAlerts object
+func (ma MetricAlerts) AddAlert(alert MetricAlert) MetricAlerts {
+	ma = append(ma, alert)
+	viper.Set("metricAlerts", ma)
+	return ma
+}
+
+// MetricAlert lets you define a test name and the criteria to alert
+// an owner via an alert channel of some sort.
+type MetricAlert struct {
+	// --- Description of Test ---
+	// Name of the metric to look for
+	Name string
+
+	// -- Description of Test Owner ---
+	// TeamOwner describes which RedHat team may own this test
+	TeamOwner string
+	// PrimaryContact is a point person or SME for this set of tests.
+	// If there isn't one, it should default to the person committing these tests.
+	PrimaryContact string
+
+	// --- Description of Alert Channels ---
+	// SlackChannel is the channel in slack to message with an alert
+	SlackChannel string
+	// SlackUser is the user to @ in a slack channel with an alert
+	SlackUser string
+	// Email is the email address to send alerts to.
+	// TODO: Make this work.
+	// This does not work yet.
+	Email string
+
+	// --- Description of Alert Triggers ---
+	// FailureThreshold is the number of failures in a rolling 24h window
+	FailureThreshold int
+	// SlowThreshold is the average time (in seconds) a test takes in a rolling 24h window
+	SlowThreshold float64
+}
+
+func (ma MetricAlerts) Run() error {
+	return nil
+}

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -281,6 +281,13 @@ var Weather = struct {
 	JobWhitelist:             "weather.jobWhitelist",
 }
 
+var Alert = struct {
+	// SlackAPIToken is a bot slack token
+	SlackAPIToken string
+}{
+	SlackAPIToken: "alert.slackAPIToken",
+}
+
 func init() {
 	// Here's where we bind environment variables to config options and set defaults
 
@@ -439,4 +446,7 @@ func init() {
 
 	viper.SetDefault(Weather.JobWhitelist, "osde2e-.*-aws-e2e-.*")
 	viper.BindEnv(Weather.JobWhitelist, "JOB_WHITELIST")
+
+	// ----- Alert ----
+	viper.BindEnv(Alert.SlackAPIToken, "SLACK_API_TOKEN")
 }

--- a/pkg/common/prometheus/connect.go
+++ b/pkg/common/prometheus/connect.go
@@ -1,38 +1,15 @@
 package prometheus
 
 import (
-	"crypto/tls"
-	"net"
-	"net/http"
-	"net/url"
-	"time"
-
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/prometheus/client_golang/api"
 	"github.com/spf13/viper"
 )
 
-// weatherRoundTripper is like api.DefaultRoundTripper with an added stripping of cert verification
-// and adding the bearer token to the HTTP request
-var weatherRoundTripper http.RoundTripper = &http.Transport{
-	Proxy: func(request *http.Request) (*url.URL, error) {
-		request.Header.Add("Authorization", "Bearer "+viper.GetString(config.Prometheus.BearerToken))
-		return http.ProxyFromEnvironment(request)
-	},
-	DialContext: (&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-	}).DialContext,
-	TLSClientConfig: &tls.Config{
-		InsecureSkipVerify: true,
-	},
-	TLSHandshakeTimeout: 10 * time.Second,
-}
-
 // CreateClient will create a Prometheus client based off of the global config.
 func CreateClient() (api.Client, error) {
 	return api.NewClient(api.Config{
 		Address:      viper.GetString(config.Prometheus.Address),
-		RoundTripper: weatherRoundTripper,
+		RoundTripper: config.WeatherRoundTripper,
 	})
 }

--- a/pkg/common/prometheus/connect.go
+++ b/pkg/common/prometheus/connect.go
@@ -1,6 +1,12 @@
 package prometheus
 
 import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/prometheus/client_golang/api"
 	"github.com/spf13/viper"
@@ -10,6 +16,23 @@ import (
 func CreateClient() (api.Client, error) {
 	return api.NewClient(api.Config{
 		Address:      viper.GetString(config.Prometheus.Address),
-		RoundTripper: config.WeatherRoundTripper,
+		RoundTripper: WeatherRoundTripper,
 	})
+}
+
+// WeatherRoundTripper is like api.DefaultRoundTripper with an added stripping of cert verification
+// and adding the bearer token to the HTTP request
+var WeatherRoundTripper http.RoundTripper = &http.Transport{
+	Proxy: func(request *http.Request) (*url.URL, error) {
+		request.Header.Add("Authorization", "Bearer "+viper.GetString(config.Prometheus.BearerToken))
+		return http.ProxyFromEnvironment(request)
+	},
+	DialContext: (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext,
+	TLSClientConfig: &tls.Config{
+		InsecureSkipVerify: true,
+	},
+	TLSHandshakeTimeout: 10 * time.Second,
 }

--- a/pkg/e2e/osd/daemonsets.go
+++ b/pkg/e2e/osd/daemonsets.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -14,21 +15,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var alert config.MetricAlert
+var testAlert alert.MetricAlert
 
 func init() {
-	ma := config.GetMetricAlerts()
-	alert = config.MetricAlert{
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
 		Name:             "[Suite: service-definition] [OSD] DaemonSets",
 		TeamOwner:        "SDCICD",
 		PrimaryContact:   "Jeffrey Sica",
+		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
 		FailureThreshold: 1,
 	}
-	ma.AddAlert(alert)
+	ma.AddAlert(testAlert)
 }
 
-var _ = ginkgo.Describe(alert.Name, func() {
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	ginkgo.Context("DaemonSets are not allowed", func() {
 		// setup helper
 		h := helper.New()

--- a/pkg/e2e/osd/daemonsets.go
+++ b/pkg/e2e/osd/daemonsets.go
@@ -20,8 +20,10 @@ func init() {
 	ma := config.GetMetricAlerts()
 	alert = config.MetricAlert{
 		Name:             "[Suite: service-definition] [OSD] DaemonSets",
+		TeamOwner:        "SDCICD",
+		PrimaryContact:   "Jeffrey Sica",
+		Email:            "sd-cicd@redhat.com",
 		FailureThreshold: 1,
-		SlowThreshold:    600,
 	}
 	ma.AddAlert(alert)
 }


### PR DESCRIPTION
This is the foundation for fine-grained alerting on test failures (SDCICD-294). 

Currently, this only supports alerting via Slack. Emails will eventually be supported. 

Using our daemonset tests as an example, we define the alert as part of the whole test definition. If, within a 24h period, a failure threshold is met, this will alert the specified slack channel.

I moved some code around (mainly the WeatherRoundTripper) so it could be reused. 