### PR TITLE
SDCICD-200. Export MOA variables in prow script.

### DIFF
--- a/ci/prow_run_tests.sh
+++ b/ci/prow_run_tests.sh
@@ -29,10 +29,9 @@ set -o pipefail
     extract_secret_from_dirs METRICS_AWS_SECRET_ACCESS_KEY "$SECRETS" metrics-aws-secret-access-key "metrics AWS secret access key file"
     extract_secret_from_dirs METRICS_AWS_REGION "$SECRETS" metrics-aws-region "metrics AWS region file"
 
-    # For the moment, MOA specific credentials must be loaded into the environment.
-    extract_secret_from_dirs AWS_ACCESS_KEY_ID "$SECRETS" moa-aws-access-key "MOA AWS access key file" false
-    extract_secret_from_dirs AWS_SECRET_ACCESS_KEY "$SECRETS" moa-aws-secret-access-key "MOA AWS secret access key file" false
-    extract_secret_from_dirs AWS_REGION "$SECRETS" moa-aws-region "MOA AWS region file" false
+    extract_secret_from_dirs MOA_AWS_ACCESS_KEY_ID "$SECRETS" moa-aws-access-key "MOA AWS access key file" false
+    extract_secret_from_dirs MOA_AWS_SECRET_ACCESS_KEY "$SECRETS" moa-aws-secret-access-key "MOA AWS secret access key file" false
+    extract_secret_from_dirs MOA_AWS_REGION "$SECRETS" moa-aws-region "MOA AWS region file" false
 
     # We explicitly want to make sure we're always uploading metrics from prow jobs.
     export UPLOAD_METRICS=true


### PR DESCRIPTION
The prow script now exports MOA variables so as not to break things.

Note; This is a stop gap until we can get the jobs adjusted in the openshift/release repo.