### PR TITLE
SDCICD-335. Skip curator tests for MOA clusters.

### DIFF
--- a/pkg/e2e/operators/curator.go
+++ b/pkg/e2e/operators/curator.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+var blacklistedProviders = []string{"moa"}
+
 var _ = ginkgo.Describe("[Suite: operators] [OSD] Curator Operator", func() {
 	h := helper.New()
 	ginkgo.Context("operator source should be curated", func() {
@@ -24,6 +26,15 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Curator Operator", func() {
 		ginkgo.It("we should use curated operator source", func() {
 			provider, err := providers.ClusterProvider()
 			Expect(err).NotTo(HaveOccurred(), "error getting cluster provider")
+
+			providerType := provider.Type()
+
+			for _, blacklistedType := range blacklistedProviders {
+				if providerType == blacklistedType {
+					ginkgo.Skip("MOA is not supported for the curator operator.")
+				}
+			}
+
 			currentClusterVersion, err := cluster.GetClusterVersion(provider, viper.GetString(config.Cluster.ID))
 			Expect(err).NotTo(HaveOccurred(), "error getting cluster version %s", viper.GetString(config.Cluster.Version))
 


### PR DESCRIPTION
Curator tests are now skipped for MOA clusters.

Note: I'm not really able to test this well because I'm hitting 403 issues with my new OCM token, but I'm fairly confident in it.