### PR TITLE
Safe handling of helper in routemonitor code

### DIFF
--- a/pkg/e2e/routemonitors/routemonitors.go
+++ b/pkg/e2e/routemonitors/routemonitors.go
@@ -37,6 +37,10 @@ const timeoutSeconds = 3 * time.Second
 func Create() (*RouteMonitors, error) {
 	h := helper.NewOutsideGinkgo()
 
+	if h == nil {
+		return nil, fmt.Errorf("Unable to generate helper outside ginkgo")
+	}
+
 	// record all targeters created in a map, accessible via a key which is their URL
 	targeters := make(map[string]vegeta.Targeter, 0)
 


### PR DESCRIPTION
Observed in CI job 1271955636241829888 that when a cluster fails to become ready, the routemonitors (OSD-3680) were triggering a panic as the helper they use is nil.

This commit should at least address the panic behaviour so that the execution of the remainder of the osde2e run continues normally.


