### PR TITLE
SDCICD-183: Support cluster creation with custom compute machine types

### DIFF
--- a/configs/ocm-aws-compute-optimized.yaml
+++ b/configs/ocm-aws-compute-optimized.yaml
@@ -1,0 +1,2 @@
+ocm:
+  computeMachineType: c5.4xlarge

--- a/configs/ocm-aws-memory-optimized.yaml
+++ b/configs/ocm-aws-memory-optimized.yaml
@@ -1,0 +1,2 @@
+ocm:
+  computeMachineType: r5.xlarge

--- a/configs/ocm-gcp-compute-optimized.yaml
+++ b/configs/ocm-gcp-compute-optimized.yaml
@@ -1,0 +1,2 @@
+ocm:
+  computeMachineType: custom-8-16384

--- a/configs/ocm-gcp-memory-optimized.yaml
+++ b/configs/ocm-gcp-memory-optimized.yaml
@@ -1,0 +1,2 @@
+ocm:
+  computeMachineType: custom-4-32768-ext

--- a/pkg/common/providers/ocmprovider/config.go
+++ b/pkg/common/providers/ocmprovider/config.go
@@ -17,6 +17,9 @@ const (
 
 	// NumRetries is the number of times to retry each OCM call.
 	NumRetries = "ocm.numRetries"
+
+	// ComputeMachineType is the specific cloud machine type to use for compute nodes.
+	ComputeMachineType = "ocm.computeMachineType"
 )
 
 func init() {
@@ -32,4 +35,7 @@ func init() {
 
 	viper.SetDefault(NumRetries, 3)
 	viper.BindEnv(NumRetries, "NUM_RETRIES")
+
+	viper.SetDefault(ComputeMachineType, "")
+	viper.BindEnv(ComputeMachineType, "OCM_COMPUTE_MACHINE_TYPE")
 }


### PR DESCRIPTION
Adds the option `ocm.computeMachineType` which we can use on cluster-creation. This is currently specific to OCM (and I think that's okay for now)

Also adds compute and memory optimized configs for AWS and GCP to be used in periodic jobs.