### PR TITLE
SDCICD-341: Add provider list method, cleanup cluster command

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -1,0 +1,86 @@
+package cleanup
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/openshift/osde2e/cmd/osde2e/common"
+	"github.com/openshift/osde2e/pkg/common/metadata"
+	"github.com/openshift/osde2e/pkg/common/providers"
+	"github.com/openshift/osde2e/pkg/common/spi"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "cleanup",
+	Short: "Cleans up expired clusters.",
+	Long:  "Cleans up expired clusters.",
+	Args:  cobra.OnlyValidArgs,
+	RunE:  run,
+}
+
+var args struct {
+	configString    string
+	customConfig    string
+	secretLocations string
+}
+
+func init() {
+	flags := Cmd.Flags()
+
+	flags.StringVar(
+		&args.configString,
+		"configs",
+		"",
+		"A comma separated list of built in configs to use",
+	)
+	flags.StringVar(
+		&args.customConfig,
+		"custom-config",
+		"",
+		"Custom config file for osde2e",
+	)
+	flags.StringVar(
+		&args.secretLocations,
+		"secret-locations",
+		"",
+		"A comma separated list of possible secret directory locations for loading secret configs.",
+	)
+
+	Cmd.RegisterFlagCompletionFunc("output-format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"json", "prom"}, cobra.ShellCompDirectiveDefault
+	})
+}
+
+func run(cmd *cobra.Command, argv []string) error {
+	var provider spi.Provider
+	var err error
+	if err = common.LoadConfigs(args.configString, args.customConfig, args.secretLocations); err != nil {
+		return fmt.Errorf("error loading initial state: %v", err)
+	}
+
+	if provider, err = providers.ClusterProvider(); err != nil {
+		return fmt.Errorf("could not setup cluster provider: %v", err)
+	}
+
+	metadata.Instance.SetEnvironment(provider.Environment())
+
+	clusters, err := provider.ListClusters("properties.MadeByOSDe2e='true'")
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+
+	for _, cluster := range clusters {
+		if !cluster.ExpirationTimestamp().IsZero() && now.UTC().After(cluster.ExpirationTimestamp().UTC()) {
+			log.Printf("%s %s has expired. Deleting cluster...", cluster.ID(), cluster.Name())
+			if err := provider.DeleteCluster(cluster.ID()); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/osde2e/main.go
+++ b/cmd/osde2e/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openshift/osde2e/cmd/osde2e/alert"
 	"github.com/openshift/osde2e/cmd/osde2e/arguments"
+	"github.com/openshift/osde2e/cmd/osde2e/cleanup"
 	"github.com/openshift/osde2e/cmd/osde2e/completion"
 	"github.com/openshift/osde2e/cmd/osde2e/query"
 	"github.com/openshift/osde2e/cmd/osde2e/test"
@@ -46,6 +47,7 @@ func init() {
 	root.AddCommand(query.Cmd)
 	root.AddCommand(completion.Cmd)
 	root.AddCommand(alert.Cmd)
+	root.AddCommand(cleanup.Cmd)
 
 }
 

--- a/pkg/common/providers/crc/crc.go
+++ b/pkg/common/providers/crc/crc.go
@@ -166,6 +166,12 @@ func (m *Provider) ScaleCluster(clusterID string, numComputeNodes int) error {
 	return fmt.Errorf("scaling is currently unsupported for CRC clusters")
 }
 
+// ListClusters returns a list of CRC Clusters based on a filter
+// TODO
+func (m *Provider) ListClusters(query string) ([]*spi.Cluster, error) {
+	return nil, nil
+}
+
 // GetCluster CRCs a get cluster operation.
 func (m *Provider) GetCluster(clusterID string) (cluster *spi.Cluster, err error) {
 	var ok bool

--- a/pkg/common/providers/moaprovider/wrapped_calls.go
+++ b/pkg/common/providers/moaprovider/wrapped_calls.go
@@ -17,6 +17,11 @@ func (m *MOAProvider) ScaleCluster(clusterID string, numComputeNodes int) error 
 	return m.ocmProvider.ScaleCluster(clusterID, numComputeNodes)
 }
 
+// ListClusters will call ListClusters from the OCM provider.
+func (m *MOAProvider) ListClusters(query string) ([]*spi.Cluster, error) {
+	return m.ocmProvider.ListClusters(query)
+}
+
 // GetCluster will call GetCluster from the OCM provider.
 func (m *MOAProvider) GetCluster(clusterID string) (*spi.Cluster, error) {
 	return m.ocmProvider.GetCluster(clusterID)

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -97,6 +97,11 @@ func (m *MockProvider) DeleteCluster(clusterID string) error {
 	return nil
 }
 
+// ListClusters mocks a list cluster operation.
+func (m *MockProvider) ListClusters(query string) ([]*spi.Cluster, error) {
+	return nil, nil
+}
+
 // GetCluster mocks a get cluster operation.
 func (m *MockProvider) GetCluster(clusterID string) (*spi.Cluster, error) {
 	if clusterID == "fail" {

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -224,76 +224,41 @@ func (o *OCMProvider) ScaleCluster(clusterID string, numComputeNodes int) error 
 	return nil
 }
 
+// ListClusters returns a list of clusters filtered on key/value pairs
+func (o *OCMProvider) ListClusters(query string) ([]*spi.Cluster, error) {
+	var clusters []*spi.Cluster
+	clusterListRequest := o.conn.ClustersMgmt().V1().Clusters().List()
+
+	response, err := clusterListRequest.Search(query).Send()
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, cluster := range response.Items().Slice() {
+		spiCluster, err := o.ocmToSPICluster(cluster)
+		if err != nil {
+			return nil, err
+		}
+		clusters = append(clusters, spiCluster)
+	}
+
+	return clusters, nil
+}
+
 // GetCluster returns a cluster from OCM.
 func (o *OCMProvider) GetCluster(clusterID string) (*spi.Cluster, error) {
-	var resp *v1.ClusterGetResponse
-
 	ocmCluster, err := o.getOCMCluster(clusterID)
-
 	if err != nil {
 		return nil, err
 	}
 
-	cluster := spi.NewClusterBuilder().
-		Name(ocmCluster.Name()).
-		Region(ocmCluster.Region().ID()).
-		Flavour(ocmCluster.Flavour().ID())
-
-	if id, ok := ocmCluster.GetID(); ok {
-		cluster.ID(id)
-	}
-
-	if version, ok := ocmCluster.GetVersion(); ok {
-		cluster.Version(version.ID())
-	}
-
-	if cloudProvider, ok := ocmCluster.GetCloudProvider(); ok {
-		cluster.CloudProvider(cloudProvider.ID())
-	}
-
-	if state, ok := ocmCluster.GetState(); ok {
-		cluster.State(ocmStateToInternalState(state))
-	}
-
-	var addonsResp *v1.AddOnInstallationsListResponse
-	err = retryer().Do(func() error {
-		var err error
-		addonsResp, err = o.conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).Addons().
-			List().
-			Send()
-
-		if err != nil {
-			err = fmt.Errorf("couldn't retrieve addons for cluster '%s': %v", clusterID, err)
-			log.Printf("%v", err)
-			return err
-		}
-
-		if addonsResp != nil && addonsResp.Error() != nil {
-			log.Printf("error while trying to retrieve addons list for cluster: %v", err)
-			return errResp(resp.Error())
-		}
-
-		return nil
-	})
-
+	cluster, err := o.ocmToSPICluster(ocmCluster)
 	if err != nil {
 		return nil, err
 	}
 
-	if addonsResp.Error() != nil {
-		return nil, addonsResp.Error()
-	}
-
-	if addons, ok := addonsResp.GetItems(); ok {
-		addons.Each(func(addon *v1.AddOnInstallation) bool {
-			cluster.AddAddon(addon.ID())
-			return true
-		})
-	}
-
-	cluster.NumComputeNodes(ocmCluster.Nodes().Compute())
-
-	return cluster.Build(), nil
+	return cluster, nil
 }
 
 func (o *OCMProvider) getOCMCluster(clusterID string) (*v1.Cluster, error) {
@@ -572,6 +537,73 @@ func (o *OCMProvider) InstallAddons(clusterID string, addonIDs []string) (num in
 	}
 
 	return num, nil
+}
+
+func (o *OCMProvider) ocmToSPICluster(ocmCluster *v1.Cluster) (*spi.Cluster, error) {
+	var err error
+	var resp *v1.ClusterGetResponse
+
+	cluster := spi.NewClusterBuilder().
+		Name(ocmCluster.Name()).
+		Region(ocmCluster.Region().ID()).
+		Flavour(ocmCluster.Flavour().ID())
+
+	if id, ok := ocmCluster.GetID(); ok {
+		cluster.ID(id)
+	}
+
+	if version, ok := ocmCluster.GetVersion(); ok {
+		cluster.Version(version.ID())
+	}
+
+	if cloudProvider, ok := ocmCluster.GetCloudProvider(); ok {
+		cluster.CloudProvider(cloudProvider.ID())
+	}
+
+	if state, ok := ocmCluster.GetState(); ok {
+		cluster.State(ocmStateToInternalState(state))
+	}
+
+	var addonsResp *v1.AddOnInstallationsListResponse
+	err = retryer().Do(func() error {
+		var err error
+		addonsResp, err = o.conn.ClustersMgmt().V1().Clusters().Cluster(ocmCluster.ID()).Addons().
+			List().
+			Send()
+
+		if err != nil {
+			err = fmt.Errorf("couldn't retrieve addons for cluster '%s': %v", ocmCluster.ID(), err)
+			log.Printf("%v", err)
+			return err
+		}
+
+		if addonsResp != nil && addonsResp.Error() != nil {
+			log.Printf("error while trying to retrieve addons list for cluster: %v", err)
+			return errResp(resp.Error())
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if addonsResp.Error() != nil {
+		return nil, addonsResp.Error()
+	}
+
+	if addons, ok := addonsResp.GetItems(); ok {
+		addons.Each(func(addon *v1.AddOnInstallation) bool {
+			cluster.AddAddon(addon.ID())
+			return true
+		})
+	}
+
+	cluster.ExpirationTimestamp(ocmCluster.ExpirationTimestamp())
+	cluster.NumComputeNodes(ocmCluster.Nodes().Compute())
+
+	return cluster.Build(), nil
 }
 
 func ocmStateToInternalState(state v1.ClusterState) spi.ClusterState {

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -28,6 +28,9 @@ type Provider interface {
 	// scaling has finished.
 	ScaleCluster(clusterID string, numComputeNodes int) error
 
+	// ListCluster lists clusters from a provider based on a SQL-like query.
+	ListClusters(query string) ([]*Cluster, error)
+
 	// GetCluster gets a cluster.
 	//
 	// This is what OSDe2e will use to gather cluster information, including whether
@@ -89,6 +92,7 @@ type Provider interface {
 	CincinnatiChannel() CincinnatiChannel
 
 	// Type is the Provider type, specific to each Plugin
+	//
 	// This simply returns the name of the Provider
 	Type() string
 }


### PR DESCRIPTION
- Adds a ListClusters command to the SPI interface. The ListClusters query arg is a SQL-like command to mirror the OCM search method.
- Created an ocmToSPICluster internal method to convert the list of clusters returned.
- Stubs out ListClusters in the other providers
- Adds a `cleanup` command to osde2e. Based on a standard osde2e run/config, it will list OSDe2e clusters in the specified environment and issue a provider delete command if they're expired.

:taco: :taco: :taco: :taco: 