### PR TITLE
SDCICD-343: Support setting ocm region to 'random'

### DIFF
--- a/configs/region-random.yaml
+++ b/configs/region-random.yaml
@@ -1,0 +1,3 @@
+cloudProvider:
+    region: random
+  


### PR DESCRIPTION
This will allow us to set a cloud provider region to "random". This queries and pulls a random region from OCM, given a cloud provider.

