### PR TITLE
SDCICD-200. Remove e2e focused make targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,50 +43,6 @@ build:
 	mkdir -p "$(OUT_DIR)"
 	go build -o "$(OUT_DIR)" "$(DIR)cmd/..."
 
-test: build
-	"$(OSDE2E)" test --configs=e2e-suite,log-metrics --custom-config=$(CUSTOM_CONFIG)
-
-test-informing: build
-	"$(OSDE2E)" test --configs=informing-suite,log-metrics --custom-config=$(CUSTOM_CONFIG)
-
-test-scale: build
-	"$(OSDE2E)" test --configs=scale-mastervertical-suite,log-metrics --custom-config=$(CUSTOM_CONFIG)
-
-test-addons: build
-	"$(OSDE2E)" test --configs=addon-suite,log-metrics --custom-config=$(CUSTOM_CONFIG)
-
-test-conformance: build
-	"$(OSDE2E)" test --configs=conformance-suite,log-metrics --custom-config=$(CUSTOM_CONFIG)
-
-test-middle-imageset: build
-	"$(OSDE2E)" test --configs=e2e-suite,use-middle-version,log-metrics --custom-config=$(CUSTOM_CONFIG)
-
-test-oldest-imageset: build
-	"$(OSDE2E)" test --configs=e2e-suite,use-oldest-version,log-metrics --custom-config=$(CUSTOM_CONFIG)
-
-test-docker:
-	$(CONTAINER_ENGINE) run \
-		-t \
-		--rm \
-		-e NO_DESTROY=$(NO_DESTROY) \
-		-e CLUSTER_ID=$(CLUSTER_ID) \
-		-e CLUSTER_NAME=$(CLUSTER_NAME) \
-		-e CLEAN_RUNS=$(CLEAN_RUNS) \
-		-e DRY_RUN=$(DRY_RUN) \
-		-e MAJOR_TARGET=$(MAJOR_TARGET) \
-		-e MINOR_TARGET=$(MINOR_TARGET) \
-		-e CLUSTER_VERSION=$(CLUSTER_VERSION) \
-		-e NO_DESTROY_DELAY=$(NO_DESTROY_DELAY) \
-		-e GINKGO_SKIP="$(GINKGO_SKIP)" \
-		-e GINKGO_FOCUS="$(GINKGO_FOCUS)" \
-		-e UPGRADE_RELEASE_STREAM=$(UPGRADE_RELEASE_STREAM) \
-		-e DEBUG_OSD=1 \
-		-e OSD_ENV=$(OSD_ENV) \
-		-e OCM_TOKEN=$(OCM_REFRESH_TOKEN) \
-		-e AWS_ACCESS_KEY_ID=$(AWS_ACCESS_KEY_ID) \
-		-e AWS_SECRET_ACCESS_KEY=$(AWS_SECRET_ACCESS_KEY) \
-		$(IMAGE_NAME):$(IMAGE_TAG)
-
 diffproviders.txt:
 	"$(DIR)scripts/generate-providers-import.sh" > diffproviders.txt
 


### PR DESCRIPTION
The various make targets that have been focused on running osde2e and
its various tests have been removed. Now that the prow test runner has
been removed, job running in prow is much more explicit. We expect that
people running osde2e manually will use an actual osde2e binary from
here on out.