### PR TITLE
Add gather of test project state at end of run

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"github.com/openshift/osde2e/pkg/e2e/routemonitors"
 	vegeta "github.com/tsenart/vegeta/lib"
 	"io/ioutil"
 	"log"
@@ -30,6 +29,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/metadata"
 	"github.com/openshift/osde2e/pkg/common/phase"
 	"github.com/openshift/osde2e/pkg/common/providers"
+	"github.com/openshift/osde2e/pkg/e2e/routemonitors"
 	"github.com/openshift/osde2e/pkg/common/runner"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/upgrade"
@@ -251,6 +251,9 @@ func cleanupAfterE2E(h *helper.H) (errors []error) {
 			}
 		}
 	}
+
+	log.Print("Gathering Test Project State...")
+	h.InspectState()
 
 	log.Print("Gathering Cluster State...")
 	clusterState := h.GetClusterState()


### PR DESCRIPTION
This PR runs an `oc adm inspect` on the OSDE2E test project namespace at the completion of an `osde2e` run.

The output is saved in a file `osde2e-project.tar.gz` in the `install` directory of the `osde2e` test output.

The contents of this file can be used either in conjunction with the `must-gather` or in isolation in order to better understand the state of the `osde2e` project upon completion of the test. This can be useful for providing better context around why a test may have failed to pass when conducting follow-up analysis.
