### PR TITLE
SDCICD-354. Make sure cluster health checks fire for MOA clusters.

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -157,6 +157,8 @@ func pollClusterHealth(provider spi.Provider, clusterID string) (status bool, er
 
 	var healthErr *multierror.Error
 	switch provider.Type() {
+	case "moa":
+		fallthrough
 	case "ocm":
 		if check, err := healthchecks.CheckCVOReadiness(oscfg.ConfigV1()); !check || err != nil {
 			healthErr = multierror.Append(healthErr, err)


### PR DESCRIPTION
Cluster health checks will now fire for MOA clusters.