### PR TITLE
SDCICD-357. Handle version out of bounds error.

### DIFF
--- a/pkg/common/versions/installselectors/delta_release_from_default.go
+++ b/pkg/common/versions/installselectors/delta_release_from_default.go
@@ -39,7 +39,7 @@ func (d deltaReleaseFromDefault) SelectVersion(versionList *spi.VersionList) (*s
 
 	targetIndex := defaultIndex + deltaReleasesFromDefault
 
-	if targetIndex < 0 {
+	if targetIndex < 0 || targetIndex >= len(availableVersions) {
 		log.Printf("not enough enabled versions to go back %d releases", deltaReleasesFromDefault)
 		viper.Set(config.Cluster.PreviousVersionFromDefaultFound, false)
 		return nil, versionType, nil


### PR DESCRIPTION
When going forward while selecting a version delta relative to the
default, it's possible to go off the end of the version array.