### PR TITLE
SDCICD-364. Rename report dir build log to reduce prow job noise.

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -44,7 +44,7 @@ const (
 	hiveLog string = "hive-log.txt"
 
 	// buildLog is the name of the build log file.
-	buildLog string = "build-log.txt"
+	buildLog string = "test_output.log"
 )
 
 // provisioner is used to deploy and manage clusters.


### PR DESCRIPTION
Prow Spyglass picks up all logs named "build-log.txt," which makes our
job dashboards look really noisy. We'll just restore the old name of
test_output.log in order to reduce the duplicative display in Spyglass.