### PR TITLE
Fix Timeout comparison

### DIFF
--- a/pkg/e2e/osd/machinehealthcheck.go
+++ b/pkg/e2e/osd/machinehealthcheck.go
@@ -37,14 +37,14 @@ var _ = ginkgo.Describe("[Suite: informing] MachineHealthChecks", func() {
 					machineV1beta1.UnhealthyCondition{
 						Type:    corev1.NodeReady,
 						Status:  corev1.ConditionFalse,
-						Timeout: "480",
+						Timeout: "480s",
 					},
 				),
 				ContainElement(
 					machineV1beta1.UnhealthyCondition{
 						Type:    corev1.NodeReady,
 						Status:  corev1.ConditionUnknown,
-						Timeout: "480",
+						Timeout: "480s",
 					},
 				),
 			))


### PR DESCRIPTION
This timeout is expected to contain the s for seconds. See https://github.com/openshift/managed-cluster-config/blob/master/deploy/osd-machine-api/011-machine-api.srep-worker-healthcheck.MachineHealthCheck.yaml#L10-L16.