### PR TITLE
SDCICD-362: Differentiate between prow URL and gcs URL

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -23,6 +23,9 @@ const (
 	// https://storage.googleapis.com/origin-ci-test/logs -- This is also our default
 	BaseJobURL = "baseJobURL"
 
+	// BaseProwURL is the root location of Prow
+	BaseProwURL = "baseProwURL"
+
 	// Artifacts is the artifacts location on prow. It is an alias for report dir.
 	Artifacts = "artifacts"
 
@@ -314,6 +317,9 @@ func init() {
 
 	viper.SetDefault(BaseJobURL, "https://storage.googleapis.com/origin-ci-test/logs")
 	viper.BindEnv(BaseJobURL, "BASE_JOB_URL")
+
+	viper.SetDefault(BaseProwURL, "https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com")
+	viper.BindEnv(BaseProwURL, "BASE_PROW_URL")
 
 	// ARTIFACTS and REPORT_DIR are basically the same, but ARTIFACTS is used on prow.
 	viper.BindEnv(Artifacts, "ARTIFACTS")

--- a/pkg/debug/diff.go
+++ b/pkg/debug/diff.go
@@ -13,19 +13,25 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/google/go-github/v31/github"
 	"github.com/kylelemons/godebug/diff"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/spf13/viper"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
 
 // GenerateDiff attempts to pull a dependency list from a previous job (job, jobID) and generate a diff against a provided string
-func GenerateDiff(baseURL, phase, dependencies, jobName string) error {
-	jobID, err := getLastJobID(baseURL, jobName)
+func GenerateDiff(phase, dependencies string) error {
+	baseJobURL := viper.GetString(config.BaseJobURL)
+	baseProwURL := viper.GetString(config.BaseProwURL)
+	jobName := viper.GetString(config.JobName)
+
+	jobID, err := getLastJobID(baseProwURL, jobName)
 	if err != nil {
 		return err
 	}
 
-	url := fmt.Sprintf("%s/%s/%d/artifacts/%s/dependencies.txt", baseURL, jobName, jobID, phase)
+	url := fmt.Sprintf("%s/%s/%d/artifacts/%s/dependencies.txt", baseJobURL, jobName, jobID, phase)
 	log.Printf("Grabbing diff from %s", url)
 	resp, err := http.Get(url)
 	if err != nil {
@@ -124,9 +130,10 @@ func GetCurrentMCCHash() (hash string, err error) {
 	return "", fmt.Errorf("No commits found for openshift/machine-cluster-config")
 }
 
-func getLastJobID(baseURL, jobName string) (int, error) {
+func getLastJobID(baseProwURL, jobName string) (int, error) {
 	// Look up the list of previous jobs with a given name
-	url := fmt.Sprintf("%s/job-history/gs/origin-ci-test/logs/%s", baseURL, jobName)
+	url := fmt.Sprintf("%s/job-history/gs/origin-ci-test/logs/%s", baseProwURL, jobName)
+	log.Printf("Looking up job history from %s", url)
 	res, err := http.Get(url)
 	if err != nil {
 		return 0, err

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -509,7 +509,7 @@ func runTestsInPhase(phase string, description string) bool {
 				log.Printf("Error writing dependencies.txt: %s", err.Error())
 			}
 
-			err := debug.GenerateDiff(viper.GetString(config.BaseJobURL), phase, dependencies, viper.GetString(config.JobName))
+			err := debug.GenerateDiff(phase, dependencies)
 			if err != nil {
 				log.Printf("Error generating diff: %s", err.Error())
 			}


### PR DESCRIPTION
Looking up job history is a different URL from the baseJobURL (which was a mistake on my part)

This adds a baseProwURL, sets it, and refactors some variable names a bit. 