### PR TITLE
SDCICD-368. Supply prometheus credentials for metrics client.

### DIFF
--- a/pkg/common/prometheus/connect.go
+++ b/pkg/common/prometheus/connect.go
@@ -2,6 +2,7 @@ package prometheus
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -12,27 +13,50 @@ import (
 	"github.com/spf13/viper"
 )
 
-// CreateClient will create a Prometheus client based off of the global config.
-func CreateClient() (api.Client, error) {
+// CreateClient will create a Prometheus client.
+// If no arguments are supplied, the global config will be used.
+// If one argument is supplied, it will be used as the address for Prometheus, but will use the global config for the bearer token.
+// If two arguments are supplied, the first will be used as the address for Prometheus and the second will be used as the bearer token.
+func CreateClient(args ...string) (api.Client, error) {
+	numArgs := len(args)
+	if numArgs > 2 {
+		return nil, fmt.Errorf("unexpected number of arguments, only 2 are supported")
+	}
+
+	var address, bearerToken string
+
+	if numArgs == 0 {
+		address = viper.GetString(config.Prometheus.Address)
+		bearerToken = viper.GetString(config.Prometheus.BearerToken)
+	} else if numArgs == 1 {
+		address = args[0]
+		bearerToken = viper.GetString(config.Prometheus.BearerToken)
+	} else if numArgs == 2 {
+		address = args[0]
+		bearerToken = args[1]
+	}
+
 	return api.NewClient(api.Config{
-		Address:      viper.GetString(config.Prometheus.Address),
-		RoundTripper: WeatherRoundTripper,
+		Address:      address,
+		RoundTripper: createRoundTripper(bearerToken),
 	})
 }
 
-// WeatherRoundTripper is like api.DefaultRoundTripper with an added stripping of cert verification
-// and adding the bearer token to the HTTP request
-var WeatherRoundTripper http.RoundTripper = &http.Transport{
-	Proxy: func(request *http.Request) (*url.URL, error) {
-		request.Header.Add("Authorization", "Bearer "+viper.GetString(config.Prometheus.BearerToken))
-		return http.ProxyFromEnvironment(request)
-	},
-	DialContext: (&net.Dialer{
-		Timeout:   30 * time.Second,
-		KeepAlive: 30 * time.Second,
-	}).DialContext,
-	TLSClientConfig: &tls.Config{
-		InsecureSkipVerify: true,
-	},
-	TLSHandshakeTimeout: 10 * time.Second,
+// createRoundTripper will create a RoundTripper like api.DefaultRoundTripper with an added stripping
+// of cert verification and adding the bearer token to the HTTP request
+func createRoundTripper(bearerToken string) http.RoundTripper {
+	return &http.Transport{
+		Proxy: func(request *http.Request) (*url.URL, error) {
+			request.Header.Add("Authorization", "Bearer "+bearerToken)
+			return http.ProxyFromEnvironment(request)
+		},
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+		TLSHandshakeTimeout: 10 * time.Second,
+	}
 }

--- a/pkg/metrics/client.go
+++ b/pkg/metrics/client.go
@@ -43,8 +43,11 @@ type Client struct {
 }
 
 // NewClient returns a new metrics client.
-func NewClient() (*Client, error) {
-	client, err := prometheus.CreateClient()
+// If no arguments are supplied, the global config will be used.
+// If one argument is supplied, it will be used as the address for Prometheus, but will use the global config for the bearer token.
+// If two arguments are supplied, the first will be used as the address for Prometheus and the second will be used as the bearer token.
+func NewClient(args ...string) (*Client, error) {
+	client, err := prometheus.CreateClient(args...)
 
 	if err != nil {
 		return nil, fmt.Errorf("error trying to create the metrics client: %v", err)


### PR DESCRIPTION
The metrics client can now be supplied with Prometheus credentials in
order to connect to a Prometheus server.