### PR TITLE
SDCICD-275: Update all e2e tests to use metricAlerts

### DIFF
--- a/pkg/e2e/openshift/app_builds.go
+++ b/pkg/e2e/openshift/app_builds.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/runner"
 	kubev1 "k8s.io/api/core/v1"
@@ -37,7 +38,22 @@ var testApplications = []string{
 	// "nodejs-mongodb",
 }
 
-var _ = ginkgo.Describe("[Suite: app-builds] OpenShift Application Build E2E", func() {
+var testAlert alert.MetricAlert
+
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: app-builds] OpenShift Application Build E2E",
+		TeamOwner:        "SD-CICD",
+		PrimaryContact:   "Jeffrey Sica",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	defer ginkgo.GinkgoRecover()
 
 	h := helper.New()

--- a/pkg/e2e/openshift/app_builds.go
+++ b/pkg/e2e/openshift/app_builds.go
@@ -48,7 +48,7 @@ func init() {
 		PrimaryContact:   "Jeffrey Sica",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/openshift/conformance.go
+++ b/pkg/e2e/openshift/conformance.go
@@ -28,7 +28,7 @@ func init() {
 		PrimaryContact:   "Jeffrey Sica",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/openshift/conformance.go
+++ b/pkg/e2e/openshift/conformance.go
@@ -5,6 +5,7 @@ import (
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/runner"
 )
@@ -19,7 +20,20 @@ var DefaultE2EConfig = E2EConfig{
 	},
 }
 
-var _ = ginkgo.Describe("[Suite: conformance][k8s]", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: conformance]",
+		TeamOwner:        "SD-CICD",
+		PrimaryContact:   "Jeffrey Sica",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name+"[k8s]", func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 
@@ -51,7 +65,7 @@ var _ = ginkgo.Describe("[Suite: conformance][k8s]", func() {
 	}, float64(e2eTimeoutInSeconds+30))
 })
 
-var _ = ginkgo.Describe("[Suite: conformance][openshift]", func() {
+var _ = ginkgo.Describe(testAlert.Name+"[openshift]", func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/pkg/e2e/openshift/disruptive.go
+++ b/pkg/e2e/openshift/disruptive.go
@@ -5,11 +5,25 @@ import (
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 )
 
 // Disruptive tests require SSH access to nodes.
-var _ = ginkgo.Describe("[Suite: openshift][disruptive]", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: openshift][disruptive]",
+		TeamOwner:        "SD-CICD",
+		PrimaryContact:   "Jeffrey Sica",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/pkg/e2e/openshift/disruptive.go
+++ b/pkg/e2e/openshift/disruptive.go
@@ -18,7 +18,7 @@ func init() {
 		PrimaryContact:   "Jeffrey Sica",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/openshift/images.go
+++ b/pkg/e2e/openshift/images.go
@@ -5,10 +5,24 @@ import (
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 )
 
-var _ = ginkgo.Describe("[Suite: openshift][image-registry]", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: openshift][image-",
+		TeamOwner:        "SD-CICD",
+		PrimaryContact:   "Jeffrey Sica",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name+"registry", func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 
@@ -38,7 +52,7 @@ var _ = ginkgo.Describe("[Suite: openshift][image-registry]", func() {
 	}, float64(e2eTimeoutInSeconds+30))
 })
 
-var _ = ginkgo.Describe("[Suite: openshift][image-ecosystem]", func() {
+var _ = ginkgo.Describe(testAlert.Name+"ecosystem", func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/pkg/e2e/openshift/images.go
+++ b/pkg/e2e/openshift/images.go
@@ -17,7 +17,7 @@ func init() {
 		PrimaryContact:   "Jeffrey Sica",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/operators/certman.go
+++ b/pkg/e2e/operators/certman.go
@@ -23,7 +23,7 @@ func init() {
 	testAlert = alert.MetricAlert{
 		Name:             "[Suite: operators] [OSD] Certman Operator",
 		TeamOwner:        "SD-SREP",
-		PrimaryContact:   "Carl Brumm",
+		PrimaryContact:   "Christoph Blecker",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
 		FailureThreshold: 1,

--- a/pkg/e2e/operators/certman.go
+++ b/pkg/e2e/operators/certman.go
@@ -7,6 +7,7 @@ import (
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	osv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/spf13/viper"
@@ -15,7 +16,22 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-var _ = ginkgo.Describe("[Suite: operators] [OSD] Certman Operator", func() {
+var testAlert alert.MetricAlert
+
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: operators] [OSD] Certman Operator",
+		TeamOwner:        "SD-SREP",
+		PrimaryContact:   "Carl Brumm",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	h := helper.New()
 	ginkgo.Context("certificate secret should be applied when cluster installed", func() {
 		var secretName string

--- a/pkg/e2e/operators/certman.go
+++ b/pkg/e2e/operators/certman.go
@@ -26,7 +26,7 @@ func init() {
 		PrimaryContact:   "Christoph Blecker",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/operators/configurealertmanager.go
+++ b/pkg/e2e/operators/configurealertmanager.go
@@ -2,10 +2,24 @@ package operators
 
 import (
 	"github.com/onsi/ginkgo"
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 )
 
-var _ = ginkgo.Describe("[Suite: operators] [OSD] Configure AlertManager Operator", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: operators] [OSD] Configure AlertManager Operator",
+		TeamOwner:        "SD-SREP",
+		PrimaryContact:   "Christopher Collins",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	var operatorName = "configure-alertmanager-operator"
 	var operatorNamespace string = "openshift-monitoring"
 	var operatorLockFile string = "configure-alertmanager-operator-lock"
@@ -37,9 +51,7 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Configure AlertManager Operato
 	checkClusterRoleBindings(h, clusterRoleBindings)
 	checkRole(h, operatorNamespace, roles)
 	checkRoleBindings(h, operatorNamespace, roleBindings)
-})
 
-var _ = ginkgo.Describe("[Suite: informing] [OSD] Upgrade Configure AlertManager Operator", func() {
 	checkUpgrade(helper.New(), "openshift-monitoring", "configure-alertmanager-operator",
 		"configure-alertmanager-operator.v0.1.171-dba3c73",
 	)

--- a/pkg/e2e/operators/configurealertmanager.go
+++ b/pkg/e2e/operators/configurealertmanager.go
@@ -14,7 +14,7 @@ func init() {
 		PrimaryContact:   "Christopher Collins",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/operators/managedvelero.go
+++ b/pkg/e2e/operators/managedvelero.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,7 +16,20 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-var _ = ginkgo.Describe("[Suite: operators] [OSD] Managed Velero Operator", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: operators] [OSD] Managed Velero Operator",
+		TeamOwner:        "SD-SREP",
+		PrimaryContact:   "Christoph Blecker",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	var operatorName = "managed-velero-operator"
 	var operatorNamespace string = "openshift-velero"
 	var operatorLockFile string = "managed-velero-operator-lock"

--- a/pkg/e2e/operators/managedvelero.go
+++ b/pkg/e2e/operators/managedvelero.go
@@ -24,7 +24,7 @@ func init() {
 		PrimaryContact:   "Christoph Blecker",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/operators/prunejob.go
+++ b/pkg/e2e/operators/prunejob.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/spf13/viper"
@@ -18,7 +19,20 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
-var _ = ginkgo.Describe("[Suite: operators] [OSD] Prune jobs", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: operators] [OSD] Prune jobs",
+		TeamOwner:        "SD-SREP",
+		PrimaryContact:   "Haoran Wang",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	h := helper.New()
 	ginkgo.Context("pruner jobs should works", func() {
 		namespace := "openshift-sre-pruning"

--- a/pkg/e2e/operators/prunejob.go
+++ b/pkg/e2e/operators/prunejob.go
@@ -27,7 +27,7 @@ func init() {
 		PrimaryContact:   "Haoran Wang",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -28,7 +28,7 @@ func init() {
 		PrimaryContact:   "Matt Bargenquest",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/onsi/ginkgo"
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -19,7 +20,20 @@ import (
 var operatorName = "rbac-permissions-operator"
 var operatorNamespace = "openshift-rbac-permissions"
 
-var _ = ginkgo.Describe("[Suite: operators] [OSD] RBAC Operator", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: operators] [OSD] RBAC",
+		TeamOwner:        "SD-SREP",
+		PrimaryContact:   "Matt Bargenquest",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name+"Operator", func() {
 	var operatorLockFile = "rbac-permissions-operator-lock"
 	var defaultDesiredReplicas int32 = 1
 
@@ -36,12 +50,12 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] RBAC Operator", func() {
 	checkClusterRoles(h, clusterRoles)
 })
 
-var _ = ginkgo.Describe("[Suite: operators] [OSD] Dedicated Admins SubjectPermission", func() {
+var _ = ginkgo.Describe(testAlert.Name+" Dedicated Admins SubjectPermission", func() {
 	h := helper.New()
 	checkSubjectPermissions(h, "dedicated-admins")
 })
 
-var _ = ginkgo.Describe("[Suite: informing] [OSD] Upgrade RBAC Permissions Operator", func() {
+var _ = ginkgo.Describe(testAlert.Name+" Upgrade RBAC Permissions Operator", func() {
 	checkUpgrade(helper.New(), "openshift-rbac-permissions", "rbac-permissions-operator",
 		"rbac-permissions-operator.v0.1.97-68cf185",
 	)

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -25,7 +25,7 @@ func init() {
 	testAlert = alert.MetricAlert{
 		Name:             "[Suite: operators] [OSD] RBAC",
 		TeamOwner:        "SD-SREP",
-		PrimaryContact:   "Matt Bargenquest",
+		PrimaryContact:   "Matt Bargenquast",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
 		FailureThreshold: 4,

--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -14,7 +14,7 @@ func init() {
 		PrimaryContact:   "Matt Bargenquest",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -2,10 +2,25 @@ package operators
 
 import (
 	"github.com/onsi/ginkgo"
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 )
 
-var _ = ginkgo.Describe("[Suite: operators] [OSD] Splunk Forwarder Operator", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: operators] [OSD] Splunk Forwarder Operator",
+		TeamOwner:        "SD-SREP",
+		PrimaryContact:   "Matt Bargenquest",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
+
 	var operatorName = "splunk-forwarder-operator"
 	var operatorNamespace string = "openshift-splunk-forwarder-operator"
 	var operatorLockFile string = "splunk-forwarder-operator-lock"
@@ -30,7 +45,7 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Splunk Forwarder Operator", fu
 	checkClusterRoles(h, clusterRoles)
 })
 
-var _ = ginkgo.Describe("[Suite: informing] [OSD] Upgrade Splunk Forwarder Operator", func() {
+var _ = ginkgo.Describe(testAlert.Name+" Upgrade", func() {
 	checkUpgrade(helper.New(), "openshift-splunk-forwarder-operator", "openshift-splunk-forwarder-operator",
 		"splunk-forwarder-operator.v0.1.157-3dca592",
 	)

--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -11,7 +11,7 @@ func init() {
 	testAlert = alert.MetricAlert{
 		Name:             "[Suite: operators] [OSD] Splunk Forwarder Operator",
 		TeamOwner:        "SD-SREP",
-		PrimaryContact:   "Matt Bargenquest",
+		PrimaryContact:   "Matt Bargenquast",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
 		FailureThreshold: 4,

--- a/pkg/e2e/osd/daemonsets.go
+++ b/pkg/e2e/osd/daemonsets.go
@@ -26,7 +26,7 @@ func init() {
 		PrimaryContact:   "Jeffrey Sica",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/osd/daemonsets.go
+++ b/pkg/e2e/osd/daemonsets.go
@@ -22,7 +22,7 @@ func init() {
 	ma := alert.GetMetricAlerts()
 	testAlert = alert.MetricAlert{
 		Name:             "[Suite: service-definition] [OSD] DaemonSets",
-		TeamOwner:        "SDCICD",
+		TeamOwner:        "SD-CICD",
 		PrimaryContact:   "Jeffrey Sica",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",

--- a/pkg/e2e/osd/dedicatedadmin.go
+++ b/pkg/e2e/osd/dedicatedadmin.go
@@ -23,7 +23,7 @@ func init() {
 		PrimaryContact:   "Matt Bargenquest",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/osd/dedicatedadmin.go
+++ b/pkg/e2e/osd/dedicatedadmin.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/spf13/viper"
@@ -12,7 +13,22 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-var _ = ginkgo.Describe("[Suite: informing] [OSD] dedicated-admin permissions", func() {
+// var testAlert alert.MetricAlert in daemonsets
+
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: informing] [OSD] dedicated-admin permissions",
+		TeamOwner:        "SD-SREP",
+		PrimaryContact:   "Matt Bargenquest",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	ginkgo.Context("dedicated-admin group permissions", func() {
 
 		// setup helper

--- a/pkg/e2e/osd/dedicatedadmin.go
+++ b/pkg/e2e/osd/dedicatedadmin.go
@@ -20,7 +20,7 @@ func init() {
 	testAlert = alert.MetricAlert{
 		Name:             "[Suite: informing] [OSD] dedicated-admin permissions",
 		TeamOwner:        "SD-SREP",
-		PrimaryContact:   "Matt Bargenquest",
+		PrimaryContact:   "Matt Bargenquast",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
 		FailureThreshold: 4,

--- a/pkg/e2e/osd/machinehealthcheck.go
+++ b/pkg/e2e/osd/machinehealthcheck.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	machineV1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +18,20 @@ const (
 	OperatorNamespace = "openshift-machine-api"
 )
 
-var _ = ginkgo.Describe("[Suite: informing] MachineHealthChecks", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: informing] MachineHealthChecks",
+		TeamOwner:        "SD-SRE",
+		PrimaryContact:   "Alex Chvatal",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	h := helper.New()
 
 	ginkgo.It("should exist", func() {

--- a/pkg/e2e/osd/machinehealthcheck.go
+++ b/pkg/e2e/osd/machinehealthcheck.go
@@ -26,7 +26,7 @@ func init() {
 		PrimaryContact:   "Alex Chvatal",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/osd/nodelabels.go
+++ b/pkg/e2e/osd/nodelabels.go
@@ -20,7 +20,7 @@ func init() {
 		PrimaryContact:   "Jeffrey Sica",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/osd/nodelabels.go
+++ b/pkg/e2e/osd/nodelabels.go
@@ -2,15 +2,30 @@ package osd
 
 import (
 	"context"
+
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/spf13/viper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = ginkgo.Describe("[Suite: service-definition] [OSD] NodeLabels", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: service-definition] [OSD] NodeLabels",
+		TeamOwner:        "SD-CICD",
+		PrimaryContact:   "Jeffrey Sica",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	ginkgo.Context("Modifying nodeLabels is not allowed", func() {
 		// setup helper
 		h := helper.New()

--- a/pkg/e2e/osd/ocm.go
+++ b/pkg/e2e/osd/ocm.go
@@ -3,12 +3,26 @@ package osd
 import (
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/providers"
 	"github.com/spf13/viper"
 )
 
-var _ = ginkgo.Describe("[Suite: informing] [OSD] OCM", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: informing] [OSD] OCM",
+		TeamOwner:        "SD-CICD",
+		PrimaryContact:   "Jeffrey Sica",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	ginkgo.Context("Metrics", func() {
 		clusterID := viper.GetString(config.Cluster.ID)
 		ginkgo.It("do exist and are not empty", func() {

--- a/pkg/e2e/osd/ocm.go
+++ b/pkg/e2e/osd/ocm.go
@@ -17,7 +17,7 @@ func init() {
 		PrimaryContact:   "Jeffrey Sica",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/osd/privileged.go
+++ b/pkg/e2e/osd/privileged.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -34,7 +35,20 @@ func makePod(name, sa string, privileged bool) v1.Pod {
 	}
 }
 
-var _ = ginkgo.Describe("[Suite: service-definition] [OSD] Privileged Containers", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: service-definition] [OSD] Privileged Containers",
+		TeamOwner:        "SD-CICD",
+		PrimaryContact:   "Jeffrey Sica",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	ginkgo.Context("Privileged containers are not allowed", func() {
 		// setup helper
 		h := helper.New()

--- a/pkg/e2e/osd/privileged.go
+++ b/pkg/e2e/osd/privileged.go
@@ -43,7 +43,7 @@ func init() {
 		PrimaryContact:   "Jeffrey Sica",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/scale/mastervertical.go
+++ b/pkg/e2e/scale/mastervertical.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/viper"
 	kubev1 "k8s.io/api/core/v1"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/cluster"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
@@ -16,7 +17,22 @@ const (
 	numNodesToScaleTo = 12
 )
 
-var _ = ginkgo.Describe("[Suite: scale-mastervertical] Scaling", func() {
+var testAlert alert.MetricAlert
+
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: scale-mastervertical] Scaling",
+		TeamOwner:        "SD-CICD",
+		PrimaryContact:   "Michael Wilson",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/pkg/e2e/scale/mastervertical.go
+++ b/pkg/e2e/scale/mastervertical.go
@@ -27,7 +27,7 @@ func init() {
 		PrimaryContact:   "Michael Wilson",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/scale/nodes_and_pods.go
+++ b/pkg/e2e/scale/nodes_and_pods.go
@@ -23,7 +23,7 @@ func init() {
 		PrimaryContact:   "Michael Wilson",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/scale/nodes_and_pods.go
+++ b/pkg/e2e/scale/nodes_and_pods.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	kubev1 "k8s.io/api/core/v1"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 )
 
@@ -14,7 +15,20 @@ const (
 	numNodesForNodeVertical = 3
 )
 
-var _ = ginkgo.Describe("[Suite: scale-nodes-and-pods] Scaling", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: scale-nodes-and-pods] Scaling",
+		TeamOwner:        "SD-CICD",
+		PrimaryContact:   "Michael Wilson",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/pkg/e2e/scale/performance.go
+++ b/pkg/e2e/scale/performance.go
@@ -5,10 +5,24 @@ import (
 	. "github.com/onsi/gomega"
 	kubev1 "k8s.io/api/core/v1"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 )
 
-var _ = ginkgo.Describe("[Suite: scale-performance] Scaling", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: scale-performance] Scaling",
+		TeamOwner:        "SD-CICD",
+		PrimaryContact:   "Michael Wilson",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/pkg/e2e/scale/performance.go
+++ b/pkg/e2e/scale/performance.go
@@ -17,7 +17,7 @@ func init() {
 		PrimaryContact:   "Michael Wilson",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/state/alerts.go
+++ b/pkg/e2e/state/alerts.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/common/log"
 	"github.com/spf13/viper"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/providers"
@@ -28,6 +29,7 @@ var ignoreAlerts = map[string]map[string][]string{
 		"int": {"MetricsClientSendFailingSRE"},
 	},
 }
+var testAlert alert.MetricAlert
 
 func init() {
 	var err error
@@ -37,9 +39,20 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("error while loading alerts command: %v", err))
 	}
+
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: e2e] Cluster state",
+		TeamOwner:        "SD-CICD",
+		PrimaryContact:   "Michael Wilson",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
 }
 
-var _ = ginkgo.Describe("[Suite: e2e] Cluster state", func() {
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/pkg/e2e/state/alerts.go
+++ b/pkg/e2e/state/alerts.go
@@ -47,7 +47,7 @@ func init() {
 		PrimaryContact:   "Michael Wilson",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/state/prometheus.go
+++ b/pkg/e2e/state/prometheus.go
@@ -4,6 +4,7 @@ import (
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/runner"
 )
@@ -13,7 +14,20 @@ const (
 	promCollectCmd = "oc exec -n openshift-monitoring prometheus-k8s-0 -c prometheus -- /bin/sh -c \"cp -ruf /prometheus /tmp/prometheus && tar cvzO -C /tmp/prometheus . "
 )
 
-var _ = ginkgo.Describe("[Suite: e2e] Cluster state", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: e2e] Cluster state",
+		TeamOwner:        "SD-CICD",
+		PrimaryContact:   "Michael Wilson",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/pkg/e2e/state/prometheus.go
+++ b/pkg/e2e/state/prometheus.go
@@ -22,7 +22,7 @@ func init() {
 		PrimaryContact:   "Michael Wilson",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/verify/imagestreams.go
+++ b/pkg/e2e/verify/imagestreams.go
@@ -22,7 +22,7 @@ func init() {
 		PrimaryContact:   "Jeffrey Sica",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/verify/imagestreams.go
+++ b/pkg/e2e/verify/imagestreams.go
@@ -8,10 +8,26 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 )
 
-var _ = ginkgo.Describe("[Suite: e2e] ImageStreams", func() {
+var testAlert alert.MetricAlert
+
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: e2e] ImageStreams",
+		TeamOwner:        "SD-CICD",
+		PrimaryContact:   "Jeffrey Sica",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	h := helper.New()
 
 	ginkgo.It("should exist in the cluster", func() {

--- a/pkg/e2e/verify/namespace_webhook.go
+++ b/pkg/e2e/verify/namespace_webhook.go
@@ -28,7 +28,7 @@ func init() {
 		PrimaryContact:   "Matt Bargenquest",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/verify/namespace_webhook.go
+++ b/pkg/e2e/verify/namespace_webhook.go
@@ -25,7 +25,7 @@ func init() {
 	testAlert = alert.MetricAlert{
 		Name:             "[Suite: informing] [OSD] namespace validating webhook",
 		TeamOwner:        "SD-SREP",
-		PrimaryContact:   "Matt Bargenquest",
+		PrimaryContact:   "Matt Bargenquast",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
 		FailureThreshold: 4,

--- a/pkg/e2e/verify/namespace_webhook.go
+++ b/pkg/e2e/verify/namespace_webhook.go
@@ -9,6 +9,7 @@ import (
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	userv1 "github.com/openshift/api/user/v1"
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -19,7 +20,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = ginkgo.Describe("[Suite: informing] [OSD] namespace validating webhook", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: informing] [OSD] namespace validating webhook",
+		TeamOwner:        "SD-SREP",
+		PrimaryContact:   "Matt Bargenquest",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 
 	const (
 		// Group to use for impersonation

--- a/pkg/e2e/verify/pods.go
+++ b/pkg/e2e/verify/pods.go
@@ -25,7 +25,7 @@ func init() {
 		PrimaryContact:   "Jeffrey Sica",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/verify/pods.go
+++ b/pkg/e2e/verify/pods.go
@@ -13,10 +13,24 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 )
 
-var _ = ginkgo.Describe("[Suite: e2e] Pods", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: e2e] Pods",
+		TeamOwner:        "SD-CICD",
+		PrimaryContact:   "Jeffrey Sica",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	h := helper.New()
 
 	ginkgo.It("should be Running or Succeeded", func() {

--- a/pkg/e2e/verify/prom_exporters.go
+++ b/pkg/e2e/verify/prom_exporters.go
@@ -22,7 +22,7 @@ func init() {
 	testAlert = alert.MetricAlert{
 		Name:             "[Suite: e2e] [OSD] Prometheus Exporters",
 		TeamOwner:        "SD-SREP",
-		PrimaryContact:   "Matt Bargenquest",
+		PrimaryContact:   "Matt Bargenquast",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
 		FailureThreshold: 4,

--- a/pkg/e2e/verify/prom_exporters.go
+++ b/pkg/e2e/verify/prom_exporters.go
@@ -25,7 +25,7 @@ func init() {
 		PrimaryContact:   "Matt Bargenquest",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/verify/prom_exporters.go
+++ b/pkg/e2e/verify/prom_exporters.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/viper"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/cluster"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
@@ -16,7 +17,20 @@ import (
 	"github.com/openshift/osde2e/pkg/common/util"
 )
 
-var _ = ginkgo.Describe("[Suite: e2e] [OSD] Prometheus Exporters", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: e2e] [OSD] Prometheus Exporters",
+		TeamOwner:        "SD-SREP",
+		PrimaryContact:   "Matt Bargenquest",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 
 	const (
 		// all represents all environments

--- a/pkg/e2e/verify/routes.go
+++ b/pkg/e2e/verify/routes.go
@@ -31,7 +31,7 @@ func init() {
 		PrimaryContact:   "Jeffrey Sica",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/verify/routes.go
+++ b/pkg/e2e/verify/routes.go
@@ -12,6 +12,7 @@ import (
 	v1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 )
 
@@ -22,7 +23,20 @@ const (
 	oauthName        = "oauth-openshift"
 )
 
-var _ = ginkgo.Describe("[Suite: e2e] Routes", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: e2e] Routes",
+		TeamOwner:        "SD-CICD",
+		PrimaryContact:   "Jeffrey Sica",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	h := helper.New()
 
 	ginkgo.It("should be created for Console", func() {

--- a/pkg/e2e/verify/storage.go
+++ b/pkg/e2e/verify/storage.go
@@ -2,15 +2,30 @@ package verify
 
 import (
 	"context"
+
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 )
 
-var _ = ginkgo.Describe("[Suite: e2e] Storage", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: e2e] Storage",
+		TeamOwner:        "SD-SREP",
+		PrimaryContact:   "Christoph Blecker",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	h := helper.New()
 	ginkgo.It("should be able to be expanded", func() {
 		scList, err := h.Kube().StorageV1().StorageClasses().List(context.TODO(), metav1.ListOptions{})

--- a/pkg/e2e/verify/storage.go
+++ b/pkg/e2e/verify/storage.go
@@ -20,7 +20,7 @@ func init() {
 		PrimaryContact:   "Christoph Blecker",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/verify/user_webhook.go
+++ b/pkg/e2e/verify/user_webhook.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/viper"
 
 	userv1 "github.com/openshift/api/user/v1"
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -21,7 +22,20 @@ const (
 	CUSTOMER_PROVIDER_NAME = "CUSTOM"
 )
 
-var _ = ginkgo.Describe("[Suite: service-definition] [OSD] user validating webhook", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: service-definition] [OSD] user validating webhook",
+		TeamOwner:        "SD-SREP",
+		PrimaryContact:   "Haoran Wang",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	h := helper.New()
 
 	ginkgo.Context("user validating webhook", func() {

--- a/pkg/e2e/verify/user_webhook.go
+++ b/pkg/e2e/verify/user_webhook.go
@@ -30,7 +30,7 @@ func init() {
 		PrimaryContact:   "Haoran Wang",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/verify/validation_webhook.go
+++ b/pkg/e2e/verify/validation_webhook.go
@@ -18,7 +18,7 @@ func init() {
 	testAlert = alert.MetricAlert{
 		Name:             "[Suite: e2e] Validation Webhook",
 		TeamOwner:        "SD-SREP",
-		PrimaryContact:   "Matt Bargenquest",
+		PrimaryContact:   "Matt Bargenquast",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
 		FailureThreshold: 4,

--- a/pkg/e2e/verify/validation_webhook.go
+++ b/pkg/e2e/verify/validation_webhook.go
@@ -9,10 +9,24 @@ import (
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 )
 
-var _ = ginkgo.Describe("[Suite: e2e] Validation Webhook", func() {
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: e2e] Validation Webhook",
+		TeamOwner:        "SD-SREP",
+		PrimaryContact:   "Matt Bargenquest",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 
 	var namespace = "openshift-validation-webhook"
 	var service = "validation-webhook"

--- a/pkg/e2e/verify/validation_webhook.go
+++ b/pkg/e2e/verify/validation_webhook.go
@@ -21,7 +21,7 @@ func init() {
 		PrimaryContact:   "Matt Bargenquest",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/workloads/guestbook/guestbook.go
+++ b/pkg/e2e/workloads/guestbook/guestbook.go
@@ -12,6 +12,7 @@ import (
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/cluster/healthchecks"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -23,7 +24,22 @@ var testDir = "/assets/workloads/e2e/guestbook"
 // Use the base folder name for the workload name. Make it easy!
 var workloadName = filepath.Base(testDir)
 
-var _ = ginkgo.Describe("[Suite: e2e] Workload ("+workloadName+")", func() {
+var testAlert alert.MetricAlert
+
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: e2e] Workload (" + workloadName + ")",
+		TeamOwner:        "SD-CICD",
+		PrimaryContact:   "Jeffrey Sica",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	defer ginkgo.GinkgoRecover()
 	// setup helper
 	h := helper.New()

--- a/pkg/e2e/workloads/guestbook/guestbook.go
+++ b/pkg/e2e/workloads/guestbook/guestbook.go
@@ -34,7 +34,7 @@ func init() {
 		PrimaryContact:   "Jeffrey Sica",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/workloads/redmine/redmine.go
+++ b/pkg/e2e/workloads/redmine/redmine.go
@@ -38,7 +38,7 @@ func init() {
 		PrimaryContact:   "Matt Bargenquest",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
-		FailureThreshold: 1,
+		FailureThreshold: 4,
 	}
 	ma.AddAlert(testAlert)
 }

--- a/pkg/e2e/workloads/redmine/redmine.go
+++ b/pkg/e2e/workloads/redmine/redmine.go
@@ -10,6 +10,7 @@ import (
 	v1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/cluster/healthchecks"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/spf13/viper"
@@ -27,7 +28,22 @@ var testDir = "/assets/workloads/e2e/redmine"
 // Use the base folder name for the workload name. Make it easy!
 var workloadName = filepath.Base(testDir)
 
-var _ = ginkgo.Describe("[Suite: e2e] Workload ("+workloadName+")", func() {
+var testAlert alert.MetricAlert
+
+func init() {
+	ma := alert.GetMetricAlerts()
+	testAlert = alert.MetricAlert{
+		Name:             "[Suite: e2e] Workload (" + workloadName + ")",
+		TeamOwner:        "SD-SREP",
+		PrimaryContact:   "Matt Bargenquest",
+		SlackChannel:     "sd-cicd-alerts",
+		Email:            "sd-cicd@redhat.com",
+		FailureThreshold: 1,
+	}
+	ma.AddAlert(testAlert)
+}
+
+var _ = ginkgo.Describe(testAlert.Name, func() {
 	defer ginkgo.GinkgoRecover()
 	// setup helper
 	h := helper.New()

--- a/pkg/e2e/workloads/redmine/redmine.go
+++ b/pkg/e2e/workloads/redmine/redmine.go
@@ -35,7 +35,7 @@ func init() {
 	testAlert = alert.MetricAlert{
 		Name:             "[Suite: e2e] Workload (" + workloadName + ")",
 		TeamOwner:        "SD-SREP",
-		PrimaryContact:   "Matt Bargenquest",
+		PrimaryContact:   "Matt Bargenquast",
 		SlackChannel:     "sd-cicd-alerts",
 		Email:            "sd-cicd@redhat.com",
 		FailureThreshold: 4,


### PR DESCRIPTION
In short, this begins the work of providing a fine-grained alerting mechanism for each test.

Also in short, if someone added a test, they are the primary contact / team for said test. That doesn't mean they'll get blasted with alerts (... yet), but if there are consistent failures and/or issues with the test, this gives SD-CICD a person / team to contact. :) 

/assign @meowfaceman 

/cc @cblecker @yithian @wanghaoran1988 @mrbarge @c-e-brumm @clcollins 
(Y'all are in these changes, thus the CC)