### PR TITLE
Restore top level logging after test failure.

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -240,6 +240,7 @@ func runGinkgoTests() error {
 	// Restore stdout and close the build log writer at the end of this function.
 	defer func() {
 		os.Stdout = stdout
+		log.SetOutput(stdout)
 		buildLogWriter.Close()
 	}()
 


### PR DESCRIPTION
Logging output is now restored after the tests run.