### PR TITLE
SDCICD-383. Bake osde2ectl into our Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@ RUN make build
 
 FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
-COPY --from=0 /go/src/github.com/openshift/osde2e/out/osde2e .
+RUN mkdir /osde2e-bin
+COPY --from=0 /go/src/github.com/openshift/osde2e/out/osde2e /osde2e-bin
+COPY --from=0 /go/src/github.com/openshift/osde2e/out/osde2ectl /osde2e-bin
 
-ENTRYPOINT [ "/osde2e" ]
+# Restore the /osde2e path for backwards compatibility
+RUN ln -s /osde2e-bin/osde2e /osde2e
+ENV PATH "/osde2e-bin:$PATH"
+
+ENTRYPOINT [ "osde2e" ]


### PR DESCRIPTION
Our docker image will now include the osde2ectl binary.