### PR TITLE
SDCICD-334: Remove missing endpoint

### DIFF
--- a/pkg/e2e/osd/ocm.go
+++ b/pkg/e2e/osd/ocm.go
@@ -27,7 +27,6 @@ var _ = ginkgo.Describe("[Suite: informing] [OSD] OCM", func() {
 			Expect(metrics.Nodes().Compute()).NotTo(BeZero())
 			Expect(metrics.Nodes().Infra()).NotTo(BeZero())
 			Expect(metrics.Nodes().Master()).NotTo(BeZero())
-			Expect(metrics.ComputeNodesCPU().Total().Empty()).NotTo(BeFalse())
 			Expect(metrics.ComputeNodesSockets().Empty()).NotTo(BeFalse())
 
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))


### PR DESCRIPTION
This metrics endpoint is returning nil and causing noisy signal. This should clean up the Informing signal for the OCM test. :) 