### PR TITLE
SDCICD-383. Add in an OCM user override for properties tagging.

### DIFF
--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -136,12 +136,15 @@ func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 	return resp.Body().ID(), nil
 }
 
+// GenerateProperties will generate a set of properties to assign to a cluster.
 func (o *OCMProvider) GenerateProperties() (map[string]string, error) {
 	var username string
 
 	// If JobID is not equal to -1, then we're running on prow.
 	if viper.GetInt(config.JobID) != -1 {
 		username = "prow"
+	} else if viper.GetString(UserOverride) != "" {
+		username = viper.GetString(UserOverride)
 	} else {
 
 		user, err := user.Current()

--- a/pkg/common/providers/ocmprovider/config.go
+++ b/pkg/common/providers/ocmprovider/config.go
@@ -20,6 +20,9 @@ const (
 
 	// ComputeMachineType is the specific cloud machine type to use for compute nodes.
 	ComputeMachineType = "ocm.computeMachineType"
+
+	// UserOverride will hard set the user assigned to the "owner" tag by the OCM provider.
+	UserOverride = "ocm.userOverride"
 )
 
 func init() {
@@ -38,4 +41,6 @@ func init() {
 
 	viper.SetDefault(ComputeMachineType, "")
 	viper.BindEnv(ComputeMachineType, "OCM_COMPUTE_MACHINE_TYPE")
+
+	viper.BindEnv(UserOverride, "OCM_USER_OVERRIDE")
 }


### PR DESCRIPTION
The username used for a properties tag can now be overridden. This will
be useful for the scale test job, which runs in Docker and will have a
"root" username. This will allow us to specify exactly what the username
should be and tailor it for the job.