### PR TITLE
SDCICD-389: Wait for subscription deletion before creating a new subscription

### DIFF
--- a/pkg/e2e/operators/operators.go
+++ b/pkg/e2e/operators/operators.go
@@ -196,6 +196,21 @@ func checkUpgrade(h *helper.H, subNamespace string, subName string, previousCSV 
 			err = h.Operator().OperatorsV1alpha1().ClusterServiceVersions(subNamespace).Delete(context.TODO(), startingCSV, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed trying to delete ClusterServiceVersion %s", startingCSV))
 
+			err = wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
+				log.Printf("Checking to see if %s/%s has been deleted... ", subNamespace, subName)
+				oldSub, err := h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Get(context.TODO(), subName, metav1.GetOptions{})
+				if oldSub.GetName() != "" {
+					log.Printf("Existing subscription found for %s/%s", subNamespace, subName)
+					log.Printf("%v", oldSub)
+					return false, nil
+				}
+				if err != nil {
+					return false, err
+				}
+				return true, nil
+			})
+			Expect(err.Error()).To(ContainSubstring("not found"))
+
 			// Create subscription to the previous version
 			sub, err = h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Create(context.TODO(), &operatorv1.Subscription{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
OLM operator upgrade testing was running into a condition where a subscription would still exist when trying to create a new subscription object.

This ensures that the object has been deleted (or times out) before the new subscription is created.