### PR TITLE
SDCICD-352. Recognize a machine as not ready if the phase is nil.

### DIFF
--- a/pkg/common/cluster/healthchecks/machines.go
+++ b/pkg/common/cluster/healthchecks/machines.go
@@ -34,7 +34,7 @@ func CheckMachinesObjectState(dynamicClient dynamic.Interface, logger *log.Logge
 			return false, fmt.Errorf("Error casting object: %s", err.Error())
 		}
 
-		if machine.Status.Phase != nil && *machine.Status.Phase != runningPhase {
+		if machine.Status.Phase == nil || *machine.Status.Phase != runningPhase {
 			logger.Printf("machine %s not ready", machine.Name)
 			return false, nil
 		}


### PR DESCRIPTION
If the phase is nil for a machine, it should be considered not ready.