### PR TITLE
SDCICD-394. Move operator upgrade tests to informing.

### DIFF
--- a/pkg/e2e/operators/configurealertmanager.go
+++ b/pkg/e2e/operators/configurealertmanager.go
@@ -41,7 +41,12 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Configure AlertManager Operato
 	checkClusterRoleBindings(h, clusterRoleBindings)
 	checkRole(h, operatorNamespace, roles)
 	checkRoleBindings(h, operatorNamespace, roleBindings)
+})
 
+var _ = ginkgo.Describe("[Suite: informing] [OSD] Configure AlertManager Operator", func() {
+	ginkgo.BeforeEach(func() {
+		alert.RegisterGinkgoAlert(ginkgo.CurrentGinkgoTestDescription().TestText, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
+	})
 	checkUpgrade(helper.New(), "openshift-monitoring", "configure-alertmanager-operator",
 		"configure-alertmanager-operator.v0.1.171-dba3c73",
 	)

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -48,7 +48,7 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] RBAC Dedicated Admins SubjectP
 	checkSubjectPermissions(h, "dedicated-admins")
 })
 
-var _ = ginkgo.Describe("[Suite: operators] [OSD] RBAC Upgrade RBAC Permissions Operator", func() {
+var _ = ginkgo.Describe("[Suite: informing] [OSD] RBAC Permissions Operator", func() {
 	ginkgo.BeforeEach(func() {
 		alert.RegisterGinkgoAlert(ginkgo.CurrentGinkgoTestDescription().TestText, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 	})

--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -35,7 +35,7 @@ var _ = ginkgo.Describe("[Suite: operators] [OSD] Splunk Forwarder Operator", fu
 	checkClusterRoles(h, clusterRoles)
 })
 
-var _ = ginkgo.Describe("[Suite: operators] [OSD] Splunk Forwarder Operator Upgrade", func() {
+var _ = ginkgo.Describe("[Suite: informing] [OSD] Splunk Forwarder Operator", func() {
 	ginkgo.BeforeEach(func() {
 		alert.RegisterGinkgoAlert(ginkgo.CurrentGinkgoTestDescription().TestText, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 	})


### PR DESCRIPTION
Operator upgrade tests are very flaky across the environments, so
they've been moved back to informing.