### PR TITLE
SDCICD-395. Don't close the timeout channel until the signal is sent.

### DIFF
--- a/cmd/osde2ectl/create/cmd.go
+++ b/cmd/osde2ectl/create/cmd.go
@@ -219,11 +219,11 @@ func setupCluster(wg *sync.WaitGroup, successfulClustersChannel chan int) {
 
 		go func() {
 			timeout := make(chan bool)
-			defer close(timeout)
 
 			for {
 
 				go func() {
+					defer close(timeout)
 					time.Sleep(time.Minute * time.Duration(5))
 					timeout <- true
 				}()


### PR DESCRIPTION
The timeout channel shoudl only be closed until after the signal has
been sent. Even if there's nothing listening for it, this should prevent
a panic.