### PR TITLE
SDCICD-396: Fix prometheus dump generation command

### DIFF
--- a/pkg/e2e/state/prometheus.go
+++ b/pkg/e2e/state/prometheus.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// cmd to collect prometheus data
-	promCollectCmd = "oc exec -n openshift-monitoring prometheus-k8s-0 -c prometheus -- /bin/sh -c \"cp -ruf /prometheus /tmp/prometheus && tar cvzO -C /tmp/prometheus . "
+	promCollectCmd = "oc exec -n openshift-monitoring prometheus-k8s-0 -c prometheus -- /bin/sh -c \"cp -ruf /prometheus /tmp/ && tar cvzO -C /tmp/prometheus . \""
 )
 
 var _ = ginkgo.Describe("[Suite: e2e] Cluster state", func() {
@@ -27,7 +27,8 @@ var _ = ginkgo.Describe("[Suite: e2e] Cluster state", func() {
 		// this command is has specific code to capture and suppress an exit code of
 		// 1 as tar 1.26 will exit 1 if files change while the tar is running, as is
 		// common for a running prometheus instance
-		cmd := promCollectCmd + " >" + runner.DefaultRunner.OutputDir + "/prometheus.tar.gz\" ; err=$? ; if (( $err != 1 )) ; then exit $err ; fi"
+		cmd := promCollectCmd + " > " + runner.DefaultRunner.OutputDir + "/prometheus.tar.gz; err=$? ; if (( $err != 0 )) ; then exit $err ; fi"
+
 		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
 		r := h.Runner(cmd)
 		r.Name = "collect-prometheus"


### PR DESCRIPTION
The command(s) we send to collect and ship the Prometheus data had both faulty logic and an incorrect redirect.

This fixes it and restores collect-prometheus data. 