### PR TITLE
SDCICD-375: Allow test harness user to be configurable

### DIFF
--- a/docs/Addons.md
+++ b/docs/Addons.md
@@ -16,7 +16,9 @@ The [Prow Operator Test] is a good example of a [Basic operator test]. It verifi
 
 Once a test harness has been written, an OSDe2e test needs to be configured to install the desired add-on, then run the test harness against it. This is done by creating a PR ([example PR]) against the [openshift/release] repo. 
 
-Regarding addon testing, OSDe2e has two primary config options: `ADDON_IDS` and `ADDON_TEST_HARNESSES`. Both of these are comma-delimited lists when supplied by environment variables, or YAML arrays when using the YAML config. `ADDON_IDS` informs OSDe2e which addons to install once a cluster is healthy. `ADDON_TEST_HARNESSES` is a list of addon test containers to run as pods within the test cluster. 
+Regarding addon testing, OSDe2e has three primary config options: `ADDON_IDS`, `ADDON_TEST_HARNESSES`, and `ADDON_TEST_USER`. The first two of these are comma-delimited lists when supplied by environment variables, or YAML arrays when using the YAML config. `ADDON_IDS` informs OSDe2e which addons to install once a cluster is healthy. `ADDON_TEST_HARNESSES` is a list of addon test containers to run as pods within the test cluster. 
+
+`ADDON_TEST_USER` will specify the in-cluster user that the test harness containers will run as. It allows for a single wildcard (`%s`) which will automatically be evaluated as the OpenShift Project the test harness is created under.
 
 ```
 env:
@@ -24,6 +26,8 @@ env:
   value: prow-operator
 - name: ADDON_TEST_HARNESSES
   value: quay.io/miwilson/prow-operator-test-harness
+- name: ADDON_TEST_USER
+  value: system:serviceaccount:%s:cluster-admin
 ```
 
 ### **Getting an OCM refresh token for your tests**

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -240,10 +240,17 @@ var Addons = struct {
 
 	// TestHarnesses is a comma separated list of container images that will test the addon
 	TestHarnesses string
+
+	// TestUser is the OpenShift user that the tests will run as
+	// If "%s" is detected in the TestUser string, it will evaluate that as the project namespace
+	// Example: "system:serviceaccount:%s:dedicated-admin"
+	// Evaluated: "system:serviceaccount:osde2e-abc123:dedicated-admin"
+	TestUser string
 }{
 	IDsAtCreation: "addons.idsAtCreation",
 	IDs:           "ids",
 	TestHarnesses: "testHarnesses",
+	TestUser:      "addons.testUser",
 }
 
 // Scale config keys.
@@ -437,6 +444,9 @@ func init() {
 	viper.BindEnv(Addons.IDs, "ADDON_IDS")
 
 	viper.BindEnv(Addons.TestHarnesses, "ADDON_TEST_HARNESSES")
+
+	viper.BindEnv(Addons.TestUser, "ADDON_TEST_USER")
+	viper.SetDefault(Addons.TestUser, "system:serviceaccount:%s:cluster-admin")
 
 	// ----- Scale -----
 	viper.SetDefault(Scale.WorkloadsRepository, "https://github.com/openshift-scale/workloads")

--- a/pkg/e2e/addons/addon_test_harness.go
+++ b/pkg/e2e/addons/addon_test_harness.go
@@ -35,8 +35,8 @@ var _ = ginkgo.Describe("[Suite: addons] Addon Test Harness", func() {
 
 	addonTimeoutInSeconds := 3600
 	ginkgo.It("should run until completion", func() {
-		// We don't know what a test harness may need so let's give them everything.
-		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+		// By default, the TestUser should run as cluster-admin. However it can be overridden.
+		h.SetServiceAccount(viper.GetString(config.Addons.TestUser))
 		addonTestHarnesses := strings.Split(viper.GetString(config.Addons.TestHarnesses), ",")
 		for _, harness := range addonTestHarnesses {
 			// configure tests


### PR DESCRIPTION
This allows the addon authors to run their test harnesses as a specific user in-cluster.

The default stays the same (cluster-admin) however they can now specify other-existing users. We do not support creation of a user at this time. 