### PR TITLE
Remove channel close from batch cluster wait.

### DIFF
--- a/cmd/osde2ectl/create/cmd.go
+++ b/cmd/osde2ectl/create/cmd.go
@@ -211,21 +211,12 @@ func setupCluster(wg *sync.WaitGroup, successfulClustersCounter *int32) {
 
 		go func() {
 			timeout := make(chan bool)
-			var shouldSendTimeout int32 = 1
-
-			defer func() {
-				atomic.StoreInt32(&shouldSendTimeout, 0)
-				close(timeout)
-			}()
 
 			for {
 
 				go func() {
 					time.Sleep(time.Minute * time.Duration(5))
-
-					if atomic.LoadInt32(&shouldSendTimeout) == 1 {
-						timeout <- true
-					}
+					timeout <- true
 				}()
 
 				select {
@@ -245,7 +236,6 @@ func setupCluster(wg *sync.WaitGroup, successfulClustersCounter *int32) {
 		err = clusterutil.WaitForClusterReady(cluster.ID(), logger)
 
 		terminate <- true
-		close(terminate)
 
 		if err != nil {
 			fmt.Printf("Cluster %s never became healthy.\n", cluster.ID())


### PR DESCRIPTION
Looks like, unbeknownst to me, closing channels isn't strictly necessary
in go. If nothing is waiting on or listening to the cluster any more, it
looks like these will be garbage collected. I'm removing the channel
close logic because I think it's an avenue of potential panics, and
hopefully this fixes any of the latent batch provisioning failures I've
seen.