### PR TITLE
SDCICD-409: Retry checking for cluster alerts

### DIFF
--- a/pkg/e2e/state/alerts.go
+++ b/pkg/e2e/state/alerts.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"text/template"
+	"time"
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -63,27 +64,31 @@ var _ = ginkgo.Describe("[Suite: e2e] Cluster state", func() {
 		r.Name = "alerts"
 		r.Cmd = alertsCommand
 
-		// run tests
-		stopCh := make(chan struct{})
-		err = r.Run(alertsTimeoutInSeconds, stopCh)
-		Expect(err).NotTo(HaveOccurred(), "failure running command on pod")
+		Eventually(func() bool {
+			// run tests
+			stopCh := make(chan struct{})
+			err = r.Run(alertsTimeoutInSeconds, stopCh)
+			Expect(err).NotTo(HaveOccurred(), "failure running command on pod")
 
-		// get results
-		results, err := r.RetrieveResults()
-		Expect(err).NotTo(HaveOccurred(), "failure retrieving results from pod")
+			// get results
+			results, err := r.RetrieveResults()
+			Expect(err).NotTo(HaveOccurred(), "failure retrieving results from pod")
 
-		// write results
-		h.WriteResults(results)
+			// write results
+			h.WriteResults(results)
 
-		queryJSON := query{}
-		err = json.Unmarshal(results["alerts.json"], &queryJSON)
-		Expect(err).NotTo(HaveOccurred(), "failure parsing JSON results from alert manager")
+			queryJSON := query{}
+			err = json.Unmarshal(results["alerts.json"], &queryJSON)
+			Expect(err).NotTo(HaveOccurred(), "failure parsing JSON results from alert manager")
 
-		clusterProvider, err := providers.ClusterProvider()
-		Expect(err).NotTo(HaveOccurred(), "failure to get cluster provider")
+			clusterProvider, err := providers.ClusterProvider()
+			Expect(err).NotTo(HaveOccurred(), "failure to get cluster provider")
 
-		foundCritical := findCriticalAlerts(queryJSON.Data.Results, viper.GetString(config.Provider), clusterProvider.Environment())
-		Expect(foundCritical).To(BeFalse(), "found a critical alert")
+			foundCritical := findCriticalAlerts(queryJSON.Data.Results, viper.GetString(config.Provider), clusterProvider.Environment())
+			Expect(foundCritical).To(BeFalse(), "found a critical alert")
+
+			return err == nil && !foundCritical
+		}, 5*time.Minute, 30*time.Second).Should(BeTrue(), "never able to find zero alerts")
 
 	}, float64(alertsTimeoutInSeconds+30))
 })


### PR DESCRIPTION
There is a chance the cluster is actually healthy, but the alerts haven't cleared. Therefore we should wrap the alert-check in an `Eventually` block. 