### PR TITLE
SDCICD-346. Add in version selector unit tests.

### DIFF
--- a/pkg/common/versions/installselectors/common_test.go
+++ b/pkg/common/versions/installselectors/common_test.go
@@ -1,0 +1,16 @@
+package installselectors
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver"
+)
+
+// Testing utility function for asserting two versions should be equal.
+func failIfVersionsNotEqual(t *testing.T, testName string, selectedVersion *semver.Version, expectedVersion *semver.Version) {
+	if (selectedVersion == nil || expectedVersion == nil) && selectedVersion != expectedVersion {
+		t.Errorf("test %s: expected selected version (%v) to match expected version (%v) and one is nil", testName, selectedVersion, expectedVersion)
+	} else if selectedVersion != nil && !selectedVersion.Equal(expectedVersion) {
+		t.Errorf("test %s: selected version (%v) does not match expected version (%v)", testName, selectedVersion, expectedVersion)
+	}
+}

--- a/pkg/common/versions/installselectors/default_version_test.go
+++ b/pkg/common/versions/installselectors/default_version_test.go
@@ -1,0 +1,67 @@
+package installselectors
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/spi"
+)
+
+func TestDefaultVersionSelectVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		versions        *spi.VersionList
+		expectedVersion *semver.Version
+	}{
+		{
+			name: "get default version",
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0")).Build(),
+				}).
+				Build(),
+			expectedVersion: semver.MustParse("4.3.0"),
+		},
+		{
+			name: "get default version with override",
+			versions: spi.NewVersionListBuilder().
+				DefaultVersionOverride(semver.MustParse("4.6.0")).
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0")).Build(),
+				}).
+				Build(),
+			expectedVersion: semver.MustParse("4.6.0"),
+		},
+		{
+			name: "empty version list",
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{}).
+				Build(),
+			expectedVersion: nil,
+		},
+	}
+
+	for _, test := range tests {
+		selector := defaultVersion{}
+
+		selectedVersion, descriptor, err := selector.SelectVersion(test.versions)
+
+		if err != nil {
+			t.Errorf("test %s: error while selecting version: %v", test.name, err)
+		}
+
+		if descriptor != "current default" {
+			t.Errorf("test %s: descriptor (%s) does not match expected 'current default'", test.name, descriptor)
+		}
+
+		failIfVersionsNotEqual(t, test.name, selectedVersion, test.expectedVersion)
+	}
+}

--- a/pkg/common/versions/installselectors/delta_release_from_default_test.go
+++ b/pkg/common/versions/installselectors/delta_release_from_default_test.go
@@ -1,0 +1,106 @@
+package installselectors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/spi"
+	"github.com/spf13/viper"
+)
+
+func TestDeltaReleaseFromDefaultVersionSelectVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		versions        *spi.VersionList
+		delta           int
+		expectedVersion *semver.Version
+		expectedErr     bool
+	}{
+		{
+			name: "get +1 from default",
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0")).Build(),
+				}).
+				Build(),
+			delta:           1,
+			expectedVersion: semver.MustParse("4.4.0"),
+		},
+		{
+			name: "get -1 from default",
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0")).Build(),
+				}).
+				Build(),
+			delta:           -1,
+			expectedVersion: semver.MustParse("4.2.0"),
+		},
+		{
+			name: "get +5 from default, expect error",
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0")).Build(),
+				}).
+				Build(),
+			delta:           5,
+			expectedVersion: nil,
+			expectedErr:     true,
+		},
+		{
+			name: "get -5 from default, expect error",
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0")).Build(),
+				}).
+				Build(),
+			delta:           -5,
+			expectedVersion: nil,
+			expectedErr:     true,
+		},
+	}
+
+	for _, test := range tests {
+		viper.Reset()
+
+		viper.Set(config.Cluster.DeltaReleaseFromDefault, test.delta)
+
+		selector := deltaReleaseFromDefault{}
+		selectedVersion, descriptor, err := selector.SelectVersion(test.versions)
+
+		if err != nil && !test.expectedErr {
+			t.Errorf("test %s: error while selecting version: %v", test.name, err)
+		}
+
+		if err == nil {
+			expectedDescriptor := fmt.Sprintf("version %d releases from the default", test.delta)
+			if descriptor != expectedDescriptor {
+				t.Errorf("test %s: descriptor (%s) does not match expected '%s'", test.name, descriptor, expectedDescriptor)
+			}
+
+			if (selectedVersion == nil || test.expectedVersion == nil) && selectedVersion != test.expectedVersion {
+				t.Errorf("test %s: expected selected version (%v) to match expected version (%v) and one is nil", test.name, selectedVersion, test.expectedVersion)
+			} else if selectedVersion != nil && !selectedVersion.Equal(test.expectedVersion) {
+				t.Errorf("test %s: selected version (%v) does not match expected version (%v)", test.name, selectedVersion, test.expectedVersion)
+			}
+		}
+	}
+}

--- a/pkg/common/versions/installselectors/latest_version_selector.go
+++ b/pkg/common/versions/installselectors/latest_version_selector.go
@@ -33,5 +33,7 @@ func (l latestVersion) SelectVersion(versionList *spi.VersionList) (*semver.Vers
 		return nil, versionType, fmt.Errorf("not enough versions to select the latest version")
 	}
 
+	sortVersions(availableVersions)
+
 	return availableVersions[len(availableVersions)-1].Version(), versionType, nil
 }

--- a/pkg/common/versions/installselectors/latest_version_selector_test.go
+++ b/pkg/common/versions/installselectors/latest_version_selector_test.go
@@ -1,0 +1,74 @@
+package installselectors
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/spi"
+)
+
+func TestLatestVersionSelectVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		versions        *spi.VersionList
+		expectedVersion *semver.Version
+		expectedErr     bool
+	}{
+		{
+			name: "get latest version",
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0")).Build(),
+				}).
+				Build(),
+			expectedVersion: semver.MustParse("4.5.0"),
+		},
+		{
+			name: "get latest version out of order",
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0")).Build(),
+				}).
+				Build(),
+			expectedVersion: semver.MustParse("4.5.0"),
+		},
+		{
+			name: "no versions",
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{}).
+				Build(),
+			expectedVersion: nil,
+			expectedErr:     true,
+		},
+	}
+
+	for _, test := range tests {
+		selector := latestVersion{}
+		selectedVersion, descriptor, err := selector.SelectVersion(test.versions)
+
+		if err != nil && !test.expectedErr {
+			t.Errorf("test %s: error while selecting version: %v", test.name, err)
+		}
+
+		if err == nil {
+			expectedDescriptor := "latest version"
+			if descriptor != expectedDescriptor {
+				t.Errorf("test %s: descriptor (%s) does not match expected '%s'", test.name, descriptor, expectedDescriptor)
+			}
+
+			if (selectedVersion == nil || test.expectedVersion == nil) && selectedVersion != test.expectedVersion {
+				t.Errorf("test %s: expected selected version (%v) to match expected version (%v) and one is nil", test.name, selectedVersion, test.expectedVersion)
+			} else if selectedVersion != nil && !selectedVersion.Equal(test.expectedVersion) {
+				t.Errorf("test %s: selected version (%v) does not match expected version (%v)", test.name, selectedVersion, test.expectedVersion)
+			}
+		}
+	}
+}

--- a/pkg/common/versions/installselectors/middle_cluster_image_set.go
+++ b/pkg/common/versions/installselectors/middle_cluster_image_set.go
@@ -34,5 +34,7 @@ func (m middleClusterImageSet) SelectVersion(versionList *spi.VersionList) (*sem
 		return nil, versionType, nil
 	}
 
+	sortVersions(versionsWithoutDefault)
+
 	return versionsWithoutDefault[numVersions/2].Version(), versionType, nil
 }

--- a/pkg/common/versions/installselectors/middle_cluster_image_set_test.go
+++ b/pkg/common/versions/installselectors/middle_cluster_image_set_test.go
@@ -1,0 +1,87 @@
+package installselectors
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/spi"
+)
+
+func TestMiddleClusterImageSetSelectVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		versions        *spi.VersionList
+		expectedVersion *semver.Version
+		expectedErr     bool
+	}{
+		{
+			name: "get middle version 1",
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0")).Build(),
+				}).
+				Build(),
+			expectedVersion: semver.MustParse("4.4.0"),
+		},
+		{
+			name: "get middle version 2",
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.3.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.5.0")).Build(),
+				}).
+				Build(),
+			expectedVersion: semver.MustParse("4.3.0"),
+		},
+		{
+			name: "get middle version out of order",
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0")).Build(),
+				}).
+				Build(),
+			expectedVersion: semver.MustParse("4.4.0"),
+		},
+		{
+			name: "no versions",
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{}).
+				Build(),
+			expectedVersion: nil,
+			expectedErr:     true,
+		},
+	}
+
+	for _, test := range tests {
+		selector := middleClusterImageSet{}
+		selectedVersion, descriptor, err := selector.SelectVersion(test.versions)
+
+		if err != nil && !test.expectedErr {
+			t.Errorf("test %s: error while selecting version: %v", test.name, err)
+		}
+
+		if err == nil {
+			expectedDescriptor := "middle version"
+			if descriptor != expectedDescriptor {
+				t.Errorf("test %s: descriptor (%s) does not match expected '%s'", test.name, descriptor, expectedDescriptor)
+			}
+
+			if (selectedVersion == nil || test.expectedVersion == nil) && selectedVersion != test.expectedVersion {
+				t.Errorf("test %s: expected selected version (%v) to match expected version (%v) and one is nil", test.name, selectedVersion, test.expectedVersion)
+			} else if selectedVersion != nil && !selectedVersion.Equal(test.expectedVersion) {
+				t.Errorf("test %s: selected version (%v) does not match expected version (%v)", test.name, selectedVersion, test.expectedVersion)
+			}
+		}
+	}
+}

--- a/pkg/common/versions/installselectors/oldest_cluster_image_set.go
+++ b/pkg/common/versions/installselectors/oldest_cluster_image_set.go
@@ -34,5 +34,7 @@ func (o oldestClusterImageSet) SelectVersion(versionList *spi.VersionList) (*sem
 		return nil, versionType, nil
 	}
 
+	sortVersions(versionsWithoutDefault)
+
 	return versionsWithoutDefault[0].Version(), versionType, nil
 }

--- a/pkg/common/versions/installselectors/oldest_cluster_image_set_test.go
+++ b/pkg/common/versions/installselectors/oldest_cluster_image_set_test.go
@@ -1,0 +1,74 @@
+package installselectors
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/spi"
+)
+
+func TestOldestClusterImageSetSelectVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		versions        *spi.VersionList
+		expectedVersion *semver.Version
+		expectedErr     bool
+	}{
+		{
+			name: "get oldest version",
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0")).Build(),
+				}).
+				Build(),
+			expectedVersion: semver.MustParse("4.1.0"),
+		},
+		{
+			name: "get oldest version out of order",
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0")).Build(),
+				}).
+				Build(),
+			expectedVersion: semver.MustParse("4.1.0"),
+		},
+		{
+			name: "no versions",
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{}).
+				Build(),
+			expectedVersion: nil,
+			expectedErr:     true,
+		},
+	}
+
+	for _, test := range tests {
+		selector := oldestClusterImageSet{}
+		selectedVersion, descriptor, err := selector.SelectVersion(test.versions)
+
+		if err != nil && !test.expectedErr {
+			t.Errorf("test %s: error while selecting version: %v", test.name, err)
+		}
+
+		if err == nil {
+			expectedDescriptor := "oldest version"
+			if descriptor != expectedDescriptor {
+				t.Errorf("test %s: descriptor (%s) does not match expected '%s'", test.name, descriptor, expectedDescriptor)
+			}
+
+			if (selectedVersion == nil || test.expectedVersion == nil) && selectedVersion != test.expectedVersion {
+				t.Errorf("test %s: expected selected version (%v) to match expected version (%v) and one is nil", test.name, selectedVersion, test.expectedVersion)
+			} else if selectedVersion != nil && !selectedVersion.Equal(test.expectedVersion) {
+				t.Errorf("test %s: selected version (%v) does not match expected version (%v)", test.name, selectedVersion, test.expectedVersion)
+			}
+		}
+	}
+}

--- a/pkg/common/versions/installselectors/utils.go
+++ b/pkg/common/versions/installselectors/utils.go
@@ -1,6 +1,10 @@
 package installselectors
 
-import "github.com/openshift/osde2e/pkg/common/spi"
+import (
+	"sort"
+
+	"github.com/openshift/osde2e/pkg/common/spi"
+)
 
 func removeDefaultVersion(versions []*spi.Version) []*spi.Version {
 	versionsWithoutDefault := []*spi.Version{}
@@ -12,4 +16,17 @@ func removeDefaultVersion(versions []*spi.Version) []*spi.Version {
 	}
 
 	return versionsWithoutDefault
+}
+
+func sortVersions(availableVersions []*spi.Version) {
+	sort.SliceStable(availableVersions, func(i, j int) bool {
+		this := availableVersions[i]
+		that := availableVersions[j]
+
+		if this == nil || that == nil {
+			return false
+		}
+
+		return this.Version().LessThan(that.Version())
+	})
 }


### PR DESCRIPTION
Version selector unit tests have been added to ensure that, if we muck
with the logic of OSDe2e version selection in the future, we are able to
verify/validate the existing behavior to ensure we don't break anything.

Upgrade selectors have not been tested due to their reliance on
Cincinnati/the release controller.