### PR TITLE
SDCICD-380. Tweak passrates for upgrade failures.

### DIFF
--- a/pkg/metrics/junitresult_test.go
+++ b/pkg/metrics/junitresult_test.go
@@ -128,6 +128,36 @@ func TestCalculatePassRates(t *testing.T) {
 			},
 		},
 		{
+			name: "one job pass rate partial success with upgrade failure",
+			jUnitResults: []JUnitResult{
+				makeJUnitResult("job1", Failed),
+				makeJUnitResult("job1", Passed),
+				makeJUnitResult("job1", Passed),
+				makeJUnitResult("job1", Passed),
+				makeUpgradeFailure("job1"),
+			},
+			expectedPassRates: map[string]float64{
+				"job1": 0.375,
+			},
+		},
+		{
+			name: "one job pass rate partial success with upgrade failure but upgrade tests run anyway",
+			jUnitResults: []JUnitResult{
+				makeJUnitResult("job1", Failed),
+				makeJUnitResult("job1", Passed),
+				makeJUnitResult("job1", Passed),
+				makeJUnitResult("job1", Passed),
+				makeUpgradeFailure("job1"),
+				makeUpgradeTest("job1", Passed),
+				makeUpgradeTest("job1", Passed),
+				makeUpgradeTest("job1", Failed),
+				makeUpgradeTest("job1", Failed),
+			},
+			expectedPassRates: map[string]float64{
+				"job1": 5.0 / 9.0,
+			},
+		},
+		{
 			name: "one job pass rate all failure",
 			jUnitResults: []JUnitResult{
 				makeJUnitResult("job1", Failed),
@@ -140,20 +170,22 @@ func TestCalculatePassRates(t *testing.T) {
 			},
 		},
 		{
-			name: "multiple jobs pass rate partial success",
+			name: "multiple jobs pass rate partial success with upgrade failures",
 			jUnitResults: []JUnitResult{
 				makeJUnitResult("job1", Failed),
 				makeJUnitResult("job1", Passed),
 				makeJUnitResult("job1", Passed),
 				makeJUnitResult("job1", Passed),
+				makeUpgradeFailure("job1"),
 				makeJUnitResult("job2", Failed),
 				makeJUnitResult("job2", Failed),
 				makeJUnitResult("job2", Passed),
 				makeJUnitResult("job2", Passed),
+				makeUpgradeFailure("job2"),
 			},
 			expectedPassRates: map[string]float64{
-				"job1": 0.75,
-				"job2": 0.5,
+				"job1": 0.375,
+				"job2": 0.25,
 			},
 		},
 		{
@@ -216,6 +248,22 @@ func makeLogMetricResult(jobName string, result Result) JUnitResult {
 	jUnitResult := makeJUnitResult(jobName, result)
 
 	jUnitResult.TestName = "[Log Metrics] test-name"
+
+	return jUnitResult
+}
+
+func makeUpgradeFailure(jobName string) JUnitResult {
+	jUnitResult := makeJUnitResult(jobName, Failed)
+
+	jUnitResult.TestName = "[upgrade] BeforeSuite"
+
+	return jUnitResult
+}
+
+func makeUpgradeTest(jobName string, result Result) JUnitResult {
+	jUnitResult := makeJUnitResult(jobName, result)
+
+	jUnitResult.TestName = "[upgrade] test-name"
 
 	return jUnitResult
 }


### PR DESCRIPTION
Upgrade failures as returned by the metrics library will now more
accurately reflect that the entire suite of upgrade tests has failed as
opposed to just one singular test failure. For instance, let's look at
the following example data:

* [install] test1 PASS
* [install] test2 PASS
* [install] test3 PASS
* [install] test4 PASS
* [upgrade] BeforeSuite FAILURE

If we're only taking test failures into account, this looks like an 80%
pass rate. However, in reality, what's happened here is that the install
suite of 4 tests passed and then the entire suite of upgrade tests
failed to run. This means that the pass rate should really be 50% (4
passing install tests + 4 failing upgrade tests).

Occasionally it looks like [upgrade] BeforeSuite test can fail but
upgrade tests do, in fact, run. If this happens, we'll just calculate
pass rates like normal.