### PR TITLE
SDCICD-376: Promote stable informing jobs

### DIFF
--- a/pkg/e2e/operators/configurealertmanager.go
+++ b/pkg/e2e/operators/configurealertmanager.go
@@ -7,11 +7,9 @@ import (
 )
 
 var configureAlertManagerOperators string = "[Suite: operators] [OSD] Configure AlertManager Operator"
-var configureAlertManagerInforming string = "[Suite: informing] [OSD] Configure AlertManager Operator"
 
 func init() {
 	alert.RegisterGinkgoAlert(configureAlertManagerOperators, "SD-SREP", "Christopher Collins", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
-	alert.RegisterGinkgoAlert(configureAlertManagerInforming, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
 var _ = ginkgo.Describe(configureAlertManagerOperators, func() {
@@ -46,9 +44,6 @@ var _ = ginkgo.Describe(configureAlertManagerOperators, func() {
 	checkClusterRoleBindings(h, clusterRoleBindings)
 	checkRole(h, operatorNamespace, roles)
 	checkRoleBindings(h, operatorNamespace, roleBindings)
-})
-
-var _ = ginkgo.Describe(configureAlertManagerInforming, func() {
 	checkUpgrade(helper.New(), "openshift-monitoring", "configure-alertmanager-operator",
 		"configure-alertmanager-operator.v0.1.171-dba3c73",
 	)

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -20,12 +20,10 @@ import (
 var operatorName = "rbac-permissions-operator"
 var operatorNamespace = "openshift-rbac-permissions"
 var rbacOperatorBlocking string = "[Suite: operators] [OSD] RBAC Operator"
-var rbacOperatorInforming string = "[Suite: informing] [OSD] RBAC Permissions Operator"
 var subjectPermissionsTestName string = "[Suite: operators] [OSD] RBAC Dedicated Admins SubjectPermission"
 
 func init() {
 	alert.RegisterGinkgoAlert(rbacOperatorBlocking, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
-	alert.RegisterGinkgoAlert(rbacOperatorInforming, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 	alert.RegisterGinkgoAlert(subjectPermissionsTestName, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
@@ -44,17 +42,14 @@ var _ = ginkgo.Describe(rbacOperatorBlocking, func() {
 	checkConfigMapLockfile(h, operatorNamespace, operatorLockFile)
 	checkDeployment(h, operatorNamespace, operatorName, defaultDesiredReplicas)
 	checkClusterRoles(h, clusterRoles)
+	checkUpgrade(helper.New(), "openshift-rbac-permissions", "rbac-permissions-operator",
+		"rbac-permissions-operator.v0.1.97-68cf185",
+	)
 })
 
 var _ = ginkgo.Describe(subjectPermissionsTestName, func() {
 	h := helper.New()
 	checkSubjectPermissions(h, "dedicated-admins")
-})
-
-var _ = ginkgo.Describe(rbacOperatorInforming, func() {
-	checkUpgrade(helper.New(), "openshift-rbac-permissions", "rbac-permissions-operator",
-		"rbac-permissions-operator.v0.1.97-68cf185",
-	)
 })
 
 func checkSubjectPermissions(h *helper.H, spName string) {

--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -7,11 +7,9 @@ import (
 )
 
 var splunkForwarderBlocking string = "[Suite: operators] [OSD] Splunk Forwarder Operator"
-var splunkForwarderInforming string = "[Suite: informing] [OSD] Splunk Forwarder Operator"
 
 func init() {
 	alert.RegisterGinkgoAlert(splunkForwarderBlocking, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
-	alert.RegisterGinkgoAlert(splunkForwarderInforming, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
 var _ = ginkgo.Describe(splunkForwarderBlocking, func() {
@@ -38,9 +36,6 @@ var _ = ginkgo.Describe(splunkForwarderBlocking, func() {
 	checkDeployment(h, operatorNamespace, operatorName, defaultDesiredReplicas)
 	checkClusterRoleBindings(h, clusterRoleBindings)
 	checkClusterRoles(h, clusterRoles)
-})
-
-var _ = ginkgo.Describe(splunkForwarderInforming, func() {
 	checkUpgrade(helper.New(), "openshift-splunk-forwarder-operator", "openshift-splunk-forwarder-operator",
 		"splunk-forwarder-operator.v0.1.157-3dca592",
 	)

--- a/pkg/e2e/osd/machinehealthcheck.go
+++ b/pkg/e2e/osd/machinehealthcheck.go
@@ -18,7 +18,7 @@ const (
 	OperatorNamespace = "openshift-machine-api"
 )
 
-var machineHealthTestName string = "[Suite: informing] MachineHealthChecks"
+var machineHealthTestName string = "[Suite: e2e] MachineHealthChecks"
 
 func init() {
 	alert.RegisterGinkgoAlert(machineHealthTestName, "SD-SRE", "Alex Chvatal", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

--- a/pkg/e2e/verify/namespace_webhook.go
+++ b/pkg/e2e/verify/namespace_webhook.go
@@ -20,7 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var namespaceWebhookTestName string = "[Suite: informing] [OSD] namespace validating webhook"
+var namespaceWebhookTestName string = "[Suite: e2e] [OSD] namespace validating webhook"
 
 func init() {
 	alert.RegisterGinkgoAlert(namespaceWebhookTestName, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)


### PR DESCRIPTION
These jobs have a clean track record for over a week and should be promoted up from informing. 

Some of them involved moving the upgrade operator tests out of a separate Describe block and under the existing one. :) 