### PR TITLE
SDCICD-415. Display available metadata in on health failure.

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -300,23 +300,6 @@ func ProvisionCluster(logger *log.Logger) (*spi.Cluster, error) {
 	return cluster, nil
 }
 
-// SetupCluster brings up a cluster, waits for it to be ready, then returns it's name.
-func SetupCluster(logger *log.Logger) (*spi.Cluster, error) {
-	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
-
-	cluster, err := ProvisionCluster(logger)
-
-	if err != nil {
-		return cluster, fmt.Errorf("error provisioning cluster: %v", err)
-	}
-
-	if err = WaitForClusterReady(cluster.ID(), logger); err != nil {
-		return cluster, fmt.Errorf("failed waiting for cluster ready: %v", err)
-	}
-
-	return cluster, nil
-}
-
 // useKubeconfig reads the path provided for a TEST_KUBECONFIG and uses it for testing.
 func useKubeconfig(logger *log.Logger) (err error) {
 	_, err = clientcmd.RESTConfigFromKubeConfig([]byte(viper.GetString(config.Kubeconfig.Contents)))

--- a/pkg/common/events/event_type.go
+++ b/pkg/common/events/event_type.go
@@ -7,19 +7,25 @@ type EventType string
 const (
 	// ------ Cluster provisioning events
 
-	// InstallSuccessful when the cluster has successfully provisioned
+	// InstallSuccessful when the cluster has successfully provisioned.
 	InstallSuccessful EventType = "InstallSuccessful"
 
-	// FailedClusterProvision when the cluster has not been successfully provisioned
+	// FailedClusterProvision when the cluster has not been successfully provisioned.
 	InstallFailed EventType = "InstallFailed"
 
-	// UpgradeSuccessful when the upgrade was successful
+	// HealthCheckSuccessful when the cluster health check has succeeded.
+	HealthCheckSuccessful EventType = "HealthCheckSuccessful"
+
+	// HealthCheckFailed when the cluster health check has failed.
+	HealthCheckFailed EventType = "HealthCheckFailed"
+
+	// UpgradeSuccessful when the upgrade was successful.
 	UpgradeSuccessful EventType = "UpgradeSuccessful"
 
-	// UpgradeFailed when the upgrade failed
+	// UpgradeFailed when the upgrade failed.
 	UpgradeFailed EventType = "UpgradeFailed"
 
-	// NoHiveLogs when no logs from Hive were collected after a cluster provisioning event
+	// NoHiveLogs when no logs from Hive were collected after a cluster provisioning event.
 	NoHiveLogs EventType = "NoHiveLogs"
 
 	// InstallKubeconfigRetrievalSuccess when the Kubeconfig was retrieved successfully.
@@ -30,9 +36,9 @@ const (
 
 	// ------ Addon installation events
 
-	// InstallAddonsSuccessful when the addons installed successfully
+	// InstallAddonsSuccessful when the addons installed successfully.
 	InstallAddonsSuccessful EventType = "InstallAddonsSuccessful"
 
-	// InstallAddonsFailed when the addons failed to install
+	// InstallAddonsFailed when the addons failed to install.
 	InstallAddonsFailed EventType = "InstallAddonsFailed"
 )

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -152,6 +152,8 @@ func (o *OCMProvider) DetermineRegion(cloudProvider string) (string, error) {
 			}
 		}
 
+		log.Printf("Random region requested, selected %s region.", region)
+
 		// Update the Config with the selected random region
 		viper.Set(config.CloudProvider.Region, region)
 	}

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/openshift/osde2e/pkg/common/aws"
 	"github.com/openshift/osde2e/pkg/common/cluster"
+	clusterutil "github.com/openshift/osde2e/pkg/common/cluster"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/events"
 	"github.com/openshift/osde2e/pkg/common/helper"
@@ -79,7 +80,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 
 	// Skip provisioning if we already have a kubeconfig
 	if viper.GetString(config.Kubeconfig.Contents) == "" {
-		cluster, err := cluster.SetupCluster(nil)
+		cluster, err := clusterutil.ProvisionCluster(nil)
 		events.HandleErrorWithEvents(err, events.InstallSuccessful, events.InstallFailed).ShouldNot(HaveOccurred(), "failed to setup cluster for testing")
 		if err != nil {
 			return []byte{}
@@ -104,9 +105,16 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 
 		metadata.Instance.SetClusterName(cluster.Name())
 		metadata.Instance.SetClusterID(cluster.ID())
+		metadata.Instance.SetRegion(cluster.Region())
 
 		if err = provider.AddProperty(cluster.ID(), "UpgradeVersion", viper.GetString(config.Upgrade.ReleaseName)); err != nil {
 			log.Printf("Error while adding upgrade version property to cluster via OCM: %v", err)
+		}
+
+		err = clusterutil.WaitForClusterReady(cluster.ID(), nil)
+		events.HandleErrorWithEvents(err, events.HealthCheckSuccessful, events.HealthCheckFailed)
+		if err != nil {
+			return []byte{}
 		}
 
 		if len(viper.GetString(config.Addons.IDs)) > 0 {


### PR DESCRIPTION
If the cluster health check fails, we'll now still display the cluster
ID/cluster region/etc. if we can. We do this by updating cluster
metadata if we can provision the cluster at all, but still fail if the
health check fails.