### PR TITLE
SDCICD-417. Remove version info from cluster name.

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/Masterminds/semver"
@@ -321,14 +320,11 @@ func useKubeconfig(logger *log.Logger) (err error) {
 
 // clusterName returns a cluster name with a format which must be short enough to support all versions
 func clusterName() string {
-	vers := strings.TrimPrefix(viper.GetString(config.Cluster.Version), util.VersionPrefix)
-	safeVersion := strings.Replace(vers, ".", "-", -1)
-
 	suffix := viper.GetString(config.Suffix)
 
 	if suffix == "" {
-		suffix = util.RandomStr(3)
+		suffix = util.RandomStr(5)
 	}
 
-	return "osde2e-" + safeVersion + "-" + suffix
+	return "osde2e-" + suffix
 }

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -326,7 +326,7 @@ func runGinkgoTests() error {
 	log.Println("Running e2e tests...")
 
 	if viper.GetString(config.Suffix) == "" {
-		viper.Set(config.Suffix, util.RandomStr(3))
+		viper.Set(config.Suffix, util.RandomStr(5))
 	}
 
 	testsPassed := runTestsInPhase(phase.InstallPhase, "OSD e2e suite")


### PR DESCRIPTION
There's no reason to have cluster version info in the cluster name, and
it's causing issues with cluste name length. It has been removed.
Additionally, the suffix has been bumped to 5 characters to reduce the
possibility of cluster name collisions.