### PR TITLE
Fix health checks.

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -112,7 +112,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		}
 
 		err = clusterutil.WaitForClusterReady(cluster.ID(), nil)
-		events.HandleErrorWithEvents(err, events.HealthCheckSuccessful, events.HealthCheckFailed)
+		events.HandleErrorWithEvents(err, events.HealthCheckSuccessful, events.HealthCheckFailed).ShouldNot(HaveOccurred(), "cluster failed health check")
 		if err != nil {
 			return []byte{}
 		}


### PR DESCRIPTION
Health checks were not actually making an assertion on the error seen by
WaitForClusterReady.