### PR TITLE
SDCICD-339: Store route metrics in Prometheus

### DIFF
--- a/pkg/e2e/routemonitors/routemonitors.go
+++ b/pkg/e2e/routemonitors/routemonitors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -156,6 +157,12 @@ func (rm *RouteMonitors) StoreMetadata() {
 		latency := float64(metric.Latencies.Mean / time.Millisecond)
 		if latency < 0 {
 			latency = 0
+		}
+		if math.IsNaN(metric.Throughput) {
+			metric.Throughput = 0
+		}
+		if math.IsNaN(metric.Success) {
+			metric.Success = 0
 		}
 		metadata.Instance.SetRouteLatency(title, latency)
 		metadata.Instance.SetRouteThroughput(title, metric.Throughput)


### PR DESCRIPTION
This collects and stores the route results in Prometheus in a new metric: `cicd-route`

In the process, I ran into/resolved three issues:

1. Prometheus metrics were generated before the route monitors closed.
2. There was a race with the route monitor channels closing (cc @mrbarge )
3. At times, the routemonitor values would return NaN, so began defaulting values to 0.
