### PR TITLE
SDCICD-296: Update slack token env var

### DIFF
--- a/scripts/granular-alerting.sh
+++ b/scripts/granular-alerting.sh
@@ -6,4 +6,4 @@
 set -e
 
 docker pull quay.io/app-sre/osde2e
-docker run -e PROMETHEUS_ADDRESS -e PROMETHEUS_BEARER_TOKEN -e SLACK_WEBHOOK quay.io/app-sre/osde2e alert
+docker run -e PROMETHEUS_ADDRESS -e PROMETHEUS_BEARER_TOKEN -e SLACK_API_TOKEN quay.io/app-sre/osde2e alert


### PR DESCRIPTION
This updates the script to expect the `SLACK_API_TOKEN` environment variable to be loaded via vault. 