### PR TITLE
SDCICD-437: Support separate addon cleanup harnesses

### DIFF
--- a/docs/Addons.md
+++ b/docs/Addons.md
@@ -20,8 +20,6 @@ Regarding addon testing, OSDe2e has three primary config options: `ADDON_IDS`, `
 
 `ADDON_TEST_USER` will specify the in-cluster user that the test harness containers will run as. It allows for a single wildcard (`%s`) which will automatically be evaluated as the OpenShift Project the test harness is created under.
 
-If your addon test creates or affects anything outside of the OSD cluster lifecycle, a separate cleanup action is required. If `ADDON_RUN_CLEANUP` is set to `true`, OSDe2e will run the test harness a **second time** passing the argument `cleanup` to the container.
-
 ```
 env:
 - name: ADDON_IDS
@@ -31,6 +29,17 @@ env:
 - name: ADDON_TEST_USER
   value: system:serviceaccount:%s:cluster-admin
 ```
+
+### Addon Cleanup
+
+If your addon test creates or affects anything outside of the OSD cluster lifecycle, a separate cleanup action is required. If `ADDON_RUN_CLEANUP` is set to `true`, OSDe2e will run the test harness a **second time** passing the argument `cleanup` to the container.
+
+There may be a case where a separate cleanup container/harness is required. That may be configured using the `ADDON_CLEANUP_HARNESSES` config option. It is formatted in the same way as `ADDON_TEST_HARNESSES`. This however, may cause some confusion as to what is run when:
+
+`ADDON_RUN_CLEANUP` is true, and `ADDON_CLEANUP_HARNESSES` is not set, OSDe2e will only run `ADDON_TEST_HARNESSES` again, passing the `cleanup` argument.
+
+`ADDON_RUN_CLEANUP` is true, and `ADDON_CLEANUP_HARNESSES` is set, OSDe2e will only run the `ADDON_CLEANUP_HARNESSES`, passing no arguments.
+
 
 ### **Getting an OCM refresh token for your tests**
 

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -250,12 +250,17 @@ var Addons = struct {
 	// RunCleanup is a boolean to specify whether the testHarnesses should have a separate
 	// cleanup phase. This phase would run at the end of all e2e testing
 	RunCleanup string
+
+	// CleanupHarnesses is a comma separated list of container images that will clean up any
+	// artifacts created after test harnesses have run
+	CleanupHarnesses string
 }{
-	IDsAtCreation: "addons.idsAtCreation",
-	IDs:           "ids",
-	TestHarnesses: "testHarnesses",
-	TestUser:      "addons.testUser",
-	RunCleanup:    "addons.runCleanup",
+	IDsAtCreation:    "addons.idsAtCreation",
+	IDs:              "addons.ids",
+	TestHarnesses:    "addons.testHarnesses",
+	TestUser:         "addons.testUser",
+	RunCleanup:       "addons.runCleanup",
+	CleanupHarnesses: "addons.cleanupHarnesses",
 }
 
 // Scale config keys.
@@ -430,6 +435,7 @@ func init() {
 	viper.BindEnv(Addons.IDs, "ADDON_IDS")
 
 	viper.BindEnv(Addons.TestHarnesses, "ADDON_TEST_HARNESSES")
+	viper.BindEnv(Addons.CleanupHarnesses, "ADDON_CLEANUP_HARNESSES")
 
 	viper.SetDefault(Addons.TestUser, "system:serviceaccount:%s:cluster-admin")
 	viper.BindEnv(Addons.TestUser, "ADDON_TEST_USER")

--- a/pkg/common/helper/addons.go
+++ b/pkg/common/helper/addons.go
@@ -7,9 +7,7 @@ import (
 	"text/template"
 
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
 
-	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/runner"
 	"github.com/openshift/osde2e/pkg/common/templates"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,7 +18,7 @@ var err error
 
 // RunAddonTests will attempt to run the configured addon tests for the current job
 // It allows you to specify a job name prefix and arguments to a test harness container
-func (h *H) RunAddonTests(name string, args []string) {
+func (h *H) RunAddonTests(name string, harnesses []string, args []string) {
 	addonTimeoutInSeconds := 3600
 	addonTestTemplate, err = templates.LoadTemplate("/assets/addons/addon-runner.template")
 
@@ -30,8 +28,7 @@ func (h *H) RunAddonTests(name string, args []string) {
 
 	// We don't know what a test harness may need so let's give them everything.
 	h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
-	addonTestHarnesses := strings.Split(viper.GetString(config.Addons.TestHarnesses), ",")
-	for key, harness := range addonTestHarnesses {
+	for key, harness := range harnesses {
 		// configure tests
 		// setup runner
 		r := h.RunnerWithNoCommand()

--- a/pkg/e2e/addons/addon_test_harness.go
+++ b/pkg/e2e/addons/addon_test_harness.go
@@ -1,6 +1,8 @@
 package addons
 
 import (
+	"strings"
+
 	"github.com/onsi/ginkgo"
 	"github.com/spf13/viper"
 
@@ -15,6 +17,6 @@ var _ = ginkgo.Describe("[Suite: addons] Addon Test Harness", func() {
 	addonTimeoutInSeconds := 3600
 	ginkgo.It("should run until completion", func() {
 		h.SetServiceAccount(viper.GetString(config.Addons.TestUser))
-		h.RunAddonTests("addon-tests", []string{})
+		h.RunAddonTests("addon-tests", strings.Split(viper.GetString(config.Addons.TestHarnesses), ","), []string{})
 	}, float64(addonTimeoutInSeconds+30))
 })

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -503,8 +503,18 @@ func cleanupAfterE2E(h *helper.H) (errors []error) {
 	// Do any addon cleanup if configured
 	log.Printf("Addon cleanup: %v", viper.GetBool(config.Addons.RunCleanup))
 	if viper.GetBool(config.Addons.RunCleanup) {
+		// By default, use the existing test harnesses for cleanup
+		harnesses := strings.Split(viper.GetString(config.Addons.TestHarnesses), ",")
+		arguments := []string{"cleanup"}
+
+		// Check if cleanup harnesses exist and if so, use those instead
+		cleanupHarnesses := viper.GetString(config.Addons.CleanupHarnesses)
+		if len(cleanupHarnesses) > 0 {
+			harnesses = strings.Split(cleanupHarnesses, ",")
+			arguments = []string{}
+		}
 		log.Println("Running addon cleanup...")
-		h.RunAddonTests("addon-cleanup", []string{"cleanup"})
+		h.RunAddonTests("addon-cleanup", harnesses, arguments)
 	}
 
 	// We need to clean up our helper tests manually.


### PR DESCRIPTION
This adds the `ADDON_CLEANUP_HARNESSES` config option and updates the docs to support it.