### PR TITLE
SDCICD-435. Create cluster properties if there are none.

### DIFF
--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -693,8 +693,10 @@ func (o *OCMProvider) AddProperty(clusterID string, tag string, value string) er
 
 	clusterproperties := ocmCluster.Properties()
 
+	// Apparently, if cluster properties are empty in OCM, the clusterproperties are nil, In this case, we'll just make our own
+	// properties map.
 	if clusterproperties == nil {
-		return fmt.Errorf("error retrieving cluster properties: cluster is nil")
+		clusterproperties = map[string]string{}
 	}
 
 	clusterproperties[tag] = value


### PR DESCRIPTION
When trying to add a property to an existing cluster, if there are no
existing cluster properties, osde2e will faulter. We now create our our
properties map, which should fix our testing against existing clusters.