### PR TITLE
SDCICD-420: Update docs removing makefile references, add more config context

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,31 @@ $ export OCM_TOKEN=<token from step 1>
 
 The `osde2e` command is the root command that executes all functionality within the osde2e repo through a number of subcommands.
 
+### Running tests locally
+
+To run osde2e locally, first build the binary (do this after all changes) by running `make build`. The resulting binaries will be in `./out/`.
+
+Once built, you can invoke osde2e by running `./out/osde2e` and osde2ectl by running `./out/osde2ectl`.
+
+A common workflow is having a local script that combines these steps and the config. Example:
+
+```bash
+#!/usr/bin/env bash
+make build
+
+GINKGO_SKIP="" \
+CLEAN_CHECK_RUNS="3" \
+POLLING_TIMEOUT="5" \
+OCM_TOKEN="[OCM token here]" \
+./out/osde2e test --configs "prod,e2e-suite"
+```
+
+Please note: Do not commit or push any local scripts into osde2e.
+
+## Configuration
+
+There are many options to drive an osde2e run. Please refer to the [config package] for the most up to date config options. While golang, each option is well documented and includes the environment variable name for the option (where applicable.)
+
 ### Composable configs
 
 OSDe2e comes with a number of [configs] that can be passed to the `osde2e test` command using the -configs argument. These can be strung together in a comma separated list to create a more complex scenario for testing.
@@ -103,17 +128,6 @@ tests:
 #### Order of precedence
 
 Config options are currently parsed by loading defaults, attempting to load environment variables, attempting to load composable configs, and finally attempting to load config data from the custom YAML file. There are instances where you may want to have most of your config in a custom YAML file while keeping one or two sensitive config options as environment variables (OCM Token)
-
-### Makefile
-
-The [Makefile] has several shortcuts to running osde2e locally. The simplest example is `make test` which will build the osde2e binary and run `osde2e test` using our default config settings. Of note: `OCM_TOKEN` will still need to be exported for the Makefile to work.
-
-There are several other shortcuts for building the binary and running specific test suites with default configs:
-
-* `make test-informing` - Runs tests that are flaky or waiting to be graduated to blocking
-* `make test-scale` - Runs scale/performance tests
-* `make test-conformance` - Runs the K8s and OpenShift conformance suites
-* `make test-addon` - Handles addon testing and requires additional configuration for the specific addon (see [Addon Testing Guide])
 
 ### Testing against non OSD clusters
 

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -10,35 +10,45 @@ import (
 
 const (
 	// Provider is what provider to use to create/delete clusters.
+	// Env: PROVIDER
 	Provider = "provider"
 
 	// JobName lets you name the current e2e job run
+	// Env: JOB_NAME
 	JobName = "jobName"
 
 	// JobID is the ID designated by prow for this run
+	// Env: BUILD_NUMBER
 	JobID = "jobID"
 
 	// BaseJobURL is the root location for all job artifacts
 	// For example, https://storage.googleapis.com/origin-ci-test/logs/osde2e-prod-gcp-e2e-next/61/build-log.txt would be
 	// https://storage.googleapis.com/origin-ci-test/logs -- This is also our default
+	// Env: BASE_JOB_URL
 	BaseJobURL = "baseJobURL"
 
 	// BaseProwURL is the root location of Prow
+	// Env: BASE_PROW_URL
 	BaseProwURL = "baseProwURL"
 
 	// Artifacts is the artifacts location on prow. It is an alias for report dir.
+	// Env: ARTIFACTS
 	Artifacts = "artifacts"
 
 	// ReportDir is the location JUnit XML results are written.
+	// Env: REPORT_DIR
 	ReportDir = "reportDir"
 
 	// Suffix is used at the end of test names to identify them.
+	// Env: SUFFIX
 	Suffix = "suffix"
 
 	// DryRun lets you run osde2e all the way up to the e2e tests then skips them.
+	// Env: DRY_RUN
 	DryRun = "dryRun"
 
 	// MustGather will run a Must-Gather process upon completion of the tests.
+	// Env: MUST_GATHER
 	MustGather = "mustGather"
 
 	// InstalledWorkloads is an internal variable used to track currently installed workloads in this test run.
@@ -58,29 +68,37 @@ var keyToSecretMappingMutex = sync.Mutex{}
 // Upgrade config keys.
 var Upgrade = struct {
 	// UpgradeToCISIfPossible will upgrade to the most recent cluster image set if it's newer than the install version
+	// Env: UPGRADE_TO_CIS_IF_POSSIBLE
 	UpgradeToCISIfPossible string
 
 	// OnlyUpgradeToZReleases will restrict upgrades to selecting Z releases on stage/prod.
+	// Env: ONLY_UPGRADE_TO_Z_RELEASES
 	OnlyUpgradeToZReleases string
 
 	// NextReleaseAfterProdDefaultForUpgrade will select the cluster image set that the given number of releases away from the the production default.
+	// Env: NEXT_RELEASE_AFTER_PROD_DEFAULT_FOR_UPGRADE
 	NextReleaseAfterProdDefaultForUpgrade string
 
 	// ReleaseStream used to retrieve latest release images. If set, it will be used to perform an upgrade.
+	// Env: UPGRADE_RELEASE_STREAM
 	ReleaseStream string
 
 	// ReleaseName is the name of the release in a release stream.
+	// Env: UPGRADE_RELEASE_NAME
 	ReleaseName string
 
 	// Image is the release image a cluster is upgraded to. If set, it overrides the release stream and upgrades.
+	// Env: UPGRADE_IMAGE
 	Image string
 
 	// UpgradeVersionEqualToInstallVersion is true if the install version and upgrade versions are the same.
 	UpgradeVersionEqualToInstallVersion string
 
 	// MonitorRoutesDuringUpgrade will monitor the availability of routes whilst an upgrade takes place
+	// Env: UPGRADE_MONITOR_ROUTES
 	MonitorRoutesDuringUpgrade string
 }{
+
 	UpgradeToCISIfPossible:                "upgrade.upgradeToCISIfPossible",
 	OnlyUpgradeToZReleases:                "upgrade.onlyUpgradeToZReleases",
 	NextReleaseAfterProdDefaultForUpgrade: "upgrade.nextReleaseAfterProdDefaultForUpgrade",
@@ -94,6 +112,7 @@ var Upgrade = struct {
 // Kubeconfig config keys.
 var Kubeconfig = struct {
 	// Path is the filepath of an existing Kubeconfig
+	// Env: TEST_KUBECONFIG
 	Path string
 
 	// Contents is the actual contents of a valid Kubeconfig
@@ -108,33 +127,43 @@ var Kubeconfig = struct {
 // Tests config keys.
 var Tests = struct {
 	// PollingTimeout is how long (in mimutes) to wait for an object to be created before failing the test.
+	// Env: POLLING_TIMEOUT
 	PollingTimeout string
 
 	// GinkgoSkip is a regex passed to Ginkgo that skips any test suites matching the regex. ex. "Operator"
+	// Env: GINKGO_SKIP
 	GinkgoSkip string
 
 	// GinkgoFocus is a regex passed to Ginkgo that focus on any test suites matching the regex. ex. "Operator"
+	// Env: GINKGO_FOCUS
 	GinkgoFocus string
 
 	// TestsToRun is a list of files which should be executed as part of a test suite
+	// Env: TESTS_TO_RUN
 	TestsToRun string
 
 	// SuppressSkipNotifications suppresses the notifications of skipped tests
+	// Env: SUPPRESS_SKIP_NOTIFICATIONS
 	SuppressSkipNotifications string
 
 	// CleanRuns is the number of times the test-version is run before skipping.
+	// Env: CLEAN_RUNS
 	CleanRuns string
 
 	// OperatorSkip is a comma-delimited list of operator names to ignore health checks from. ex. "insights,telemetry"
+	// Env: OPERATOR_SKIP
 	OperatorSkip string
 
 	// SkipClusterHealthChecks skips the cluster health checks. Useful when developing against a running cluster.
+	// Env: SKIP_CLUSTER_HEALTH_CHECKS
 	SkipClusterHealthChecks string
 
 	// MetricsBucket is the bucket that metrics data will be uploaded to.
+	// Env: METRICS_BUCKET
 	MetricsBucket string
 
 	// ServiceAccount defines what user the tests should run as. By default, osde2e uses system:admin
+	// Env: SERVICE_ACCOUNT
 	ServiceAccount string
 }{
 
@@ -153,45 +182,59 @@ var Tests = struct {
 // Cluster config keys.
 var Cluster = struct {
 	// MultiAZ deploys a cluster across multiple availability zones.
+	// Env: MULTI_AZ
 	MultiAZ string
 
 	// DestroyClusterAfterTest set to true if you want to the cluster to be explicitly deleted after the test.
+	// Env: DESTROY_CLUSTER
 	DestroyAfterTest string
 
 	// ExpiryInMinutes is how long before a cluster expires and is deleted by OSD.
+	// Env: CLUSTER_EXPIRY_IN_MINUTES
 	ExpiryInMinutes string
 
 	// AfterTestWait is how long to keep a cluster around after tests have run.
+	// Env: AFTER_TEST_CLUSTER_WAIT
 	AfterTestWait string
 
 	// InstallTimeout is how long to wait before failing a cluster launch.
+	// Env: CLUSTER_UP_TIMEOUT
 	InstallTimeout string
 
 	// UseLatestVersionForInstall will select the latest cluster image set available for a fresh install.
+	// Env: USE_LATEST_VERSION_FOR_INSTALL
 	UseLatestVersionForInstall string
 
 	// UseMiddleClusterImageSetForInstall will select the cluster image set that is in the middle of the list of ordered cluster versions known to OCM.
+	// Env: USE_MIDDLE_CLUSTER_IMAGE_SET_FOR_INSTALL
 	UseMiddleClusterImageSetForInstall string
 
 	// UseOldestClusterImageSetForInstall will select the cluster image set that is in the end of the list of ordered cluster versions known to OCM.
+	// Env: USE_OLDEST_CLUSTER_IMAGE_SET_FOR_INSTALL
 	UseOldestClusterImageSetForInstall string
 
 	// DeltaReleaseFromDefault will select the cluster image set that is the given number of releases from the current default in either direction.
+	// Env: DELTA_RELEASE_FROM_DEFAULT
 	DeltaReleaseFromDefault string
 
 	// NextReleaseAfterProdDefault will select the cluster image set that the given number of releases away from the the production default.
+	// Env: NEXT_RELEASE_AFTER_PROD_DEFAULT
 	NextReleaseAfterProdDefault string
 
 	// CleanCheckRuns lets us set the number of osd-verify checks we want to run before deeming a cluster "healthy"
+	// Env: CLEAN_CHECK_RUNS
 	CleanCheckRuns string
 
 	// ID identifies the cluster. If set at start, an existing cluster is tested.
+	// Env: CLUSTER_ID
 	ID string
 
 	// Name is the name of the cluster being created.
+	// Env: CLUSTER_NAME
 	Name string
 
 	// Version is the version of the cluster being deployed.
+	// Env: CLUSTER_VERSION
 	Version string
 
 	// EnoughVersionsForOldestOrMiddleTest is true if there were enough versions for an older/middle test.
@@ -221,9 +264,11 @@ var Cluster = struct {
 // CloudProvider config keys.
 var CloudProvider = struct {
 	// CloudProviderID is the cloud provider ID to use to provision the cluster.
+	// Env: CLOUD_PROVIDER_ID
 	CloudProviderID string
 
 	// Region is the cloud provider region to use to provision the cluster.
+	// Env: CLOUD_PROVIDER_REGION
 	Region string
 }{
 	CloudProviderID: "cloudProvider.providerId",
@@ -233,26 +278,32 @@ var CloudProvider = struct {
 // Addons config keys.
 var Addons = struct {
 	// IDsAtCreation is a comma separated list of IDs to create at cluster creation time.
+	// Env: ADDON_IDS_AT_CREATION
 	IDsAtCreation string
 
 	// IDs is a comma separated list of IDs to install after a cluster is created.
+	// Env: ADDON_IDS
 	IDs string
 
 	// TestHarnesses is a comma separated list of container images that will test the addon
+	// Env: ADDON_TEST_HARNESSES
 	TestHarnesses string
 
 	// TestUser is the OpenShift user that the tests will run as
 	// If "%s" is detected in the TestUser string, it will evaluate that as the project namespace
 	// Example: "system:serviceaccount:%s:dedicated-admin"
 	// Evaluated: "system:serviceaccount:osde2e-abc123:dedicated-admin"
+	// Env: ADDON_TEST_USER
 	TestUser string
 
 	// RunCleanup is a boolean to specify whether the testHarnesses should have a separate
 	// cleanup phase. This phase would run at the end of all e2e testing
+	// Env: ADDON_RUN_CLEANUP
 	RunCleanup string
 
 	// CleanupHarnesses is a comma separated list of container images that will clean up any
 	// artifacts created after test harnesses have run
+	// Env: ADDON_CLEANUP_HARNESSES
 	CleanupHarnesses string
 }{
 	IDsAtCreation:    "addons.idsAtCreation",
@@ -266,9 +317,11 @@ var Addons = struct {
 // Scale config keys.
 var Scale = struct {
 	// WorkloadsRepository is the git repository where the openshift-scale workloads are located.
+	// Env: WORKLOADS_REPO
 	WorkloadsRepository string
 
 	// WorkloadsRepositoryBranch is the branch of the git repository to use.
+	// Env: WORKLOADS_REPO_BRANCH
 	WorkloadsRepositoryBranch string
 }{
 	WorkloadsRepository:       "scale.workloadsRepository",
@@ -278,9 +331,11 @@ var Scale = struct {
 // Prometheus config keys.
 var Prometheus = struct {
 	// Address is the address of the Prometheus instance to connect to.
+	// Env: PROMETHEUS_ADDRESS
 	Address string
 
 	// BearerToken is the token needed for communicating with Prometheus.
+	// Env: PROMETHEUS_BEARER_TOKEN
 	BearerToken string
 }{
 	Address:     "prometheus.address",
@@ -290,6 +345,7 @@ var Prometheus = struct {
 // Alert config keys.
 var Alert = struct {
 	// SlackAPIToken is a bot slack token
+	// Env: SLACK_API_TOKEN
 	SlackAPIToken string
 }{
 	SlackAPIToken: "alert.slackAPIToken",


### PR DESCRIPTION
This PR removes all references to the old `make test` usage and updates the docs with the current style of how to run `osde2e` locally. 

As config options are bountiful, it also updates the config package with inline-comments of their environment variables. This should clear up most questions when writing a local script that uses environment variables, and also show up in the godoc (eventually)

cc @cblecker 