### PR TITLE
Move quota check to launch method, remove need for viper.set

### DIFF
--- a/pkg/common/providers/crc/crc.go
+++ b/pkg/common/providers/crc/crc.go
@@ -205,7 +205,7 @@ func (m *Provider) ClusterKubeconfig(clusterID string) ([]byte, error) {
 }
 
 // CheckQuota CRCs a check quota operation.
-func (m *Provider) CheckQuota() (bool, error) {
+func (m *Provider) CheckQuota(flavour string) (bool, error) {
 	if len(m.clusters) > 0 {
 		return false, fmt.Errorf("only one CRC cluster may be used at a time")
 	}

--- a/pkg/common/providers/moaprovider/wrapped_calls.go
+++ b/pkg/common/providers/moaprovider/wrapped_calls.go
@@ -33,8 +33,8 @@ func (m *MOAProvider) ClusterKubeconfig(clusterID string) ([]byte, error) {
 }
 
 // CheckQuota will call CheckQuota from the OCM provider.
-func (m *MOAProvider) CheckQuota() (bool, error) {
-	return m.ocmProvider.CheckQuota()
+func (m *MOAProvider) CheckQuota(flavour string) (bool, error) {
+	return m.ocmProvider.CheckQuota(flavour)
 }
 
 // InstallAddons will call InstallAddons from the OCM provider.

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -142,7 +142,7 @@ func (m *MockProvider) ClusterKubeconfig(clusterID string) ([]byte, error) {
 }
 
 // CheckQuota mocks a check quota operation.
-func (m *MockProvider) CheckQuota() (bool, error) {
+func (m *MockProvider) CheckQuota(flavour string) (bool, error) {
 	if m.env == "fail" {
 		return false, fmt.Errorf("failed to get versions: Some fake error")
 	}

--- a/pkg/common/providers/mock/mock_test.go
+++ b/pkg/common/providers/mock/mock_test.go
@@ -13,7 +13,7 @@ import (
 func TestClusterInteraction(t *testing.T) {
 	mockProvider := makeMockProviderWithEnv("mockEnv")
 
-	if hasQuota, err := mockProvider.CheckQuota(); !hasQuota || err != nil {
+	if hasQuota, err := mockProvider.CheckQuota(""); !hasQuota || err != nil {
 		t.Errorf("expected quota or no error, got: %v, %v", hasQuota, err.Error())
 	}
 
@@ -57,7 +57,7 @@ func TestIntentionalFailures(t *testing.T) {
 	mockProvider := makeMockProviderWithEnv("fail")
 
 	// Quota Check
-	quotaCheck, err := mockProvider.CheckQuota()
+	quotaCheck, err := mockProvider.CheckQuota("")
 	if quotaCheck {
 		t.Error("expected quota to be false for fail environment")
 	}

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -23,6 +23,13 @@ func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 		return "", fmt.Errorf("No flavour has been selected")
 	}
 
+	// check that enough quota exists for this test if creating cluster
+	if enoughQuota, err := o.CheckQuota(flavourID); err != nil {
+		log.Printf("Failed to check if enough quota is available: %v", err)
+	} else if !enoughQuota {
+		return "", fmt.Errorf("currently not enough quota exists to run this test")
+	}
+
 	multiAZ := viper.GetBool(config.Cluster.MultiAZ)
 	computeMachineType := viper.GetString(ComputeMachineType)
 	cloudProvider := viper.GetString(config.CloudProvider.CloudProviderID)

--- a/pkg/common/providers/ocmprovider/flavour.go
+++ b/pkg/common/providers/ocmprovider/flavour.go
@@ -1,6 +1,7 @@
 package ocmprovider
 
 import (
+	"log"
 	"math/rand"
 	"strings"
 
@@ -23,7 +24,7 @@ func getFlavour() string {
 	default:
 		flavourID = flavours[rand.Intn(flavourLength)]
 	}
+	log.Printf("Using flavour: %s", flavourID)
 
-	viper.Set(Flavour, flavourID)
 	return flavourID
 }

--- a/pkg/common/providers/ocmprovider/quota.go
+++ b/pkg/common/providers/ocmprovider/quota.go
@@ -17,16 +17,15 @@ const (
 )
 
 // CheckQuota determines if enough quota is available to launch with cfg.
-func (o *OCMProvider) CheckQuota() (bool, error) {
+func (o *OCMProvider) CheckQuota(flavourID string) (bool, error) {
 	// get flavour being deployed
 	var flavourResp *v1.FlavourGetResponse
 	err := retryer().Do(func() error {
 		var err error
-		flavour := getFlavour()
-		if flavour == "" {
+		if flavourID == "" {
 			return fmt.Errorf("No valid flavour selected")
 		}
-		flavourResp, err = o.conn.ClustersMgmt().V1().Flavours().Flavour(flavour).Get().Send()
+		flavourResp, err = o.conn.ClustersMgmt().V1().Flavours().Flavour(flavourID).Get().Send()
 
 		if err != nil {
 			return err

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -50,7 +50,7 @@ type Provider interface {
 	//
 	// To prevent a provisioning attempt, OSDe2e will first check the quota first. This quota
 	// is currently expected to be configured by the global config object.
-	CheckQuota() (bool, error)
+	CheckQuota(flavour string) (bool, error)
 
 	// InstallAddons will install addons onto the cluster.
 	//

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -304,17 +304,6 @@ func runGinkgoTests() error {
 			log.Printf("No valid upgrade versions were found. Skipping tests.")
 			return nil
 		}
-
-		// check that enough quota exists for this test if creating cluster
-		if len(clusterID) == 0 {
-			if dryRun {
-				log.Printf("This is a dry run. Skipping quota check.")
-			} else if enoughQuota, err := provider.CheckQuota(); err != nil {
-				log.Printf("Failed to check if enough quota is available: %v", err)
-			} else if !enoughQuota {
-				return fmt.Errorf("currently not enough quota exists to run this test")
-			}
-		}
 	}
 
 	// Update the metadata object to use the report directory.


### PR DESCRIPTION
Viper apparently isn't entirely thread safe. So I removed the need for it entirely. 

It required a minor refactor of our quotaCheck method, which now expects a `flavour` argument.