### PR TITLE
SDCICD-454/455: Return list of failing checks, update cluster property / metrics with it

### DIFF
--- a/cmd/osde2ectl/create/cmd.go
+++ b/cmd/osde2ectl/create/cmd.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -221,11 +222,14 @@ func setupCluster(wg *sync.WaitGroup, successfulClustersCounter *int32) {
 
 				select {
 				case <-timeout:
-					isHealthy, _ := clusterutil.PollClusterHealth(cluster.ID(), discardLogger)
+					isHealthy, failures, _ := clusterutil.PollClusterHealth(cluster.ID(), discardLogger)
 					if isHealthy {
 						fmt.Printf("Cluster %s is healthy (could be transient).\n", cluster.ID())
 					} else {
 						fmt.Printf("Cluster %s is not healthy yet.\n", cluster.ID())
+						if len(failures) > 0 {
+							fmt.Printf("Currently failing %s health checks", strings.Join(failures, ", "))
+						}
 					}
 				case <-terminate:
 					return

--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver"
@@ -108,11 +109,12 @@ func waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID string, l
 			currentStatus := properties[clusterproperties.Status]
 
 			if currentStatus == clusterproperties.StatusProvisioning && !readinessSet {
-				err = provider.AddProperty(clusterID, clusterproperties.Status, clusterproperties.StatusWaitingForReady)
+				err = provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusWaitingForReady)
 				if err != nil {
 					log.Printf("Error adding property to cluster: %s", err.Error())
 					return false, nil
 				}
+
 			}
 
 			if cluster != nil && cluster.State() == spi.ClusterStateReady {
@@ -124,19 +126,19 @@ func waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID string, l
 					}
 
 					if currentStatus == clusterproperties.StatusUpgrading {
-						err = provider.AddProperty(clusterID, clusterproperties.Status, clusterproperties.StatusUpgradeHealthCheck)
+						err = provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusUpgradeHealthCheck)
 					} else {
-						err = provider.AddProperty(clusterID, clusterproperties.Status, clusterproperties.StatusHealthCheck)
+						err = provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusHealthCheck)
 					}
 
 					if err != nil {
-						log.Printf("Error trying to add health-check property to cluster ID %s: %v", clusterID, err)
+						log.Printf("error trying to add health-check property to cluster ID %s: %v", cluster.ID(), err)
 						return false, nil
 					}
 
 					readinessStarted = time.Now()
 				}
-				if success, err := PollClusterHealth(clusterID, logger); success {
+				if success, failures, err := PollClusterHealth(clusterID, logger); success {
 					cleanRuns++
 					logger.Printf("Clean run %d/%d...", cleanRuns, cleanRunsNeeded)
 					errRuns = 0
@@ -148,18 +150,27 @@ func waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID string, l
 						}
 
 						if currentStatus == clusterproperties.StatusUpgradeHealthCheck {
-							err = provider.AddProperty(clusterID, clusterproperties.Status, clusterproperties.StatusUpgradeHealthy)
+							err = provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusUpgradeHealthy)
 						} else {
-							err = provider.AddProperty(clusterID, clusterproperties.Status, clusterproperties.StatusHealthy)
+							err = provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusHealthy)
 						}
 
 						if err != nil {
-							log.Printf("error trying to add healthy property to cluster ID %s: %v", clusterID, err)
+							log.Printf("error trying to add healthy property to cluster ID %s: %v", cluster.ID(), err)
 							return false, nil
 						}
 
 						return true, nil
 					}
+
+					failureString := strings.Join(failures, ",")
+					if currentStatus != failureString {
+						err = provider.AddProperty(cluster, clusterproperties.Status, failureString)
+						if err != nil {
+							return false, fmt.Errorf("error trying to add property to cluster ID %s: %v", cluster.ID(), err)
+						}
+					}
+
 					return false, nil
 				} else {
 					if err != nil {
@@ -167,9 +178,9 @@ func waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID string, l
 						logger.Printf("Error in PollClusterHealth: %v", err)
 						if errRuns >= errorWindow {
 							if currentStatus == clusterproperties.StatusUpgradeHealthCheck {
-								err = provider.AddProperty(clusterID, clusterproperties.Status, clusterproperties.StatusUpgradeUnhealthy)
+								err = provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusUpgradeUnhealthy)
 							} else {
-								err = provider.AddProperty(clusterID, clusterproperties.Status, clusterproperties.StatusUnhealthy)
+								err = provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusUnhealthy)
 							}
 
 							if err != nil {
@@ -197,38 +208,38 @@ func waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID string, l
 }
 
 // PollClusterHealth looks at CVO data to determine if a cluster is alive/healthy or not
-func PollClusterHealth(clusterID string, logger *log.Logger) (status bool, err error) {
+func PollClusterHealth(clusterID string, logger *log.Logger) (status bool, failures []string, err error) {
 	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 
 	provider, err := providers.ClusterProvider()
 
 	if err != nil {
-		return false, fmt.Errorf("error getting cluster provisioning client: %v", err)
+		return false, nil, fmt.Errorf("error getting cluster provisioning client: %v", err)
 	}
 
 	logger.Print("Polling Cluster Health...\n")
 	restConfig, err := getRestConfig(provider, clusterID)
 	if err != nil {
 		logger.Printf("Error generating Rest Config: %v\n", err)
-		return false, nil
+		return false, nil, nil
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		logger.Printf("Error generating Kube Clientset: %v\n", err)
-		return false, nil
+		return false, nil, nil
 	}
 
 	oscfg, err := osconfig.NewForConfig(restConfig)
 	if err != nil {
 		logger.Printf("Error generating OpenShift Clientset: %v\n", err)
-		return false, nil
+		return false, nil, nil
 	}
 
 	dynamicClient, err := dynamic.NewForConfig(restConfig)
 	if err != nil {
 		logger.Printf("Error generating Dynamic Clientset: %v\n", err)
-		return false, nil
+		return false, nil, nil
 	}
 
 	clusterHealthy := true
@@ -240,38 +251,44 @@ func PollClusterHealth(clusterID string, logger *log.Logger) (status bool, err e
 	case "ocm":
 		if check, err := healthchecks.CheckCVOReadiness(oscfg.ConfigV1(), logger); !check || err != nil {
 			healthErr = multierror.Append(healthErr, err)
+			failures = append(failures, "cvo")
 			clusterHealthy = false
 		}
 
 		if check, err := healthchecks.CheckNodeHealth(kubeClient.CoreV1(), logger); !check || err != nil {
 			healthErr = multierror.Append(healthErr, err)
+			failures = append(failures, "node")
 			clusterHealthy = false
 		}
 
 		if check, err := healthchecks.CheckMachinesObjectState(dynamicClient, logger); !check || err != nil {
 			healthErr = multierror.Append(healthErr, err)
+			failures = append(failures, "machine")
 			clusterHealthy = false
 		}
 
 		if check, err := healthchecks.CheckOperatorReadiness(oscfg.ConfigV1(), logger); !check || err != nil {
 			healthErr = multierror.Append(healthErr, err)
+			failures = append(failures, "operator")
 			clusterHealthy = false
 		}
 
 		if check, err := healthchecks.CheckPodHealth(kubeClient.CoreV1(), logger); !check || err != nil {
 			healthErr = multierror.Append(healthErr, err)
+			failures = append(failures, "pod")
 			clusterHealthy = false
 		}
 
 		if check, err := healthchecks.CheckCerts(kubeClient.CoreV1(), logger); !check || err != nil {
 			healthErr = multierror.Append(healthErr, err)
+			failures = append(failures, "cert")
 			clusterHealthy = false
 		}
 	default:
 		logger.Printf("No provisioner-specific logic for %s", provider.Type())
 	}
 
-	return clusterHealthy, healthErr.ErrorOrNil()
+	return clusterHealthy, failures, healthErr.ErrorOrNil()
 }
 
 func getRestConfig(provider spi.Provider, clusterID string) (*rest.Config, error) {

--- a/pkg/common/providers/crc/crc.go
+++ b/pkg/common/providers/crc/crc.go
@@ -292,7 +292,7 @@ func (m *Provider) ExtendExpiry(clusterID string, hours uint64, minutes uint64, 
 }
 
 // AddProperty CRCs an add new cluster property operation.
-func (m *Provider) AddProperty(clusterID string, tag string, value string) error {
+func (m *Provider) AddProperty(cluster *spi.Cluster, tag string, value string) error {
 	// Noop for now and just note it.
 	log.Printf("AddProperty is unsupported by CRC clusters")
 	return nil

--- a/pkg/common/providers/moaprovider/wrapped_calls.go
+++ b/pkg/common/providers/moaprovider/wrapped_calls.go
@@ -78,6 +78,6 @@ func (m *MOAProvider) ExtendExpiry(clusterID string, hours uint64, minutes uint6
 }
 
 // AddProperty will call AddProperty from the OCM provider.
-func (m *MOAProvider) AddProperty(clusterID string, tag string, value string) error {
-	return m.ocmProvider.AddProperty(clusterID, tag, value)
+func (m *MOAProvider) AddProperty(cluster *spi.Cluster, tag string, value string) error {
+	return m.ocmProvider.AddProperty(cluster, tag, value)
 }

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -240,6 +240,6 @@ func (m *MockProvider) ExtendExpiry(clusterID string, hours uint64, minutes uint
 }
 
 // AddProperty mocks an add new cluster property operation.
-func (m *MockProvider) AddProperty(clusterID string, tag string, value string) error {
+func (m *MockProvider) AddProperty(cluster *spi.Cluster, tag string, value string) error {
 	return fmt.Errorf("AddProperty is unsupported by mock clusters")
 }

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -102,5 +102,5 @@ type Provider interface {
 	ExtendExpiry(clusterID string, hours uint64, minutes uint64, seconds uint64) error
 
 	// AddProperty adds a new property to the properties field of an existing cluster.
-	AddProperty(clusterID string, tag string, value string) error
+	AddProperty(cluster *Cluster, tag string, value string) error
 }

--- a/pkg/common/upgrade/upgrade.go
+++ b/pkg/common/upgrade/upgrade.go
@@ -131,7 +131,12 @@ func TriggerUpgrade(h *helper.H) (*configv1.ClusterVersion, error) {
 		return nil, fmt.Errorf("error getting cluster provider: %v", err)
 	}
 
-	provider.AddProperty(clusterID, clusterproperties.Status, clusterproperties.StatusUpgrading)
+	cluster, err := provider.GetCluster(clusterID)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving cluster: %v", err)
+	}
+
+	provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusUpgrading)
 
 	// set requested upgrade targets
 	if image != "" {

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -107,7 +107,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		metadata.Instance.SetClusterID(cluster.ID())
 		metadata.Instance.SetRegion(cluster.Region())
 
-		if err = provider.AddProperty(cluster.ID(), "UpgradeVersion", viper.GetString(config.Upgrade.ReleaseName)); err != nil {
+		if err = provider.AddProperty(cluster, "UpgradeVersion", viper.GetString(config.Upgrade.ReleaseName)); err != nil {
 			log.Printf("Error while adding upgrade version property to cluster via OCM: %v", err)
 		}
 


### PR DESCRIPTION
- Refactor `PollClusterHealth` to return an array of failures (abbreviated, ie CheckCVOReadiness would be "cvo")
- Refactor `AddProperty` to expect an `*spi.Cluster` object instead of a ClusterID (This cuts down on OCM calls significantly)
- Update the Cluster Status property at every failure change from PollClusterHealth
- Create / Upload a prometheus file to our metrics inbox S3 bucket for processing (current job processes every 5min)