### PR TITLE
SDCICD-482: Only look at stable channels in stage/prod

### DIFF
--- a/pkg/common/providers/ocmprovider/versions.go
+++ b/pkg/common/providers/ocmprovider/versions.go
@@ -72,6 +72,9 @@ func (o *OCMProvider) Versions() (*spi.VersionList, error) {
 				if version, err := util.OpenshiftVersionToSemver(v.ID()); err != nil {
 					log.Printf("could not parse version '%s': %v", v.ID(), err)
 				} else if v.Enabled() {
+					if (o.Environment() == "stage" || o.Environment() == "prod") && v.ChannelGroup() != "stable" {
+						return true
+					}
 					versions = append(versions, spi.NewVersionBuilder().
 						Version(version).
 						Default(v.Default()).


### PR DESCRIPTION
This is a temporary fix to unblock some pipelines while we build more robust support for channel groups in versions.