### PR TITLE
Provision shard for OCM cluster through osde2e

### DIFF
--- a/pkg/common/clusterproperties/properties.go
+++ b/pkg/common/clusterproperties/properties.go
@@ -22,4 +22,7 @@ const (
 
 	// JobID is the name of the job ID that is associated with the cluster.
 	JobID = "JobID"
+
+	// ProvisionShardID is the shard ID that is set to provision a shard for the cluster.
+	ProvisionShardID = "provision_shard_id"
 )

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -253,6 +253,9 @@ var Cluster = struct {
 
 	// PreviousVersionFromDefaultFound is true if a previous version from default was found.
 	PreviousVersionFromDefaultFound string
+
+	// ProvisionShardID is the shard ID that is set to provision a shard for the cluster.
+	ProvisionShardID string
 }{
 	MultiAZ:                             "cluster.multiAZ",
 	DestroyAfterTest:                    "cluster.destroyAfterTest",
@@ -270,6 +273,7 @@ var Cluster = struct {
 	Version:                             "cluster.version",
 	EnoughVersionsForOldestOrMiddleTest: "cluster.enoughVersionForOldestOrMiddleTest",
 	PreviousVersionFromDefaultFound:     "cluster.previousVersionFromDefaultFound",
+	ProvisionShardID:                    "cluster.provisionshardID",
 }
 
 // CloudProvider config keys.
@@ -497,6 +501,9 @@ func init() {
 	viper.SetDefault(Cluster.EnoughVersionsForOldestOrMiddleTest, true)
 
 	viper.SetDefault(Cluster.PreviousVersionFromDefaultFound, true)
+
+	viper.SetDefault(Cluster.ProvisionShardID, "")
+	viper.BindEnv(Cluster.ProvisionShardID, "PROVISION_SHARD_ID")
 
 	// ----- Cloud Provider -----
 	viper.SetDefault(CloudProvider.CloudProviderID, "aws")

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -176,12 +176,18 @@ func (o *OCMProvider) GenerateProperties() (map[string]string, error) {
 
 	installedversion := viper.GetString(config.Cluster.Version)
 
+	provisionshardID := viper.GetString(config.Cluster.ProvisionShardID)
+
 	properties := map[string]string{
 		clusterproperties.MadeByOSDe2e:     "true",
 		clusterproperties.OwnedBy:          username,
 		clusterproperties.InstalledVersion: installedversion,
 		clusterproperties.UpgradeVersion:   "--",
 		clusterproperties.Status:           clusterproperties.StatusProvisioning,
+	}
+
+	if provisionshardID != "" {
+		properties[clusterproperties.ProvisionShardID] = provisionshardID
 	}
 
 	additionalLabels := viper.GetString(AdditionalLabels)


### PR DESCRIPTION
Added support for pinning OCM cluster to a hive shard using osde2e. 