### PR TITLE
Removed node check for OCM metrics test

### DIFF
--- a/pkg/e2e/osd/ocm.go
+++ b/pkg/e2e/osd/ocm.go
@@ -27,9 +27,6 @@ var _ = ginkgo.Describe(ocmTestName, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(metrics.CriticalAlertsFiring()).NotTo(BeNil())
 			Expect(metrics.OperatorsConditionFailing()).NotTo(BeNil())
-			Expect(metrics.Nodes().Compute()).NotTo(BeZero())
-			Expect(metrics.Nodes().Infra()).NotTo(BeZero())
-			Expect(metrics.Nodes().Master()).NotTo(BeZero())
 			Expect(metrics.ComputeNodesSockets().Empty()).NotTo(BeFalse())
 
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))


### PR DESCRIPTION
Removed the count check for nodes during an OCM metrics test on a created cluster.