### PR TITLE
OSD-5292 always be overriding managed-upgrade config

### DIFF
--- a/pkg/common/upgrade/upgrade.go
+++ b/pkg/common/upgrade/upgrade.go
@@ -78,6 +78,12 @@ func RunUpgrade() error {
 	done = false
 	if err = wait.PollImmediate(10*time.Second, MaxDuration, func() (bool, error) {
 		if viper.GetBool(config.Upgrade.ManagedUpgrade) && viper.GetBool(config.Upgrade.WaitForWorkersToManagedUpgrade) {
+			// Keep the managed upgrade's configuration overrides in place, in case Hive has replaced them
+			err = overrideOperatorConfig(h)
+			// Log if it errored, but don't cancel the upgrade because of it
+			if err != nil {
+				log.Printf("problem overriding managed upgrade config: %v", err)
+			}
 			// If performing a managed upgrade, check if we want to wait for workers to fully upgrade too
 			done, msg, err = isManagedUpgradeDone(h, desired.Spec.DesiredUpdate)
 		} else {


### PR DESCRIPTION
This PR corrects an issue whereby the `managed-upgrade-operator`'s E2E-tailored configmap may get overridden by a Hive sync mid-upgrade. 

The configmap is now checked and (only if needed) corrected during OSDE2E's repeated "is the upgrade finished" checks, so that even if it is replaced by a Hive sync it will be quickly corrected with the overriding values.


