### PR TITLE
Rename managed-upgrade CR name

### DIFF
--- a/pkg/common/upgrade/managed.go
+++ b/pkg/common/upgrade/managed.go
@@ -31,7 +31,7 @@ const (
 	// the 'upgrade type' that the upgrade operator should use when upgrading
 	muoUpgradeType = upgradev1alpha1.OSD
 	// the name of the generated UpgradeConfig resource containing upgrade configuration
-	upgradeConfigName = "osde2e-upgrade-config"
+	upgradeConfigName = "osd-upgrade-config"
 
 	// name of the workload for pod disruption budget tests
 	pdbWorkloadName = "pdb"

--- a/pkg/e2e/operators/managedupgrade.go
+++ b/pkg/e2e/operators/managedupgrade.go
@@ -30,7 +30,7 @@ var _ = ginkgo.Describe(managedUpgradeOperatorTestName, func() {
 	var operatorName = "managed-upgrade-operator"
 	var operatorNamespace string = "openshift-managed-upgrade-operator"
 	var operatorLockFile string = "managed-upgrade-operator-lock"
-	var upgradeConfigResourceName string = "osde2e-upgrade-config"
+	var upgradeConfigResourceName string = "osd-upgrade-config"
 	var defaultDesiredReplicas int32 = 1
 	var clusterRoles = []string{
 		"managed-upgrade-operator",
@@ -161,7 +161,7 @@ var _ = ginkgo.Describe(managedUpgradeOperatorTestName, func() {
 
 			// Wait a minute for the operator to flag this as a problem
 			err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
-				query := fmt.Sprintf("upgradeoperator_upgrade_window_breached{upgradeconfig_name=\"%s\"} == 1", "osde2e-upgrade-config")
+				query := fmt.Sprintf("upgradeoperator_upgrade_window_breached{upgradeconfig_name=\"%s\"} == 1", "osd-upgrade-config")
 				context, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
 				defer cancel()
 				value, _, err := promAPI.Query(context, query, time.Now())


### PR DESCRIPTION
`managed-upgrade-operator` now standardizes on a `UpgradeConfig` CustomResource name of `osd-upgrade-config`. When this change was made, it caused E2E upgades to no longer occur because E2E was creating a CR name of `osde2e-upgrade-config`. 

This PR rectifies this so that E2E will now create a CR with the expected name which will allow upgrades to occur.