### PR TITLE
SDCICD-502: Support AWS CCS clusters and support supplying a list of AWS accounts for multi-cluster testing

### DIFF
--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -64,6 +64,19 @@ func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 			ID(cloudProvider)).
 		Properties(clusterProperties)
 
+	// If AWS credentials are set, this must be a CCS cluster
+	awsAccount := viper.GetString(AWSAccount)
+	awsAccessKey := viper.GetString(AWSAccessKey)
+	awsSecretKey := viper.GetString(AWSSecretKey)
+
+	if awsAccount != "" && awsAccessKey != "" && awsSecretKey != "" {
+		newCluster.CCS(v1.NewCCS().Enabled(true)).AWS(
+			v1.NewAWS().
+				AccountID(awsAccount).
+				AccessKeyID(awsAccessKey).
+				SecretAccessKey(awsSecretKey))
+	}
+
 	expiryInMinutes := viper.GetDuration(config.Cluster.ExpiryInMinutes)
 	if expiryInMinutes > 0 {
 		// Calculate an expiration date for the cluster so that it will be automatically deleted if

--- a/pkg/common/providers/ocmprovider/config.go
+++ b/pkg/common/providers/ocmprovider/config.go
@@ -29,6 +29,13 @@ const (
 
 	// AdditionalLabels is used to add more specific labels to a cluster in OCM.
 	AdditionalLabels = "ocm.additionalLabels"
+
+	// AWSAccount is used in CCS clusters
+	AWSAccount = "ocm.aws.account"
+	// AWSAccessKey is used in CCS clusters
+	AWSAccessKey = "ocm.aws.accessKey"
+	// AWSSecretKey is used in CCS clusters
+	AWSSecretKey = "ocm.aws.secretKey"
 )
 
 func init() {
@@ -54,4 +61,8 @@ func init() {
 	viper.BindEnv(Flavour, "OCM_FLAVOUR")
 
 	viper.BindEnv(AdditionalLabels, "OCM_ADDITIONAL_LABELS")
+
+	viper.BindEnv(AWSAccount, "OCM_AWS_ACCOUNT")
+	viper.BindEnv(AWSAccessKey, "OCM_AWS_ACCESS_KEY")
+	viper.BindEnv(AWSSecretKey, "OCM_AWS_SECRET_KEY")
 }


### PR DESCRIPTION
- Adds AWS account configs to the OCM Provider
- Creates `aws-accounts-file` argument to `osde2ectl create` to supply multiple accounts during cluster creation
  - Mutex is used for modifying the OCM AWS account configs between cluster creation to prevent `viper.Set` concurrent read/write error

