### PR TITLE
resolves OCM restrictions on value

### DIFF
--- a/pkg/common/upgrade/managed.go
+++ b/pkg/common/upgrade/managed.go
@@ -47,7 +47,7 @@ const (
 	configProviderWatchInterval = 60  // minutes
 	configScaleTimeout          = 15  // minutes
 	configUpgradeWindow         = 120 // minutes
-	configNodeDrainTimeout      = 7   // minutes
+	configNodeDrainTimeout      = 15  // minutes
 	configExpectedDrainTime     = 8   // minutes
 	configControlPlaneTime      = 90  // minutes
 )


### PR DESCRIPTION
```
2020/10/27 01:30:20 Tests failed: error performing upgrade: failed triggering upgrade: can't initiate managed upgrade: error initiating upgrade from provider: identifier is '400', code is 'CLUSTERS-[MGMT-400](https://issues.redhat.com/browse/MGMT-400)' and operation identifier is '1giikb0ua6p2dcna9692hdnq3qku0t11': Value '5' is invalid. 'node_drain_grace_period' can only be set in 15 minutes interval up to 60 minutes, then hourly intervals up until 8 hours
testing failed
```