### PR TITLE
Increase PDB timeout duration for upgrades

### DIFF
--- a/pkg/common/providers/crc/crc.go
+++ b/pkg/common/providers/crc/crc.go
@@ -299,7 +299,7 @@ func (m *Provider) AddProperty(cluster *spi.Cluster, tag string, value string) e
 }
 
 // Upgrade CRCs initiates a cluster upgrade to the given version
-func (m *Provider) Upgrade(clusterID string, version string, t time.Time) error {
+func (m *Provider) Upgrade(clusterID string, version string, pdbTimeoutMinutes int, t time.Time) error {
 	// Noop for now and just note it.
 	log.Printf("Upgrade is unsupported by CRC clusters")
 	return nil

--- a/pkg/common/providers/moaprovider/wrapped_calls.go
+++ b/pkg/common/providers/moaprovider/wrapped_calls.go
@@ -79,6 +79,6 @@ func (m *MOAProvider) AddProperty(cluster *spi.Cluster, tag string, value string
 }
 
 // Upgrade initiates a cluster upgrade from the OCM provider.
-func (m *MOAProvider) Upgrade(clusterID string, version string, t time.Time) error {
-	return m.ocmProvider.Upgrade(clusterID, version, t)
+func (m *MOAProvider) Upgrade(clusterID string, version string, pdbTimeoutMinutes int, t time.Time) error {
+	return m.ocmProvider.Upgrade(clusterID, version, pdbTimeoutMinutes, t)
 }

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -245,6 +245,6 @@ func (m *MockProvider) AddProperty(cluster *spi.Cluster, tag string, value strin
 }
 
 // Upgrade mocks initiates a cluster upgrade to the given version
-func (m *MockProvider) Upgrade(clusterID string, version string, t time.Time) error {
+func (m *MockProvider) Upgrade(clusterID string, version string, pdbTimeoutMinutes int, t time.Time) error {
 	return fmt.Errorf("Upgrade is unsupported by mock clusters")
 }

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -787,9 +787,9 @@ func (o *OCMProvider) AddProperty(cluster *spi.Cluster, tag string, value string
 }
 
 // Upgrade initiates a cluster upgrade to the given version
-func (o *OCMProvider) Upgrade(clusterID string, version string, t time.Time) error {
+func (o *OCMProvider) Upgrade(clusterID string, version string, pdbTimeoutMinutes int, t time.Time) error {
 
-	nodeDrain := v1.NewValue().Value(5).Unit("minutes")
+	nodeDrain := v1.NewValue().Value(float64(pdbTimeoutMinutes)).Unit("minutes")
 	policy, err := v1.NewUpgradePolicy().Version(version).NextRun(t).ScheduleType("manual").NodeDrainGracePeriod(nodeDrain).Build()
 	if err != nil {
 		return err

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -106,6 +106,6 @@ type Provider interface {
 	AddProperty(cluster *Cluster, tag string, value string) error
 
 	// Upgrade requests the provider initiate a cluster upgrade to the given version
-	Upgrade(clusterID string, version string, t time.Time) error
+	Upgrade(clusterID string, version string, pdbTimeoutMinutes int, t time.Time) error
 
 }

--- a/pkg/common/upgrade/managed.go
+++ b/pkg/common/upgrade/managed.go
@@ -48,8 +48,10 @@ const (
 	configScaleTimeout          = 15  // minutes
 	configUpgradeWindow         = 120 // minutes
 	configNodeDrainTimeout      = 7   // minutes
-	configExpectedDrainTime     = 8   // minutes
+	configExpectedDrainTime     = 15  // minutes
 	configControlPlaneTime      = 90  // minutes
+	configPdbDrainTimeout       = 15  // minutes
+
 )
 
 // TriggerManagedUpgrade initiates an upgrade using the managed-upgrade-operator
@@ -268,7 +270,7 @@ func scheduleUpgradeWithProvider(version string) error {
 	// Our time will be as closely allowed as possible by the provider (now + 6 min)
 	t := time.Now().UTC().Add(6 * time.Minute)
 
-	err = clusterProvider.Upgrade(clusterID, version, t)
+	err = clusterProvider.Upgrade(clusterID, version, configPdbDrainTimeout, t)
 	if err != nil {
 		return fmt.Errorf("error initiating upgrade from provider: %v", err)
 	}


### PR DESCRIPTION
This PR increases the Pod Disruption Budget timeout for upgrades from 5 minutes to 15, as '15' is now the minimum value enforced by OCM when scheduling an upgrade. The maximum node drain time was increased to 15 accordingly.

This should correct job errors such as [this](https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/osde2e-stage-aws-e2e-upgrade-default-next/1320878116121350144).

Fixes [OSD-5674](https://issues.redhat.com/browse/OSD-5674)
