### PR TITLE
OSD-5692 fix panic during upgrade scheduling

### DIFF
--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -799,8 +799,8 @@ func (o *OCMProvider) Upgrade(clusterID string, version string, pdbTimeoutMinute
 	if err != nil {
 		return err
 	}
-	if addResp.Status() != http.StatusOK {
-		log.Printf("Unable to schedule upgrade with provider (status %d, response %s)", addResp.Status(), addResp.Error().String())
+	if addResp.Status() != http.StatusCreated {
+		log.Printf("Unable to schedule upgrade with provider (status %d, response %v)", addResp.Status(), addResp.Error())
 		return err
 	}
 


### PR DESCRIPTION
This corrects the issue identified in [OSD-5692](https://issues.redhat.com/browse/OSD-5692)

The call to Upgrade() now returns a http.StatusCreated. This, in conjunction with the fact that Error() in the SDK is 'nil', resulted in a panic when Error().String() was called.

The code around restarting the upgrade operator during the upgrade scheduling was also made slightly more robust to combat a niche issue where `object has been modified` was being reported when patching the `deployment`, using retries.
