### PR TITLE
Fixes SDCICD-513 duplicate clusterName upon create

### DIFF
--- a/pkg/common/providers/crc/crc.go
+++ b/pkg/common/providers/crc/crc.go
@@ -84,6 +84,12 @@ func New() (*Provider, error) {
 	return provider, nil
 }
 
+// IsValidClusterName validates the clustername prior to proceeding with it
+// in launching a cluster.
+func (m *Provider) IsValidClusterName(clusterName string) (bool, error) {
+	return true, nil
+}
+
 // LaunchCluster CRCs a launch cluster operation.
 func (m *Provider) LaunchCluster(clusterName string) (string, error) {
 	home, err := os.UserHomeDir()

--- a/pkg/common/providers/moaprovider/cluster.go
+++ b/pkg/common/providers/moaprovider/cluster.go
@@ -27,9 +27,9 @@ func (m *MOAProvider) IsValidClusterName(clusterName string) (bool, error) {
 
 	// Retrieve the list of clusters using pages of ten items, till we get a page that has less
 	// items than requests, as that marks the end of the collection:
-	size := 10
+	size := 50
 	page := 1
-	searchPhrase := fmt.Sprintf("name like '%s'", clusterName)
+	searchPhrase := fmt.Sprintf("name = '%s'", clusterName)
 	for {
 		// Retrieve the page:
 		response, err := collection.List().

--- a/pkg/common/providers/moaprovider/cluster.go
+++ b/pkg/common/providers/moaprovider/cluster.go
@@ -1,6 +1,7 @@
 package moaprovider
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
@@ -15,6 +16,47 @@ import (
 	"github.com/openshift/osde2e/pkg/common/util"
 	"github.com/spf13/viper"
 )
+
+// IsValidClusterName validates the clustername prior to proceeding with it
+// in launching a cluster.
+func (m *MOAProvider) IsValidClusterName(clusterName string) (bool, error) {
+	// Create a context:
+	ctx := context.Background()
+
+	collection := m.ocmProvider.GetConnection().ClustersMgmt().V1().Clusters()
+
+	// Retrieve the list of clusters using pages of ten items, till we get a page that has less
+	// items than requests, as that marks the end of the collection:
+	size := 10
+	page := 1
+	searchPhrase := fmt.Sprintf("name like '%s'", clusterName)
+	for {
+		// Retrieve the page:
+		response, err := collection.List().
+			Search(searchPhrase).
+			Size(size).
+			Page(page).
+			SendContext(ctx)
+		if err != nil {
+			return false, fmt.Errorf("Can't retrieve page %d: %s\n", page, err)
+		}
+
+		if response.Total() != 0 {
+			return false, nil
+		}
+
+		// Break the loop if the size of the page is less than requested, otherwise go to
+		// the next page:
+		if response.Size() < size {
+			break
+		}
+		page++
+	}
+
+	// Name is valid.
+	return true, nil
+
+}
 
 // LaunchCluster will provision an AWS cluster.
 func (m *MOAProvider) LaunchCluster(clusterName string) (string, error) {

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -65,6 +65,19 @@ func New() (*MockProvider, error) {
 	}, nil
 }
 
+// IsValidClusterName mocks a validation of cluster name
+func (m *MockProvider) IsValidClusterName(clusterName string) (bool, error) {
+	if m.env == "fail" {
+		switch clusterName {
+		case "error":
+			return false, fmt.Errorf("Fake IsValidClusterName error")
+		case "false":
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
 // LaunchCluster mocks a launch cluster operation.
 func (m *MockProvider) LaunchCluster(clusterName string) (string, error) {
 	clusterID := uuid.New().String()

--- a/pkg/common/providers/mock/mock_test.go
+++ b/pkg/common/providers/mock/mock_test.go
@@ -17,8 +17,19 @@ func TestClusterInteraction(t *testing.T) {
 		t.Errorf("expected quota or no error, got: %v, %v", hasQuota, err.Error())
 	}
 
-	clusterID1, _ := mockProvider.LaunchCluster("cluster1")
-	clusterID2, _ := mockProvider.LaunchCluster("cluster2")
+	clusterName1 := "cluster1"
+	clusterName2 := "cluster2"
+
+	if isValidClusterName1, err := mockProvider.IsValidClusterName(clusterName1); isValidClusterName1 != true || err != nil {
+		t.Errorf("unexpected validation or error using cluster name: %s", clusterName1)
+	}
+
+	if isValidClusterName2, err := mockProvider.IsValidClusterName(clusterName2); isValidClusterName2 != true || err != nil {
+		t.Errorf("unexpected validation or error using cluster name: %s", clusterName2)
+	}
+
+	clusterID1, _ := mockProvider.LaunchCluster(clusterName1)
+	clusterID2, _ := mockProvider.LaunchCluster(clusterName2)
 
 	cluster1, err := mockProvider.GetCluster(clusterID1)
 
@@ -63,6 +74,13 @@ func TestIntentionalFailures(t *testing.T) {
 	}
 	if err == nil {
 		t.Error("expected error to occur while checking quota")
+	}
+
+	failNames := []string{"error", "false"}
+	for _, name := range failNames {
+		if validClusterName, _ := mockProvider.IsValidClusterName(name); validClusterName != false {
+			t.Errorf("expected an error to occur of validation to fail using cluster name: %s", name)
+		}
 	}
 
 	clusterID1, _ := mockProvider.LaunchCluster("cluster1")

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -29,7 +29,7 @@ func (o *OCMProvider) IsValidClusterName(clusterName string) (bool, error) {
 
 	// Retrieve the list of clusters using pages of ten items, till we get a page that has less
 	// items than requests, as that marks the end of the collection:
-	size := 10
+	size := 50
 	page := 1
 	searchPhrase := fmt.Sprintf("name = '%s'", clusterName)
 	for {

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -19,6 +19,46 @@ import (
 	"github.com/spf13/viper"
 )
 
+// IsValidClusterName validates the clustername prior to proceeding with it
+// in launching a cluster.
+func (o *OCMProvider) IsValidClusterName(clusterName string) (bool, error) {
+	// Create a context:
+	ctx := context.Background()
+
+	collection := o.conn.ClustersMgmt().V1().Clusters()
+
+	// Retrieve the list of clusters using pages of ten items, till we get a page that has less
+	// items than requests, as that marks the end of the collection:
+	size := 10
+	page := 1
+	searchPhrase := fmt.Sprintf("name = '%s'", clusterName)
+	for {
+		// Retrieve the page:
+		response, err := collection.List().
+			Search(searchPhrase).
+			Size(size).
+			Page(page).
+			SendContext(ctx)
+		if err != nil {
+			return false, fmt.Errorf("Can't retrieve page %d: %s\n", page, err)
+		}
+
+		if response.Total() != 0 {
+			return false, nil
+		}
+
+		// Break the loop if the size of the page is less than requested, otherwise go to
+		// the next page:
+		if response.Size() < size {
+			break
+		}
+		page++
+	}
+
+	// Name is valid.
+	return true, nil
+}
+
 // LaunchCluster setups an new cluster using the OSD API and returns it's ID.
 func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 	flavourID := getFlavour()

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -2,12 +2,19 @@
 package spi
 
 import (
-	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"time"
+
+	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 // Provider is the interface that must be implemented in order to provision clusters in osde2e.
 type Provider interface {
+	// IsValidClusterName validates that the proposed name used for creating the cluster.
+	//
+	// Currently this validates if the proposed clusterName already exists before attempting to
+	// create and cycling on OCM errors.
+	IsValidClusterName(clusterName string) (bool, error)
+
 	// LaunchCluster creates a new cluster and returns the cluster ID.
 	//
 	// This is expected to kick off the cluster provisioning process and
@@ -107,5 +114,4 @@ type Provider interface {
 
 	// Upgrade requests the provider initiate a cluster upgrade to the given version
 	Upgrade(clusterID string, version string, pdbTimeoutMinutes int, t time.Time) error
-
 }


### PR DESCRIPTION
Checks if proposed cluster name exists before attempting to launch
cluster.

Will fail after 10 attempts to validate name. Can fail due to a
combination of 10 failure of duplicate names and/or OCM errors upstream
Ideally when this actually fails, it indicates we have much larger
issue that needs addressing.