### PR TITLE
OSD-5252 fix occasional operator upgrade test errors

### DIFF
--- a/pkg/e2e/operators/operators.go
+++ b/pkg/e2e/operators/operators.go
@@ -12,8 +12,12 @@ import (
 	"github.com/openshift/osde2e/pkg/common/runner"
 	"github.com/openshift/osde2e/pkg/common/templates"
 
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kerror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -21,10 +25,6 @@ import (
 
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
-
-	appsv1 "k8s.io/api/apps/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
@@ -157,42 +157,63 @@ func checkSecrets(h *helper.H, namespace string, secrets []string) {
 	})
 }
 
-func getInstallPlan(h *helper.H, sub *operatorv1.Subscription) (*operatorv1.InstallPlan, error) {
-	subNamespace := sub.Namespace
-	subName := sub.Name
-	err := wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
-		s, err := h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Get(context.TODO(), subName, metav1.GetOptions{})
-		if err != nil {
-			return false, nil
-		}
-		if s.Status.InstallPlanRef != nil {
-			sub = s
-			return true, nil
-		}
+func approveInstallPlan(h *helper.H, csv string, sub *operatorv1.Subscription) error {
 
+	// find the install plan associated with the CSV
+	var ip operatorv1.InstallPlan
+	err := wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
+		ips, err := h.Operator().OperatorsV1alpha1().InstallPlans(sub.Namespace).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+		for _, i := range ips.Items {
+			for _, c := range i.Spec.ClusterServiceVersionNames {
+				if c == csv {
+					ip = i
+					return true, nil
+				}
+			}
+		}
 		return false, nil
 	})
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("no install plan found for csv %s", csv)
 	}
 
-	return h.Operator().OperatorsV1alpha1().InstallPlans(subNamespace).Get(context.TODO(), sub.Status.InstallPlanRef.Name, metav1.GetOptions{})
-}
-
-func approveInstallPlan(h *helper.H, ip *operatorv1.InstallPlan) error {
-	ip.Spec.Approved = true
-	_, err := h.Operator().OperatorsV1alpha1().InstallPlans(ip.Namespace).Update(context.TODO(), ip, metav1.UpdateOptions{})
-	if err != nil {
-		return err
+	log.Printf("Found install plan %s for csv %s", ip.Name, csv)
+	if ip.Spec.Approved == true {
+		log.Printf("Install plan %s already approved", ip.Name)
+		return nil
 	}
 
-	return nil
+	err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		ipToUpdate, err := h.Operator().OperatorsV1alpha1().InstallPlans(sub.Namespace).Get(context.TODO(), ip.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		// Flag the install plan as approved
+		ipToUpdate.Spec.Approved = true
+		_, err = h.Operator().OperatorsV1alpha1().InstallPlans(ipToUpdate.Namespace).Update(context.TODO(), ipToUpdate, metav1.UpdateOptions{})
+		if err != nil {
+			log.Printf("Could not approve install plan %s", ipToUpdate.Name)
+			return err
+		}
+		log.Printf("Approved install plan %s", ipToUpdate.Name)
+		return nil
+	})
+	return err
 }
 
-func ensureCSVIsInstalled(h *helper.H, csvName string, namespace string) error {
+func ensureCSVIsInstalled(h *helper.H, csvName string, sub *operatorv1.Subscription) error {
 	err := wait.PollImmediate(5*time.Second, 15*time.Minute, func() (bool, error) {
-		csv, err := h.Operator().OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(context.TODO(), csvName, metav1.GetOptions{})
+		// Ensure the install plan for the CSV is approved
+		err := approveInstallPlan(h, csvName, sub)
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed approving InstallPlan for CSV %s", csvName))
+		log.Printf("Approved install plan for sub %s, now checking CSV %s is installed", sub.Name, csvName)
+
+		csv, err := h.Operator().OperatorsV1alpha1().ClusterServiceVersions(sub.Namespace).Get(context.TODO(), csvName, metav1.GetOptions{})
 		if err != nil && !kerror.IsNotFound(err) {
+			log.Printf("Returning err %v", err)
 			return false, err
 		}
 
@@ -213,25 +234,31 @@ func checkUpgrade(h *helper.H, subNamespace string, subName string, packageName 
 	ginkgo.Context("Operator Upgrade", func() {
 		ginkgo.It("should upgrade from the replaced version", func() {
 
-			// Get the N-1 version of the CSV to test an upgrade from
-			previousCSV, err := getReplacesCSV(h, subNamespace, packageName, regServiceName)
-			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed trying to get previous CSV for Subscription %s in %s namespace", subName, subNamespace))
-
-			log.Printf("Reverting to package %v to test upgrade of %v", previousCSV, subName)
+			// Get the CSV we're currently installed with
 			sub, err := h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Get(context.TODO(), subName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed trying to get Subscription %s in %s namespace", subName, subNamespace))
 			startingCSV := sub.Status.CurrentCSV
 
+			// Get the N-1 version of the CSV to test an upgrade from
+			previousCSV, err := getReplacesCSV(h, subNamespace, packageName, regServiceName)
+			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed trying to get previous CSV for Subscription %s in %s namespace", subName, subNamespace))
+
+			log.Printf("Reverting to package %v from %v to test upgrade of %v", previousCSV, startingCSV, subName)
+
 			// Delete current Operator installation
 			err = h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Delete(context.TODO(), subName, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed trying to delete Subscription %s", subName))
+			log.Printf("Removed subscription %s", subName)
+
 			err = h.Operator().OperatorsV1alpha1().ClusterServiceVersions(subNamespace).Delete(context.TODO(), startingCSV, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed trying to delete ClusterServiceVersion %s", startingCSV))
+			log.Printf("Removed csv %s", startingCSV)
 
 			Eventually(func() bool {
 				_, err := h.Operator().OperatorsV1alpha1().InstallPlans(subNamespace).Get(context.TODO(), sub.Status.Install.Name, metav1.GetOptions{})
 				return apierrors.IsNotFound(err)
 			}, 5*time.Minute, 10*time.Second).Should(BeTrue(), "installplan never garbage collected")
+			log.Printf("Verified installplan removal")
 
 			// Create subscription to the previous version
 			sub, err = h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Create(context.TODO(), &operatorv1.Subscription{
@@ -250,30 +277,35 @@ func checkUpgrade(h *helper.H, subNamespace string, subName string, packageName 
 			}, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed trying to create Subscription %s", subName))
 
+			log.Printf("Created replacement subscription %s", subName)
+
 			// Approve and manually verify the first installation to previousCSV
-			ip, err := getInstallPlan(h, sub)
-			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed getting InstallPlan for CSV %s", previousCSV))
-			err = approveInstallPlan(h, ip)
-			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed approving InstallPlan for CSV %s", previousCSV))
-			err = ensureCSVIsInstalled(h, previousCSV, subNamespace)
+			err = ensureCSVIsInstalled(h, previousCSV, sub)
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("CSV %s did not install successfully", previousCSV))
 
+			log.Printf("Verified installation of previous CSV %s", previousCSV)
+
 			// Update the Subscription to apply Automatic updates from now on in order to reach currentCSV
-			sub, err = h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Get(context.TODO(), subName, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed retrieving updated subscription for %s", subName))
-			sub.Spec.InstallPlanApproval = operatorv1.ApprovalAutomatic
-			sub, err = h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Update(context.TODO(), sub, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed updating subscription to Automatic for CSV %s", previousCSV))
+			err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				sub, err = h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Get(context.TODO(), subName, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+				sub.Spec.InstallPlanApproval = operatorv1.ApprovalAutomatic
+				sub, err = h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Update(context.TODO(), sub, metav1.UpdateOptions{})
+				if err != nil {
+					return err
+				}
+				return nil
+			})
+			Expect(err).To(BeNil(), fmt.Sprintf("unable to set Subscription to Automatic"))
+
+			log.Printf("Set subscription %s to Automatic approval", subName)
 
 			// The previous CSV is now installed and a new InstallPlan is also created ready for approval to upgrade to startingCSV
 			// Approve and verify install to startingCSV
-			ip, err = getInstallPlan(h, sub)
-			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed getting InstallPlan for CSV %s", startingCSV))
-			err = approveInstallPlan(h, ip)
-			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed approving InstallPlan for CSV %s", startingCSV))
-			err = ensureCSVIsInstalled(h, startingCSV, subNamespace)
+			err = ensureCSVIsInstalled(h, startingCSV, sub)
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("CSV %s did not install successfully", startingCSV))
-
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 	})
 }

--- a/vendor/k8s.io/client-go/util/retry/OWNERS
+++ b/vendor/k8s.io/client-go/util/retry/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- caesarxuchao

--- a/vendor/k8s.io/client-go/util/retry/util.go
+++ b/vendor/k8s.io/client-go/util/retry/util.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// DefaultRetry is the recommended retry for a conflict where multiple clients
+// are making changes to the same resource.
+var DefaultRetry = wait.Backoff{
+	Steps:    5,
+	Duration: 10 * time.Millisecond,
+	Factor:   1.0,
+	Jitter:   0.1,
+}
+
+// DefaultBackoff is the recommended backoff for a conflict where a client
+// may be attempting to make an unrelated modification to a resource under
+// active management by one or more controllers.
+var DefaultBackoff = wait.Backoff{
+	Steps:    4,
+	Duration: 10 * time.Millisecond,
+	Factor:   5.0,
+	Jitter:   0.1,
+}
+
+// OnError allows the caller to retry fn in case the error returned by fn is retriable
+// according to the provided function. backoff defines the maximum retries and the wait
+// interval between two retries.
+func OnError(backoff wait.Backoff, retriable func(error) bool, fn func() error) error {
+	var lastErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := fn()
+		switch {
+		case err == nil:
+			return true, nil
+		case retriable(err):
+			lastErr = err
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if err == wait.ErrWaitTimeout {
+		err = lastErr
+	}
+	return err
+}
+
+// RetryOnConflict is used to make an update to a resource when you have to worry about
+// conflicts caused by other code making unrelated updates to the resource at the same
+// time. fn should fetch the resource to be modified, make appropriate changes to it, try
+// to update it, and return (unmodified) the error from the update function. On a
+// successful update, RetryOnConflict will return nil. If the update function returns a
+// "Conflict" error, RetryOnConflict will wait some amount of time as described by
+// backoff, and then try again. On a non-"Conflict" error, or if it retries too many times
+// and gives up, RetryOnConflict will return an error to the caller.
+//
+//     err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+//         // Fetch the resource here; you need to refetch it on every try, since
+//         // if you got a conflict on the last update attempt then you need to get
+//         // the current version before making your own changes.
+//         pod, err := c.Pods("mynamespace").Get(name, metav1.GetOptions{})
+//         if err ! nil {
+//             return err
+//         }
+//
+//         // Make whatever updates to the resource are needed
+//         pod.Status.Phase = v1.PodFailed
+//
+//         // Try to update
+//         _, err = c.Pods("mynamespace").UpdateStatus(pod)
+//         // You have to return err itself here (not wrapped inside another error)
+//         // so that RetryOnConflict can identify it correctly.
+//         return err
+//     })
+//     if err != nil {
+//         // May be conflict if max retries were hit, or may be something unrelated
+//         // like permissions or a network error
+//         return err
+//     }
+//     ...
+//
+// TODO: Make Backoff an interface?
+func RetryOnConflict(backoff wait.Backoff, fn func() error) error {
+	return OnError(backoff, errors.IsConflict, fn)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -765,6 +765,7 @@ k8s.io/client-go/util/connrotation
 k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/util/homedir
 k8s.io/client-go/util/keyutil
+k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
 # k8s.io/klog v1.0.0
 k8s.io/klog


### PR DESCRIPTION
This PR attempts to fix several issues around sporadic failures of the operator "should upgrade from previous version" test. This affected the `configure-alertmanager-operator`, `splunk-forwarder-operator` and `rbac-permissions-operator`.

Some issues were identified:

- Updating the `subscription` could occasionally return `object has been modified`, so it's now surrounded in a `RetryOnConflict` block.
- Instead of incrementally approving `InstallPlan`s, the test was occasionally approving multiple (a race condition dependent on a delay when approving the first), which caused it to then get stuck in a holding pattern looking for a `ClusterServiceVersion` that didn't exist.

Refs [OSD-5252](https://issues.redhat.com/browse/OSD-5252)