### PR TITLE
Add cloud-ingress-operator tests to operators suite

### DIFF
--- a/pkg/e2e/operators/cloudingress/apischeme_cr.go
+++ b/pkg/e2e/operators/cloudingress/apischeme_cr.go
@@ -15,12 +15,9 @@ import (
 )
 
 var _ = ginkgo.Describe(CloudIngressTestName, func() {
-	var operatorNamespace = "openshift-cloud-ingress-operator"
-
 	h := helper.New()
-	testDaCRapischemes(h, operatorNamespace)
-	testCRapischemes(h, operatorNamespace)
-
+	testDaCRapischemes(h, CloudIngressNamespace)
+	testCRapischemes(h, CloudIngressNamespace)
 })
 
 func createApischeme() cloudingress.APIScheme {

--- a/pkg/e2e/operators/cloudingress/cloudingress.go
+++ b/pkg/e2e/operators/cloudingress/cloudingress.go
@@ -5,12 +5,14 @@ import (
 )
 
 const (
-	CloudIngressNamespace = "openshift-cloud-ingress-operator"
-	CloudIngressTestName  = "[Suite: informing] CloudIngressOperator"
-	OperatorName          = "cloud-ingress-operator"
+	CloudIngressNamespace         = "openshift-cloud-ingress-operator"
+	CloudIngressTestName          = "[Suite: operators] [OSD] Cloud Ingress Operator"
+	CloudIngressInformingTestName = "[Suite: informing] [OSD] Cloud Ingress Operator"
+	OperatorName                  = "cloud-ingress-operator"
 )
 
 // utils
 func init() {
 	alert.RegisterGinkgoAlert(CloudIngressTestName, "SD-SRE", "Alex Chvatal", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
+	alert.RegisterGinkgoAlert(CloudIngressInformingTestName, "SD-SRE", "Alex Chvatal", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }

--- a/pkg/e2e/operators/cloudingress/public_private.go
+++ b/pkg/e2e/operators/cloudingress/public_private.go
@@ -12,7 +12,7 @@ import (
 )
 
 // tests
-var _ = ginkgo.Describe(CloudIngressTestName, func() {
+var _ = ginkgo.Describe(CloudIngressInformingTestName, func() {
 	h := helper.New()
 
 	ginkgo.It("is a placeholder", func() {

--- a/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
+++ b/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
@@ -15,11 +15,9 @@ import (
 )
 
 var _ = ginkgo.Describe(CloudIngressTestName, func() {
-	var operatorNamespace = "openshift-cloud-ingress-operator"
-
 	h := helper.New()
-	testDaCRpublishingstrategies(h, operatorNamespace)
-	testCRpublishingstrategies(h, operatorNamespace)
+	testDaCRpublishingstrategies(h, CloudIngressNamespace)
+	testCRpublishingstrategies(h, CloudIngressNamespace)
 
 })
 

--- a/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
@@ -12,7 +12,7 @@ import (
 )
 
 // tests
-var _ = ginkgo.Describe(CloudIngressTestName, func() {
+var _ = ginkgo.Describe(CloudIngressInformingTestName, func() {
 	h := helper.New()
 
 	ginkgo.It("is a placeholder", func() {


### PR DESCRIPTION
Enable all CIO tests that aren't placeholders.

They worked all on last run: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/osde2e-prod-aws-informing-default/1323626158381600768