### PR TITLE
Revert "Add cloud-ingress-operator tests to operators suite"

### DIFF
--- a/pkg/e2e/operators/cloudingress/apischeme_cr.go
+++ b/pkg/e2e/operators/cloudingress/apischeme_cr.go
@@ -15,9 +15,12 @@ import (
 )
 
 var _ = ginkgo.Describe(CloudIngressTestName, func() {
+	var operatorNamespace = "openshift-cloud-ingress-operator"
+
 	h := helper.New()
-	testDaCRapischemes(h, CloudIngressNamespace)
-	testCRapischemes(h, CloudIngressNamespace)
+	testDaCRapischemes(h, operatorNamespace)
+	testCRapischemes(h, operatorNamespace)
+
 })
 
 func createApischeme() cloudingress.APIScheme {

--- a/pkg/e2e/operators/cloudingress/cloudingress.go
+++ b/pkg/e2e/operators/cloudingress/cloudingress.go
@@ -5,14 +5,12 @@ import (
 )
 
 const (
-	CloudIngressNamespace         = "openshift-cloud-ingress-operator"
-	CloudIngressTestName          = "[Suite: operators] [OSD] Cloud Ingress Operator"
-	CloudIngressInformingTestName = "[Suite: informing] [OSD] Cloud Ingress Operator"
-	OperatorName                  = "cloud-ingress-operator"
+	CloudIngressNamespace = "openshift-cloud-ingress-operator"
+	CloudIngressTestName  = "[Suite: informing] CloudIngressOperator"
+	OperatorName          = "cloud-ingress-operator"
 )
 
 // utils
 func init() {
 	alert.RegisterGinkgoAlert(CloudIngressTestName, "SD-SRE", "Alex Chvatal", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
-	alert.RegisterGinkgoAlert(CloudIngressInformingTestName, "SD-SRE", "Alex Chvatal", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }

--- a/pkg/e2e/operators/cloudingress/public_private.go
+++ b/pkg/e2e/operators/cloudingress/public_private.go
@@ -12,7 +12,7 @@ import (
 )
 
 // tests
-var _ = ginkgo.Describe(CloudIngressInformingTestName, func() {
+var _ = ginkgo.Describe(CloudIngressTestName, func() {
 	h := helper.New()
 
 	ginkgo.It("is a placeholder", func() {

--- a/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
+++ b/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
@@ -15,9 +15,11 @@ import (
 )
 
 var _ = ginkgo.Describe(CloudIngressTestName, func() {
+	var operatorNamespace = "openshift-cloud-ingress-operator"
+
 	h := helper.New()
-	testDaCRpublishingstrategies(h, CloudIngressNamespace)
-	testCRpublishingstrategies(h, CloudIngressNamespace)
+	testDaCRpublishingstrategies(h, operatorNamespace)
+	testCRpublishingstrategies(h, operatorNamespace)
 
 })
 

--- a/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
@@ -12,7 +12,7 @@ import (
 )
 
 // tests
-var _ = ginkgo.Describe(CloudIngressInformingTestName, func() {
+var _ = ginkgo.Describe(CloudIngressTestName, func() {
 	h := helper.New()
 
 	ginkgo.It("is a placeholder", func() {


### PR DESCRIPTION
Reverts openshift/osde2e#619
These tests fail on GCP clusters, @cblecker I think we need to either make the tests aware of the platform they are running on or disable them until the operator is ready to run on GCP.
Currently the operator is deployed to AWS clusters only: https://github.com/openshift/cloud-ingress-operator/blob/master/hack/templates/selectorsyncset.yaml#L13