### PR TITLE
OSD-5445

### DIFF
--- a/pkg/e2e/verify/regularuser_webhook.go
+++ b/pkg/e2e/verify/regularuser_webhook.go
@@ -5,13 +5,12 @@ import (
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/spf13/viper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 )
 
@@ -25,19 +24,24 @@ var _ = ginkgo.Describe(regularuserWebhookTestName, func() {
 	h := helper.New()
 
 	ginkgo.Context("regularuser validating webhook", func() {
-		ginkgo.It("unpriv users cannot create autoscalers", func() {
+		ginkgo.It("Privledged users allowed to create autoscalers and delete clusterversion objects", func() {
 			h.Impersonate(rest.ImpersonationConfig{
-				UserName: "test@customdomain",
+				UserName: "system:admin",
 				Groups: []string{
 					"system:authenticated",
 					"system:authenticated:oauth",
 				},
 			})
-			_, err := h.Dynamic().Resource(schema.GroupVersionResource{
-				Group:    "autoscaling.openshift.io",
-				Version:  "v1",
-				Resource: "ClusterAutoscaler"}).Create(context.TODO(), &unstructured.Unstructured{}, metav1.CreateOptions{})
-			Expect(err).To(HaveOccurred())
+			defer func() {
+				err := h.Cfg().ConfigV1().ClusterVersions().Delete(context.TODO(), "osde2e-version", metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}()
+			_, err := h.Cfg().ConfigV1().ClusterVersions().Create(context.TODO(), &v1.ClusterVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "osde2e-version",
+				},
+			}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 	})
 })


### PR DESCRIPTION
Removed a test for clusterautoscalers, new test added for verifying the webhooks will allow admins to manage clusterversion objects.