### PR TITLE
OSD-5799 Promote SCC Dedicated Admin check from informing

### DIFF
--- a/pkg/e2e/verify/sccs.go
+++ b/pkg/e2e/verify/sccs.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var dedicatedAdminSccTestName = "[Suite: informing] [OSD] RBAC Dedicated Admins SCC permissions"
+var dedicatedAdminSccTestName = "[Suite: e2e] [OSD] RBAC Dedicated Admins SCC permissions"
 
 func init() {
 	alert.RegisterGinkgoAlert(dedicatedAdminSccTestName, "SD-CICD", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)


### PR DESCRIPTION
This promotes the work of [OSD-5213](https://issues.redhat.com/browse/OSD-5213) to the main e2e suite, as there has been a clear run during it's time in `informing` with no failures.
