### PR TITLE
SDCICD-387: Add script/test to test ocm adoption of an OCP cluster

### DIFF
--- a/ci/prow-ocm-adoption.sh
+++ b/ci/prow-ocm-adoption.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+go get -u github.com/openshift-online/ocm-cli/cmd/ocm
+
+if [ -z "$OCM_TOKEN" ]; then
+    echo "Assuming the token should be read from Prow";
+    export OCM_TOKEN=$(cat /usr/local/osde2e-credentials/ocm-refresh-token)
+fi
+
+if [ -z "$OCM_URL" ]; then
+    ocm login --token=$OCM_TOKEN
+else 
+    ocm login --url=$OCM_URL --token=$OCM_TOKEN
+    cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    telemeterClient:
+      telemeterServerURL: https://infogw.api.stage.openshift.com
+EOF
+    sleep 300;
+fi
+
+COUNT=$(CLUSTER_ID=$(oc get clusterversion -o jsonpath='{.items[].spec.clusterID}{"\n"}'); ocm get clusters --parameter search="external_id is '$CLUSTER_ID'" | jq '.size')
+
+if [[ "$COUNT" == "0" ]]; then
+    echo "No cluster found!";
+    exit 1
+else
+    echo "Cluster found!";
+    exit 0
+fi


### PR DESCRIPTION
This is a script to validate that a vanilla OCP cluster shows up in OCM.

We test this by using a CI-created cluster and looking up its external cluster ID in OCM. To validate the workflow in Stage, we need to patch the cluster's Telemetry endpoint then wait until the telemetry operator cycles and registers the cluster. 

There will be a subsequent PR in openshift/release with the Prow Job that uses this