### PR TITLE
OSD-5867 remove PDB configuration for upgrades

### DIFF
--- a/pkg/common/providers/crc/crc.go
+++ b/pkg/common/providers/crc/crc.go
@@ -305,7 +305,7 @@ func (m *Provider) AddProperty(cluster *spi.Cluster, tag string, value string) e
 }
 
 // Upgrade CRCs initiates a cluster upgrade to the given version
-func (m *Provider) Upgrade(clusterID string, version string, pdbTimeoutMinutes int, t time.Time) error {
+func (m *Provider) Upgrade(clusterID string, version string, t time.Time) error {
 	// Noop for now and just note it.
 	log.Printf("Upgrade is unsupported by CRC clusters")
 	return nil

--- a/pkg/common/providers/moaprovider/wrapped_calls.go
+++ b/pkg/common/providers/moaprovider/wrapped_calls.go
@@ -79,6 +79,6 @@ func (m *MOAProvider) AddProperty(cluster *spi.Cluster, tag string, value string
 }
 
 // Upgrade initiates a cluster upgrade from the OCM provider.
-func (m *MOAProvider) Upgrade(clusterID string, version string, pdbTimeoutMinutes int, t time.Time) error {
-	return m.ocmProvider.Upgrade(clusterID, version, pdbTimeoutMinutes, t)
+func (m *MOAProvider) Upgrade(clusterID string, version string, t time.Time) error {
+	return m.ocmProvider.Upgrade(clusterID, version, t)
 }

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -258,6 +258,6 @@ func (m *MockProvider) AddProperty(cluster *spi.Cluster, tag string, value strin
 }
 
 // Upgrade mocks initiates a cluster upgrade to the given version
-func (m *MockProvider) Upgrade(clusterID string, version string, pdbTimeoutMinutes int, t time.Time) error {
+func (m *MockProvider) Upgrade(clusterID string, version string, t time.Time) error {
 	return fmt.Errorf("Upgrade is unsupported by mock clusters")
 }

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -831,10 +831,9 @@ func (o *OCMProvider) AddProperty(cluster *spi.Cluster, tag string, value string
 }
 
 // Upgrade initiates a cluster upgrade to the given version
-func (o *OCMProvider) Upgrade(clusterID string, version string, pdbTimeoutMinutes int, t time.Time) error {
+func (o *OCMProvider) Upgrade(clusterID string, version string, t time.Time) error {
 
-	nodeDrain := v1.NewValue().Value(float64(pdbTimeoutMinutes)).Unit("minutes")
-	policy, err := v1.NewUpgradePolicy().Version(version).NextRun(t).ScheduleType("manual").NodeDrainGracePeriod(nodeDrain).Build()
+	policy, err := v1.NewUpgradePolicy().Version(version).NextRun(t).ScheduleType("manual").Build()
 	if err != nil {
 		return err
 	}

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -113,5 +113,5 @@ type Provider interface {
 	AddProperty(cluster *Cluster, tag string, value string) error
 
 	// Upgrade requests the provider initiate a cluster upgrade to the given version
-	Upgrade(clusterID string, version string, pdbTimeoutMinutes int, t time.Time) error
+	Upgrade(clusterID string, version string, t time.Time) error
 }

--- a/pkg/common/upgrade/managed.go
+++ b/pkg/common/upgrade/managed.go
@@ -51,7 +51,6 @@ const (
 	configNodeDrainTimeout        = 6   // minutes
 	configExpectedDrainTime       = 7   // minutes
 	configControlPlaneTime        = 90  // minutes
-	configPdbPolicyDrainTimeout   = 15  // minutes
 	configPdbDrainTimeoutOverride = 5   // minutes
 
 )
@@ -308,7 +307,7 @@ func scheduleUpgradeWithProvider(version string) error {
 	// Our time will be as closely allowed as possible by the provider (now + 6 min)
 	t := time.Now().UTC().Add(6 * time.Minute)
 
-	err = clusterProvider.Upgrade(clusterID, version, configPdbPolicyDrainTimeout, t)
+	err = clusterProvider.Upgrade(clusterID, version, t)
 	if err != nil {
 		return fmt.Errorf("error initiating upgrade from provider: %v", err)
 	}


### PR DESCRIPTION
This PR removes the setting of a `pod disruption budget` policy when creating an upgrade policy, as that setting is soon to be managed at the cluster level rather than at an upgrade policy level.

This PR has been successfully tested in staging with an E2E upgrade run.

Refs [OSD-5867](https://issues.redhat.com/browse/OSD-5867)
