### PR TITLE
Added function to clean up apischeme-cr-test

### DIFF
--- a/pkg/e2e/operators/cloudingress/apischeme_cr.go
+++ b/pkg/e2e/operators/cloudingress/apischeme_cr.go
@@ -74,6 +74,9 @@ func testCRapischemes(h *helper.H) {
 			err := addApischeme(h, as)
 			Expect(err).NotTo(HaveOccurred())
 
+			err = apiSchemeCleanup(h, as.Name)
+			Expect(err).NotTo(HaveOccurred())
+
 		})
 	})
 }
@@ -87,4 +90,10 @@ func testCRapiSchemesPresent(h *helper.H) {
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
+}
+
+func apiSchemeCleanup(h *helper.H, apiSchemeName string) error {
+	return h.Dynamic().Resource(schema.GroupVersionResource{
+		Group: "cloudingress.managed.openshift.io", Version: "v1alpha1", Resource: "apischemes",
+	}).Namespace(OperatorNamespace).Delete(context.TODO(), apiSchemeName, metav1.DeleteOptions{})
 }

--- a/pkg/e2e/operators/cloudingress/apischeme_cr.go
+++ b/pkg/e2e/operators/cloudingress/apischeme_cr.go
@@ -71,10 +71,8 @@ func testCRapischemes(h *helper.H) {
 	ginkgo.Context("apischeme-cr-test", func() {
 		ginkgo.It("admin should be allowed to manage apischemes CR", func() {
 			as := createApischeme()
+			defer apiSchemeCleanup(h, as.Name)
 			err := addApischeme(h, as)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = apiSchemeCleanup(h, as.Name)
 			Expect(err).NotTo(HaveOccurred())
 
 		})


### PR DESCRIPTION
Added a clean up functionality to the test. 
after the test for creation of the apischeme is ran the resource will be deleted allowing for extra executions
without failures or having to manually delete the apischeme from the cluster.

https://issues.redhat.com/browse/OSD-5881