### PR TITLE
Cleanup of cloud-ingress-operator e2e tests

### DIFF
--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -1,0 +1,7 @@
+// Package provides constants that are consumable when designing test suites
+package constants
+
+const (
+	SuiteInforming = "[Suite: informing] "
+	SuiteOperators = "[Suite: operators] "
+)

--- a/pkg/e2e/operators/cloudingress/apischeme_cr.go
+++ b/pkg/e2e/operators/cloudingress/apischeme_cr.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 	h := helper.New()
 	testCRapiSchemesPresent(h)
 	testDaCRapischemes(h)

--- a/pkg/e2e/operators/cloudingress/cloudingress.go
+++ b/pkg/e2e/operators/cloudingress/cloudingress.go
@@ -2,16 +2,18 @@ package cloudingress
 
 import (
 	"github.com/openshift/osde2e/pkg/common/alert"
+	"github.com/openshift/osde2e/pkg/common/constants"
 )
 
 const (
-	CloudIngressNamespace = "openshift-cloud-ingress-operator"
-	CloudIngressTestName  = "[Suite: informing] CloudIngressOperator"
+	TestPrefix            = "CloudIngressOperator"
 	OperatorName          = "cloud-ingress-operator"
+	OperatorNamespace     = "openshift-cloud-ingress-operator"
 	apiSchemeResourceName = "rh-api"
 )
 
 // utils
 func init() {
-	alert.RegisterGinkgoAlert(CloudIngressTestName, "SD-SRE", "Alex Chvatal", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
+	alert.RegisterGinkgoAlert(constants.SuiteInforming+TestPrefix, "SD-SRE", "Alex Chvatal", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
+	alert.RegisterGinkgoAlert(constants.SuiteOperators+TestPrefix, "SD-SRE", "Alex Chvatal", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }

--- a/pkg/e2e/operators/cloudingress/installed.go
+++ b/pkg/e2e/operators/cloudingress/installed.go
@@ -20,7 +20,7 @@ import (
 
 // tests
 
-var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 
 	var defaultDesiredReplicas int32 = 1
 

--- a/pkg/e2e/operators/cloudingress/installed.go
+++ b/pkg/e2e/operators/cloudingress/installed.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/spf13/viper"
 
@@ -19,7 +20,7 @@ import (
 
 // tests
 
-var _ = ginkgo.Describe(CloudIngressTestName, func() {
+var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 
 	var defaultDesiredReplicas int32 = 1
 
@@ -28,13 +29,13 @@ var _ = ginkgo.Describe(CloudIngressTestName, func() {
 	// Check that the operator deployment exists in the operator namespace
 	ginkgo.Context("deployment", func() {
 		ginkgo.It("should exist", func() {
-			deployment, err := pollDeployment(h, CloudIngressNamespace, OperatorName)
+			deployment, err := pollDeployment(h, OperatorNamespace, OperatorName)
 			Expect(err).ToNot(HaveOccurred(), "failed fetching deployment")
 			Expect(deployment).NotTo(BeNil(), "deployment is nil")
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 
 		ginkgo.It("should have all desired replicas ready", func() {
-			deployment, err := pollDeployment(h, CloudIngressNamespace, OperatorName)
+			deployment, err := pollDeployment(h, OperatorNamespace, OperatorName)
 			Expect(err).ToNot(HaveOccurred(), "failed fetching deployment")
 
 			readyReplicas := deployment.Status.ReadyReplicas

--- a/pkg/e2e/operators/cloudingress/public_private.go
+++ b/pkg/e2e/operators/cloudingress/public_private.go
@@ -6,25 +6,28 @@ import (
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // tests
-var _ = ginkgo.Describe(CloudIngressTestName, func() {
+var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 	h := helper.New()
 
-	ginkgo.It("is a placeholder", func() {
-		_, _ = h.Kube().CoreV1().Pods(CloudIngressNamespace).Get(context.TODO(), "something", metav1.GetOptions{})
+	ginkgo.Context("publishingstrategy-public-private", func() {
+		ginkgo.It("is a placeholder", func() {
+			_, _ = h.Kube().CoreV1().Pods(TestPrefix).Get(context.TODO(), "something", metav1.GetOptions{})
 
-		tests := []struct {
-			Name string
-		}{}
+			tests := []struct {
+				Name string
+			}{}
 
-		for _, test := range tests {
-			Expect(test.Name).To(Equal(""))
-		}
+			for _, test := range tests {
+				Expect(test.Name).To(Equal(""))
+			}
+		})
 	})
 })
 

--- a/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
+++ b/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 	h := helper.New()
 	testDaCRpublishingstrategies(h)
 	testCRpublishingstrategies(h)

--- a/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
@@ -14,6 +14,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/spf13/viper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -25,8 +26,7 @@ import (
 
 // tests
 
-var _ = ginkgo.Describe(CloudIngressTestName, func() {
-
+var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 	h := helper.New()
 
 	testHostnameResolves(h)
@@ -80,7 +80,7 @@ func testCIDRBlockUpdates(h *helper.H) {
 			//Get the APIScheme
 			APISchemeRawData, err := h.Dynamic().Resource(schema.GroupVersionResource{
 				Group: "cloudingress.managed.openshift.io", Version: "v1alpha1", Resource: "apischemes",
-			}).Namespace(CloudIngressNamespace).Get(context.TODO(), apiSchemeResourceName, metav1.GetOptions{})
+			}).Namespace(OperatorNamespace).Get(context.TODO(), apiSchemeResourceName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			//structure the APIScheme unstructured data into a APIScheme object
@@ -104,7 +104,7 @@ func testCIDRBlockUpdates(h *helper.H) {
 			// //Update the APIScheme
 			APISchemeRawData, err = h.Dynamic().Resource(schema.GroupVersionResource{
 				Group: "cloudingress.managed.openshift.io", Version: "v1alpha1", Resource: "apischemes",
-			}).Namespace(CloudIngressNamespace).Update(context.TODO(), APISchemeRawData, metav1.UpdateOptions{})
+			}).Namespace(OperatorNamespace).Update(context.TODO(), APISchemeRawData, metav1.UpdateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			//Create a service Object

--- a/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
@@ -26,7 +26,7 @@ import (
 
 // tests
 
-var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 	h := helper.New()
 
 	testHostnameResolves(h)


### PR DESCRIPTION
Some test cleanup to add a bit more consistency:
- Create a common/constants package with the suite prefixes in them. Allows us to use these across tests.
- Clean up variables inside the CIO e2e tests to have them be a bit more consistent
- Enable tests we expect to pass