### PR TITLE
Add optional pod prefix to pod health check

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -272,7 +272,7 @@ func PollClusterHealth(clusterID string, logger *log.Logger) (status bool, failu
 			clusterHealthy = false
 		}
 
-		if check, err := healthchecks.CheckPodHealth(kubeClient.CoreV1(), logger); !check || err != nil {
+		if check, err := healthchecks.CheckClusterPodHealth(kubeClient.CoreV1(), logger); !check || err != nil {
 			healthErr = multierror.Append(healthErr, err)
 			failures = append(failures, "pod")
 			clusterHealthy = false

--- a/pkg/common/cluster/healthchecks/pod_predicates.go
+++ b/pkg/common/cluster/healthchecks/pod_predicates.go
@@ -1,0 +1,38 @@
+package healthchecks
+
+import kubev1 "k8s.io/api/core/v1"
+
+type PodPredicate func(kubev1.Pod) bool
+
+func IsClusterPod(pod kubev1.Pod) bool {
+	return containsPrefixes(pod.Namespace, "openshift-", "kube-", "redhat-")
+}
+
+func MatchesNames(name ...string) PodPredicate {
+	return func(p kubev1.Pod) bool {
+		return matchingNamePrefix(p, name...)
+	}
+}
+
+func MatchesNamespace(ns string) PodPredicate {
+	return func(p kubev1.Pod) bool {
+		return matchingNS(p, ns)
+	}
+}
+
+func IsNotRunning(pod kubev1.Pod) bool {
+	return pod.Status.Phase != kubev1.PodRunning
+}
+
+func IsNotCompleted(pod kubev1.Pod) bool {
+	return pod.Status.Phase != kubev1.PodSucceeded
+}
+
+func matchingNamePrefix(pod kubev1.Pod, name ...string) bool {
+	return containsPrefixes(pod.Name, name...)
+}
+
+func matchingNS(pod kubev1.Pod, ns string) bool {
+	return pod.Namespace == ns
+}
+

--- a/pkg/common/cluster/healthchecks/pods.go
+++ b/pkg/common/cluster/healthchecks/pods.go
@@ -14,7 +14,7 @@ import (
 )
 
 // CheckPodHealth attempts to look at the state of all pods and returns true if things are healthy.
-func CheckPodHealth(podClient v1.CoreV1Interface, logger *log.Logger) (bool, error) {
+func CheckPodHealth(podClient v1.CoreV1Interface, logger *log.Logger, podPrefixes ...string) (bool, error) {
 	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 
 	var notReady []kubev1.Pod
@@ -39,6 +39,11 @@ func CheckPodHealth(podClient v1.CoreV1Interface, logger *log.Logger) (bool, err
 		if !containsPrefixes(pod.Namespace, "openshift-", "redhat-", "osde2e-") {
 			continue
 		}
+		// if pod prefixes are supplied, look for them specifically
+		if len(podPrefixes) > 0 && !containsPrefixes(pod.Name, podPrefixes...) {
+			continue
+		}
+
 		total++
 		phase := pod.Status.Phase
 

--- a/pkg/common/cluster/healthchecks/pods.go
+++ b/pkg/common/cluster/healthchecks/pods.go
@@ -7,17 +7,44 @@ import (
 	"strings"
 
 	"github.com/openshift/osde2e/pkg/common/logging"
-	"github.com/openshift/osde2e/pkg/common/metadata"
 	kubev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
-// CheckPodHealth attempts to look at the state of all pods and returns true if things are healthy.
-func CheckPodHealth(podClient v1.CoreV1Interface, logger *log.Logger, podPrefixes ...string) (bool, error) {
-	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
+// CheckClusterPodHealth attempts to look at the state of all internal cluster pods and
+// returns true if things are healthy.
+func CheckClusterPodHealth(podClient v1.CoreV1Interface, logger *log.Logger) (bool, error) {
+	filters := []PodPredicate{
+		IsClusterPod,
+		IsNotRunning,
+		IsNotCompleted,
+	}
+	foundErrorPods, err := checkPods(podClient, logger, filters...)
+	if err != nil {
+		return false, err
+	}
+	return !foundErrorPods, err
+}
 
-	var notReady []kubev1.Pod
+// CheckPodHealth attempts to look at the state of all pods and returns true if things are healthy.
+func CheckPodHealth(podClient v1.CoreV1Interface, logger *log.Logger, ns string, podPrefixes ...string) (bool, error) {
+	filters := []PodPredicate{
+		MatchesNamespace(ns),
+		MatchesNames(podPrefixes...),
+		IsNotRunning,
+		IsNotCompleted,
+	}
+	foundErrorPods, err := checkPods(podClient, logger, filters...)
+	if err != nil {
+		return false, err
+	}
+	return !foundErrorPods, err
+}
+
+// checkPods looks for pods matching the supplied predicates and returns true if any are found
+func checkPods(podClient v1.CoreV1Interface, logger *log.Logger, filters ...PodPredicate) (bool, error) {
+	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 
 	logger.Print("Checking that all Pods are running or completed...")
 
@@ -31,44 +58,17 @@ func CheckPodHealth(podClient v1.CoreV1Interface, logger *log.Logger, podPrefixe
 		return false, fmt.Errorf("pod list is empty. this should NOT happen")
 	}
 
-	var metadataState []string
+	pods := filterPods(list, filters...)
 
-	total := 0
-	for _, pod := range list.Items {
-		// we only care about the openshift, redhat, and osde2e namespaces
-		if !containsPrefixes(pod.Namespace, "openshift-", "redhat-", "osde2e-") {
-			continue
+	logger.Printf("%v pods are currently not running or complete:", len(pods.Items))
+	for _, pod := range pods.Items {
+		if pod.Status.Phase != kubev1.PodPending {
+			return false, fmt.Errorf("Pod %s errored: %s - %s", pod.GetName(), pod.Status.Reason, pod.Status.Message)
 		}
-		// if pod prefixes are supplied, look for them specifically
-		if len(podPrefixes) > 0 && !containsPrefixes(pod.Name, podPrefixes...) {
-			continue
-		}
-
-		total++
-		phase := pod.Status.Phase
-
-		if phase != kubev1.PodRunning && phase != kubev1.PodSucceeded {
-			metadataState = append(metadataState, fmt.Sprintf("%v", pod))
-			if phase != kubev1.PodPending {
-				return false, fmt.Errorf("Pod %s errored: %s - %s", pod.GetName(), pod.Status.Reason, pod.Status.Message)
-			}
-			notReady = append(notReady, pod)
-			logger.Printf("%s is not ready. Phase: %s, Message: %s, Reason: %s", pod.Name, pod.Status.Phase, pod.Status.Message, pod.Status.Reason)
-		}
+		logger.Printf("%s is not ready. Phase: %s, Message: %s, Reason: %s", pod.Name, pod.Status.Phase, pod.Status.Message, pod.Status.Reason)
 	}
 
-	ready := float64(total - len(notReady))
-	curRatio := (ready / float64(total)) * 100
-
-	logger.Printf("%v%% of %v pods are currently alive...", curRatio, total)
-
-	if len(metadataState) > 0 {
-		metadata.Instance.SetHealthcheckValue("pods", metadataState)
-	} else {
-		metadata.Instance.ClearHealthcheckValue("pods")
-	}
-
-	return len(notReady) == 0, nil
+	return len(pods.Items) > 0, nil
 }
 
 func containsPrefixes(str string, subs ...string) bool {
@@ -78,4 +78,21 @@ func containsPrefixes(str string, subs ...string) bool {
 		}
 	}
 	return false
+}
+
+func filterPods(podList *kubev1.PodList, predicates ...PodPredicate) *kubev1.PodList {
+	filteredPods := &kubev1.PodList{}
+	for _, pod := range podList.Items {
+		var match = true
+		for _, p := range predicates {
+			if !p(pod) {
+				match = false
+				break
+			}
+		}
+		if match {
+			filteredPods.Items = append(filteredPods.Items, pod)
+		}
+	}
+	return filteredPods
 }

--- a/pkg/common/cluster/healthchecks/pods_test.go
+++ b/pkg/common/cluster/healthchecks/pods_test.go
@@ -51,7 +51,7 @@ func TestCheckPodHealth(t *testing.T) {
 
 	for _, test := range tests {
 		kubeClient := kubernetes.NewSimpleClientset(test.objs...)
-		state, err := CheckPodHealth(kubeClient.CoreV1(), nil)
+		state, err := CheckClusterPodHealth(kubeClient.CoreV1(), nil)
 
 		if state != test.expectedState {
 			t.Errorf("%v: Expected state doesn't match returned value (%v, %v)", test.description, test.expectedState, state)

--- a/pkg/common/upgrade/managed.go
+++ b/pkg/common/upgrade/managed.go
@@ -231,7 +231,7 @@ func createManagedUpgradeWorkload(workLoadName string, workLoadDir string, podPr
 	// Wait for all pods to come up healthy
 	err = wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
 
-		if check, err := healthchecks.CheckPodHealth(h.Kube().CoreV1(), nil, podPrefixes...); !check || err != nil {
+		if check, err := healthchecks.CheckPodHealth(h.Kube().CoreV1(), nil, h.CurrentProject(), podPrefixes...); !check || err != nil {
 			return false, nil
 		}
 		return true, nil

--- a/pkg/common/upgrade/managed.go
+++ b/pkg/common/upgrade/managed.go
@@ -78,7 +78,8 @@ func TriggerManagedUpgrade(h *helper.H) (*configv1.ClusterVersion, error) {
 
 	// Create Pod Disruption Budget test workloads if desired
 	if viper.GetBool(config.Upgrade.ManagedUpgradeTestPodDisruptionBudgets) {
-		err = createManagedUpgradeWorkload(pdbWorkloadName, pdbWorkloadDir, h)
+		pdbPodPrefixes := []string{"pdb"}
+		err = createManagedUpgradeWorkload(pdbWorkloadName, pdbWorkloadDir, pdbPodPrefixes, h)
 		if err != nil {
 			return cVersion, fmt.Errorf("unable to setup PDB workload for upgrade: %v", err)
 		}
@@ -86,7 +87,8 @@ func TriggerManagedUpgrade(h *helper.H) (*configv1.ClusterVersion, error) {
 
 	// Create Node Drain test workloads if desired
 	if viper.GetBool(config.Upgrade.ManagedUpgradeTestNodeDrain) {
-		err = createManagedUpgradeWorkload(drainWorkloadName, drainWorkloadDir, h)
+		drainPodPrefixes := []string{"node-drain-test"}
+		err = createManagedUpgradeWorkload(drainWorkloadName, drainWorkloadDir, drainPodPrefixes, h)
 		if err != nil {
 			return cVersion, fmt.Errorf("unable to setup node drain test workload for upgrade: %v", err)
 		}
@@ -207,7 +209,7 @@ func overrideUpgradeConfig(uc upgradev1alpha1.UpgradeConfig, h *helper.H) error 
 	return nil
 }
 
-func createManagedUpgradeWorkload(workLoadName string, workLoadDir string, h *helper.H) error {
+func createManagedUpgradeWorkload(workLoadName string, workLoadDir string, podPrefixes []string, h *helper.H) error {
 
 	if _, ok := h.GetWorkload(workLoadName); ok {
 		return nil
@@ -228,7 +230,8 @@ func createManagedUpgradeWorkload(workLoadName string, workLoadDir string, h *he
 
 	// Wait for all pods to come up healthy
 	err = wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
-		if check, err := healthchecks.CheckPodHealth(h.Kube().CoreV1(), nil); !check || err != nil {
+
+		if check, err := healthchecks.CheckPodHealth(h.Kube().CoreV1(), nil, podPrefixes...); !check || err != nil {
 			return false, nil
 		}
 		return true, nil

--- a/pkg/e2e/workloads/guestbook/guestbook.go
+++ b/pkg/e2e/workloads/guestbook/guestbook.go
@@ -78,7 +78,7 @@ var _ = ginkgo.Describe(testName, func() {
 			// Wait for all pods to come up healthy
 			err = wait.PollImmediate(15*time.Second, 5*time.Minute, func() (bool, error) {
 				// This is pretty basic. Are all the pods up? Cool.
-				if check, err := healthchecks.CheckPodHealth(h.Kube().CoreV1(), nil, podPrefixes...); !check || err != nil {
+				if check, err := healthchecks.CheckPodHealth(h.Kube().CoreV1(), nil, h.CurrentProject(), podPrefixes...); !check || err != nil {
 					return false, nil
 				}
 				return true, nil

--- a/pkg/e2e/workloads/guestbook/guestbook.go
+++ b/pkg/e2e/workloads/guestbook/guestbook.go
@@ -35,7 +35,11 @@ var _ = ginkgo.Describe(testName, func() {
 	// setup helper
 	h := helper.New()
 
+	// used for verifying creation of workload pods
+	podPrefixes := []string{"frontend", "redis-master", "redis-slave"}
+
 	ginkgo.It("should get created in the cluster", func() {
+
 		// Does this workload exist? If so, this must be a repeat run.
 		// In this case we should assume the workload has had a valid run once already
 		// And simply run another test validating the workload.
@@ -74,7 +78,7 @@ var _ = ginkgo.Describe(testName, func() {
 			// Wait for all pods to come up healthy
 			err = wait.PollImmediate(15*time.Second, 5*time.Minute, func() (bool, error) {
 				// This is pretty basic. Are all the pods up? Cool.
-				if check, err := healthchecks.CheckPodHealth(h.Kube().CoreV1(), nil); !check || err != nil {
+				if check, err := healthchecks.CheckPodHealth(h.Kube().CoreV1(), nil, podPrefixes...); !check || err != nil {
 					return false, nil
 				}
 				return true, nil

--- a/pkg/e2e/workloads/redmine/redmine.go
+++ b/pkg/e2e/workloads/redmine/redmine.go
@@ -39,8 +39,13 @@ var _ = ginkgo.Describe(testName, func() {
 	// setup helper
 	h := helper.New()
 
+	// used for verifying creation of workload pods
+	podPrefixes := []string{"redmine"}
+
 	redmineTimeoutInSeconds := 900
 	ginkgo.It("should get created in the cluster", func() {
+
+
 		// Does this workload exist? If so, this must be a repeat run.
 		// In this case we should assume the workload has had a valid run once already
 		// And simply run another test validating the workload.
@@ -60,7 +65,7 @@ var _ = ginkgo.Describe(testName, func() {
 			// Wait for all pods to come up healthy
 			err = wait.PollImmediate(15*time.Second, 10*time.Minute, func() (bool, error) {
 				// This is pretty basic. Are all the pods up? Cool.
-				if check, err := healthchecks.CheckPodHealth(h.Kube().CoreV1(), nil); !check || err != nil {
+				if check, err := healthchecks.CheckPodHealth(h.Kube().CoreV1(), nil, podPrefixes...); !check || err != nil {
 					return false, nil
 				}
 				return true, nil

--- a/pkg/e2e/workloads/redmine/redmine.go
+++ b/pkg/e2e/workloads/redmine/redmine.go
@@ -65,7 +65,7 @@ var _ = ginkgo.Describe(testName, func() {
 			// Wait for all pods to come up healthy
 			err = wait.PollImmediate(15*time.Second, 10*time.Minute, func() (bool, error) {
 				// This is pretty basic. Are all the pods up? Cool.
-				if check, err := healthchecks.CheckPodHealth(h.Kube().CoreV1(), nil, podPrefixes...); !check || err != nil {
+				if check, err := healthchecks.CheckPodHealth(h.Kube().CoreV1(), nil, h.CurrentProject(), podPrefixes...); !check || err != nil {
 					return false, nil
 				}
 				return true, nil


### PR DESCRIPTION
This PR adds a variadic argument section to `CheckPodHealth`, allowing for more refined checking of pod status by comparing the list of retrieved pods against a supplied slice of pod name prefixes.

This allows tests which (re)use `CheckPodHealth` to not be impacted if another unrelated pod in the cluster happens to be in a Pending state.

The `guestbook` and `redmine` tests, and the managed upgrade code, have been updated to make use of the additional arguments. Features such as the cluster health check will continue to scan through all pods.