### PR TITLE
Make TEST_KUBECONFIG use the mock provider

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -324,7 +324,11 @@ func ProvisionCluster(logger *log.Logger) (*spi.Cluster, error) {
 
 	// if TEST_KUBECONFIG has been set, skip configuring OCM
 	if len(viper.GetString(config.Kubeconfig.Contents)) > 0 || len(viper.GetString(config.Kubeconfig.Path)) > 0 {
-		return nil, useKubeconfig(logger)
+		err := useKubeconfig(logger)
+		if err != nil {
+			return nil, err
+		}
+		viper.Set(config.Provider, "mock")
 	}
 
 	provider, err := providers.ClusterProvider()

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -287,6 +287,11 @@ func runGinkgoTests() error {
 	// setup OSD unless Kubeconfig is present
 	if len(viper.GetString(config.Kubeconfig.Path)) > 0 {
 		log.Print("Found an existing Kubeconfig!")
+		viper.Set(config.Provider, "mock")
+		if provider, err = providers.ClusterProvider(); err != nil {
+			return fmt.Errorf("could not setup cluster provider: %v", err)
+		}
+		metadata.Instance.SetEnvironment(provider.Environment())
 	} else {
 		if provider, err = providers.ClusterProvider(); err != nil {
 			return fmt.Errorf("could not setup cluster provider: %v", err)


### PR DESCRIPTION
Since OCM provider-driven testing is having issues for SRE with fetching the kubeconfig, this PR attempts to get the `TEST_KUBECONFIG` method of local `kubeconfig`-based testing working again, by setting it up with the mock provider.

I found that with the existing `osde2e`, trying to use `TEST_KUBECONFIG` caused code panics because it assumes that a provider is created, but one never is. So this change attempts to address that problem in a pretty crude way via the mock provider, so that there is at least some avenue for SRE to continue using `osde2e` for testing whilst this whole issue is figured out.

