### PR TITLE
add upgrade test for reschedule

### DIFF
--- a/configs/upgrade-rescheduled.yaml
+++ b/configs/upgrade-rescheduled.yaml
@@ -1,2 +1,3 @@
 upgrade:
+  toLatestZ: true
   rescheduled: true

--- a/configs/upgrade-rescheduled.yaml
+++ b/configs/upgrade-rescheduled.yaml
@@ -1,0 +1,2 @@
+upgrade:
+  rescheduled: true

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -69,6 +69,8 @@ Some environment variables commonly used for pipelines under osde2e are indicate
 |UPGRADE_MANAGED| Perform an upgrade using the Managed Upgrade Operator.|
 |UPGRADE_MANAGED_TEST_PDBS| Create disruptive Pod Disruption Budget workloads to test the Managed Upgrade Operator's ability to handle them.|
 |UPGRADE_WAIT_FOR_WORKERS| Wait for workers to upgrade before considering the upgrade complete.|
+|UPGRADE_MANAGED_TEST_RESCHEDULE| Test the managed upgrade when the upgrade schedule changed.|
+
  
  
 ### Job related:-
@@ -214,3 +216,4 @@ The following are the values that can be plugged in for the --configs flag when 
 |upgrade-to-latest| To select the newest valid version to upgrade to|
 |upgrade-to-latest-z| To select the newest valid patch version to upgrade to|
 |upgrade-to-next-y| To select the newest valid minor release to upgrade to|
+|upgrade-rescheduled| To test the upgrade being rescheduled.|

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -123,7 +123,7 @@ var Upgrade = struct {
 	WaitForWorkersToManagedUpgrade:         "upgrade.waitForWorkersToManagedUpgrade",
 	ManagedUpgradeTestPodDisruptionBudgets: "upgrade.managedUpgradeTestPodDisruptionBudgets",
 	ManagedUpgradeTestNodeDrain:            "upgrade.managedUpgradeTestNodeDrain",
-	ManagedUpgradeRescheduled:				"upgrade.managedUpgradeRescheduled",
+	ManagedUpgradeRescheduled:              "upgrade.managedUpgradeRescheduled",
 }
 
 // Kubeconfig config keys.

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -108,6 +108,9 @@ var Upgrade = struct {
 
 	// Create disruptive Node Drain workload to test the Managed Upgrade Operator's ability to handle them.
 	ManagedUpgradeTestNodeDrain string
+
+	// Reschedule the upgrade via provider before commence
+	ManagedUpgradeRescheduled string
 }{
 	UpgradeToLatest:                        "upgrade.toLatest",
 	UpgradeToLatestZ:                       "upgrade.ToLatestZ",
@@ -120,6 +123,7 @@ var Upgrade = struct {
 	WaitForWorkersToManagedUpgrade:         "upgrade.waitForWorkersToManagedUpgrade",
 	ManagedUpgradeTestPodDisruptionBudgets: "upgrade.managedUpgradeTestPodDisruptionBudgets",
 	ManagedUpgradeTestNodeDrain:            "upgrade.managedUpgradeTestNodeDrain",
+	ManagedUpgradeRescheduled:				"upgrade.managedUpgradeRescheduled",
 }
 
 // Kubeconfig config keys.
@@ -450,6 +454,9 @@ func init() {
 
 	viper.BindEnv(Upgrade.ManagedUpgradeTestNodeDrain, "UPGRADE_MANAGED_TEST_DRAIN")
 	viper.SetDefault(Upgrade.ManagedUpgradeTestNodeDrain, true)
+
+	viper.BindEnv(Upgrade.ManagedUpgradeRescheduled, "UPGRADE_MANAGED_TEST_RESCHEDULE")
+	viper.SetDefault(Upgrade.ManagedUpgradeRescheduled, false)
 
 	viper.BindEnv(Upgrade.WaitForWorkersToManagedUpgrade, "UPGRADE_WAIT_FOR_WORKERS")
 	viper.SetDefault(Upgrade.WaitForWorkersToManagedUpgrade, true)

--- a/pkg/common/providers/crc/crc.go
+++ b/pkg/common/providers/crc/crc.go
@@ -318,7 +318,7 @@ func (m *Provider) UpdateSchedule(clusterID string, version string, t time.Time,
 	return nil
 }
 
-// GetUpgradePolicy CRCs gets the first upgrade policy for the cluster
-func (m *Provider) GetUpgradePolicy(clusterID string) (string, error) {
+// GetUpgradePolicyID CRCs gets the first upgrade policy for the cluster
+func (m *Provider) GetUpgradePolicyID(clusterID string) (string, error) {
 	return "", nil
 }

--- a/pkg/common/providers/crc/crc.go
+++ b/pkg/common/providers/crc/crc.go
@@ -310,3 +310,15 @@ func (m *Provider) Upgrade(clusterID string, version string, t time.Time) error 
 	log.Printf("Upgrade is unsupported by CRC clusters")
 	return nil
 }
+
+// UpdateSchedule CRCs updates the upgrade schedule for a given cluster
+func (m *Provider) UpdateSchedule(clusterID string, version string, t time.Time, policyID string) error {
+	// Noop for now and just note it.
+	log.Printf("UpdateSchedule is unsupported by CRC clusters")
+	return nil
+}
+
+// GetUpgradePolicy CRCs gets the first upgrade policy for the cluster
+func (m *Provider) GetUpgradePolicy(clusterID string) (string, error) {
+	return "", nil
+}

--- a/pkg/common/providers/moaprovider/wrapped_calls.go
+++ b/pkg/common/providers/moaprovider/wrapped_calls.go
@@ -1,9 +1,10 @@
 package moaprovider
 
 import (
+	"time"
+
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/osde2e/pkg/common/spi"
-	"time"
 )
 
 // The rest of the SPI functions will be wrapped by the OCM provider until the MOA provider can be adequately refactored.
@@ -81,4 +82,14 @@ func (m *MOAProvider) AddProperty(cluster *spi.Cluster, tag string, value string
 // Upgrade initiates a cluster upgrade from the OCM provider.
 func (m *MOAProvider) Upgrade(clusterID string, version string, t time.Time) error {
 	return m.ocmProvider.Upgrade(clusterID, version, t)
+}
+
+// GetUpgradePolicy fetchs the upgrade policy from the OCM provider
+func (m *MOAProvider) GetUpgradePolicy(clusterID string) (string, error) {
+	return m.ocmProvider.GetUpgradePolicy(clusterID)
+}
+
+// UpdateSchedule mocks reschedule the upgrade via the OCM provider
+func (m *MOAProvider) UpdateSchedule(clusterID string, version string, t time.Time, policyID string) error {
+	return m.ocmProvider.UpdateSchedule(clusterID, version, t, policyID)
 }

--- a/pkg/common/providers/moaprovider/wrapped_calls.go
+++ b/pkg/common/providers/moaprovider/wrapped_calls.go
@@ -84,9 +84,9 @@ func (m *MOAProvider) Upgrade(clusterID string, version string, t time.Time) err
 	return m.ocmProvider.Upgrade(clusterID, version, t)
 }
 
-// GetUpgradePolicy fetchs the upgrade policy from the OCM provider
-func (m *MOAProvider) GetUpgradePolicy(clusterID string) (string, error) {
-	return m.ocmProvider.GetUpgradePolicy(clusterID)
+// GetUpgradePolicyID fetchs the upgrade policy from the OCM provider
+func (m *MOAProvider) GetUpgradePolicyID(clusterID string) (string, error) {
+	return m.ocmProvider.GetUpgradePolicyID(clusterID)
 }
 
 // UpdateSchedule mocks reschedule the upgrade via the OCM provider

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -272,3 +272,13 @@ func (m *MockProvider) AddProperty(cluster *spi.Cluster, tag string, value strin
 func (m *MockProvider) Upgrade(clusterID string, version string, t time.Time) error {
 	return fmt.Errorf("Upgrade is unsupported by mock clusters")
 }
+
+// Get upgrade policy mocks fetch the upgrade policy for a cluster
+func (m *MockProvider) GetUpgradePolicy(clusterID string) (string, error) {
+	return "mock", fmt.Errorf("Get mock upgrade policy failed")
+}
+
+// UpdateSchedule mocks reschedule the upgrade
+func (m *MockProvider) UpdateSchedule(clusterID string, version string, t time.Time, policyID string) error {
+	return fmt.Errorf("Upgrade Schedule is not supported by mock clusters")
+}

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -273,8 +273,8 @@ func (m *MockProvider) Upgrade(clusterID string, version string, t time.Time) er
 	return fmt.Errorf("Upgrade is unsupported by mock clusters")
 }
 
-// Get upgrade policy mocks fetch the upgrade policy for a cluster
-func (m *MockProvider) GetUpgradePolicy(clusterID string) (string, error) {
+// Get upgrade policy ID mocks fetch the upgrade policy for a cluster
+func (m *MockProvider) GetUpgradePolicyID(clusterID string) (string, error) {
 	return "mock", fmt.Errorf("Get mock upgrade policy failed")
 }
 

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -874,21 +874,22 @@ func (o *OCMProvider) Upgrade(clusterID string, version string, t time.Time) err
 	return nil
 }
 
-//GetUpgradePolicy gets the first upgrade policy from the top
-func (o *OCMProvider) GetUpgradePolicy(clusterID string) (string, error) {
+//GetUpgradePolicyID gets the first upgrade policy from the top
+func (o *OCMProvider) GetUpgradePolicyID(clusterID string) (string, error) {
 
-	getResp, err := o.conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).UpgradePolicies().List().Size(1).Send()
+	listResp, err := o.conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).UpgradePolicies().List().SendContext(context.TODO())
+
 	if err != nil {
 		return "", err
 	}
-	if getResp.Status() != http.StatusOK {
-		log.Printf("Unable to find upgrade schedule with provider (status %d, response %v)", getResp.Status(), getResp.Error())
-		return "", getResp.Error()
+	if listResp.Status() != http.StatusOK {
+		log.Printf("Unable to find upgrade schedule with provider (status %d, response %v)", listResp.Status(), listResp.Error())
+		return "", listResp.Error()
 	}
 
-	policyID, ok := getResp.Items().Get(1).GetID()
-	if !ok {
-		return "", fmt.Errorf("Failed to get the policy ID")
+	policyID := listResp.Items().Get(0).ID()
+	if policyID == "" {
+		return "", fmt.Errorf("failed to get the policy ID")
 	}
 
 	return policyID, nil

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -115,8 +115,8 @@ type Provider interface {
 	// Upgrade requests the provider initiate a cluster upgrade to the given version
 	Upgrade(clusterID string, version string, t time.Time) error
 
-	// GetUpgradePolicy gets the first upgrade policy from the top
-	GetUpgradePolicy(clusterID string) (string, error)
+	// GetUpgradePolicyID gets the first upgrade policy from the top
+	GetUpgradePolicyID(clusterID string) (string, error)
 
 	// UpdateSchedule updates the existing upgrade policy for re-scheduling
 	UpdateSchedule(clusterID string, version string, t time.Time, policyID string) error

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -114,4 +114,10 @@ type Provider interface {
 
 	// Upgrade requests the provider initiate a cluster upgrade to the given version
 	Upgrade(clusterID string, version string, t time.Time) error
+
+	// GetUpgradePolicy gets the first upgrade policy from the top
+	GetUpgradePolicy(clusterID string) (string, error)
+
+	// UpdateSchedule updates the existing upgrade policy for re-scheduling
+	UpdateSchedule(clusterID string, version string, t time.Time, policyID string) error
 }

--- a/pkg/common/upgrade/upgrade.go
+++ b/pkg/common/upgrade/upgrade.go
@@ -91,7 +91,7 @@ func RunUpgrade() error {
 
 	// When the upgrade being rescheduled, we should expect that the upgrade will not be triggered
 	if viper.GetBool(config.Upgrade.ManagedUpgradeRescheduled) {
-		time.Sleep(6 * time.Minute)
+		time.Sleep(10 * time.Minute)
 		triggered, err := isUpgradeTriggered(h, desired.Spec.DesiredUpdate)
 		if triggered {
 			return fmt.Errorf("the upgrade was triggered unexpectly: %v", err)

--- a/pkg/common/upgrade/upgrade.go
+++ b/pkg/common/upgrade/upgrade.go
@@ -89,6 +89,18 @@ func RunUpgrade() error {
 		}
 	}
 
+	// When the upgrade being rescheduled, we should expect that the upgrade will not be triggered
+	if viper.GetBool(config.Upgrade.ManagedUpgradeRescheduled) {
+		time.Sleep(6 * time.Minute)
+		triggered, err := isUpgradeTriggered(h, desired.Spec.DesiredUpdate)
+		if triggered {
+			return fmt.Errorf("the upgrade was triggered unexpectly: %v", err)
+		} else {
+			log.Println("Upgrade has been rescheduled/cancelled")
+			return nil
+		}
+	}
+
 	log.Println("Cluster acknowledged update request.")
 
 	log.Println("Upgrading...")

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -354,8 +354,11 @@ func runGinkgoTests() error {
 			}
 			events.RecordEvent(events.UpgradeSuccessful)
 
-			log.Println("Running e2e tests POST-UPGRADE...")
-			upgradeTestsPassed = runTestsInPhase(phase.UpgradePhase, "OSD e2e suite post-upgrade")
+			if !viper.GetBool(config.Upgrade.ManagedUpgradeRescheduled) {
+				log.Println("Running e2e tests POST-UPGRADE...")
+				upgradeTestsPassed = runTestsInPhase(phase.UpgradePhase, "OSD e2e suite post-upgrade")
+			}
+			log.Println("Upgrade rescheduled, skip the POST-UPGRADE testing")
 		} else {
 			log.Println("No Kubeconfig found from initial cluster setup. Unable to run upgrade.")
 		}


### PR DESCRIPTION
Adding the upgrade test for reschedule the upgrade policy before the upgrade triggered.

Haven't test this yet, since the kubeconfig issue on stage env.