### PR TITLE
OSD-3985 remove image-pruner cronjob test

### DIFF
--- a/pkg/e2e/operators/prunejob.go
+++ b/pkg/e2e/operators/prunejob.go
@@ -29,7 +29,7 @@ var _ = ginkgo.Describe(pruneJobsTestName, func() {
 	h := helper.New()
 	ginkgo.Context("pruner jobs should works", func() {
 		namespace := "openshift-sre-pruning"
-		cronJobs := []string{"builds-pruner", "deployments-pruner", "image-pruner"}
+		cronJobs := []string{"builds-pruner", "deployments-pruner"}
 		for _, cronJob := range cronJobs {
 			ginkgo.It(cronJob+" should run successfully", func() {
 				getOpts := metav1.GetOptions{}


### PR DESCRIPTION
As part of [OSD-3985](https://issues.redhat.com/browse/OSD-3985) we will be removing the SRE image pruner cronjob on 4.6.x clusters in favour of the existing cluster image pruner.

This PR adjusts the `Prune Jobs` test so that it will not attempt to test the ability to create jobs from the SRE image pruner cronjob, as this cronjob will not exist on 4.6 clusters when [OSD-3985](https://issues.redhat.com/browse/OSD-3985) is promoted.

cc @wanghaoran1988 as original test author.