### PR TITLE
osde2ectl delete should error when no id is passed

### DIFF
--- a/cmd/osde2ectl/delete/cmd.go
+++ b/cmd/osde2ectl/delete/cmd.go
@@ -132,6 +132,8 @@ func run(cmd *cobra.Command, argv []string) error {
 			}
 		}
 		return allErrors.ErrorOrNil()
+	} else {
+		return fmt.Errorf("could not delete cluster: %v", "No cluster ID or cluster owner provided")
 	}
 
 	fmt.Printf("Clusters may take a while to disappear from OCM.\n")


### PR DESCRIPTION
Modified the osde2ectl delete command to return an error if no cluster ID or owner arguments are passed.