### PR TITLE
Fix AlertmanagerInhibitions

### DIFF
--- a/pkg/e2e/osd/inhibitions.go
+++ b/pkg/e2e/osd/inhibitions.go
@@ -75,7 +75,16 @@ var _ = ginkgo.Describe(inhibitionsTestName, func() {
 				expectedSource: "KubeNodeNotReady",
 				expectedTarget: "KubeDaemonSetRolloutStuck",
 				expectedEqual: prometheusModel.LabelNames{
-					"namespace",
+					"instance",
+				},
+				expectedPresent: true,
+			},
+			{
+				name:           "KubeNodeUnreachable inhibits KubeNodeNotReady",
+				expectedSource: "KubeNodeUnreachable",
+				expectedTarget: "KubeNodeNotReady",
+				expectedEqual: prometheusModel.LabelNames{
+					"node",
 					"instance",
 				},
 				expectedPresent: true,


### PR DESCRIPTION
Fix AlertmanagerInhibitions due to changes in https://github.com/openshift/configure-alertmanager-operator/pull/126

fixes [OSD-6013](https://issues.redhat.com/browse/OSD-6013)