### PR TITLE
Allow override of OCM provider credentials request

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Config options are currently parsed by loading defaults, attempting to load envi
 It is possible to test against non-OSD clusters by specifying a kubeconfig to test against.
  
 ```
+PROVIDER=mock \
 TEST_KUBECONFIG=~/.kube/config \
 osde2e test --configs prod --custom-config .osde2e.yaml
 ```

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -9,7 +9,7 @@ Some environment variables commonly used for pipelines under osde2e are indicate
 
 | Environment variable | Usage |
 | --------------| ------------------------|
-|TEST_KUBECONFIG| This variable represents the filepath of an existing Kubeconfig | 
+|TEST_KUBECONFIG| This variable represents the filepath of an existing Kubeconfig. Will override fetching credentials from the OCM provider if specified. | 
 |OSD_ENV |  int, stage, prod|
 |CLOUD_PROVIDER_ID| aws, gcp| 
 |CLOUD_PROVIDER_REGION| Must be a valid region enabled within OCM. Ex. us-east-1|
@@ -43,7 +43,7 @@ Some environment variables commonly used for pipelines under osde2e are indicate
 ### OCM related:-
  
 | Environment variable | Usage |
-| --------------| ------------------------| 
+| --------------| ------------------------|
 |DEBUG_OSD| Debug shows debug level messages when enabled.|
 |NUM_RETRIES|NumRetries is the number of times to retry each OCM call.|
 |OCM_COMPUTE_MACHINE_TYPE| ComputeMachineType is the specific cloud machine type to use for compute nodes.|
@@ -54,6 +54,7 @@ Some environment variables commonly used for pipelines under osde2e are indicate
 |OCM_AWS_ACCOUNT| |
 |OCM_AWS_ACCESS_KEY| |
 |OCM_AWS_SECRET_KEY| |
+|TEST_KUBECONFIG| Path to a local kubeconfig; will override fetching Kubeconfig credentials from OCM if specified.| 
   
 ### Upgrade variables:-
 

--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -324,17 +324,7 @@ func getRestConfig(provider spi.Provider, clusterID string) (*rest.Config, error
 func ProvisionCluster(logger *log.Logger) (*spi.Cluster, error) {
 	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 
-	// if TEST_KUBECONFIG has been set, skip configuring OCM
-	if len(viper.GetString(config.Kubeconfig.Contents)) > 0 || len(viper.GetString(config.Kubeconfig.Path)) > 0 {
-		err := useKubeconfig(logger)
-		if err != nil {
-			return nil, err
-		}
-		viper.Set(config.Provider, "mock")
-	}
-
 	provider, err := providers.ClusterProvider()
-
 	if err != nil {
 		return nil, fmt.Errorf("error getting cluster provisioning client: %v", err)
 	}
@@ -380,25 +370,6 @@ func ProvisionCluster(logger *log.Logger) (*spi.Cluster, error) {
 	}
 
 	return cluster, nil
-}
-
-// useKubeconfig reads the path provided for a TEST_KUBECONFIG and uses it for testing.
-func useKubeconfig(logger *log.Logger) (err error) {
-	_, err = clientcmd.RESTConfigFromKubeConfig([]byte(viper.GetString(config.Kubeconfig.Contents)))
-	if err != nil {
-		logger.Println("Not an existing Kubeconfig, attempting to read file instead...")
-	} else {
-		logger.Println("Existing valid kubeconfig!")
-		return nil
-	}
-
-	kubeconfigPath := viper.GetString(config.Kubeconfig.Path)
-	_, err = ioutil.ReadFile(kubeconfigPath)
-	if err != nil {
-		return fmt.Errorf("failed reading '%s' which has been set as the TEST_KUBECONFIG: %v", kubeconfigPath, err)
-	}
-	logger.Printf("Using a set TEST_KUBECONFIG of '%s' for Origin API calls.", kubeconfigPath)
-	return nil
 }
 
 // clusterName returns a cluster name with a format which must be short enough to support all versions

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -285,10 +285,10 @@ func runGinkgoTests() error {
 
 	// Get the cluster ID now to test against later
 	clusterID := viper.GetString(config.Cluster.ID)
+	providerCfg := viper.GetString(config.Provider)
 	// setup OSD unless Kubeconfig is present
-	if len(viper.GetString(config.Kubeconfig.Path)) > 0 {
+	if len(viper.GetString(config.Kubeconfig.Path)) > 0 && providerCfg == "mock" {
 		log.Print("Found an existing Kubeconfig!")
-		viper.Set(config.Provider, "mock")
 		if provider, err = providers.ClusterProvider(); err != nil {
 			return fmt.Errorf("could not setup cluster provider: %v", err)
 		}


### PR DESCRIPTION
This PR allows for the ability to override the `credentials` request made by the OCM provider with a locally-hosted kubeconfig using the `TEST_KUBECONFIG` environment variable. This allows SRE-P, who do not possess the permissions to obtain `credentials` from OCM, to continue to operator OSDE2E with an OCM provider.

Their steps would now be:
- Log in to the OSD cluster locally, to create the local kubeconfig
- Elevate permissions on the cluster to `osd-sre-cluster-admins` if needed (required by many tests)
- Set `TEST_KUBECONFIG` to the path to that kubeconfig, eg. `$HOME/.kube/config`
- Run OSDE2E as normal.

The existing method of using osde2e to test non-OSD clusters via `TEST_KUBECONFIG` is retained, however must be opted in explicitly through setting the `PROVIDER` viper config to `mock`:

`PROVIDER=mock TEST_KUBECONFIG=$HOME/.kube/config osde2e test ....`

The documentation has been updated to reflect the updated usage of `TEST_KUBECONFIG` in both scenarios.
