### PR TITLE
Ensure configure-alertmanager-operator service account exists

### DIFF
--- a/pkg/e2e/operators/configurealertmanager.go
+++ b/pkg/e2e/operators/configurealertmanager.go
@@ -31,6 +31,9 @@ var _ = ginkgo.Describe(configureAlertManagerOperators, func() {
 	var roles = []string{
 		"configure-alertmanager-operator",
 	}
+	var serviceAccounts = []string{
+		"configure-alertmanager-operator",
+	}
 
 	h := helper.New()
 	checkClusterServiceVersion(h, operatorNamespace, operatorName)
@@ -40,6 +43,7 @@ var _ = ginkgo.Describe(configureAlertManagerOperators, func() {
 	checkClusterRoleBindings(h, clusterRoleBindings, true)
 	checkRole(h, operatorNamespace, roles)
 	checkRoleBindings(h, operatorNamespace, roleBindings)
+	checkServiceAccounts(h, operatorNamespace, serviceAccounts)
 	checkUpgrade(helper.New(), "openshift-monitoring", "configure-alertmanager-operator",
 		"configure-alertmanager-operator", "configure-alertmanager-operator-registry")
 })

--- a/pkg/e2e/operators/operators.go
+++ b/pkg/e2e/operators/operators.go
@@ -73,6 +73,18 @@ func checkDeployment(h *helper.H, namespace string, name string, defaultDesiredR
 	})
 }
 
+func checkServiceAccount(h *helper.H, serviceAccounts []string) {
+	// Check that deployed serviceAccounts exist
+	ginkgo.Context("serviceAccounts", func() {
+		ginkgo.It("should exist", func() {
+			for _, serviceAccountName := range serviceAccounts {
+				_, err := h.Kube().CoreV1().serviceAccounts(namespace).Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred(), "failed to get serviceAccount %v\n", serviceAccountName)
+			}
+		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
+	})
+}
+
 func checkClusterRoles(h *helper.H, clusterRoles []string, matchPrefix bool) {
 	// Check that the clusterRoles exist
 	ginkgo.Context("clusterRoles", func() {


### PR DESCRIPTION
After a recent upgrade to latest stable, the required serviceAccount wasn't existing anymore.
We have to make sure during tests this doesn't happen