### PR TITLE
Add an ad-hoc healthcheck command to osde2ectl

### DIFF
--- a/cmd/osde2ectl/healthcheck/cmd.go
+++ b/cmd/osde2ectl/healthcheck/cmd.go
@@ -1,0 +1,100 @@
+package healthcheck
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/openshift/osde2e/cmd/osde2e/common"
+	"github.com/openshift/osde2e/cmd/osde2e/helpers"
+	clusterutil "github.com/openshift/osde2e/pkg/common/cluster"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "healthcheck",
+	Short: "Runs a healthcheck.",
+	Long:  "Runs a healthcheck on a cluster using the provided arguments.",
+	Args:  cobra.OnlyValidArgs,
+	RunE:  run,
+}
+
+var args struct {
+	configString    string
+	customConfig    string
+	secretLocations string
+	clusterID       string
+	environment     string
+	kubeConfig      string
+}
+
+func init() {
+	pfs := Cmd.PersistentFlags()
+	pfs.StringVar(
+		&args.configString,
+		"configs",
+		"",
+		"A comma separated list of built in configs to use",
+	)
+	Cmd.RegisterFlagCompletionFunc("configs", helpers.ConfigComplete)
+	pfs.StringVar(
+		&args.customConfig,
+		"custom-config",
+		"",
+		"Custom config file for osde2ectl",
+	)
+	pfs.StringVar(
+		&args.secretLocations,
+		"secret-locations",
+		"",
+		"A comma separated list of possible secret directory locations for loading secret configs.",
+	)
+	pfs.StringVarP(
+		&args.clusterID,
+		"cluster-id",
+		"i",
+		"",
+		"Existing OCM cluster ID to run healthchecks against.",
+	)
+	pfs.StringVarP(
+		&args.environment,
+		"environment",
+		"e",
+		"",
+		"Cluster provider environment to use.",
+	)
+
+	pfs.StringVarP(
+		&args.kubeConfig,
+		"kube-config",
+		"k",
+		"",
+		"Path to local Kube config for running healthchecks against.",
+	)
+
+	viper.BindPFlag(config.Cluster.ID, Cmd.PersistentFlags().Lookup("cluster-id"))
+	viper.BindPFlag(ocmprovider.Env, Cmd.PersistentFlags().Lookup("environment"))
+	viper.BindPFlag(config.Kubeconfig.Path, Cmd.PersistentFlags().Lookup("kube-config"))
+}
+
+func run(cmd *cobra.Command, argv []string) error {
+	if err := common.LoadConfigs(args.configString, args.customConfig, args.secretLocations); err != nil {
+		return fmt.Errorf("error loading initial state: %v", err)
+	}
+	logger := log.New(os.Stdout, "", log.LstdFlags)
+	isHealthy, failures, _ := clusterutil.PollClusterHealth(args.clusterID, logger)
+	if isHealthy {
+		log.Printf("Cluster %s is healthy!\n", args.clusterID)
+	} else {
+		log.Printf("Cluster %s is not healthy yet.\n", args.clusterID)
+		if len(failures) > 0 {
+			log.Printf("Currently failing %s health checks", strings.Join(failures, ", "))
+		}
+		return fmt.Errorf("healthcheck failed")
+	}
+	return nil
+}

--- a/cmd/osde2ectl/main.go
+++ b/cmd/osde2ectl/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openshift/osde2e/cmd/osde2ectl/delete"
 	"github.com/openshift/osde2e/cmd/osde2ectl/extend"
 	"github.com/openshift/osde2e/cmd/osde2ectl/get"
+	"github.com/openshift/osde2e/cmd/osde2ectl/healthcheck"
 	"github.com/openshift/osde2e/cmd/osde2ectl/list"
 	"github.com/spf13/cobra"
 )
@@ -27,6 +28,7 @@ func init() {
 	root.AddCommand(list.Cmd)
 	root.AddCommand(get.Cmd)
 	root.AddCommand(extend.Cmd)
+	root.AddCommand(healthcheck.Cmd)
 
 }
 


### PR DESCRIPTION
Added a command to run a healthcheck against a cluster with the help of a local kubeconfig or a cluster ID.