### PR TITLE
OSD-6013 Fix AlertmanagerInhibitions test

### DIFF
--- a/pkg/e2e/osd/inhibitions.go
+++ b/pkg/e2e/osd/inhibitions.go
@@ -101,11 +101,20 @@ var _ = ginkgo.Describe(inhibitionsTestName, func() {
 			},
 			{
 				name:           "KubePodCrashLooping inhibits KubeDeploymentReplicasMismatch",
-				expectedSource: "KubePodNotReady",
+				expectedSource: "KubePodCrashLooping",
 				expectedTarget: "KubeDeploymentReplicasMismatch",
 				expectedEqual: prometheusModel.LabelNames{
 					"namespace",
 					"pod",
+				},
+				expectedPresent: true,
+			},
+			{
+				name:           "KubeNodeNotReady inhibits TargetDown",
+				expectedSource: "KubeNodeNotReady",
+				expectedTarget: "TargetDown",
+				expectedEqual: prometheusModel.LabelNames{
+					"instance",
 				},
 				expectedPresent: true,
 			},
@@ -124,12 +133,12 @@ var _ = ginkgo.Describe(inhibitionsTestName, func() {
 					// match the source
 					if rule.SourceMatch["alertname"] == test.expectedSource {
 						// match the target
-						rulePresent = rule.TargetMatchRE["alertname"].Regexp.Match([]byte(test.expectedTarget))
+						rulePresent = rulePresent || rule.TargetMatchRE["alertname"].Regexp.Match([]byte(test.expectedTarget))
 					}
 				}
 			}
 
-			Expect(rulePresent).To(Equal(test.expectedPresent))
+			Expect(rulePresent).To(Equal(test.expectedPresent), test.name)
 		}
 	})
 


### PR DESCRIPTION
Corrects a couple of issues in the `AlertmanagerInhibitions` test.

- This test was breaking if multiple tests had the same "equals" and the same "source" (#652 introduced one). This has been fixed.
- Corrects a broken inhibition rule test (it was looking for `KubePodNotReady` as a source instead of `KubePodCrashLooping` - and there already exists a test for the that)
- Added an optional description to the `Expect()` clause so that now if one of the tests fails it will print out what AM Inhibition test actually failed.
- Added a new missing inhibition rule to test for that 's been introduced recently.

Refs [OSD-6013](https://issues.redhat.com/browse/OSD-6013)