### PR TITLE
Allow non-managed image-based upgrades

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -319,7 +319,7 @@ func runGinkgoTests() error {
 		case viper.GetString(config.Upgrade.ReleaseName) == util.NoVersionFound:
 			log.Printf("No valid upgrade versions were found. Skipping tests.")
 			return nil
-		case viper.GetString(config.Upgrade.Image) != "":
+		case viper.GetString(config.Upgrade.Image) != "" && viper.GetBool(config.Upgrade.ManagedUpgrade):
 			log.Printf("image-based managed upgrades are unsupported: %s", viper.GetString(config.Upgrade.Image))
 			return nil
 		}


### PR DESCRIPTION
This tiny little PR resumes allowing OSDE2E to perform image-based upgrades. Previously this was being blocked outright, regardless of whether managed upgrades were enabled or disabled in the viper config.

I've tested this successfully with an image-based upgrade in `osde2e`. Should have no impact to our existing `e2e` runs which use managed upgrades.
