### PR TITLE
SDCICD-519 only create route monitors when necessary

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -338,39 +338,44 @@ func runGinkgoTests() error {
 	getLogs()
 	upgradeTestsPassed := true
 
-	var routeMonitorChan chan struct{}
-	closeMonitorChan := make(chan struct{})
-	if viper.GetBool(config.Upgrade.MonitorRoutesDuringUpgrade) && !dryRun {
-		routeMonitorChan = setupRouteMonitors(closeMonitorChan)
-		log.Println("Route Monitors created.")
-	}
-
 	// upgrade cluster if requested
 	if viper.GetString(config.Upgrade.Image) != "" || viper.GetString(config.Upgrade.ReleaseName) != "" {
+
 		if len(viper.GetString(config.Kubeconfig.Contents)) > 0 {
+			// create route monitors for the upgrade
+			var routeMonitorChan chan struct{}
+			closeMonitorChan := make(chan struct{})
+			if viper.GetBool(config.Upgrade.MonitorRoutesDuringUpgrade) && !dryRun {
+				routeMonitorChan = setupRouteMonitors(closeMonitorChan)
+				log.Println("Route Monitors created.")
+			}
+
+			// run the upgrade
 			if err = upgrade.RunUpgrade(); err != nil {
 				events.RecordEvent(events.UpgradeFailed)
 				return fmt.Errorf("error performing upgrade: %v", err)
 			}
 			events.RecordEvent(events.UpgradeSuccessful)
 
+			// test upgrade rescheduling if desired
 			if !viper.GetBool(config.Upgrade.ManagedUpgradeRescheduled) {
 				log.Println("Running e2e tests POST-UPGRADE...")
 				upgradeTestsPassed = runTestsInPhase(phase.UpgradePhase, "OSD e2e suite post-upgrade")
 			}
 			log.Println("Upgrade rescheduled, skip the POST-UPGRADE testing")
+
+			// close route monitors
+			if viper.GetBool(config.Upgrade.MonitorRoutesDuringUpgrade) && !dryRun {
+				close(routeMonitorChan)
+				_ = <-closeMonitorChan
+				log.Println("Route monitors reconciled")
+			}
+
 		} else {
 			log.Println("No Kubeconfig found from initial cluster setup. Unable to run upgrade.")
 		}
 	}
-
-	if viper.GetBool(config.Upgrade.MonitorRoutesDuringUpgrade) && !dryRun {
-		close(routeMonitorChan)
-		_ = <-closeMonitorChan
-		log.Println("Route monitors reconciled")
-
-	}
-
+	
 	if reportDir != "" {
 		if err = metadata.Instance.WriteToJSON(reportDir); err != nil {
 			return fmt.Errorf("error while writing the custom metadata: %v", err)


### PR DESCRIPTION
This PR addresses [SDCICD-519](https://issues.redhat.com/browse/SDCICD-519) whereby the following concerning error messages were being logged:
```
Error creating route monitors: Unable to generate helper outside ginkgo
```
which, to a newcomer to reviewing CI logs, may look like a problem.

In reality this was occuring because the route monitors were being created regardless of whether or not the cluster had successfully been able to set up its kubeconfig credentials (needed to create a `helper`), and also being created unnecessarily if no upgrade needed to occur.

This PR adjusts creation of the route monitors so that they only get created if:
- E2E has been able to obtain the cluster's kubeconfig
- E2E is running a test job to upgrade a cluster

So the aforementioned error won't show up when it shouldn't.

Has been successfully tested on an E2E upgrade to verify route monitors still get created when they should.