### PR TITLE
Select random machine type for a given cluster

### DIFF
--- a/pkg/common/providers/crc/crc.go
+++ b/pkg/common/providers/crc/crc.go
@@ -322,3 +322,8 @@ func (m *Provider) UpdateSchedule(clusterID string, version string, t time.Time,
 func (m *Provider) GetUpgradePolicyID(clusterID string) (string, error) {
 	return "", nil
 }
+
+// DetermineMachineType returns a random machine type for a given cluster
+func (m *Provider) DetermineMachineType(cloudProvider string) (string, error) {
+	return "", nil
+}

--- a/pkg/common/providers/moaprovider/wrapped_calls.go
+++ b/pkg/common/providers/moaprovider/wrapped_calls.go
@@ -93,3 +93,8 @@ func (m *MOAProvider) GetUpgradePolicyID(clusterID string) (string, error) {
 func (m *MOAProvider) UpdateSchedule(clusterID string, version string, t time.Time, policyID string) error {
 	return m.ocmProvider.UpdateSchedule(clusterID, version, t, policyID)
 }
+
+// DetermineMachineType calls DetermineMachineType from the OCM provider
+func (m *MOAProvider) DetermineMachineType(cloudProvider string) (string, error) {
+	return m.ocmProvider.DetermineMachineType(cloudProvider)
+}

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -143,7 +143,6 @@ func (m *MockProvider) ClusterKubeconfig(clusterID string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to get versions: Some fake error")
 	}
 
-
 	localKubeConfig := viper.GetString(config.Kubeconfig.Path)
 	if len(localKubeConfig) > 0 {
 		// Read from the TEST_KUBECONFIG if it's been specified
@@ -281,4 +280,9 @@ func (m *MockProvider) GetUpgradePolicyID(clusterID string) (string, error) {
 // UpdateSchedule mocks reschedule the upgrade
 func (m *MockProvider) UpdateSchedule(clusterID string, version string, t time.Time, policyID string) error {
 	return fmt.Errorf("Upgrade Schedule is not supported by mock clusters")
+}
+
+// DetermineMachineType returns a random machine type for a given cluster
+func (m *MockProvider) DetermineMachineType(cloudProvider string) (string, error) {
+	return "mock", fmt.Errorf("DetermineMachineType is not supported by mock clusters")
 }

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -223,6 +223,36 @@ func (o *OCMProvider) DetermineRegion(cloudProvider string) (string, error) {
 	return region, nil
 }
 
+// DetermineMachineType will return the machine type provided by configs. This mainly wraps the random functionality for use
+// by the OCM provider. (Returns a random machine type if the config suggests it to be random.)
+func (o *OCMProvider) DetermineMachineType(cloudProvider string) (string, error) {
+	computeMachineType := viper.GetString(ComputeMachineType)
+
+	// If a region is set to "random", it will poll OCM for all the regions available
+	// It then will pull a random entry from the list of regions and set the ID to that
+	if computeMachineType == "random" {
+		searchstring := fmt.Sprintf("cloud_provider.id like '%s'", cloudProvider)
+		machinetypeClient := o.conn.ClustersMgmt().V1().MachineTypes().List().Search(searchstring)
+
+		machinetypes, err := machinetypeClient.Send()
+		if err != nil {
+			return "", err
+		}
+
+		for range machinetypes.Items().Slice() {
+			machinetypeObj := machinetypes.Items().Slice()[rand.Intn(machinetypes.Total())]
+			computeMachineType = machinetypeObj.ID()
+			break
+		}
+
+		log.Printf("Random machine type requested, selected %s machine type.", computeMachineType)
+
+		// Update the Config with the selected random region
+		viper.Set(ComputeMachineType, computeMachineType)
+	}
+	return computeMachineType, nil
+}
+
 // GenerateProperties will generate a set of properties to assign to a cluster.
 func (o *OCMProvider) GenerateProperties() (map[string]string, error) {
 	var username string

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -76,8 +76,12 @@ func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 	}
 
 	multiAZ := viper.GetBool(config.Cluster.MultiAZ)
-	computeMachineType := viper.GetString(ComputeMachineType)
 	cloudProvider := viper.GetString(config.CloudProvider.CloudProviderID)
+	computeMachineType, err := o.DetermineMachineType(cloudProvider)
+
+	if err != nil {
+		return "", fmt.Errorf("error while determining machine type: %v", err)
+	}
 
 	region, err := o.DetermineRegion(cloudProvider)
 

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -120,4 +120,7 @@ type Provider interface {
 
 	// UpdateSchedule updates the existing upgrade policy for re-scheduling
 	UpdateSchedule(clusterID string, version string, t time.Time, policyID string) error
+
+	// DetermineMachineType selects a random machine type for a given cluster.
+	DetermineMachineType(cloudProvider string) (string, error)
 }


### PR DESCRIPTION
Osde2e now supports random selection of an instance/machine type for a given cloud provider and cluster under ocm. Users can make use of the OCM_COMPUTE_MACHINE_TYPE env variable to use random values.