### PR TITLE
Remove CI registry from version image during selection

### DIFF
--- a/pkg/common/versions/installselectors/specific_image.go
+++ b/pkg/common/versions/installselectors/specific_image.go
@@ -39,6 +39,7 @@ func (m specificImage) SelectVersion(versionList *spi.VersionList) (*semver.Vers
 	common.SortVersions(versionsWithoutDefault)
 
 	versionFromImage := strings.Replace(specificImage, "registry.svc.ci.openshift.org/ocp/release:", "", -1)
+	versionFromImage = strings.Replace(versionFromImage, "registry.ci.openshift.org/ocp/release:", "", -1)
 
 	if strings.Contains(versionFromImage, "nightly") {
 		versionFromImage += "-nightly"


### PR DESCRIPTION
This PR removes the registry server `registry.ci.openshift.org` from version images, prior to performing semantic version parsing.

Some Prow CI jobs are currently failing because they're trying to create clusters with an image reported by Cincinnati as `registry.ci.openshift.org/ocp/release:...` [0], which looks to be a recent change from `registry.svc.ci.openshift.org/ocp/release`. The jobs fail because it doesn't parse the version as a valid semantic version - which is because it isn't removing the `registry.ci.openshift.org/org/release:` text of the image prior to parsing check. Examples: [1] [2]

OSDE2E currently removes `registry.svc.ci.openshift.org` from the image, but isn't removing `registry.ci.openshift.org`. This PR makes it attempt to remove both.

This change has been successfully tested with a new build of a 4.7 nightly.

[0] https://openshift-release.apps.ci.l2s4.p1.openshiftapps.com/graph
[1] https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/osde2e-prod-gcp-e2e-osd-nightly-4.7/1346215560303611904
[2] https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/osde2e-prod-aws-e2e-osd-nightly-4.7/1346215551155834880
