### PR TITLE
Validate no nodes have the no schedule taint

### DIFF
--- a/pkg/common/cluster/healthchecks/nodes.go
+++ b/pkg/common/cluster/healthchecks/nodes.go
@@ -42,6 +42,14 @@ func CheckNodeHealth(nodeClient v1.CoreV1Interface, logger *log.Logger) (bool, e
 				success = false
 			}
 		}
+		// Check taints to ensure node is schedulable
+		for _, nt := range node.Spec.Taints {
+			if nt.Effect == "NoSchedule" && nt.Key == "node.kubernetes.io/unschedulable" {
+				metadataState = append(metadataState, fmt.Sprintf("%v", node))
+				logger.Printf("Node (%v) not ready taint: %v=%v\n", node.ObjectMeta.Name, nt.Key, nt.Effect)
+				success = false
+			}
+		}
 	}
 
 	if len(metadataState) > 0 {


### PR DESCRIPTION
This change attempts to validate that no nodes in a cluster have the "NoSchedule" effect.