### PR TITLE
add notification channel config to addon harness

### DIFF
--- a/pkg/common/alert/alert.go
+++ b/pkg/common/alert/alert.go
@@ -96,7 +96,7 @@ func (ma MetricAlert) Check(client *metrics.Client) error {
 
 	if len(results) >= ma.FailureThreshold {
 		log.Printf("Alert triggered for %s: %d >= %d", ma.Name, len(results), ma.FailureThreshold)
-		if err := sendSlackMessage(ma.SlackChannel, fmt.Sprintf("%s has seen %d failures in the last 24h", ma.Name, len(results))); err != nil {
+		if err := SendSlackMessage(ma.SlackChannel, fmt.Sprintf("%s has seen %d failures in the last 24h", ma.Name, len(results))); err != nil {
 			log.Printf("Error sending slack message: %s", err.Error())
 		}
 	}
@@ -132,7 +132,8 @@ func RegisterGinkgoAlert(test, team, contact, slack, email string, threshold int
 	ma.AddAlert(testAlert)
 }
 
-func sendSlackMessage(channel, message string) error {
+// SendSlackMessage sends the message text to the provided channel (if it can be found).
+func SendSlackMessage(channel, message string) error {
 	slackAPI := slack.New(viper.GetString(config.Alert.SlackAPIToken))
 	var slackChannel slack.Channel
 	var ok bool

--- a/pkg/common/alert/alert.go
+++ b/pkg/common/alert/alert.go
@@ -134,7 +134,11 @@ func RegisterGinkgoAlert(test, team, contact, slack, email string, threshold int
 
 // SendSlackMessage sends the message text to the provided channel (if it can be found).
 func SendSlackMessage(channel, message string) error {
-	slackAPI := slack.New(viper.GetString(config.Alert.SlackAPIToken))
+	token := viper.GetString(config.Alert.SlackAPIToken)
+	if len(token) == 0 {
+		return fmt.Errorf("no slack token configured")
+	}
+	slackAPI := slack.New(token)
 	var slackChannel slack.Channel
 	var ok bool
 

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -346,6 +346,11 @@ var Addons = struct {
 	// artifacts created after test harnesses have run
 	// Env: ADDON_CLEANUP_HARNESSES
 	CleanupHarnesses string
+
+	// SlackChannel is the name of a slack channel in the CoreOS slack workspace that will
+	// receive an alert if the tests fail.
+	// Env: ADDON_SLACK_CHANNEL
+	SlackChannel string
 }{
 	IDsAtCreation:    "addons.idsAtCreation",
 	IDs:              "addons.ids",
@@ -353,6 +358,7 @@ var Addons = struct {
 	TestUser:         "addons.testUser",
 	RunCleanup:       "addons.runCleanup",
 	CleanupHarnesses: "addons.cleanupHarnesses",
+	SlackChannel:     "addons.slackChannel",
 }
 
 // Scale config keys.
@@ -570,6 +576,9 @@ func init() {
 
 	viper.SetDefault(Addons.RunCleanup, false)
 	viper.BindEnv(Addons.RunCleanup, "ADDON_RUN_CLEANUP")
+
+	viper.SetDefault(Addons.SlackChannel, "sd-cicd-alerts")
+	viper.BindEnv(Addons.SlackChannel, "ADDON_SLACK_CHANNEL")
 
 	// ----- Scale -----
 	viper.SetDefault(Scale.WorkloadsRepository, "https://github.com/openshift-scale/workloads")

--- a/pkg/e2e/addons/addon_test_harness.go
+++ b/pkg/e2e/addons/addon_test_harness.go
@@ -1,12 +1,14 @@
 package addons
 
 import (
+	"fmt"
 	"log"
 	"strings"
 
 	"github.com/onsi/ginkgo"
 	"github.com/spf13/viper"
 
+	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 )
@@ -24,6 +26,11 @@ var _ = ginkgo.Describe("[Suite: addons] Addon Test Harness", func() {
 	}
 	ginkgo.It("should run until completion", func() {
 		h.SetServiceAccount(viper.GetString(config.Addons.TestUser))
-		h.RunAddonTests("addon-tests", int(addonTimeoutInSeconds), strings.Split(viper.GetString(config.Addons.TestHarnesses), ","), []string{})
+		harnesses := strings.Split(viper.GetString(config.Addons.TestHarnesses), ",")
+		failed := h.RunAddonTests("addon-tests", int(addonTimeoutInSeconds), harnesses, []string{})
+		if len(failed) > 0 {
+			// tests failed, notify
+			alert.SendSlackMessage(viper.GetString(config.Addons.SlackChannel), fmt.Sprintf("Addon tests failed: %v", failed))
+		}
 	}, addonTimeoutInSeconds+30)
 })


### PR DESCRIPTION
This will simply list the harnesses that failed in slack. @jeefy mentioned perhaps providing links to review the test output (which would be cool), but I'm putting this up in its current state to get feedback about the high-level approach.