### PR TITLE
cmd/osde2ectl/get/cmd.go: do not panic if directoy exists

### DIFF
--- a/cmd/osde2ectl/get/cmd.go
+++ b/cmd/osde2ectl/get/cmd.go
@@ -162,7 +162,8 @@ func run(cmd *cobra.Command, argv []string) error {
 				if err != nil {
 					return fmt.Errorf("Unable to create a new directory - %s", err.Error())
 				}
-			} else {
+			}
+			if err != nil {
 				return fmt.Errorf("Unable to stat file path: %s", err.Error())
 			}
 			filePath = filepath.Join(args.kubeConfigPath, filename)


### PR DESCRIPTION
this fixes #657 
If the given directory exists, we should be using that.
Nil pointer was thrown because we didn't have an error in this case but still tried to use it.
Now we only cast an error when we actually have one