### PR TITLE
Enable osd-cluster-ready in-cluster healthcheck

### DIFF
--- a/pkg/common/cluster/healthchecks/pod_predicates.go
+++ b/pkg/common/cluster/healthchecks/pod_predicates.go
@@ -8,6 +8,13 @@ func IsClusterPod(pod kubev1.Pod) bool {
 	return containsPrefixes(pod.Namespace, "openshift-", "kube-", "redhat-")
 }
 
+// IsNotReadinessPod ignores the chicken/egg situation where we're running health checks
+// from within an ephemeral osd-cluster-ready-* Pod. That Pod would otherwise fail the
+// health check it is running because it's in Pending state.
+func IsNotReadinessPod(pod kubev1.Pod) bool {
+	return !matchingNamePrefix(pod, "osd-cluster-ready-")
+}
+
 func MatchesNames(name ...string) PodPredicate {
 	return func(p kubev1.Pod) bool {
 		return matchingNamePrefix(p, name...)

--- a/pkg/common/cluster/healthchecks/pods.go
+++ b/pkg/common/cluster/healthchecks/pods.go
@@ -17,6 +17,7 @@ import (
 func CheckClusterPodHealth(podClient v1.CoreV1Interface, logger *log.Logger) (bool, error) {
 	filters := []PodPredicate{
 		IsClusterPod,
+		IsNotReadinessPod,
 		IsNotRunning,
 		IsNotCompleted,
 	}


### PR DESCRIPTION
This commit enables real health checks to be run from the [osd-cluster-ready Job](https://github.com/iamkirkbater/osd-cluster-ready-job) by:
- Tweaking `PollClusterHealth` to use in-cluster REST config if the `clusterID` is not specified (empty string).
- Ignoring the `osd-cluster-ready` pod itself, as it will be Pending while it's running the health check.