### PR TITLE
Add OLM Inspection to end of test run

### DIFF
--- a/pkg/common/helper/olm.go
+++ b/pkg/common/helper/olm.go
@@ -1,0 +1,29 @@
+package helper
+
+import (
+	"fmt"
+	"github.com/openshift/osde2e/pkg/common/runner"
+)
+
+// InspectOLM inspects the OLM state of the cluster and saves the state to disk for later debugging
+func (h *H) InspectOLM() error {
+	inspectTimeoutInSeconds := 200
+	h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+	r := h.Runner(fmt.Sprintf("oc adm inspect --dest-dir=%v -A olm", runner.DefaultRunner.OutputDir))
+	r.Name = "olm-inspect"
+	r.Tarball = true
+	stopCh := make(chan struct{})
+
+	err := r.Run(inspectTimeoutInSeconds, stopCh)
+	if err != nil {
+		return fmt.Errorf("Error running OLM inspection: %s", err.Error())
+	}
+
+	gatherResults, err := r.RetrieveResults()
+	if err != nil {
+		return fmt.Errorf("Error retrieving OLM inspection results: %s", err.Error())
+	}
+
+	h.WriteResults(gatherResults)
+	return nil
+}

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -464,6 +464,9 @@ func cleanupAfterE2E(h *helper.H) (errors []error) {
 	log.Print("Gathering Test Project State...")
 	h.InspectState()
 
+	log.Print("Gathering OLM State...")
+	h.InspectOLM()
+
 	log.Print("Gathering Cluster State...")
 	clusterState := h.GetClusterState()
 	stateResults := make(map[string][]byte, len(clusterState))


### PR DESCRIPTION
This PR allows `osde2e` to perform an OLM inspection during its end-of-test data gathering process. This will result in an `olm-inspect.tgz` file as part of the generated test artifacts, which can be used alongside existing must-gather data.

Doing this allows us to gather the OLM state of operators on the cluster, which is presently not included as part of must-gathers. The lack of this data makes it quite hard to debug failing tests such as the `Should upgrade from a previous version` ones, and equally hard to provide relevant data to a Bugzilla if we encounter OLM bugs as part of E2E testing.

The must-gather image has recently had an enhancement to do this for us [0], but unfortunately it is not something we can yet make use of. When it makes its way into a release and we start getting it as part of the regular MG we can remove this.

[0] https://github.com/openshift/must-gather/pull/182/files