### PR TITLE
Ignore readiness pod in health checks

### DIFF
--- a/pkg/common/cluster/healthchecks/pods.go
+++ b/pkg/common/cluster/healthchecks/pods.go
@@ -33,6 +33,7 @@ func CheckPodHealth(podClient v1.CoreV1Interface, logger *log.Logger, ns string,
 	filters := []PodPredicate{
 		MatchesNamespace(ns),
 		MatchesNames(podPrefixes...),
+		IsNotReadinessPod,
 		IsNotRunning,
 		IsNotCompleted,
 	}


### PR DESCRIPTION
PR #681 [added](https://github.com/openshift/osde2e/pull/681/files#diff-eeb67b7723fc2c3c66c4d4e7e85f31e1a38d43f7268e0e56e1c997c87b899aaeR11-R17) a predicate to skip the osd-cluster-ready pod when checking whether "all" pods are healthy, because that pod is itself checking whether all pods are healthy. The predicate was [added to CheckClusterPodHealth](https://github.com/openshift/osde2e/pull/681/files#diff-140e0200e3dd96daa38c05e5a3877f19ec4b3b11337d50db24ac917f619b2020R20) but not CheckPodHealth, so tests running through that function can still fail. This commit adds the predicate there.