### PR TITLE
Disable addon list on scale tests

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -357,7 +357,7 @@ var Addons = struct {
 	// Env: ADDON_SLACK_CHANNEL
 	SlackChannel string
 
-	// SkipAddonList is a boolean to indicate whether the listing of addons has to be disbaled or not.
+	// SkipAddonList is a boolean to indicate whether the listing of addons has to be disabled or not.
 	// Env: SKIP_ADDON_LIST
 	SkipAddonList string
 }{

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -356,6 +356,10 @@ var Addons = struct {
 	// receive an alert if the tests fail.
 	// Env: ADDON_SLACK_CHANNEL
 	SlackChannel string
+
+	// SkipAddonList is a boolean to indicate whether the listing of addons has to be disbaled or not.
+	// Env: SKIP_ADDON_LIST
+	SkipAddonList string
 }{
 	IDsAtCreation:    "addons.idsAtCreation",
 	IDs:              "addons.ids",
@@ -364,6 +368,7 @@ var Addons = struct {
 	RunCleanup:       "addons.runCleanup",
 	CleanupHarnesses: "addons.cleanupHarnesses",
 	SlackChannel:     "addons.slackChannel",
+	SkipAddonList:    "addons.skipAddonlist",
 }
 
 // Scale config keys.
@@ -587,6 +592,9 @@ func init() {
 
 	viper.SetDefault(Addons.SlackChannel, "sd-cicd-alerts")
 	viper.BindEnv(Addons.SlackChannel, "ADDON_SLACK_CHANNEL")
+
+	viper.SetDefault(Addons.SkipAddonList, false)
+	viper.BindEnv(Addons.SkipAddonList, "SKIP_ADDON_LIST")
 
 	// ----- Scale -----
 	viper.SetDefault(Scale.WorkloadsRepository, "https://github.com/openshift-scale/workloads")

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -35,6 +35,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/metadata"
 	"github.com/openshift/osde2e/pkg/common/phase"
 	"github.com/openshift/osde2e/pkg/common/providers"
+	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
 	"github.com/openshift/osde2e/pkg/common/runner"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/upgrade"
@@ -102,7 +103,19 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		viper.Set(config.CloudProvider.Region, cluster.Region())
 		log.Printf("CLOUD_PROVIDER_REGION set to %s from OCM.", viper.GetString(config.CloudProvider.Region))
 
-		log.Printf("Found addons: %s", strings.Join(cluster.Addons(), ","))
+		scaleTestCluster := false
+		additionalLabels := viper.GetString(ocmprovider.AdditionalLabels)
+		if len(additionalLabels) > 0 {
+			for _, label := range strings.Split(additionalLabels, ",") {
+				if label == "scaleTestCluster" {
+					scaleTestCluster = true
+				}
+			}
+		}
+
+		if !scaleTestCluster {
+			log.Printf("Found addons: %s", strings.Join(cluster.Addons(), ","))
+		}
 
 		metadata.Instance.SetClusterName(cluster.Name())
 		metadata.Instance.SetClusterID(cluster.ID())

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -35,7 +35,6 @@ import (
 	"github.com/openshift/osde2e/pkg/common/metadata"
 	"github.com/openshift/osde2e/pkg/common/phase"
 	"github.com/openshift/osde2e/pkg/common/providers"
-	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
 	"github.com/openshift/osde2e/pkg/common/runner"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/upgrade"
@@ -103,17 +102,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		viper.Set(config.CloudProvider.Region, cluster.Region())
 		log.Printf("CLOUD_PROVIDER_REGION set to %s from OCM.", viper.GetString(config.CloudProvider.Region))
 
-		scaleTestCluster := false
-		additionalLabels := viper.GetString(ocmprovider.AdditionalLabels)
-		if len(additionalLabels) > 0 {
-			for _, label := range strings.Split(additionalLabels, ",") {
-				if label == "scaleTestCluster" {
-					scaleTestCluster = true
-				}
-			}
-		}
-
-		if !scaleTestCluster {
+		if !viper.GetBool(config.Addons.SkipAddonList) {
 			log.Printf("Found addons: %s", strings.Join(cluster.Addons(), ","))
 		}
 


### PR DESCRIPTION
Inserted a config flag check to disable listing of addons in clusters for a scale test during health check polling.