### PR TITLE
SDCICD-574: Ensure supplied versions retain their channel suffix so CIS matches

### DIFF
--- a/pkg/common/versions/version_selector.go
+++ b/pkg/common/versions/version_selector.go
@@ -4,12 +4,15 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"strings"
 
 	"github.com/Masterminds/semver"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/util"
 	"github.com/openshift/osde2e/pkg/common/versions/installselectors"
 	"github.com/openshift/osde2e/pkg/common/versions/upgradeselectors"
+	"github.com/spf13/viper"
 )
 
 // GetVersionForInstall will get a version based upon available configuration options.
@@ -32,6 +35,11 @@ func GetVersionForInstall(versionList *spi.VersionList) (*semver.Version, string
 	}
 
 	v, selector, err := selectedVersionSelector.SelectVersion(versionList)
+
+	channel := viper.GetString(config.Cluster.Channel)
+	if channel != "stable" && !strings.Contains(v.Original(), channel) {
+		v = semver.MustParse(fmt.Sprintf("%s-%s", v.Original(), channel))
+	}
 
 	return v, selector, err
 }

--- a/pkg/e2e/version.go
+++ b/pkg/e2e/version.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/Masterminds/semver"
@@ -129,10 +128,6 @@ func setupUpgradeVersion(clusterVersion *semver.Version, versionList *spi.Versio
 		log.Printf("No upgrade selector found. Not selecting an upgrade version.")
 		return nil
 	}
-
-	releaseName = strings.Replace(releaseName, "-nightly", "", -1)
-	releaseName = strings.Replace(releaseName, "-candidate", "", -1)
-	releaseName = strings.Replace(releaseName, "-fast", "", -1)
 
 	viper.Set(config.Upgrade.ReleaseName, releaseName)
 	viper.Set(config.Upgrade.Image, image)


### PR DESCRIPTION
Previously we had to strip the channel names from versions to match installed CISs.

Now CISs have the channel as a suffix and we support multiple channels. :) 