### PR TITLE
fix: use junit data to determine openshift-suite pass/fail status

### DIFF
--- a/pkg/common/runner/results_test.go
+++ b/pkg/common/runner/results_test.go
@@ -168,26 +168,6 @@ func (r ResultsServerReactor) React(action kubetest.Action) (handled bool, ret r
 	return
 }
 
-func resultsServerReactor(action kubetest.Action) (handled bool, ret rest.ResponseWrapper, err error) {
-	proxyAction := action.(kubetest.ProxyGetActionImpl)
-
-	// only respond to service proxy requests
-	if handled = proxyAction.Matches(http.MethodGet, "services"); !handled {
-		return
-	}
-
-	path := strings.TrimPrefix(proxyAction.Path, "/")
-	if path == "" {
-		ret = resultPage
-	} else if data, ok := goodResults[path]; ok {
-		ret = response(data)
-	} else {
-		ret = response{}
-	}
-
-	return
-}
-
 type response []byte
 
 func (r response) DoRaw(context.Context) ([]byte, error) {

--- a/pkg/common/runner/results_test.go
+++ b/pkg/common/runner/results_test.go
@@ -17,13 +17,50 @@ import (
 )
 
 var (
-	expectedResults = map[string][]byte{
+	goodResults = map[string][]byte{
+		"a":                 []byte("testdata"),
+		"b":                 []byte("moretestdata"),
+		"c":                 []byte("evenmoretestdata"),
+		"junit-results.xml": []byte(goodXML),
+	}
+	badResults = map[string][]byte{
+		"a":                     []byte("testdata"),
+		"b":                     []byte("moretestdata"),
+		"c":                     []byte("evenmoretestdata"),
+		"junit-bad-results.xml": []byte(badXML),
+	}
+	noXMLResults = map[string][]byte{
 		"a": []byte("testdata"),
 		"b": []byte("moretestdata"),
 		"c": []byte("evenmoretestdata"),
 	}
+	goodXML = `<testsuite name="Suite" tests="1" failures="0" errors="0" time="0">
+    <testcase name="[Suite] testname" classname="classname" time="0">
+        <passed>Passed with 0 matches
+        </passed>
+    </testcase>
+</testsuite>`
+
+	badXML = `<testsuite name="Suite" tests="1" failures="0" errors="0" time="0">
+    <test`
 
 	resultPage = response(`
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN"><html>
+<title>Directory listing for /</title>
+<body>
+<h2>Directory listing for /</h2>
+<hr>
+<ul>
+<li><a href="a">a</a>
+<li><a href="b">b</a>
+<li><a href="c">c</a>
+<li><a href="junit-results.xml">junit-results.xml</a>
+</ul>
+<hr>
+</body>
+</html>
+`)
+	noXMLResultPage = response(`
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN"><html>
 <title>Directory listing for /</title>
 <body>
@@ -38,39 +75,109 @@ var (
 </body>
 </html>
 `)
+	badXMLResultPage = response(`
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 3.2 Final//EN"><html>
+<title>Directory listing for /</title>
+<body>
+<h2>Directory listing for /</h2>
+<hr>
+<ul>
+<li><a href="a">a</a>
+<li><a href="b">b</a>
+<li><a href="c">c</a>
+<li><a href="junit-bad-results.xml">junit-bad-results.xml</a>
+</ul>
+<hr>
+</body>
+</html>
+`)
 )
 
 func TestRetrieveResults(t *testing.T) {
-	// setup mock client
-	client := fake.NewSimpleClientset()
-	client.AddProxyReactor("services", resultsServerReactor)
-
-	// setup runner
-	def := *DefaultRunner
-	r := &def
-	r.Kube = client
-
-	// create results service
-	svc, err := r.createService(new(kubev1.Pod))
-	if err != nil {
-		t.Fatalf("Failed to create example service: %v", err)
+	type testcase struct {
+		Name string
+		ResultsServerReactor
+		Expected    map[string][]byte
+		ShouldError bool
 	}
-	r.svc = svc
+	for _, testcase := range []testcase{
+		{
+			Name:                 "validXMLPresent",
+			ResultsServerReactor: ResultsServerReactor{resultPage},
+			Expected:             goodResults,
+			ShouldError:          false,
+		},
+		{
+			Name:                 "XMLMissing",
+			ResultsServerReactor: ResultsServerReactor{noXMLResultPage},
+			Expected:             noXMLResults,
+			ShouldError:          true,
+		},
+		{
+			Name:                 "XMLMissing",
+			ResultsServerReactor: ResultsServerReactor{badXMLResultPage},
+			Expected:             badResults,
+			ShouldError:          true,
+		},
+	} {
+		t.Run(testcase.Name, func(t *testing.T) {
+			// setup mock client
+			client := fake.NewSimpleClientset()
+			client.AddProxyReactor("services", testcase.React)
 
-	// get results
-	results, err := r.RetrieveResults()
-	if err != nil {
-		t.Fatalf("Failed to get results: %v", err)
+			// setup runner
+			def := *DefaultRunner
+			r := &def
+			r.Kube = client
+
+			// create results service
+			svc, err := r.createService(new(kubev1.Pod))
+			if err != nil {
+				t.Fatalf("Failed to create example service: %v", err)
+			}
+			r.svc = svc
+
+			// get results
+			results, err := r.RetrieveResults()
+			if err != nil && !testcase.ShouldError {
+				t.Fatalf("Failed to get results: %v", err)
+			}
+			if !testcase.ShouldError {
+				// compare to expected
+				for k, v := range testcase.Expected {
+					if actualV, ok := results[k]; !ok {
+						t.Fatalf("missing file '%s' in results", k)
+					} else if !bytes.Equal(actualV, v) {
+						t.Fatalf("file '%s' has been corrupted: want '%s', got '%s'", k, v, actualV)
+					}
+				}
+			}
+		})
+	}
+}
+
+type ResultsServerReactor struct {
+	IndexPage rest.ResponseWrapper
+}
+
+func (r ResultsServerReactor) React(action kubetest.Action) (handled bool, ret rest.ResponseWrapper, err error) {
+	proxyAction := action.(kubetest.ProxyGetActionImpl)
+
+	// only respond to service proxy requests
+	if handled = proxyAction.Matches(http.MethodGet, "services"); !handled {
+		return
 	}
 
-	// compare to expected
-	for k, v := range expectedResults {
-		if actualV, ok := results[k]; !ok {
-			t.Fatalf("missing file '%s' in results", k)
-		} else if !bytes.Equal(actualV, v) {
-			t.Fatalf("file '%s' has been corrupted: want '%s', got '%s'", k, v, actualV)
-		}
+	path := strings.TrimPrefix(proxyAction.Path, "/")
+	if path == "" {
+		ret = r.IndexPage
+	} else if data, ok := goodResults[path]; ok {
+		ret = response(data)
+	} else {
+		ret = response{}
 	}
+
+	return
 }
 
 func resultsServerReactor(action kubetest.Action) (handled bool, ret rest.ResponseWrapper, err error) {
@@ -84,7 +191,7 @@ func resultsServerReactor(action kubetest.Action) (handled bool, ret rest.Respon
 	path := strings.TrimPrefix(proxyAction.Path, "/")
 	if path == "" {
 		ret = resultPage
-	} else if data, ok := expectedResults[path]; ok {
+	} else if data, ok := goodResults[path]; ok {
 		ret = response(data)
 	} else {
 		ret = response{}

--- a/pkg/e2e/openshift/config.go
+++ b/pkg/e2e/openshift/config.go
@@ -10,11 +10,11 @@ import (
 )
 
 const testCmd = `
-oc config set-cluster {{.Name}} --server=https://kubernetes.default --certificate-authority={{.CA}}
-oc config set-credentials {{.Name}} --token=$(cat {{.TokenFile}})
-oc config set-context {{.Name}} --cluster={{.Name}} --user={{.Name}}
-oc config use-context {{.Name}}
-oc config view > /tmp/kubeconfig
+oc config set-cluster cluster --server=https://kubernetes.default.svc --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+oc config set-credentials user --token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+oc config set-context cluster --cluster=cluster --user=user
+oc config use-context cluster
+oc config view --raw=true > /tmp/kubeconfig
 export KUBECONFIG=/tmp/kubeconfig
 
 {{printTests .TestNames}} | {{unwrap .Env}} openshift-tests {{.TestCmd}} {{selectTests .Suite .TestNames}} {{unwrap .Flags}}

--- a/pkg/e2e/openshift/disruptive.go
+++ b/pkg/e2e/openshift/disruptive.go
@@ -26,6 +26,7 @@ var _ = ginkgo.Describe(disruptiveTestName, func() {
 		cfg := DefaultE2EConfig
 		cfg.Suite = "openshift/disruptive"
 		cmd := cfg.Cmd()
+		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
 
 		// setup runner
 		r := h.Runner(cmd)

--- a/pkg/e2e/openshift/images.go
+++ b/pkg/e2e/openshift/images.go
@@ -23,6 +23,7 @@ var _ = ginkgo.Describe(imageRegistryTestName, func() {
 
 	e2eTimeoutInSeconds := 3600
 	ginkgo.It("should run until completion", func() {
+		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
 		// configure tests
 		cfg := DefaultE2EConfig
 		cfg.Suite = "openshift/image-registry"
@@ -58,6 +59,7 @@ var _ = ginkgo.Describe(imageEcosystemTestName, func() {
 		cfg.Suite = "openshift/image-ecosystem"
 		cmd := cfg.Cmd()
 
+		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
 		// setup runner
 		r := h.Runner(cmd)
 


### PR DESCRIPTION
This commit does several things:
- Fixes all of the tests to be configured as cluster admin
- Stops overriding the user account in use away from cluster admin
- Changes the way that we determine failure from exit status to
  parsing the junit XML. Unparsable xml, lack of xml, or failures
  in XML will cause the test to fail.

Signed-off-by: Chris Waldon <cwaldon@redhat.com>