### PR TITLE
add informing to run suites that are marked as informing locally

### DIFF
--- a/configs/informing.yaml
+++ b/configs/informing.yaml
@@ -1,0 +1,3 @@
+tests:
+  testsToRun:
+  - '[Suite: informing]'


### PR DESCRIPTION
that might enable running informing suites locally with `GINKGO_FOCUS` flag