### PR TITLE
SDCICD-583: update latest filter to follow latest-y and latest-z filters

### DIFF
--- a/pkg/common/versions/upgradeselectors/latest_version_selector.go
+++ b/pkg/common/versions/upgradeselectors/latest_version_selector.go
@@ -30,15 +30,19 @@ func (l latestVersion) SelectVersion(installVersion *spi.Version, versionList *s
 
 	for _, v := range versionList.FindVersion(installVersion.Version().Original()) {
 		for upgradeVersion := range v.AvailableUpgrades() {
-			if upgradeVersion.Prerelease() != "" {
-				if strings.Contains(upgradeVersion.Prerelease(), "nightly") && upgradeVersion.GreaterThan(newestVersion.Version()) {
+			if strings.Contains(upgradeVersion.Original(), "nightly") && !strings.Contains(newestVersion.Version().Original(), "nightly") {
+				newestVersion = spi.NewVersionBuilder().Version(upgradeVersion).Build()
+				continue
+			}
+
+			// Catch the rest
+			if strings.Contains(upgradeVersion.Original(), "nightly") && strings.Contains(newestVersion.Version().Original(), "nightly") {
+				if upgradeVersion.Original() > newestVersion.Version().Original() {
 					newestVersion = spi.NewVersionBuilder().Version(upgradeVersion).Build()
 				}
 			} else {
-				if newestVersion.Version().Prerelease() == "" {
-					if upgradeVersion.GreaterThan(newestVersion.Version()) {
-						newestVersion = spi.NewVersionBuilder().Version(upgradeVersion).Build()
-					}
+				if upgradeVersion.GreaterThan(newestVersion.Version()) {
+					newestVersion = spi.NewVersionBuilder().Version(upgradeVersion).Build()
 				}
 			}
 		}

--- a/pkg/common/versions/upgradeselectors/latest_version_selector.go
+++ b/pkg/common/versions/upgradeselectors/latest_version_selector.go
@@ -30,20 +30,10 @@ func (l latestVersion) SelectVersion(installVersion *spi.Version, versionList *s
 
 	for _, v := range versionList.FindVersion(installVersion.Version().Original()) {
 		for upgradeVersion := range v.AvailableUpgrades() {
-			if strings.Contains(upgradeVersion.Original(), "nightly") && !strings.Contains(newestVersion.Version().Original(), "nightly") {
+			upgradeIsNightly := strings.Contains(upgradeVersion.Original(), "nightly")
+			newestIsNightly := strings.Contains(newestVersion.Version().Original(), "nightly")
+			if (upgradeIsNightly && !newestIsNightly) || upgradeVersion.GreaterThan(newestVersion.Version()) {
 				newestVersion = spi.NewVersionBuilder().Version(upgradeVersion).Build()
-				continue
-			}
-
-			// Catch the rest
-			if strings.Contains(upgradeVersion.Original(), "nightly") && strings.Contains(newestVersion.Version().Original(), "nightly") {
-				if upgradeVersion.Original() > newestVersion.Version().Original() {
-					newestVersion = spi.NewVersionBuilder().Version(upgradeVersion).Build()
-				}
-			} else {
-				if upgradeVersion.GreaterThan(newestVersion.Version()) {
-					newestVersion = spi.NewVersionBuilder().Version(upgradeVersion).Build()
-				}
 			}
 		}
 	}

--- a/pkg/common/versions/upgradeselectors/latest_version_selector_test.go
+++ b/pkg/common/versions/upgradeselectors/latest_version_selector_test.go
@@ -88,6 +88,72 @@ func TestLatestVersionSelectVersion(t *testing.T) {
 			expectedVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.3.3")).Build(),
 		},
 		{
+			name:           "get latest version from candidate channel",
+			installVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.2.0-candidate")).Build(),
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0-candidate")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0-candidate")).AvailableUpgrades(map[*semver.Version]bool{
+						semver.MustParse("4.2.2-candidate"): true,
+						semver.MustParse("4.2.4-candidate"): true,
+						semver.MustParse("4.3.3-candidate"): true,
+					}).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0-candidate")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0-candidate")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0-candidate")).AvailableUpgrades(map[*semver.Version]bool{
+						semver.MustParse("4.3.2-candidate"): true,
+						semver.MustParse("4.3.4-candidate"): true,
+						semver.MustParse("4.4.0-candidate"): true,
+					}).Build(),
+				}).
+				Build(),
+			expectedVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.3.3-candidate")).Build(),
+		},
+		{
+			name:           "get latest feature candidate from candidate channel",
+			installVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.2.0-candidate")).Build(),
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0-candidate")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0-candidate")).AvailableUpgrades(map[*semver.Version]bool{
+						semver.MustParse("4.2.2-candidate"): true,
+						semver.MustParse("4.2.4-candidate"): true,
+						semver.MustParse("4.3.3-fc.0"):      true,
+					}).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0-candidate")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0-candidate")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0-candidate")).AvailableUpgrades(map[*semver.Version]bool{
+						semver.MustParse("4.3.2-candidate"): true,
+						semver.MustParse("4.3.4-candidate"): true,
+						semver.MustParse("4.4.0-candidate"): true,
+					}).Build(),
+				}).
+				Build(),
+			expectedVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.3.3-fc.0")).Build(),
+		},
+		{
+			name:           "get latest release candidate from candidate channel",
+			installVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.2.0-candidate")).Build(),
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0-candidate")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0-candidate")).AvailableUpgrades(map[*semver.Version]bool{
+						semver.MustParse("4.2.2-candidate"): true,
+						semver.MustParse("4.2.4-candidate"): true,
+						semver.MustParse("4.3.3-rc.0"):      true,
+					}).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0-candidate")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0-candidate")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0-candidate")).AvailableUpgrades(map[*semver.Version]bool{
+						semver.MustParse("4.3.2-candidate"): true,
+						semver.MustParse("4.3.4-candidate"): true,
+						semver.MustParse("4.4.0-candidate"): true,
+					}).Build(),
+				}).
+				Build(),
+			expectedVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.3.3-rc.0")).Build(),
+		},
+		{
 			name:           "no versions",
 			installVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.2.0")).Build(),
 			versions: spi.NewVersionListBuilder().

--- a/pkg/common/versions/upgradeselectors/latest_y_selector.go
+++ b/pkg/common/versions/upgradeselectors/latest_y_selector.go
@@ -34,22 +34,10 @@ func (l latestYVersion) SelectVersion(installVersion *spi.Version, versionList *
 				continue
 			}
 
-			// Automatically assume a Y+1 nightly is greater than a non-nightly-build
-			if strings.Contains(upgradeVersion.Original(), "nightly") && !strings.Contains(newestVersion.Version().Original(), "nightly") {
+			upgradeIsNightly := strings.Contains(upgradeVersion.Original(), "nightly")
+			newestIsNightly := strings.Contains(newestVersion.Version().Original(), "nightly")
+			if (upgradeIsNightly && !newestIsNightly) || upgradeVersion.GreaterThan(newestVersion.Version()) {
 				newestVersion = spi.NewVersionBuilder().Version(upgradeVersion).Build()
-				continue
-			}
-
-			// Automatically assume a Y+1 nightly is greater than a non-nightly-build
-			if strings.Contains(upgradeVersion.Original(), "nightly") && strings.Contains(newestVersion.Version().Original(), "nightly") {
-				if upgradeVersion.Original() > newestVersion.Version().Original() {
-					newestVersion = spi.NewVersionBuilder().Version(upgradeVersion).Build()
-				}
-			} else {
-				// Catch the rest
-				if upgradeVersion.GreaterThan(newestVersion.Version()) {
-					newestVersion = spi.NewVersionBuilder().Version(upgradeVersion).Build()
-				}
 			}
 		}
 	}

--- a/pkg/common/versions/upgradeselectors/latest_y_selector_test.go
+++ b/pkg/common/versions/upgradeselectors/latest_y_selector_test.go
@@ -84,6 +84,72 @@ func TestLatestYVersionSelectVersion(t *testing.T) {
 			expectedVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.3.0")).Build(),
 		},
 		{
+			name:           "get latest version from candidate channel",
+			installVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.2.0-candidate")).Build(),
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0-candidate")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0-candidate")).AvailableUpgrades(map[*semver.Version]bool{
+						semver.MustParse("4.2.2-candidate"): true,
+						semver.MustParse("4.2.4-candidate"): true,
+						semver.MustParse("4.3.3-candidate"): true,
+					}).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0-candidate")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0-candidate")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0-candidate")).AvailableUpgrades(map[*semver.Version]bool{
+						semver.MustParse("4.3.2-candidate"): true,
+						semver.MustParse("4.3.4-candidate"): true,
+						semver.MustParse("4.4.0-candidate"): true,
+					}).Build(),
+				}).
+				Build(),
+			expectedVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.3.3-candidate")).Build(),
+		},
+		{
+			name:           "get latest feature candidate from candidate channel",
+			installVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.2.0-candidate")).Build(),
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0-candidate")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0-candidate")).AvailableUpgrades(map[*semver.Version]bool{
+						semver.MustParse("4.2.2-candidate"): true,
+						semver.MustParse("4.2.4-candidate"): true,
+						semver.MustParse("4.3.3-fc.0"):      true,
+					}).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0-candidate")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0-candidate")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0-candidate")).AvailableUpgrades(map[*semver.Version]bool{
+						semver.MustParse("4.3.2-candidate"): true,
+						semver.MustParse("4.3.4-candidate"): true,
+						semver.MustParse("4.4.0-candidate"): true,
+					}).Build(),
+				}).
+				Build(),
+			expectedVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.3.3-fc.0")).Build(),
+		},
+		{
+			name:           "get latest release candidate from candidate channel",
+			installVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.2.0-candidate")).Build(),
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0-candidate")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0-candidate")).AvailableUpgrades(map[*semver.Version]bool{
+						semver.MustParse("4.2.2-candidate"): true,
+						semver.MustParse("4.2.4-candidate"): true,
+						semver.MustParse("4.3.3-rc.0"):      true,
+					}).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0-candidate")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0-candidate")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0-candidate")).AvailableUpgrades(map[*semver.Version]bool{
+						semver.MustParse("4.3.2-candidate"): true,
+						semver.MustParse("4.3.4-candidate"): true,
+						semver.MustParse("4.4.0-candidate"): true,
+					}).Build(),
+				}).
+				Build(),
+			expectedVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.3.3-rc.0")).Build(),
+		},
+		{
 			name:           "no versions",
 			installVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.2.0")).Build(),
 			versions: spi.NewVersionListBuilder().

--- a/pkg/common/versions/upgradeselectors/latest_z_selector.go
+++ b/pkg/common/versions/upgradeselectors/latest_z_selector.go
@@ -41,15 +41,10 @@ func (l latestZVersion) SelectVersion(installVersion *spi.Version, versionList *
 				continue
 			}
 
-			// Catch the rest
-			if strings.Contains(upgradeVersion.Original(), "nightly") && strings.Contains(newestVersion.Version().Original(), "nightly") {
-				if upgradeVersion.Original() > newestVersion.Version().Original() {
-					newestVersion = spi.NewVersionBuilder().Version(upgradeVersion).Build()
-				}
-			} else {
-				if upgradeVersion.GreaterThan(newestVersion.Version()) {
-					newestVersion = spi.NewVersionBuilder().Version(upgradeVersion).Build()
-				}
+			upgradeIsNightly := strings.Contains(upgradeVersion.Original(), "nightly")
+			newestIsNightly := strings.Contains(newestVersion.Version().Original(), "nightly")
+			if (upgradeIsNightly && !newestIsNightly) || upgradeVersion.GreaterThan(newestVersion.Version()) {
+				newestVersion = spi.NewVersionBuilder().Version(upgradeVersion).Build()
 			}
 		}
 	}

--- a/pkg/common/versions/upgradeselectors/latest_z_selector_test.go
+++ b/pkg/common/versions/upgradeselectors/latest_z_selector_test.go
@@ -82,6 +82,28 @@ func TestLatestZVersionSelectVersion(t *testing.T) {
 			expectedVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.2.4")).Build(),
 		},
 		{
+			name:           "get latest version from candidate channel",
+			installVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.2.0-candidate")).Build(),
+			versions: spi.NewVersionListBuilder().
+				AvailableVersions([]*spi.Version{
+					spi.NewVersionBuilder().Version(semver.MustParse("4.4.0-candidate")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.2.0-candidate")).AvailableUpgrades(map[*semver.Version]bool{
+						semver.MustParse("4.2.2-candidate"): true,
+						semver.MustParse("4.2.4-candidate"): true,
+						semver.MustParse("4.3.3-candidate"): true,
+					}).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.5.0-candidate")).Build(),
+					spi.NewVersionBuilder().Version(semver.MustParse("4.1.0-candidate")).Build(),
+					spi.NewVersionBuilder().Default(true).Version(semver.MustParse("4.3.0-candidate")).AvailableUpgrades(map[*semver.Version]bool{
+						semver.MustParse("4.3.2-candidate"): true,
+						semver.MustParse("4.3.4-candidate"): true,
+						semver.MustParse("4.4.0-candidate"): true,
+					}).Build(),
+				}).
+				Build(),
+			expectedVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.2.4-candidate")).Build(),
+		},
+		{
 			name:           "no versions",
 			installVersion: spi.NewVersionBuilder().Version(semver.MustParse("4.2.0")).Build(),
 			versions: spi.NewVersionListBuilder().


### PR DESCRIPTION
I didn't update the basic "latest" filter with the same logic I did y/z. :upside_down_face: 