### PR TITLE
fix: ensure results fetch returns partial results on error

### DIFF
--- a/pkg/common/runner/results.go
+++ b/pkg/common/runner/results.go
@@ -62,10 +62,10 @@ func (r *Runner) RetrieveResults() (map[string][]byte, error) {
 	}
 	hadXML, err := ensurePassingXML(results)
 	if err != nil {
-		return nil, fmt.Errorf("failed checking results for Junit XML report: %w", err)
+		return results, fmt.Errorf("failed checking results for Junit XML report: %w", err)
 	}
 	if !hadXML {
-		return nil, fmt.Errorf("results did not contain Junit XML report")
+		return results, fmt.Errorf("results did not contain Junit XML report")
 	}
 	return results, err
 }


### PR DESCRIPTION
This ensures that whatever logs are available actually make it into the
artifacts for a given run even when the junit data is missing or indicates
problems.

Fixes [SDCICD-587](https://issues.redhat.com/browse/SDCICD-587)

Signed-off-by: Chris Waldon <cwaldon@redhat.com>