### PR TITLE
fix: introduce RetrieveTestResults

### DIFF
--- a/pkg/common/helper/addons.go
+++ b/pkg/common/helper/addons.go
@@ -78,7 +78,7 @@ func (h *H) RunAddonTests(name string, timeout int, harnesses, args []string) (f
 		Expect(err).NotTo(HaveOccurred())
 
 		// get results
-		results, err := r.RetrieveResults()
+		results, err := r.RetrieveTestResults()
 		Expect(err).NotTo(HaveOccurred())
 
 		// write results

--- a/pkg/common/runner/results.go
+++ b/pkg/common/runner/results.go
@@ -60,6 +60,15 @@ func (r *Runner) RetrieveResults() (map[string][]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed retrieving results: %w", err)
 	}
+	return results, err
+}
+
+// RetrieveTestResults gathers and validates the results from the test Pod. Should only be called after tests are finished. This method both fetches the results and ensures that they contain valid JUnit XML indicating that all tests passed.
+func (r *Runner) RetrieveTestResults() (map[string][]byte, error) {
+	results, err := r.RetrieveResults()
+	if err != nil {
+		return nil, fmt.Errorf("failed retrieving results: %w", err)
+	}
 	hadXML, err := ensurePassingXML(results)
 	if err != nil {
 		return results, fmt.Errorf("failed checking results for Junit XML report: %w", err)

--- a/pkg/common/runner/results_test.go
+++ b/pkg/common/runner/results_test.go
@@ -76,7 +76,7 @@ var (
 `))
 )
 
-func TestRetrieveResults(t *testing.T) {
+func TestRetrieveTestResults(t *testing.T) {
 	type testcase struct {
 		Name        string
 		Expected    map[string][]byte
@@ -121,7 +121,7 @@ func TestRetrieveResults(t *testing.T) {
 			r.svc = svc
 
 			// get results
-			results, err := r.RetrieveResults()
+			results, err := r.RetrieveTestResults()
 			if err != nil && !testcase.ShouldError {
 				t.Fatalf("Failed to get results: %v", err)
 			} else if err == nil && testcase.ShouldError {

--- a/pkg/e2e/openshift/app_builds.go
+++ b/pkg/e2e/openshift/app_builds.go
@@ -103,7 +103,7 @@ var _ = ginkgo.Describe(appBuildsTestName, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// get results
-			results, err := r.RetrieveResults()
+			results, err := r.RetrieveTestResults()
 			Expect(err).NotTo(HaveOccurred())
 
 			// write results

--- a/pkg/e2e/openshift/conformance.go
+++ b/pkg/e2e/openshift/conformance.go
@@ -57,7 +57,7 @@ var _ = ginkgo.Describe(conformanceK8sTestName, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// get results
-		results, err := r.RetrieveResults()
+		results, err := r.RetrieveTestResults()
 		Expect(err).NotTo(HaveOccurred())
 
 		// write results
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe(conformanceOpenshiftTestName, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// get results
-		results, err := r.RetrieveResults()
+		results, err := r.RetrieveTestResults()
 		Expect(err).NotTo(HaveOccurred())
 
 		// write results

--- a/pkg/e2e/openshift/disruptive.go
+++ b/pkg/e2e/openshift/disruptive.go
@@ -39,7 +39,7 @@ var _ = ginkgo.Describe(disruptiveTestName, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// get results
-		results, err := r.RetrieveResults()
+		results, err := r.RetrieveTestResults()
 		Expect(err).NotTo(HaveOccurred())
 
 		// write results

--- a/pkg/e2e/openshift/images.go
+++ b/pkg/e2e/openshift/images.go
@@ -40,7 +40,7 @@ var _ = ginkgo.Describe(imageRegistryTestName, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// get results
-		results, err := r.RetrieveResults()
+		results, err := r.RetrieveTestResults()
 		Expect(err).NotTo(HaveOccurred())
 
 		// write results
@@ -71,7 +71,7 @@ var _ = ginkgo.Describe(imageEcosystemTestName, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// get results
-		results, err := r.RetrieveResults()
+		results, err := r.RetrieveTestResults()
 		Expect(err).NotTo(HaveOccurred())
 
 		// write results

--- a/pkg/e2e/operators/operators.go
+++ b/pkg/e2e/operators/operators.go
@@ -516,7 +516,7 @@ func getReplacesCSV(h *helper.H, subscriptionNS string, csvDisplayName string, c
 	Expect(err).NotTo(HaveOccurred())
 
 	// get results
-	results, err := r.RetrieveResults()
+	results, err := r.RetrieveTestResults()
 	Expect(err).NotTo(HaveOccurred())
 
 	var result map[string]interface{}


### PR DESCRIPTION
I had previously altered RetrieveResults to validate that there
was a present, valid, passing Junit XML in the results, but it
turns out that RetrieveResults is often used for other things.
Changing its behavior broke a lot of stuff throughout the code-
base, so I instead introduced a new method with the additional
validation.

Signed-off-by: Chris Waldon <cwaldon@redhat.com>