### PR TITLE
fix: ensure we do not panic when selecting versions

### DIFF
--- a/pkg/common/versions/version_selector.go
+++ b/pkg/common/versions/version_selector.go
@@ -35,6 +35,10 @@ func GetVersionForInstall(versionList *spi.VersionList) (*semver.Version, string
 	}
 
 	v, selector, err := selectedVersionSelector.SelectVersion(versionList)
+	if err != nil {
+		return v, selector, fmt.Errorf("could not select a version from versionlist %v: %w", versionList, err)
+
+	}
 
 	channel := viper.GetString(config.Cluster.Channel)
 	if channel != "stable" && !strings.Contains(v.Original(), channel) {


### PR DESCRIPTION
This introduces an error guard before we attempt to use the results of
selectedVersionSelect.SelectVersion(). This used to be unnecessary, as
we immediately returned from the function, but we recently need to
add new logic.

This should prevent crashes like:

https://prow.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-ocp-osd-aws-nightly-4.7/1362027280439709696

Signed-off-by: Chris Waldon <cwaldon@redhat.com>