### PR TITLE
fix: accept multi-suite junit xml in e2e harness

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/hpcloud/tail"
+	junit "github.com/joshdk/go-junit"
 	vegeta "github.com/tsenart/vegeta/lib"
 
 	"github.com/onsi/ginkgo"
@@ -42,6 +43,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/util"
 	"github.com/openshift/osde2e/pkg/debug"
 	"github.com/openshift/osde2e/pkg/e2e/routemonitors"
+	"github.com/openshift/osde2e/pkg/reporting/ginkgorep"
 )
 
 const (
@@ -569,7 +571,7 @@ func runTestsInPhase(phase string, description string, dryrun bool) bool {
 	}
 	suffix := viper.GetString(config.Suffix)
 	phaseReportPath := filepath.Join(phaseDirectory, fmt.Sprintf("junit_%v.xml", suffix))
-	phaseReporter := reporters.NewJUnitReporter(phaseReportPath)
+	phaseReporter := ginkgorep.NewPhaseReporter(phase, phaseReportPath)
 	ginkgoPassed := false
 
 	// We need this anonymous function to make sure GinkgoRecover runs where we want it to
@@ -592,39 +594,24 @@ func runTestsInPhase(phase string, description string, dryrun bool) bool {
 		if file != nil {
 			// Process the jUnit XML result files
 			if junitFileRegex.MatchString(file.Name()) {
-				data, err := ioutil.ReadFile(filepath.Join(phaseDirectory, file.Name()))
+				suites, err := junit.IngestFile(filepath.Join(phaseDirectory, file.Name()))
 				if err != nil {
-					log.Printf("error opening junit file %s: %s", file.Name(), err.Error())
-					return false
-				}
-				// Use Ginkgo's JUnitTestSuite to unmarshal the JUnit XML file
-				var testSuite reporters.JUnitTestSuite
-
-				if err = xml.Unmarshal(data, &testSuite); err != nil {
-					log.Printf("error unmarshalling junit xml: %s", err.Error())
+					log.Printf("error reading junit xml file %s: %s", file.Name(), err.Error())
 					return false
 				}
 
-				for i, testcase := range testSuite.TestCases {
-					isSkipped := testcase.Skipped != nil
-					isFail := testcase.FailureMessage != nil
+				for _, testSuite := range suites {
+					for _, testcase := range testSuite.Tests {
+						isSkipped := testcase.Status == junit.StatusSkipped
+						isFail := testcase.Status == junit.StatusFailed
 
-					if !isSkipped {
-						numTests++
+						if !isSkipped {
+							numTests++
+						}
+						if !isFail && !isSkipped {
+							numPassingTests++
+						}
 					}
-					if !isFail && !isSkipped {
-						numPassingTests++
-					}
-
-					testSuite.TestCases[i].Name = fmt.Sprintf("[%s] %s", phase, testcase.Name)
-				}
-
-				data, err = xml.Marshal(&testSuite)
-
-				err = ioutil.WriteFile(filepath.Join(phaseDirectory, file.Name()), data, 0644)
-				if err != nil {
-					log.Printf("error writing to junit file: %s", err.Error())
-					return false
 				}
 			}
 		}

--- a/pkg/reporting/ginkgorep/ginkgorep.go
+++ b/pkg/reporting/ginkgorep/ginkgorep.go
@@ -1,0 +1,37 @@
+/*
+Package ginkgorep provides custom ginkgo reporters.
+*/
+package ginkgorep
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo/reporters"
+	"github.com/onsi/ginkgo/types"
+)
+
+// PhaseReporter wraps a normal JUnitReporter with the ability to specify
+// a testing phase in the names of the generated XML tests.
+type PhaseReporter struct {
+	*reporters.JUnitReporter
+	phase string
+}
+
+func NewPhaseReporter(phase, filename string) PhaseReporter {
+	return PhaseReporter{
+		phase:         phase,
+		JUnitReporter: reporters.NewJUnitReporter(filename),
+	}
+}
+
+var _ reporters.Reporter = PhaseReporter{}
+
+func (r PhaseReporter) SpecDidComplete(specSummary *types.SpecSummary) {
+	// Inject the phase into the name of the test case.
+	const testCaseNameIndex = 1
+	if len(specSummary.ComponentTexts) > testCaseNameIndex {
+		text := fmt.Sprintf("[%s] %s", r.phase, specSummary.ComponentTexts[testCaseNameIndex])
+		specSummary.ComponentTexts[testCaseNameIndex] = text
+	}
+	r.JUnitReporter.SpecDidComplete(specSummary)
+}


### PR DESCRIPTION
This was originally broken because our parsing method only
accepted xml with a single <testsuite> tag, but it's valid
for Junit xml to contain a <testsuites> tag with multiple
child <testsuite> tags.

I first tried to simply use the new parsing library (junit-go)
to do the parse, and that worked fine. However, once parsed
that library cannot re-serialize the xml, so our approach of
loading, transforming, and then saving the XML was no longer
viable.

To work around this, I implemented a custom wrapper type for
ginkgo's report generator that injects the phase names at the
time of initial XML creation. This seems to produce the same
XML and is cleaner to read.

Signed-off-by: Chris Waldon <cwaldon@redhat.com>