### PR TITLE
Fix CSV checking loop

### DIFF
--- a/pkg/e2e/operators/operators.go
+++ b/pkg/e2e/operators/operators.go
@@ -424,11 +424,15 @@ func pollCsvList(h *helper.H, namespace, csvDisplayName string) (*operatorv1.Clu
 Loop:
 	for {
 		csvList, err = h.Operator().OperatorsV1alpha1().ClusterServiceVersions(namespace).List(context.TODO(), metav1.ListOptions{})
+
+	CSVCheck:
 		for _, csv := range csvList.Items {
 			switch {
 			case csvDisplayName == csv.Spec.DisplayName:
 				// Success
 				err = nil
+				// Don't check any other CSVs since we found the target
+				break CSVCheck
 			default:
 				err = fmt.Errorf("No matching clusterServiceVersion in CSV List")
 			}


### PR DESCRIPTION
Currently, if there are multiple CSVs in a namespace checked by the pollCsvList function, it can mistakenly return false. Even if the correct CSV is present, if there are subsequest CSVs still in the list to check, err will be set to `No matching clusterServiceVersion in CSV List`. 

To fix this, a name is applied to the outer for loop and a break to that loop is added to the switch case where the CSV is found. 