### PR TITLE
SDCICD-387: Break out create/delete to separate scripts

### DIFF
--- a/ci/create-ocp-cluster.sh
+++ b/ci/create-ocp-cluster.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+mkdir -p installer
+
+RELEASE_URL="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest"
+RELEASE_IMAGE=$(curl -s "${RELEASE_URL}/release.txt" | grep 'Pull From: quay.io' | awk -F ' ' '{print $3}')
+
+if [ -z "${OCM_TOKEN+x}" ]; then
+    echo "Assuming the OCM token should be read from Prow";
+    OCM_TOKEN=$(cat /usr/local/osde2e-credentials/ocm-refresh-token)
+fi
+
+if [ -z "${AWS_ACCESS_KEY_ID+x}" ]; then
+    echo "Assuming the AWS Access token should be read from Prow";
+    AWS_ACCESS_KEY_ID=$(cat /usr/local/osde2e-credentials/aws-access-key-id)
+fi
+
+if [ -z "${AWS_SECRET_ACCESS_KEY+x}" ]; then
+    echo "Assuming the AWS Secret token should be read from Prow";
+    AWS_SECRET_ACCESS_KEY=$(cat /usr/local/osde2e-credentials/aws-secret-access-key)
+fi
+
+if [ -z "${PULL_SECRET_FILE+x}" ]; then
+    echo "Assuming the Pull Secret should be read from Prow";
+    PULL_SECRET_FILE=/usr/local/osde2e-credentials/stage-ocm-pull-secret
+fi
+
+if [ -z "${INSTALLER_CONFIG+x}" ]; then
+    echo "Assuming the Installer Config should be read from Prow";
+    INSTALLER_CONFIG=/usr/local/osde2e-credentials/stage-installer-config
+fi
+
+cp "${INSTALLER_CONFIG}" ./installer/install-config.yaml
+
+curl -s "${RELEASE_URL}/openshift-client-linux.tar.gz" | tar zxvf - oc
+
+chmod +x oc
+
+./oc adm release extract --registry-config "${PULL_SECRET_FILE}" --command=openshift-install --to "$(pwd)/" "${RELEASE_IMAGE}"
+
+chmod +x openshift-install
+
+./openshift-install create cluster --dir=./installer/ --log-level info
+
+cp "${INSTALLER_CONFIG}" "${SHARED_DIR}"
+cp ./installer/metadata.json "${SHARED_DIR}"
+cp ./installer/auth/kubeconfig "${SHARED_DIR}"

--- a/ci/destroy-ocp-cluster.sh
+++ b/ci/destroy-ocp-cluster.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+RELEASE_URL="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest"
+RELEASE_IMAGE=$(curl -s "${RELEASE_URL}/release.txt" | grep 'Pull From: quay.io' | awk -F ' ' '{print $3}')
+
+if [ -z "${AWS_ACCESS_KEY_ID+x}" ]; then
+    echo "Assuming the AWS Access token should be read from Prow";
+    AWS_ACCESS_KEY_ID=$(cat /usr/local/osde2e-credentials/aws-access-key-id)
+fi
+
+if [ -z "${AWS_SECRET_ACCESS_KEY+x}" ]; then
+    echo "Assuming the AWS Secret token should be read from Prow";
+    AWS_SECRET_ACCESS_KEY=$(cat /usr/local/osde2e-credentials/aws-secret-access-key)
+fi
+
+if [ -z "${PULL_SECRET_FILE+x}" ]; then
+    echo "Assuming the Pull Secret should be read from Prow";
+    PULL_SECRET_FILE=/usr/local/osde2e-credentials/stage-ocm-pull-secret
+fi
+
+export KUBECONFIG=${SHARED_DIR}/installer/auth/kubeconfig
+
+curl -s "${RELEASE_URL}/openshift-client-linux.tar.gz" | tar zxvf - oc
+
+chmod +x oc
+
+./oc adm release extract --registry-config "${PULL_SECRET_FILE}" --command=openshift-install --to "$(pwd)/" "${RELEASE_IMAGE}"
+
+chmod +x openshift-install
+
+./openshift-install destroy cluster --dir="${SHARED_DIR}" --log-level info

--- a/ci/prow-ocm-adoption.sh
+++ b/ci/prow-ocm-adoption.sh
@@ -1,70 +1,66 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o pipefail
 
-mkdir -p installer
+OCM_URL="https://api.stage.openshift.com"
 
-export VERSION=latest
-export RELEASE_IMAGE=$(curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$VERSION/release.txt | grep 'Pull From: quay.io' | awk -F ' ' '{print $3}')
-
-export cmd=openshift-install
-export pullsecret_file=~/Downloads/crc-pull-secret.txt
-export extract_dir=$(pwd)
-
-if [ -z "$OCM_TOKEN" ]; then
-    echo "Assuming the token should be read from Prow";
-    export OCM_TOKEN=$(cat /usr/local/osde2e-credentials/ocm-refresh-token)
+if [ -z "${OCM_TOKEN+x}" ]; then
+    echo "Assuming the OCM token should be read from Prow";
+    OCM_TOKEN=$(cat /usr/local/osde2e-credentials/ocm-refresh-token)
 fi
 
-if [ -z "AWS_ACCESS_KEY_ID" ]; then
-    export AWS_ACCESS_KEY_ID=$(cat /usr/local/osde2e-credentials/aws-access-key-id)
+if [ -z "${AWS_ACCESS_KEY_ID+x}" ]; then
+    echo "Assuming the AWS Access token should be read from Prow";
+    AWS_ACCESS_KEY_ID=$(cat /usr/local/osde2e-credentials/aws-access-key-id)
 fi
 
-if [ -z "AWS_SECRET_ACCESS_KEY" ]; then
-    export AWS_SECRET_ACCESS_KEY=$(cat /usr/local/osde2e-credentials/aws-secret-access-key)
+if [ -z "${AWS_SECRET_ACCESS_KEY+x}" ]; then
+    echo "Assuming the AWS Secret token should be read from Prow";
+    AWS_SECRET_ACCESS_KEY=$(cat /usr/local/osde2e-credentials/aws-secret-access-key)
 fi
 
+if [ -z "${PULL_SECRET_FILE+x}" ]; then
+    echo "Assuming the Pull Secret should be read from Prow";
+    PULL_SECRET_FILE=/usr/local/osde2e-credentials/stage-ocm-pull-secret
+fi
 
-cp /usr/local/osde2e-credentials/stage-installer-config ./installer/installer-config.yaml
+if [ -z "${INSTALLER_CONFIG+x}" ]; then
+    echo "Assuming the Installer Config should be read from Prow";
+    INSTALLER_CONFIG=/usr/local/osde2e-credentials/stage-installer-config
+fi
 
+export OCM_CONFIG=./.ocm.json
+export KUBECONFIG="${SHARED_DIR}/kubeconfig"
 
+curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar zxvf - oc
 
-curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$VERSION/openshift-client-linux.tar.gz | tar zxvf - oc
+chmod +x oc
 
-./oc adm release extract --registry-config "${pullsecret_file}" --command=$cmd --to "${extract_dir}" ${RELEASE_IMAGE}
+GO111MODULE=on go get github.com/openshift-online/ocm-cli/cmd/ocm@master
 
-./openshift-install create cluster --dir=$(pwd)/installer/ --log-level info
-
-export OCM_CONFIG=$(pwd)/.ocm.json
-export KUBECONFIG=$(pwd)/installer/auth/kubeconfig
-
-{
-
-go get -u github.com/openshift-online/ocm-cli/cmd/ocm
-
-if [ -z "$OCM_URL" ]; then
-    ocm login --token=$OCM_TOKEN
+if [ -z "${OCM_URL}" ]; then
+    ocm login --token="${OCM_TOKEN}"
 else 
-    ocm login --url=$OCM_URL --token=$OCM_TOKEN
+    ocm login --url="${OCM_URL}" --token="${OCM_TOKEN}"
+fi
 
-    cat <<EOF | oc create -n openshift-monitoring -f -
+cat <<EOF | ./oc create -n openshift-monitoring -f -
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: cluster-monitoring-config
-  namespace: openshift-monitoring
+    name: cluster-monitoring-config
+    namespace: openshift-monitoring
 data:
-  config.yaml: |
+    config.yaml: |
     telemeterClient:
-      telemeterServerURL: https://infogw.api.stage.openshift.com
-
+        telemeterServerURL: https://infogw.api.stage.openshift.com
 EOF
-    sleep 600;
-    echo "Output new config"
-    oc get -n openshift-monitoring configmap/cluster-monitoring-config -o yaml
-fi
 
-COUNT=$(CLUSTER_ID=$(oc get clusterversion -o jsonpath='{.items[].spec.clusterID}{"\n"}'); ocm get clusters --parameter search="external_id is '$CLUSTER_ID'" | jq '.size')
+sleep 600;
+echo "Output new config"
+./oc get -n openshift-monitoring configmap/cluster-monitoring-config -o yaml
+
+COUNT=$(CLUSTER_ID=$(./oc get clusterversion -o jsonpath='{.items[].spec.clusterID}{""}'); ocm get clusters --parameter search="external_id is '${CLUSTER_ID}'" | jq '.size')
 
 if [[ "$COUNT" == "0" ]]; then
     echo "No cluster found!";
@@ -73,5 +69,3 @@ else
     echo "Cluster found!";
     exit 0
 fi
-
-} 2>&1 | tee -a /tmp/artifacts/test_output.log


### PR DESCRIPTION
This adds ocp create and delete helper scripts to be used in Prow and with the `osde2e-credentials` secret.

This also cleans up the adoption test logic. :tada: