### PR TITLE
SDCICD-387: export variables expected in env, remove unnecessary secrets

### DIFF
--- a/ci/create-ocp-cluster.sh
+++ b/ci/create-ocp-cluster.sh
@@ -5,19 +5,16 @@ mkdir -p installer
 RELEASE_URL="https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest"
 RELEASE_IMAGE=$(curl -s "${RELEASE_URL}/release.txt" | grep 'Pull From: quay.io' | awk -F ' ' '{print $3}')
 
-if [ -z "${OCM_TOKEN+x}" ]; then
-    echo "Assuming the OCM token should be read from Prow";
-    OCM_TOKEN=$(cat /usr/local/osde2e-credentials/ocm-refresh-token)
-fi
-
 if [ -z "${AWS_ACCESS_KEY_ID+x}" ]; then
     echo "Assuming the AWS Access token should be read from Prow";
     AWS_ACCESS_KEY_ID=$(cat /usr/local/osde2e-credentials/aws-access-key-id)
+    export AWS_ACCESS_KEY_ID
 fi
 
 if [ -z "${AWS_SECRET_ACCESS_KEY+x}" ]; then
     echo "Assuming the AWS Secret token should be read from Prow";
     AWS_SECRET_ACCESS_KEY=$(cat /usr/local/osde2e-credentials/aws-secret-access-key)
+    export AWS_SECRET_ACCESS_KEY
 fi
 
 if [ -z "${PULL_SECRET_FILE+x}" ]; then

--- a/ci/destroy-ocp-cluster.sh
+++ b/ci/destroy-ocp-cluster.sh
@@ -6,11 +6,13 @@ RELEASE_IMAGE=$(curl -s "${RELEASE_URL}/release.txt" | grep 'Pull From: quay.io'
 if [ -z "${AWS_ACCESS_KEY_ID+x}" ]; then
     echo "Assuming the AWS Access token should be read from Prow";
     AWS_ACCESS_KEY_ID=$(cat /usr/local/osde2e-credentials/aws-access-key-id)
+    export AWS_ACCESS_KEY_ID
 fi
 
 if [ -z "${AWS_SECRET_ACCESS_KEY+x}" ]; then
     echo "Assuming the AWS Secret token should be read from Prow";
     AWS_SECRET_ACCESS_KEY=$(cat /usr/local/osde2e-credentials/aws-secret-access-key)
+    export AWS_SECRET_ACCESS_KEY
 fi
 
 if [ -z "${PULL_SECRET_FILE+x}" ]; then

--- a/ci/prow-ocm-adoption.sh
+++ b/ci/prow-ocm-adoption.sh
@@ -9,26 +9,6 @@ if [ -z "${OCM_TOKEN+x}" ]; then
     OCM_TOKEN=$(cat /usr/local/osde2e-credentials/ocm-refresh-token)
 fi
 
-if [ -z "${AWS_ACCESS_KEY_ID+x}" ]; then
-    echo "Assuming the AWS Access token should be read from Prow";
-    AWS_ACCESS_KEY_ID=$(cat /usr/local/osde2e-credentials/aws-access-key-id)
-fi
-
-if [ -z "${AWS_SECRET_ACCESS_KEY+x}" ]; then
-    echo "Assuming the AWS Secret token should be read from Prow";
-    AWS_SECRET_ACCESS_KEY=$(cat /usr/local/osde2e-credentials/aws-secret-access-key)
-fi
-
-if [ -z "${PULL_SECRET_FILE+x}" ]; then
-    echo "Assuming the Pull Secret should be read from Prow";
-    PULL_SECRET_FILE=/usr/local/osde2e-credentials/stage-ocm-pull-secret
-fi
-
-if [ -z "${INSTALLER_CONFIG+x}" ]; then
-    echo "Assuming the Installer Config should be read from Prow";
-    INSTALLER_CONFIG=/usr/local/osde2e-credentials/stage-installer-config
-fi
-
 export OCM_CONFIG=./.ocm.json
 export KUBECONFIG="${SHARED_DIR}/kubeconfig"
 


### PR DESCRIPTION
Some variables are expected in the environment and therefore need to be exported.

Additionally, some other variables aren't needed in certain phases of the test so they've been removed.