### PR TITLE
Added support for better pending pods check before failing them

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -30,6 +30,7 @@ import (
 const (
 	// errorWindow is the number of checks made to determine if a cluster has truly failed.
 	errorWindow         = 20
+	// pendingPodThreshold is the maximum number of times a pod is allowed to be in pending state before erroring out in PollClusterHealth.
 	pendingPodThreshold = 10
 )
 

--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -301,13 +301,12 @@ func PollClusterHealth(clusterID string, logger *log.Logger) (status bool, failu
 			failures = append(failures, "pod")
 			clusterHealthy = false
 		} else {
-			newpodcount, podcheck, err := healthchecks.CheckPendingPods(podlist, podErrorCount, pendingPodThreshold)
+			podcheck, err := healthchecks.CheckPendingPods(podlist, podErrorCount, pendingPodThreshold)
 			if err != nil || !podcheck {
 				healthErr = multierror.Append(healthErr, err)
 				failures = append(failures, "pod")
 				clusterHealthy = false
 			}
-			podErrorCount = newpodcount
 		}
 
 		if check, err := healthchecks.CheckCerts(kubeClient.CoreV1(), logger); !check || err != nil {

--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -30,7 +30,7 @@ import (
 const (
 	// errorWindow is the number of checks made to determine if a cluster has truly failed.
 	errorWindow         = 20
-	pendingPodThreshold = 5
+	pendingPodThreshold = 10
 )
 
 var podErrorCount = make(map[string]int)
@@ -296,7 +296,7 @@ func PollClusterHealth(clusterID string, logger *log.Logger) (status bool, failu
 			clusterHealthy = false
 		}
 
-		if podlist, err := healthchecks.CheckClusterPodHealth(kubeClient.CoreV1(), logger); (podlist == nil) || err != nil {
+		if podlist, err := healthchecks.CheckClusterPodHealth(kubeClient.CoreV1(), logger); (podlist == nil) && err != nil {
 			healthErr = multierror.Append(healthErr, err)
 			failures = append(failures, "pod")
 			clusterHealthy = false

--- a/pkg/common/cluster/healthchecks/pods.go
+++ b/pkg/common/cluster/healthchecks/pods.go
@@ -101,17 +101,17 @@ func filterPods(podList *kubev1.PodList, predicates ...PodPredicate) *kubev1.Pod
 }
 
 // CheckPendingPods looks for a pod that still remains under pending state for a given number of times in a row
-func CheckPendingPods(podlist []kubev1.Pod, podErrorCount map[string]int, pendingPodThreshold int) (map[string]int, bool, error) {
+func CheckPendingPods(podlist []kubev1.Pod, podErrorCount map[string]int, pendingPodThreshold int) (bool, error) {
 	for _, pod := range podlist {
 		if val, found := podErrorCount[pod.Name]; found {
 			podErrorCount[pod.Name]++
 			if val >= pendingPodThreshold {
-				return podErrorCount, false, fmt.Errorf("Pod %s is pending beyond normal threshold: %s - %s", pod.GetName(), pod.Status.Reason, pod.Status.Message)
+				return false, fmt.Errorf("Pod %s is pending beyond normal threshold: %s - %s", pod.GetName(), pod.Status.Reason, pod.Status.Message)
 			}
 		} else {
 			podErrorCount[pod.Name] = 1
 		}
 	}
 
-	return podErrorCount, true, nil
+	return true, nil
 }

--- a/pkg/common/cluster/healthchecks/pods.go
+++ b/pkg/common/cluster/healthchecks/pods.go
@@ -58,12 +58,13 @@ func checkPods(podClient v1.CoreV1Interface, logger *log.Logger, filters ...PodP
 	}
 
 	if len(list.Items) == 0 {
-		return nil, fmt.Errorf("pod list is empty. this should NOT happen") //false
+		return nil, fmt.Errorf("pod list is empty. this should NOT happen")
 	}
 
 	pods := filterPods(list, filters...)
 
 	logger.Printf("%v pods are currently not running or complete:", len(pods.Items))
+
 	for _, pod := range pods.Items {
 		if pod.Status.Phase != kubev1.PodPending {
 			return nil, fmt.Errorf("Pod %s errored: %s - %s", pod.GetName(), pod.Status.Reason, pod.Status.Message)
@@ -111,5 +112,6 @@ func CheckPendingPods(podlist []kubev1.Pod, podErrorCount map[string]int, pendin
 			podErrorCount[pod.Name] = 1
 		}
 	}
+
 	return podErrorCount, true, nil
 }

--- a/pkg/common/cluster/healthchecks/pods.go
+++ b/pkg/common/cluster/healthchecks/pods.go
@@ -13,7 +13,7 @@ import (
 )
 
 // CheckClusterPodHealth attempts to look at the state of all internal cluster pods and
-// returns true if things are healthy.
+// returns the list of pending pods if any exist.
 func CheckClusterPodHealth(podClient v1.CoreV1Interface, logger *log.Logger) ([]kubev1.Pod, error) {
 	filters := []PodPredicate{
 		IsClusterPod,
@@ -45,7 +45,7 @@ func CheckPodHealth(podClient v1.CoreV1Interface, logger *log.Logger, ns string,
 	return !(len(podlist) > 0), err
 }
 
-// checkPods looks for pods matching the supplied predicates and returns true if any are found
+// checkPods looks for pods matching the supplied predicates and returns the list of pods (pending pods) if any are found
 func checkPods(podClient v1.CoreV1Interface, logger *log.Logger, filters ...PodPredicate) ([]kubev1.Pod, error) {
 	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 

--- a/pkg/common/cluster/healthchecks/pods_test.go
+++ b/pkg/common/cluster/healthchecks/pods_test.go
@@ -38,7 +38,7 @@ func TestCheckPodHealth(t *testing.T) {
 		objs           []runtime.Object
 	}{
 		{"no pods", 0, true, nil},
-		{"single pod failed", 1, true, []runtime.Object{pod("a", ns1, v1.PodFailed)}},
+		{"single pod failed", 0, true, []runtime.Object{pod("a", ns1, v1.PodFailed)}},
 		{"pod is pending beyond specified threshold", 1, false, []runtime.Object{pod("a", "foobar", v1.PodPending)}},
 		{"single pod running", 0, false, []runtime.Object{pod("a", ns1, v1.PodRunning)}},
 		{"single pod succeeded", 0, false, []runtime.Object{pod("a", ns1, v1.PodSucceeded)}},
@@ -49,8 +49,8 @@ func TestCheckPodHealth(t *testing.T) {
 		state, err := CheckClusterPodHealth(kubeClient.CoreV1(), nil)
 
 		// Length of the pending pods list is validated here. The list may have multiple pending pods even if the error is for one pending pod.
-		if len(state) < test.expectedLength {
-			t.Errorf("%v: Expected length of state doesn't match returned value (%v, %v)", test.description, test.expectedLength, state)
+		if len(state) >= test.expectedLength {
+			t.Errorf("%v: Expected length of state doesn't match returned value (%v, %v)", test.description, test.expectedLength, len(state))
 		}
 
 		if (err != nil && test.expectedError == false) || (err == nil && test.expectedError == true) {

--- a/pkg/common/cluster/healthchecks/pods_test.go
+++ b/pkg/common/cluster/healthchecks/pods_test.go
@@ -49,7 +49,7 @@ func TestCheckPodHealth(t *testing.T) {
 		state, err := CheckClusterPodHealth(kubeClient.CoreV1(), nil)
 
 		// Length of the pending pods list is validated here. The list may have multiple pending pods even if the error is for one pending pod.
-		if len(state) >= test.expectedLength {
+		if len(state) < test.expectedLength {
 			t.Errorf("%v: Expected length of state doesn't match returned value (%v, %v)", test.description, test.expectedLength, len(state))
 		}
 

--- a/pkg/common/cluster/healthchecks/pods_test.go
+++ b/pkg/common/cluster/healthchecks/pods_test.go
@@ -39,7 +39,7 @@ func TestCheckPodHealth(t *testing.T) {
 	}{
 		{"no pods", 0, true, nil},
 		{"single pod failed", 0, true, []runtime.Object{pod("a", ns1, v1.PodFailed)}},
-		{"pod is pending beyond specified threshold", 1, false, []runtime.Object{pod("a", "foobar", v1.PodPending)}},
+		{"pod is pending beyond specified threshold", 1, false, []runtime.Object{pod("a", ns1, v1.PodPending)}},
 		{"single pod running", 0, false, []runtime.Object{pod("a", ns1, v1.PodRunning)}},
 		{"single pod succeeded", 0, false, []runtime.Object{pod("a", ns1, v1.PodSucceeded)}},
 	}

--- a/pkg/common/cluster/healthchecks/pods_test.go
+++ b/pkg/common/cluster/healthchecks/pods_test.go
@@ -42,6 +42,12 @@ func TestCheckPodHealth(t *testing.T) {
 		{"pod is pending beyond specified threshold", 1, false, []runtime.Object{pod("a", ns1, v1.PodPending)}},
 		{"single pod running", 0, false, []runtime.Object{pod("a", ns1, v1.PodRunning)}},
 		{"single pod succeeded", 0, false, []runtime.Object{pod("a", ns1, v1.PodSucceeded)}},
+		{"single pod failed bad namespace", 0, false, []runtime.Object{pod("a", "foobar", v1.PodFailed)}},
+		{"one pod good one pod bad same namespace", 0, true, []runtime.Object{pod("a", ns1, v1.PodFailed), pod("b", ns1, v1.PodRunning)}},
+		{"one pod good one pod pending same namespace", 0, false, []runtime.Object{pod("a", ns1, v1.PodPending), pod("b", ns1, v1.PodRunning)}},
+		{"one pod good one pod bad diff namespace", 0, true, []runtime.Object{pod("a", ns1, v1.PodFailed), pod("b", ns2, v1.PodRunning)}},
+		{"two succeeded pods diff namespace", 0, false, []runtime.Object{pod("a", ns1, v1.PodSucceeded), pod("b", ns2, v1.PodSucceeded)}},
+		{"two running pods diff namespace", 0, false, []runtime.Object{pod("a", ns1, v1.PodRunning), pod("b", ns2, v1.PodRunning)}},
 	}
 
 	for _, test := range tests {

--- a/pkg/common/cluster/healthchecks/pods_test.go
+++ b/pkg/common/cluster/healthchecks/pods_test.go
@@ -32,29 +32,25 @@ func TestCheckPodHealth(t *testing.T) {
 		ns2 = "openshift-2"
 	)
 	var tests = []struct {
-		description   string
-		expectedState bool
-		expectedError bool
-		objs          []runtime.Object
+		description    string
+		expectedLength int
+		expectedError  bool
+		objs           []runtime.Object
 	}{
-		{"no pods", false, true, nil},
-		{"single pod failed", false, true, []runtime.Object{pod("a", ns1, v1.PodFailed)}},
-		{"single pod failed bad namespace", true, false, []runtime.Object{pod("a", "foobar", v1.PodFailed)}},
-		{"one pod good one pod bad same namespace", false, true, []runtime.Object{pod("a", ns1, v1.PodFailed), pod("b", ns1, v1.PodRunning)}},
-		{"one pod good one pod pending same namespace", false, false, []runtime.Object{pod("a", ns1, v1.PodPending), pod("b", ns1, v1.PodRunning)}},
-		{"one pod good one pod bad diff namespace", false, true, []runtime.Object{pod("a", ns1, v1.PodFailed), pod("b", ns2, v1.PodRunning)}},
-		{"single pod running", true, false, []runtime.Object{pod("a", ns1, v1.PodRunning)}},
-		{"single pod succeeded", true, false, []runtime.Object{pod("a", ns1, v1.PodSucceeded)}},
-		{"two succeeded pods diff namespace", true, false, []runtime.Object{pod("a", ns1, v1.PodSucceeded), pod("b", ns2, v1.PodSucceeded)}},
-		{"two running pods diff namespace", true, false, []runtime.Object{pod("a", ns1, v1.PodRunning), pod("b", ns2, v1.PodRunning)}},
+		{"no pods", 0, true, nil},
+		{"single pod failed", 1, true, []runtime.Object{pod("a", ns1, v1.PodFailed)}},
+		{"pod is pending beyond specified threshold", 1, false, []runtime.Object{pod("a", "foobar", v1.PodPending)}},
+		{"single pod running", 0, false, []runtime.Object{pod("a", ns1, v1.PodRunning)}},
+		{"single pod succeeded", 0, false, []runtime.Object{pod("a", ns1, v1.PodSucceeded)}},
 	}
 
 	for _, test := range tests {
 		kubeClient := kubernetes.NewSimpleClientset(test.objs...)
 		state, err := CheckClusterPodHealth(kubeClient.CoreV1(), nil)
 
-		if state != test.expectedState {
-			t.Errorf("%v: Expected state doesn't match returned value (%v, %v)", test.description, test.expectedState, state)
+		// Length of the pending pods list is validated here. The list may have multiple pending pods even if the error is for one pending pod.
+		if len(state) < test.expectedLength {
+			t.Errorf("%v: Expected length of state doesn't match returned value (%v, %v)", test.description, test.expectedLength, state)
 		}
 
 		if (err != nil && test.expectedError == false) || (err == nil && test.expectedError == true) {


### PR DESCRIPTION
Made changes within PollClusterHealth to only reflect on pending pod failures if the same pod remains in 'pending' state 10 times in a row. Otherwise, pending pod alerts are ignored in the clean run iteration. Key points to note here:-
1. The pending pod threshold for the same pod failing 10 times is set by the constant "pendingPodThreshold" in pkg/common/cluster/clusterutil.go.
2. In pkg/common/cluster/healthchecks/pods.go, the function checkPods returns the list of pending pods which is used by the function CheckClusterPodHealth which then returns the list of pending pods if they exist rather than returning the bool of the length of this list. This list is used by PollClusterHealth to keep track of the pending pods to see if any pod crosses the given threshold of being in pending state X times by calling the function CheckPendingPods. The map variable podErrorCount is used to keep track of a pod and its counter.
3. The pending pod check support is currently only fixed for the default e2e test suite. Support for e2e workload suites - redmine, guestbook and the managed upgrade workload can adopt the same strategy if needed.
4. The function CheckPodHealth is used by the above workload suites. As it uses the same checkPods function which returns a pod list rather than a bool of the length of this list, I've retained the bool in this function by checking the length. In the future, this can also be changed if support is needed for the workload suites.
5. The function CheckPendingPods is used by PollClusterHealth to keep track of pending pods and their corresponding counters of how many times they have remained under "pending state" consecutively. It takes in the pod list returned in each inner loop of PollClusterHealth and goes through each pod to see if it crosses the threshold (pendingPodThreshold) parameter. The podErrorCount variable which is also passed as a parameter is modified in each call to reflect the current state. This variable keeps track of pods and their current pending state counters.