### PR TITLE
fix: mark clusters as completed properly

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -586,6 +586,7 @@ func cleanupAfterE2E(h *helper.H) (errors []error) {
 		cluster, err := provider.GetCluster(clusterID)
 		if err != nil {
 			log.Printf("error getting Cluster state: %s", err.Error())
+		} else {
 			defer func() {
 				// set the completed property right before this function returns, which should be after
 				// all cleanup is finished.
@@ -594,7 +595,6 @@ func cleanupAfterE2E(h *helper.H) (errors []error) {
 					log.Printf("Failed setting completed status: %v", err)
 				}
 			}()
-		} else {
 			log.Printf("Cluster addons: %v", cluster.Addons())
 			log.Printf("Cluster cloud provider: %v", cluster.CloudProvider())
 			log.Printf("Cluster expiration: %v", cluster.ExpirationTimestamp())


### PR DESCRIPTION
Previously we put this into the err branch of the if statement,
but we actually needed the cluster id for this to work.

Signed-off-by: Chris Waldon <cwaldon@redhat.com>