### PR TITLE
SDCICD-603: Better handle retrieving and writing test artifacts

### DIFF
--- a/pkg/common/helper/addons.go
+++ b/pkg/common/helper/addons.go
@@ -79,10 +79,12 @@ func (h *H) RunAddonTests(name string, timeout int, harnesses, args []string) (f
 
 		// get results
 		results, err := r.RetrieveTestResults()
-		Expect(err).NotTo(HaveOccurred())
 
 		// write results
 		h.WriteResults(results)
+
+		// evaluate results
+		Expect(err).NotTo(HaveOccurred())
 
 		// ensure job has not failed
 		job, err := h.Kube().BatchV1().Jobs(r.Namespace).Get(context.TODO(), jobName, metav1.GetOptions{})

--- a/pkg/common/runner/results.go
+++ b/pkg/common/runner/results.go
@@ -138,7 +138,8 @@ func (r *Runner) downloadLinks(n *html.Node, results map[string][]byte, director
 					directoryResults, err := r.retrieveResultsForDirectory(newDirectory)
 
 					if err != nil {
-						return fmt.Errorf("error while getting results for directory %s: %v", newDirectory, err)
+						log.Printf("error while getting results for directory %s: %v", newDirectory, err)
+						continue
 					}
 
 					for k, v := range directoryResults {

--- a/pkg/e2e/openshift/conformance.go
+++ b/pkg/e2e/openshift/conformance.go
@@ -37,7 +37,7 @@ var _ = ginkgo.Describe(conformanceK8sTestName, func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 
-	e2eTimeoutInSeconds := 3600
+	e2eTimeoutInSeconds := 7200
 	ginkgo.It("should run until completion", func() {
 		// configure tests
 		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
@@ -58,10 +58,13 @@ var _ = ginkgo.Describe(conformanceK8sTestName, func() {
 
 		// get results
 		results, err := r.RetrieveTestResults()
-		Expect(err).NotTo(HaveOccurred())
 
 		// write results
 		h.WriteResults(results)
+
+		// evaluate results
+		Expect(err).NotTo(HaveOccurred())
+
 	}, float64(e2eTimeoutInSeconds+30))
 })
 
@@ -90,9 +93,11 @@ var _ = ginkgo.Describe(conformanceOpenshiftTestName, func() {
 
 		// get results
 		results, err := r.RetrieveTestResults()
-		Expect(err).NotTo(HaveOccurred())
 
 		// write results
 		h.WriteResults(results)
+
+		// evaluate results
+		Expect(err).NotTo(HaveOccurred())
 	}, float64(e2eTimeoutInSeconds+30))
 })

--- a/pkg/e2e/openshift/disruptive.go
+++ b/pkg/e2e/openshift/disruptive.go
@@ -40,9 +40,11 @@ var _ = ginkgo.Describe(disruptiveTestName, func() {
 
 		// get results
 		results, err := r.RetrieveTestResults()
-		Expect(err).NotTo(HaveOccurred())
 
 		// write results
 		h.WriteResults(results)
+
+		// evaluate results
+		Expect(err).NotTo(HaveOccurred())
 	}, float64(e2eTimeoutInSeconds+30))
 })

--- a/pkg/e2e/openshift/images.go
+++ b/pkg/e2e/openshift/images.go
@@ -41,10 +41,12 @@ var _ = ginkgo.Describe(imageRegistryTestName, func() {
 
 		// get results
 		results, err := r.RetrieveTestResults()
-		Expect(err).NotTo(HaveOccurred())
 
 		// write results
 		h.WriteResults(results)
+
+		// evaluate results
+		Expect(err).NotTo(HaveOccurred())
 	}, float64(e2eTimeoutInSeconds+30))
 })
 
@@ -72,9 +74,11 @@ var _ = ginkgo.Describe(imageEcosystemTestName, func() {
 
 		// get results
 		results, err := r.RetrieveTestResults()
-		Expect(err).NotTo(HaveOccurred())
 
 		// write results
 		h.WriteResults(results)
+
+		// evaluate results
+		Expect(err).NotTo(HaveOccurred())
 	}, float64(e2eTimeoutInSeconds+30))
 })


### PR DESCRIPTION
We should write results before evaluating errors, don't fail writing results when there's an error downloading from a directory

Also adjusting conformance timeouts to be in line with one another.