### PR TITLE
Use healthcheck cron job to determine cluster readiness

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -207,6 +207,10 @@ func waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID string, l
 	return nil
 }
 
+// ClusterConfig returns the rest API config for a given cluster as well as the provider it
+// inferred to discover the config.
+// param clusterID: If specified, Provider will be discovered through OCM. If the empty string,
+// 		assume we are running in a cluster and use in-cluster REST config instead.
 func ClusterConfig(clusterID string) (restConfig *rest.Config, providerType string, err error) {
 	if clusterID == "" {
 		if restConfig, err = rest.InClusterConfig(); err != nil {

--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -207,6 +207,34 @@ func waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID string, l
 	return nil
 }
 
+func ClusterConfig(clusterID string) (restConfig *rest.Config, providerType string, err error) {
+	if clusterID == "" {
+		if restConfig, err = rest.InClusterConfig(); err != nil {
+			return nil, "", fmt.Errorf("error getting in-cluster rest config: %w", err)
+		}
+
+		// FIXME: Is there a way to discover this from within the cluster?
+		// For now, ocm and rosa behave the same, so hardcode either.
+		providerType = "ocm"
+		return
+
+	}
+	provider, err := providers.ClusterProvider()
+
+	if err != nil {
+		return nil, "", fmt.Errorf("error getting cluster provisioning client: %w", err)
+	}
+	providerType = provider.Type()
+
+	restConfig, err = getRestConfig(provider, clusterID)
+	if err != nil {
+
+		return nil, "", fmt.Errorf("error generating rest config: %w", err)
+	}
+
+	return
+}
+
 // PollClusterHealth looks at CVO data to determine if a cluster is alive/healthy or not
 // param clusterID: If specified, Provider will be discovered through OCM. If the empty string,
 // 		assume we are running in a cluster and use in-cluster REST config instead.
@@ -215,33 +243,10 @@ func PollClusterHealth(clusterID string, logger *log.Logger) (status bool, failu
 
 	logger.Print("Polling Cluster Health...\n")
 
-	var restConfig *rest.Config
-	var providerType string
-
-	if clusterID == "" {
-		if restConfig, err = rest.InClusterConfig(); err != nil {
-			logger.Printf("Error getting in-cluster REST config: %v\n", err)
-			return false, nil, nil
-		}
-
-		// FIXME: Is there a way to discover this from within the cluster?
-		// For now, ocm and rosa behave the same, so hardcode either.
-		providerType = "ocm"
-
-	} else {
-		provider, err := providers.ClusterProvider()
-
-		if err != nil {
-			return false, nil, fmt.Errorf("error getting cluster provisioning client: %v", err)
-		}
-
-		restConfig, err = getRestConfig(provider, clusterID)
-		if err != nil {
-			logger.Printf("Error generating Rest Config: %v\n", err)
-			return false, nil, nil
-		}
-
-		providerType = provider.Type()
+	restConfig, providerType, err := ClusterConfig(clusterID)
+	if err != nil {
+		logger.Printf("Error getting cluster config: %v\n", err)
+		return false, nil, nil
 	}
 
 	kubeClient, err := kubernetes.NewForConfig(restConfig)

--- a/pkg/common/cluster/healthchecks/healthcheckjob.go
+++ b/pkg/common/cluster/healthchecks/healthcheckjob.go
@@ -1,0 +1,58 @@
+package healthchecks
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/openshift/osde2e/pkg/common/logging"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+// CheckHealthcheckJob uses the `openshift-cluster-ready-*` healthcheck job to determine cluster readiness.
+func CheckHealthcheckJob(k8sClient v1.CoreV1Interface, ctx context.Context, logger *log.Logger) (bool, error) {
+	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
+
+	logger.Print("Checking that all Nodes are running or completed...")
+
+	bv1C := batchv1client.New(k8sClient.RESTClient())
+	watcher, err := bv1C.Jobs("openshift-monitoring").Watch(ctx, metav1.ListOptions{
+		Watch:         true,
+		FieldSelector: "metadata.name=osd-cluster-ready",
+	})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Job doesn't exist yet
+			return false, nil
+		}
+		// Failed checking for job
+		return false, fmt.Errorf("failed looking up job: %w", err)
+	}
+	for {
+		select {
+		case event := <-watcher.ResultChan():
+			switch event.Type {
+			case watch.Added:
+				fallthrough
+			case watch.Modified:
+				job := event.Object.(*batchv1.Job)
+				if job.Status.Succeeded > 0 {
+					return true, nil
+				}
+			case watch.Deleted:
+				return false, fmt.Errorf("cluster readiness job deleted before becoming ready")
+			case watch.Error:
+				return false, fmt.Errorf("watch returned error event: %v", event)
+			default:
+				logger.Printf("Unrecognized event type while watching for healthcheck job updates: %v", event.Type)
+			}
+		case <-ctx.Done():
+			return false, fmt.Errorf("healtcheck watch context cancelled while still waiting for success")
+		}
+	}
+}

--- a/pkg/common/cluster/healthchecks/healthcheckjob.go
+++ b/pkg/common/cluster/healthchecks/healthcheckjob.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/openshift/osde2e/pkg/common/logging"
 	batchv1 "k8s.io/api/batch/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
@@ -22,14 +21,11 @@ func CheckHealthcheckJob(k8sClient v1.CoreV1Interface, ctx context.Context, logg
 
 	bv1C := batchv1client.New(k8sClient.RESTClient())
 	watcher, err := bv1C.Jobs("openshift-monitoring").Watch(ctx, metav1.ListOptions{
-		Watch:         true,
-		FieldSelector: "metadata.name=osd-cluster-ready",
+		Watch:           true,
+		FieldSelector:   "metadata.name=osd-cluster-ready",
+		ResourceVersion: "0",
 	})
 	if err != nil {
-		if errors.IsNotFound(err) {
-			// Job doesn't exist yet
-			return false, nil
-		}
 		// Failed checking for job
 		return false, fmt.Errorf("failed looking up job: %w", err)
 	}

--- a/pkg/common/cluster/healthchecks/healthcheckjob.go
+++ b/pkg/common/cluster/healthchecks/healthcheckjob.go
@@ -12,11 +12,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-// CheckHealthcheckJob uses the `openshift-cluster-ready-*` healthcheck job to determine cluster readiness.
+// CheckHealthcheckJob uses the `osd-cluster-ready` healthcheck job to determine cluster readiness.
 func CheckHealthcheckJob(k8sClient *kubernetes.Clientset, ctx context.Context, logger *log.Logger) (bool, error) {
 	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 
-	logger.Print("Checking that all Nodes are running or completed...")
+	logger.Print("Checking whether cluster is healthy before proceeding...")
 
 	bv1C := k8sClient.BatchV1()
 	namespace := "openshift-monitoring"

--- a/pkg/common/cluster/healthchecks/healthcheckjob.go
+++ b/pkg/common/cluster/healthchecks/healthcheckjob.go
@@ -9,25 +9,38 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
-	batchv1client "k8s.io/client-go/kubernetes/typed/batch/v1"
-	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 // CheckHealthcheckJob uses the `openshift-cluster-ready-*` healthcheck job to determine cluster readiness.
-func CheckHealthcheckJob(k8sClient v1.CoreV1Interface, ctx context.Context, logger *log.Logger) (bool, error) {
+func CheckHealthcheckJob(k8sClient *kubernetes.Clientset, ctx context.Context, logger *log.Logger) (bool, error) {
 	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 
 	logger.Print("Checking that all Nodes are running or completed...")
 
-	bv1C := batchv1client.New(k8sClient.RESTClient())
-	watcher, err := bv1C.Jobs("openshift-monitoring").Watch(ctx, metav1.ListOptions{
-		Watch:           true,
+	bv1C := k8sClient.BatchV1()
+	namespace := "openshift-monitoring"
+	name := "osd-cluster-ready"
+	jobs, err := bv1C.Jobs(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed listing jobs: %w", err)
+	}
+	for _, job := range jobs.Items {
+		if job.Name != name {
+			continue
+		}
+		if job.Status.Succeeded > 0 {
+			log.Println("Healthcheck job has already succeeded")
+			return true, nil
+		}
+		log.Println("Healthcheck job has not yet succeeded, watching...")
+	}
+	watcher, err := bv1C.Jobs(namespace).Watch(ctx, metav1.ListOptions{
+		ResourceVersion: jobs.ResourceVersion,
 		FieldSelector:   "metadata.name=osd-cluster-ready",
-		ResourceVersion: "0",
 	})
 	if err != nil {
-		// Failed checking for job
-		return false, fmt.Errorf("failed looking up job: %w", err)
+		return false, fmt.Errorf("failed watching job: %w", err)
 	}
 	for {
 		select {

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -175,6 +175,12 @@ var Tests = struct {
 	// Env: SKIP_CLUSTER_HEALTH_CHECKS
 	SkipClusterHealthChecks string
 
+	// ClusterHealthChecksTimeout defines the duration for which the harness will
+	// wait for the cluster to indicate it is healthy before cancelling the test
+	// run. This value should be formatted for use with time.ParseDuration.
+	// Env: CLUSTER_HEALTH_CHECKS_TIMEOUT
+	ClusterHealthChecksTimeout string
+
 	// MetricsBucket is the bucket that metrics data will be uploaded to.
 	// Env: METRICS_BUCKET
 	MetricsBucket string
@@ -184,16 +190,17 @@ var Tests = struct {
 	ServiceAccount string
 }{
 
-	PollingTimeout:            "tests.pollingTimeout",
-	GinkgoSkip:                "tests.ginkgoSkip",
-	GinkgoFocus:               "tests.focus",
-	TestsToRun:                "tests.testsToRun",
-	SuppressSkipNotifications: "tests.suppressSkipNotifications",
-	CleanRuns:                 "tests.cleanRuns",
-	OperatorSkip:              "tests.operatorSkip",
-	SkipClusterHealthChecks:   "tests.skipClusterHealthChecks",
-	MetricsBucket:             "tests.metricsBucket",
-	ServiceAccount:            "tests.serviceAccount",
+	PollingTimeout:             "tests.pollingTimeout",
+	GinkgoSkip:                 "tests.ginkgoSkip",
+	GinkgoFocus:                "tests.focus",
+	TestsToRun:                 "tests.testsToRun",
+	SuppressSkipNotifications:  "tests.suppressSkipNotifications",
+	CleanRuns:                  "tests.cleanRuns",
+	OperatorSkip:               "tests.operatorSkip",
+	SkipClusterHealthChecks:    "tests.skipClusterHealthChecks",
+	MetricsBucket:              "tests.metricsBucket",
+	ServiceAccount:             "tests.serviceAccount",
+	ClusterHealthChecksTimeout: "tests.clusterHealthChecksTimeout",
 }
 
 // Cluster config keys.
@@ -515,6 +522,9 @@ func init() {
 
 	viper.SetDefault(Tests.SkipClusterHealthChecks, false)
 	viper.BindEnv(Tests.OperatorSkip, "SKIP_CLUSTER_HEALTH_CHECKS")
+
+	viper.SetDefault(Tests.ClusterHealthChecksTimeout, "2h")
+	viper.BindEnv(Tests.ClusterHealthChecksTimeout, "CLUSTER_HEALTH_CHECKS_TIMEOUT")
 
 	viper.SetDefault(Tests.MetricsBucket, "osde2e-metrics")
 	viper.BindEnv(Tests.MetricsBucket, "METRICS_BUCKET")

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -128,10 +128,12 @@ func beforeSuite() bool {
 			clusterConfig, _, err := clusterutil.ClusterConfig(cluster.ID())
 			if err != nil {
 				log.Printf("Failed looking up cluster config for healthcheck: %v", err)
+				return false
 			}
 			kubeClient, err := kubernetes.NewForConfig(clusterConfig)
 			if err != nil {
 				log.Printf("Error generating Kube Clientset: %v\n", err)
+				return false
 			}
 			duration, err := time.ParseDuration(viper.GetString(config.Tests.ClusterHealthChecksTimeout))
 			if err != nil {

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -132,7 +132,8 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		if err != nil {
 			log.Printf("Error generating Kube Clientset: %v\n", err)
 		}
-		ctx, _ := context.WithTimeout(context.Background(), time.Hour*2)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Hour*2)
+		defer cancel()
 		ready, err := healthchecks.CheckHealthcheckJob(kubeClient, ctx, nil)
 		if !ready && err == nil {
 			err = fmt.Errorf("Cluster not ready")

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -134,6 +134,9 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), time.Hour*2)
 		defer cancel()
+		if viper.GetString(config.Tests.SkipClusterHealthChecks) != "" {
+			log.Println("WARNING: Skipping cluster health checks is no longer supported, as they no longer introduce delay into the build. Ignoring your request to skip them.")
+		}
 		ready, err := healthchecks.CheckHealthcheckJob(kubeClient, ctx, nil)
 		if !ready && err == nil {
 			err = fmt.Errorf("Cluster not ready")

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -132,7 +132,12 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		if err != nil {
 			log.Printf("Error generating Kube Clientset: %v\n", err)
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), time.Hour*2)
+		duration, err := time.ParseDuration(viper.GetString(config.Tests.ClusterHealthChecksTimeout))
+		if err != nil {
+			log.Printf("Failed parsing health check timeout, using 2 hours: %v", err)
+			duration = time.Hour * 2
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), duration)
 		defer cancel()
 		if viper.GetString(config.Tests.SkipClusterHealthChecks) != "" {
 			log.Println("WARNING: Skipping cluster health checks is no longer supported, as they no longer introduce delay into the build. Ignoring your request to skip them.")

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -137,18 +137,13 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		if viper.GetString(config.Tests.SkipClusterHealthChecks) != "" {
 			log.Println("WARNING: Skipping cluster health checks is no longer supported, as they no longer introduce delay into the build. Ignoring your request to skip them.")
 		}
-		ready, err := healthchecks.CheckHealthcheckJob(kubeClient, ctx, nil)
-		if !ready && err == nil {
-			err = fmt.Errorf("Cluster not ready")
-		}
-		if ready {
-			log.Println("Cluster is healthy and ready for testing")
-		}
+		err = healthchecks.CheckHealthcheckJob(kubeClient, ctx, nil)
 		events.HandleErrorWithEvents(err, events.HealthCheckSuccessful, events.HealthCheckFailed).ShouldNot(HaveOccurred(), "cluster failed health check")
 		if err != nil {
 			getLogs()
 			return []byte{}
 		}
+		log.Println("Cluster is healthy and ready for testing")
 
 		if len(viper.GetString(config.Addons.IDs)) > 0 {
 			if viper.GetString(config.Provider) != "mock" {

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -134,8 +134,8 @@ func beforeSuite() bool {
 		}
 		duration, err := time.ParseDuration(viper.GetString(config.Tests.ClusterHealthChecksTimeout))
 		if err != nil {
-			log.Printf("Failed parsing health check timeout, using 2 hours: %v", err)
-			duration = time.Hour * 2
+			log.Printf("Failed parsing health check timeout: %v", err)
+			return false
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), duration)
 		defer cancel()

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -139,7 +139,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), duration)
 		defer cancel()
-		if viper.GetString(config.Tests.SkipClusterHealthChecks) != "" {
+		if viper.GetString(config.Tests.SkipClusterHealthChecks) != "false" {
 			log.Println("WARNING: Skipping cluster health checks is no longer supported, as they no longer introduce delay into the build. Ignoring your request to skip them.")
 		}
 		err = healthchecks.CheckHealthcheckJob(kubeClient, ctx, nil)

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -132,9 +132,8 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		if err != nil {
 			log.Printf("Error generating Kube Clientset: %v\n", err)
 		}
-
 		ctx, _ := context.WithTimeout(context.Background(), time.Hour*2)
-		ready, err := healthchecks.CheckHealthcheckJob(kubeClient.CoreV1(), ctx, nil)
+		ready, err := healthchecks.CheckHealthcheckJob(kubeClient, ctx, nil)
 		if !ready && err == nil {
 			err = fmt.Errorf("Cluster not ready")
 		}

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -137,6 +137,9 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		if !ready && err == nil {
 			err = fmt.Errorf("Cluster not ready")
 		}
+		if ready {
+			log.Println("Cluster is healthy and ready for testing")
+		}
 		events.HandleErrorWithEvents(err, events.HealthCheckSuccessful, events.HealthCheckFailed).ShouldNot(HaveOccurred(), "cluster failed health check")
 		if err != nil {
 			getLogs()

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -148,6 +148,8 @@ func beforeSuite() bool {
 				return false
 			}
 			log.Println("Cluster is healthy and ready for testing")
+		} else {
+			log.Println("Skipping health checks as requested")
 		}
 		if len(viper.GetString(config.Addons.IDs)) > 0 {
 			if viper.GetString(config.Provider) != "mock" {


### PR DESCRIPTION
This is always failing with an error that indicates it can't find the cron job, but I can see it if I look manually. I'm pretty confused.

Here's an example of the error:

```
 cluster failed health check
  Unexpected error:
      <*fmt.wrapError | 0xc000565140>: {
          msg: "failed looking up job: the server could not find the requested resource (get jobs)",
          err: {
              ErrStatus: {
                  TypeMeta: {Kind: "", APIVersion: ""},
                  ListMeta: {
                      SelfLink: "",
                      ResourceVersion: "",
                      Continue: "",
                      RemainingItemCount: nil,
                  },
                  Status: "Failure",
                  Message: "the server could not find the requested resource (get jobs)",
                  Reason: "NotFound",
                  Details: {
                      Name: "",
                      Group: "",
                      Kind: "jobs",
                      UID: "",
                      Causes: [
                          {
                              Type: "UnexpectedServerResponse",
                              Message: "unknown",
                              Field: "",
                          },
                      ],
                      RetryAfterSeconds: 0,
                  },
                  Code: 404,
              },
          },
      }
      failed looking up job: the server could not find the requested resource (get jobs)
  occurred

```
