### PR TITLE
SDCICD-603: Update conformance tests, improve error handling when downloading files

### DIFF
--- a/pkg/common/runner/results.go
+++ b/pkg/common/runner/results.go
@@ -162,7 +162,7 @@ func (r *Runner) downloadLinks(n *html.Node, results map[string][]byte, director
 
 	for c := n.FirstChild; c != nil; c = c.NextSibling {
 		if err := r.downloadLinks(c, results, directory); err != nil {
-			return err
+			log.Printf("error while getting results for %s: %v", directory, err)
 		}
 	}
 	return nil

--- a/pkg/e2e/openshift/config.go
+++ b/pkg/e2e/openshift/config.go
@@ -17,7 +17,11 @@ oc config use-context cluster
 oc config view --raw=true > /tmp/kubeconfig
 export KUBECONFIG=/tmp/kubeconfig
 
-{{printTests .TestNames}} | {{unwrap .Env}} openshift-tests {{.TestCmd}} {{selectTests .Suite .TestNames}} {{unwrap .Flags}}
+REGION="$(oc get -o jsonpath='{.status.platformStatus.aws.region}' infrastructure cluster)"
+ZONE="$(oc get -o jsonpath='{.items[0].metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}' nodes)"
+export TEST_PROVIDER="{\"type\":\"aws\",\"region\":\"${REGION}\",\"zone\":\"${ZONE}\",\"multizone\":true,\"multimaster\":true}"
+
+{{printTests .TestNames}} | {{unwrap .Env}} openshift-tests {{.TestCmd}} {{selectTests .Suite .TestNames}} {{unwrap .Flags}} --provider "${TEST_PROVIDER}"
 
 # create a Tarball of OutputDir if requested
 {{$outDir := .OutputDir}}

--- a/pkg/e2e/openshift/conformance.go
+++ b/pkg/e2e/openshift/conformance.go
@@ -77,7 +77,7 @@ var _ = ginkgo.Describe(conformanceOpenshiftTestName, func() {
 		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
 		// configure tests
 		cfg := DefaultE2EConfig
-		cfg.Suite = "openshift/conformance"
+		cfg.Suite = "openshift/conformance/parallel suite"
 		cfg.Name = "openshift-conformance"
 		cmd := cfg.Cmd()
 


### PR DESCRIPTION
This changes the error handling to not stall any downloading when there's an error grabbing any files (I missed a spot from the other PR)

Additionally, this updates our conformance tests by adding similar logic to the upstream ci-step-registry.