### PR TITLE
SDCICD-595: Add additional logging into BeforeSuite, check for nil during version selection

### DIFF
--- a/pkg/common/events/events.go
+++ b/pkg/common/events/events.go
@@ -1,6 +1,8 @@
 package events
 
 import (
+	"log"
+
 	"github.com/onsi/gomega"
 )
 
@@ -24,8 +26,10 @@ func initializeEvents() {
 // HandleErrorWithEvents returns a gomega assertion and records events depending on the error state.
 func HandleErrorWithEvents(err error, successEvent EventType, failEvent EventType) gomega.Assertion {
 	if err != nil {
+		log.Printf("Fail event: %v", failEvent)
 		RecordEvent(failEvent)
 	} else {
+		log.Printf("Success event: %v", successEvent)
 		RecordEvent(successEvent)
 	}
 	return gomega.Expect(err)

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -87,9 +87,11 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 
 	// Skip provisioning if we already have a kubeconfig
 	if viper.GetString(config.Kubeconfig.Contents) == "" {
+
 		cluster, err := clusterutil.ProvisionCluster(nil)
 		events.HandleErrorWithEvents(err, events.InstallSuccessful, events.InstallFailed).ShouldNot(HaveOccurred(), "failed to setup cluster for testing")
 		if err != nil {
+			log.Printf("Failed to set up or retrieve cluster: %v", err)
 			getLogs()
 			return []byte{}
 		}
@@ -124,6 +126,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		err = clusterutil.WaitForClusterReady(cluster.ID(), nil)
 		events.HandleErrorWithEvents(err, events.HealthCheckSuccessful, events.HealthCheckFailed).ShouldNot(HaveOccurred(), "cluster failed health check")
 		if err != nil {
+			log.Printf("Cluster failed health check: %v", err)
 			getLogs()
 			return []byte{}
 		}
@@ -133,6 +136,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 				err = installAddons()
 				events.HandleErrorWithEvents(err, events.InstallAddonsSuccessful, events.InstallAddonsFailed).ShouldNot(HaveOccurred(), "failed while installing addons")
 				if err != nil {
+					log.Printf("Cluster failed installing addons: %v", err)
 					getLogs()
 					return []byte{}
 				}
@@ -145,6 +149,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		var kubeconfigBytes []byte
 		if kubeconfigBytes, err = provider.ClusterKubeconfig(cluster.ID()); err != nil {
 			events.HandleErrorWithEvents(err, events.InstallKubeconfigRetrievalSuccess, events.InstallKubeconfigRetrievalFailure).ShouldNot(HaveOccurred(), "failed while retrieve kubeconfig")
+			log.Printf("Failed retrieving kubeconfig: %v", err)
 			getLogs()
 			return []byte{}
 		}

--- a/pkg/e2e/version.go
+++ b/pkg/e2e/version.go
@@ -79,7 +79,7 @@ func setupVersion(versionList *spi.VersionList) (*semver.Version, string, error)
 		var err error
 
 		selectedVersion, versionType, err = versions.GetVersionForInstall(versionList)
-		if err == nil {
+		if err == nil && selectedVersion != nil {
 			if viper.GetBool(config.Cluster.EnoughVersionsForOldestOrMiddleTest) && viper.GetBool(config.Cluster.PreviousVersionFromDefaultFound) {
 				viper.Set(config.Cluster.Version, util.SemverToOpenshiftVersion(selectedVersion))
 			} else {


### PR DESCRIPTION
Adding some verbose logging to conditions that may cause BeforeSuite to fail without any logging as to why.

Additionally, adding a check to validate that the OpenShift version string isn't nil, hopefully preventing other error conditions observed.

:tada: