### PR TITLE
fix: correct the secret name for aws secret access key

### DIFF
--- a/docs/Addons.md
+++ b/docs/Addons.md
@@ -173,7 +173,7 @@ If you want to test a CCS (bring your own AWS account) cluster, you'll need to p
 ```
 ocm-aws-account
 ocm-aws-access-key
-ocm-aws-secret-key
+ocm-aws-secret-access-key
 ocm-token
 ```
 


### PR DESCRIPTION
Signed-off-by: Chris Waldon <cwaldon@redhat.com>