### PR TITLE
fix: actually retry talking to prometheus

### DIFF
--- a/pkg/e2e/state/alerts.go
+++ b/pkg/e2e/state/alerts.go
@@ -57,11 +57,15 @@ var _ = ginkgo.Describe(clusterStateTestName, func() {
 			defer cancel()
 			value, _, err := promAPI.Query(context, query, time.Now())
 			if err != nil {
-				return false, fmt.Errorf("Unable to query prom API: %w", err)
+				log.Printf("Unable to query prom API: %v", err)
+				// try again
+				return false, nil
 			}
 			queryresult, err = json.MarshalIndent(value, "", "  ")
 			if err != nil {
-				return false, fmt.Errorf("error marshaling results: %w", err)
+				log.Printf("Error marshaling results: %v", err)
+				// try again
+				return false, nil
 			}
 			return true, nil
 		})


### PR DESCRIPTION
The documentation for wait.PollImmediate indicates that it does
not retry if the condition function returns an error. There was
no code path in which we did not either return an error or true,
so this PollImmediate invocation would always exit after one try.

Signed-off-by: Chris Waldon <cwaldon@redhat.com>