### PR TITLE
[WIP] Add region to list output

### DIFF
--- a/cmd/osde2ectl/list/cmd.go
+++ b/cmd/osde2ectl/list/cmd.go
@@ -126,7 +126,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	if len(clusters) == 0 {
 		log.Printf("No results found")
 	} else {
-		statuslengthmax, installedverlengthmax, ownerlengthmax := 0, 0, 0
+		statuslengthmax, installedverlengthmax, ownerlengthmax, upgradeversionlengthmax := 0, 0, 0, 0
 		for _, cluster := range clusters {
 			properties := cluster.Properties()
 			if len(properties[clusterproperties.Status]) > statuslengthmax {
@@ -135,16 +135,19 @@ func run(cmd *cobra.Command, argv []string) error {
 			if len(properties[clusterproperties.InstalledVersion]) > installedverlengthmax {
 				installedverlengthmax = len(properties[clusterproperties.InstalledVersion])
 			}
+			if len(properties[clusterproperties.UpgradeVersion]) > upgradeversionlengthmax {
+				upgradeversionlengthmax = len(properties[clusterproperties.UpgradeVersion])
+			}
 			if len(properties[clusterproperties.OwnedBy]) > ownerlengthmax {
 				ownerlengthmax = len(properties[clusterproperties.OwnedBy])
 			}
 		}
 
-		headerspace := "%-25s%-35s%-15s%-" + strconv.Itoa(statuslengthmax+5) + "s%-" + strconv.Itoa(ownerlengthmax+5) + "s%-" + strconv.Itoa(installedverlengthmax+5) + "s%s\n"
-		fmt.Printf(headerspace, "NAME", "ID", "STATE", "STATUS", "OWNER", "INSTALLED VERSION", "UPGRADE VERSION")
+		headerspace := "%-25s%-35s%-15s%-" + strconv.Itoa(statuslengthmax+5) + "s%-" + strconv.Itoa(ownerlengthmax+5) + "s%-" + strconv.Itoa(installedverlengthmax+5) + "s%-" + strconv.Itoa(upgradeversionlengthmax+5) + "s%s\n"
+		fmt.Printf(headerspace, "NAME", "ID", "STATE", "STATUS", "OWNER", "INSTALLED VERSION", "UPGRADE VERSION", "REGION")
 		for _, cluster := range clusters {
 			properties := cluster.Properties()
-			fmt.Printf(headerspace, cluster.Name(), cluster.ID(), cluster.State(), properties[clusterproperties.Status], properties[clusterproperties.OwnedBy], properties[clusterproperties.InstalledVersion], properties[clusterproperties.UpgradeVersion])
+			fmt.Printf(headerspace, cluster.Name(), cluster.ID(), cluster.State(), properties[clusterproperties.Status], properties[clusterproperties.OwnedBy], properties[clusterproperties.InstalledVersion], properties[clusterproperties.UpgradeVersion], cluster.Region())
 		}
 	}
 


### PR DESCRIPTION
I created this during the last scale test because I wanted to easily see the region of each cluster.

I marked it as WIP because the region name seems to loose a `-` which appears to be coming from the OCM SDK. I'll investigate this tomorrow opening the PR so I don't forget.

```
osde2e-z23pg             1jkpsd8bmlrbq6cu3v2s7592qmmi695j   ready          operator         prow     openshift-v4.7.0-0.nightly-2021-03-25-013802-nightly          us-east1
us-east-1
osde2e-il4w8             1jkpsdj7tfg05kvnamgb4aen2m0glbag   ready          operator,pod     prow     openshift-v4.7.0-0.nightly-2021-03-25-013802-nightly          us-east-1
```

```
ocm describe cluster 1jkpsd8bmlrbq6cu3v2s7592qmmi695j

ID:            1jkpsd8bmlrbq6cu3v2s7592qmmi695j
External ID:  REDACTED
Name:          osde2e-z23pg.nc4m.p2.openshiftapps.com
API URL:      REDACTED
API Listening: external
Console URL:   REDACTED
Masters:       3
Infra:         2
Computes:      4
Product:       osd
Provider:      gcp
Region:        us-east1
Multi-az:      false
CCS:           false
Channel Group: nightly
Cluster Admin: false
Organization:  Red Hat
Creator:       REDACTED
Email:         REDACTED
Created:       2021-03-25T01:49:42Z
Expiration:    2021-03-25T07:49:41Z
Shard:         REDACTED

```