### PR TITLE
Modified pending pods health check

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -34,6 +34,7 @@ const (
 	pendingPodThreshold = 10
 )
 
+// podErrorTracker is the data structure that keeps track of pending state counters for each pod against their pod UIDs.
 var podErrorTracker healthchecks.PodErrorTracker
 
 // GetClusterVersion will get the current cluster version for the cluster.


### PR DESCRIPTION
Added a few changes on reviewing the PR comments for the initial pull request on the same -  https://github.com/openshift/osde2e/pull/737.

Changes made:-
1. The key in the pod error counter has been changed from pod name to pod UID.
2. The pod error counter deletes pod entries once a pod changes from "pending" state.
3. The healthcheck only passes if the pod error counter is entirely empty.