### PR TITLE
SDCICD-595: Refactor out synchronizedbeforesuite to a new function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,8 +52,7 @@ require (
 	github.com/tsenart/go-tsz v0.0.0-20180814235614-0bd30b3df1c3 // indirect
 	github.com/tsenart/vegeta v12.7.0+incompatible
 	github.com/vmware-tanzu/velero v1.5.0-beta.1.0.20200831161009-1dcaa1bf7512
-	golang.org/x/net v0.0.0-20200707034311-ab3426394381
-	golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 // indirect
+	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	k8s.io/api v0.20.0
 	k8s.io/apimachinery v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -1430,6 +1430,8 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb h1:eBmm0M9fYhWpKZLjQUUKka/LtIxf46G4fxeEz5KJr9U=
+golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1520,8 +1522,8 @@ golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211 h1:9UQO31fZ+0aKQOFldThf7BKPMJTiBfWycGh/u3UoO88=
-golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/common/events/events.go
+++ b/pkg/common/events/events.go
@@ -2,8 +2,6 @@ package events
 
 import (
 	"log"
-
-	"github.com/onsi/gomega"
 )
 
 // Events records individual events that occur during the execution of osde2e
@@ -23,8 +21,8 @@ func initializeEvents() {
 	Instance.Events = map[string]bool{}
 }
 
-// HandleErrorWithEvents returns a gomega assertion and records events depending on the error state.
-func HandleErrorWithEvents(err error, successEvent EventType, failEvent EventType) gomega.Assertion {
+// HandleErrorWithEvents records events depending on the error state.
+func HandleErrorWithEvents(err error, successEvent EventType, failEvent EventType) {
 	if err != nil {
 		log.Printf("Fail event: %v", failEvent)
 		RecordEvent(failEvent)
@@ -32,7 +30,6 @@ func HandleErrorWithEvents(err error, successEvent EventType, failEvent EventTyp
 		log.Printf("Success event: %v", successEvent)
 		RecordEvent(successEvent)
 	}
-	return gomega.Expect(err)
 }
 
 // RecordEvent records the given event in the global events instance

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -645,7 +645,7 @@ func runTestsInPhase(phase string, description string, dryrun bool) bool {
 	ginkgoPassed := false
 
 	if !dryrun || !ginkgoConfig.GinkgoConfig.DryRun {
-		if result := beforeSuite(); result == false {
+		if !beforeSuite() {
 			log.Println("Error getting kubeconfig from beforeSuite function")
 			return false
 		}

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -644,7 +644,7 @@ func runTestsInPhase(phase string, description string, dryrun bool) bool {
 	phaseReporter := ginkgorep.NewPhaseReporter(phase, phaseReportPath)
 	ginkgoPassed := false
 
-	if !dryrun || ginkgoConfig.GinkgoConfig.DryRun {
+	if !dryrun || !ginkgoConfig.GinkgoConfig.DryRun {
 		if result := beforeSuite(); result == false {
 			log.Println("Error getting kubeconfig from beforeSuite function")
 			return false


### PR DESCRIPTION
We were getting errors when attempting to run Ginkgo a second time post-Upgrades. Since the use case for SynchronizedBeforeSuite is not needed anymore, we should remove it. 

Ran a full set of upgrade tests locally after this change and things came back solid. 

During debugging, also upgraded `gomega` and `ginkgo` packages. 