### PR TITLE
SDCICD-459: Add install_config option, randomize imagecontentsource

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -281,6 +281,15 @@ var Cluster = struct {
 
 	// NumWorkerNodes overrides the flavour's number of worker nodes specified
 	NumWorkerNodes string
+
+	// Specify a key in the pre-defined imageContentSource array in the ocmprovider
+	// Blank will default to a randomized option
+	ImageContentSource string
+
+	//InstallConfig overrides merges on top of the installer's default OCP installer config
+	// Blank will do nothing
+	// Cannot specify imageContentSources within this config
+	InstallConfig string
 }{
 	MultiAZ:                             "cluster.multiAZ",
 	Channel:                             "cluster.channel",
@@ -583,6 +592,9 @@ func init() {
 
 	viper.SetDefault(Cluster.NumWorkerNodes, "")
 	viper.BindEnv(Cluster.NumWorkerNodes, "NUM_WORKER_NODES")
+
+	viper.BindEnv(Cluster.ImageContentSource, "CLUSTER_IMAGE_CONTENT_SOURCE")
+	viper.BindEnv(Cluster.InstallConfig, "CLUSTER_INSTALL_CONFIG")
 
 	// ----- Cloud Provider -----
 	viper.SetDefault(CloudProvider.CloudProviderID, "aws")

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -92,9 +92,12 @@ func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 	nodeBuilder := &v1.ClusterNodesBuilder{}
 
 	clusterProperties, err := o.GenerateProperties()
-
 	if err != nil {
 		return "", fmt.Errorf("error generating cluster properties: %v", err)
+	}
+
+	if o.Environment() != "prod" {
+		clusterProperties["install_config"] = fmt.Sprintf("%s\n%s", o.ChooseImageSource(viper.GetString(config.Cluster.ImageContentSource)), viper.GetString(config.Cluster.InstallConfig))
 	}
 
 	newCluster := v1.NewCluster().

--- a/pkg/common/providers/ocmprovider/cluster_image_sources.go
+++ b/pkg/common/providers/ocmprovider/cluster_image_sources.go
@@ -1,0 +1,73 @@
+package ocmprovider
+
+import (
+	"log"
+	"math/rand"
+)
+
+var clusterImageSources = map[string]string{"standard": `imageContentSources:
+- mirrors:
+  - quay.io/openshift-release-dev/ocp-release
+  - 950916221866.dkr.ecr.us-east-1.amazonaws.com/ocp-release
+  source: quay.io/openshift-release-dev/ocp-release
+- mirrors:
+  - quay.io/openshift-release-dev/ocp-v4.0-art-dev
+  - 950916221866.dkr.ecr.us-east-1.amazonaws.com/ocp-art-dev
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - quay.io/app-sre/managed-upgrade-operator
+  - 950916221866.dkr.ecr.us-east-1.amazonaws.com/managed-upgrade-operator
+  source: quay.io/app-sre/managed-upgrade-operator
+- mirrors:
+  - quay.io/app-sre/managed-upgrade-operator-registry
+  - 950916221866.dkr.ecr.us-east-1.amazonaws.com/managed-upgrade-operator-registry
+  source: quay.io/app-sre/managed-upgrade-operator-registry`,
+	"ecr-only": `imageContentSources:
+- mirrors:
+  - 950916221866.dkr.ecr.us-east-1.amazonaws.com/ocp-release
+  source: 950916221866.dkr.ecr.us-east-1.amazonaws.com/ocp-release
+- mirrors:
+  - 950916221866.dkr.ecr.us-east-1.amazonaws.com/ocp-art-dev
+  source: 950916221866.dkr.ecr.us-east-1.amazonaws.com/ocp-art-dev
+- mirrors:
+  - 950916221866.dkr.ecr.us-east-1.amazonaws.com/managed-upgrade-operator
+  source: 950916221866.dkr.ecr.us-east-1.amazonaws.com/managed-upgrade-operator
+- mirrors:
+  - 950916221866.dkr.ecr.us-east-1.amazonaws.com/managed-upgrade-operator-registry
+  source: 950916221866.dkr.ecr.us-east-1.amazonaws.com/managed-upgrade-operator-registry`,
+	"quay-only": `imageContentSources:
+- mirrors:
+  - quay.io/openshift-release-dev/ocp-release
+  source: quay.io/openshift-release-dev/ocp-release
+- mirrors:
+  - quay.io/openshift-release-dev/ocp-v4.0-art-dev
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+- mirrors:
+  - quay.io/app-sre/managed-upgrade-operator
+  source: quay.io/app-sre/managed-upgrade-operator
+- mirrors:
+  - quay.io/app-sre/managed-upgrade-operator-registry
+  source: quay.io/app-sre/managed-upgrade-operator-registry`}
+
+func (o *OCMProvider) ChooseImageSource(choice string) (source string) {
+	var ok bool
+	if choice == "random" || choice == "" {
+		chosenKey := rand.Intn(len(clusterImageSources))
+		key := 0
+		for _, val := range clusterImageSources {
+			if key == chosenKey {
+				source = val
+			}
+			key++
+		}
+	} else {
+		if source, ok = clusterImageSources[choice]; !ok {
+			log.Printf("Image source not found: %s", choice)
+			return ""
+		}
+	}
+
+	log.Printf("Choice: %s", choice)
+	log.Println(source)
+	return source
+}

--- a/pkg/common/providers/ocmprovider/cluster_image_sources.go
+++ b/pkg/common/providers/ocmprovider/cluster_image_sources.go
@@ -52,19 +52,15 @@ var clusterImageSources = map[string]string{"standard": `imageContentSources:
 func (o *OCMProvider) ChooseImageSource(choice string) (source string) {
 	var ok bool
 	if choice == "random" || choice == "" {
-		chosenKey := rand.Intn(len(clusterImageSources))
-		key := 0
-		for _, val := range clusterImageSources {
-			if key == chosenKey {
-				source = val
-			}
-			key++
+		var sources []string
+		for key := range clusterImageSources {
+			sources=append(sources, key)
 		}
-	} else {
-		if source, ok = clusterImageSources[choice]; !ok {
-			log.Printf("Image source not found: %s", choice)
-			return ""
-		}
+		choice = sources[rand.Intn(len(sources))]
+	}
+	if source, ok = clusterImageSources[choice]; !ok {
+		log.Printf("Image source not found: %s", choice)
+		return ""
 	}
 
 	log.Printf("Choice: %s", choice)


### PR DESCRIPTION
This allows us to specify/use the `install_config` option within OCM now. It also allows us to specify an ImageContentSource as a config (with several options pre-populated as a key-value pair in the ocmprovider.)

If no Image Source is specified, it will default to a random entry within the ocmprovider map. 

Note: This is only applicable in Int/Stage currently. 