### PR TITLE
fix: Don't set install_config for addon jobs

### DIFF
--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -96,7 +96,9 @@ func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 		return "", fmt.Errorf("error generating cluster properties: %v", err)
 	}
 
-	if o.Environment() != "prod" {
+	// This skips setting install_config for any prod job OR any periodic addon job.
+	// To invoke this logic locally you will have to set JOB_TYPE to "periodic".
+	if o.Environment() != "prod" || (os.Getenv("JOB_TYPE") == "periodic" && !strings.Contains(os.Getenv("JOB_NAME"), "addon")) {
 		imageSource := viper.GetString(config.Cluster.ImageContentSource)
 		log.Printf("Setting imageSource: %s", imageSource)
 		clusterProperties["install_config"] = fmt.Sprintf("%s\n%s", o.ChooseImageSource(imageSource), viper.GetString(config.Cluster.InstallConfig))


### PR DESCRIPTION
Don't set install_config in prod or if a job name has "addon" in it. :) 