### PR TITLE
fix: remove # character from slack channel name

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -489,7 +489,7 @@ func openPDAlerts(suites []junit.Suite, jobName, jobURL string) {
 		}); err != nil {
 			log.Printf("Failed creating pagerduty incident for failure: %v", err)
 		} else {
-			if err := alert.SendSlackMessage("#sd-cicd", fmt.Sprintf(`@osde2e A bunch of tests failed at once:
+			if err := alert.SendSlackMessage("sd-cicd", fmt.Sprintf(`@osde2e A bunch of tests failed at once:
 pipeline: %s
 URL: %s
 PD info: %v`, jobName, jobURL, event)); err != nil {


### PR DESCRIPTION
This symbol isn't actually part of the channel name, and causes this notification attempt to always fail.