### PR TITLE
SDCICD-628: Remove reliance on CS metrics, leave stubs for AMS metrics

### DIFF
--- a/pkg/common/providers/crc/crc.go
+++ b/pkg/common/providers/crc/crc.go
@@ -18,7 +18,6 @@ import (
 	"github.com/code-ready/crc/pkg/crc/preflight"
 	"github.com/code-ready/crc/pkg/crc/validation"
 	"github.com/code-ready/crc/pkg/crc/version"
-	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -249,8 +248,8 @@ func (m *Provider) Environment() string {
 }
 
 // Metrics is a stub function for now
-func (m *Provider) Metrics(clusterID string) (*v1.ClusterMetrics, error) {
-	return &v1.ClusterMetrics{}, nil
+func (m *Provider) Metrics(clusterID string) (bool, error) {
+	return true, nil
 }
 
 // UpgradeSource CRCs an environment source operation.

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/google/uuid"
 	"github.com/markbates/pkger"
-	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/spf13/viper"
@@ -232,8 +231,8 @@ func (m *MockProvider) Environment() string {
 }
 
 // Metrics is a stub function for now
-func (m *MockProvider) Metrics(clusterID string) (*v1.ClusterMetrics, error) {
-	return nil, nil
+func (m *MockProvider) Metrics(clusterID string) (bool, error) {
+	return true, nil
 }
 
 // UpgradeSource mocks an environment source operation.

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -648,20 +648,6 @@ func getLocalKubeConfig(path string) ([]byte, error) {
 	return []byte(f), nil
 }
 
-// GetMetrics gathers metrics from OCM on a cluster
-func (o *OCMProvider) GetMetrics(clusterID string) (*v1.ClusterMetrics, error) {
-	var err error
-
-	clusterClient := o.conn.ClustersMgmt().V1().Clusters().Cluster(clusterID)
-
-	cluster, err := clusterClient.Get().Send()
-	if err != nil {
-		return nil, err
-	}
-
-	return cluster.Body().Metrics(), nil
-}
-
 // InstallAddons loops through the addons list in the config
 // and performs the CRUD operation to trigger addon installation
 func (o *OCMProvider) InstallAddons(clusterID string, addonIDs []spi.AddOnID, addonParams map[spi.AddOnID]spi.AddOnParams) (num int, err error) {

--- a/pkg/common/providers/ocmprovider/ocm.go
+++ b/pkg/common/providers/ocmprovider/ocm.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/viper"
 
 	ocm "github.com/openshift-online/ocm-sdk-go"
-	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	ocmerr "github.com/openshift-online/ocm-sdk-go/errors"
 )
 
@@ -137,8 +136,8 @@ func (o *OCMProvider) Environment() string {
 }
 
 // Metrics returns the metrics of the cluster
-func (o *OCMProvider) Metrics(clusterID string) (*v1.ClusterMetrics, error) {
-	return o.GetMetrics(clusterID)
+func (o *OCMProvider) Metrics(clusterID string) (bool, error) {
+	return true, nil
 }
 
 // UpgradeSource indicates that for stage/production clusters, we should use Cincinnati.

--- a/pkg/common/providers/rosaprovider/wrapped_calls.go
+++ b/pkg/common/providers/rosaprovider/wrapped_calls.go
@@ -3,7 +3,6 @@ package rosaprovider
 import (
 	"time"
 
-	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/osde2e/pkg/common/spi"
 )
 
@@ -55,7 +54,7 @@ func (m *ROSAProvider) Environment() string {
 }
 
 // Metrics will call Metrics from the OCM provider.
-func (m *ROSAProvider) Metrics(clusterID string) (*v1.ClusterMetrics, error) {
+func (m *ROSAProvider) Metrics(clusterID string) (bool, error) {
 	return m.ocmProvider.Metrics(clusterID)
 }
 

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -3,8 +3,6 @@ package spi
 
 import (
 	"time"
-
-	clustersmgmtv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 )
 
 // AddOnID is a string used as the identifier for an addon
@@ -87,7 +85,7 @@ type Provider interface {
 	Logs(clusterID string) (map[string][]byte, error)
 
 	// Metrics will get metrics relevant to the cluster from the provider.
-	Metrics(clusterID string) (*clustersmgmtv1.ClusterMetrics, error)
+	Metrics(clusterID string) (bool, error)
 
 	// Environment retrives the environment from the provider.
 	//

--- a/pkg/e2e/osd/ocm.go
+++ b/pkg/e2e/osd/ocm.go
@@ -25,9 +25,7 @@ var _ = ginkgo.Describe(ocmTestName, func() {
 			metrics, err := provider.Metrics(clusterID)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(metrics.CriticalAlertsFiring()).NotTo(BeNil())
-			Expect(metrics.OperatorsConditionFailing()).NotTo(BeNil())
-			Expect(metrics.ComputeNodesSockets().Empty()).NotTo(BeFalse())
+			Expect(metrics).To(BeTrue())
 
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 	})


### PR DESCRIPTION
This removes code referring to the CS Metrics endpoint. It still leaves the OCM Metrics test as well as the SPI Metrics endpoint in place, for when AMS adds an endpoint to consume metrics from. 