### PR TITLE
Sdcicd 577

### DIFF
--- a/cmd/osde2ectl/create/cmd.go
+++ b/cmd/osde2ectl/create/cmd.go
@@ -298,7 +298,7 @@ func setupCluster(wg *sync.WaitGroup, successfulClustersCounter *int32) {
 			}
 		}()
 
-		err = clusterutil.WaitForClusterReady(cluster.ID(), logger)
+		err = clusterutil.WaitForClusterReadyPostInstall(cluster.ID(), logger)
 
 		terminate <- true
 

--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -76,24 +77,84 @@ func ScaleCluster(clusterID string, numComputeNodes int) error {
 	}
 
 	podErrorTracker.NewPodErrorTracker(pendingPodThreshold)
-	return waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID, nil, true)
+	return waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID, nil, false, true)
 }
 
-// WaitForClusterReady blocks until the cluster is ready for testing.
-func WaitForClusterReady(clusterID string, logger *log.Logger) error {
+// WaitForClusterReadyPostInstall blocks until the cluster is ready for testing using mechanisms appropriate
+// for a newly-installed cluster.
+func WaitForClusterReadyPostInstall(clusterID string, logger *log.Logger) error {
+	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 	podErrorTracker.NewPodErrorTracker(pendingPodThreshold)
-	return waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID, logger, false)
+	provider, err := providers.ClusterProvider()
+	if err != nil {
+		return fmt.Errorf("error getting cluster provisioning client: %v", err)
+	}
+
+	installTimeout := viper.GetInt64(config.Cluster.InstallTimeout)
+	logger.Printf("Waiting %v minutes for cluster '%s' to be ready...\n", installTimeout, clusterID)
+
+	_, err = waitForOCMProvisioning(provider, clusterID, installTimeout, logger, false)
+	if err != nil {
+		return fmt.Errorf("OCM never became ready: %w", err)
+	}
+	logger.Println("Cluster is provisioned in OCM")
+	clusterConfig, _, err := ClusterConfig(clusterID)
+	if err != nil {
+		return fmt.Errorf("failed looking up cluster config for healthcheck: %w", err)
+	}
+	kubeClient, err := kubernetes.NewForConfig(clusterConfig)
+	if err != nil {
+		return fmt.Errorf("error generating Kube Clientset: %w", err)
+	}
+	duration, err := time.ParseDuration(viper.GetString(config.Tests.ClusterHealthChecksTimeout))
+	if err != nil {
+		return fmt.Errorf("failed parsing health check timeout: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), duration)
+	defer cancel()
+	err = healthchecks.CheckHealthcheckJob(kubeClient, ctx, nil)
+	if err != nil {
+		return fmt.Errorf("cluster failed health check: %w", err)
+	}
+	cluster, err := provider.GetCluster(clusterID)
+	if err != nil {
+		return fmt.Errorf("failed getting cluster from provider: %w", err)
+	}
+	if err := provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusHealthy); err != nil {
+		return fmt.Errorf("error trying to add healthy property to cluster ID %s: %w", cluster.ID(), err)
+	}
+	return nil
 }
 
-func waitForOCMProvisioning(provider spi.Provider, clusterID string, installTimeout int64, logger *log.Logger) (becameReadyAt time.Time, err error) {
-	ocmReady := false
+// WaitForClusterReadyPostUpgrade blocks until the cluster is ready for testing using healthcheck mechanisms appropriate
+// for after a cluster version upgrade.
+func WaitForClusterReadyPostUpgrade(clusterID string, logger *log.Logger) error {
+	podErrorTracker.NewPodErrorTracker(pendingPodThreshold)
+	return waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID, logger, true, false)
+}
+
+// WaitForClusterReadyPostScale blocks until the cluster is ready for testing and uses healthcheck mechanisms appropriate
+// for after the cluster has been scaled.
+func WaitForClusterReadyPostScale(clusterID string, logger *log.Logger) error {
+	podErrorTracker.NewPodErrorTracker(pendingPodThreshold)
+	return waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID, logger, false, false)
+}
+
+func waitForOCMProvisioning(provider spi.Provider, clusterID string, installTimeout int64, logger *log.Logger, isUpgrade bool) (becameReadyAt time.Time, err error) {
+	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 	readinessSet := false
 	var readinessStarted time.Time
 	clusterStarted := time.Now()
+
+	healthcheckStatus := clusterproperties.StatusHealthCheck
+	if isUpgrade {
+		healthcheckStatus = clusterproperties.StatusUpgradeHealthCheck
+	}
+
 	return readinessStarted, wait.PollImmediate(30*time.Second, time.Duration(installTimeout)*time.Minute, func() (bool, error) {
 		cluster, err := provider.GetCluster(clusterID)
 		if err != nil {
-			log.Printf("Error fetching cluster details from provider: %s", err)
+			logger.Printf("Error fetching cluster details from provider: %s", err)
 			return false, nil
 		}
 
@@ -104,46 +165,47 @@ func waitForOCMProvisioning(provider spi.Provider, clusterID string, installTime
 		if currentStatus == clusterproperties.StatusProvisioning && !readinessSet {
 			err = provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusWaitingForReady)
 			if err != nil {
-				log.Printf("Error adding property to cluster: %s", err.Error())
+				logger.Printf("Error adding property to cluster: %s", err.Error())
+				return false, nil
+			}
+		}
+
+		if cluster.State() == spi.ClusterStateReady {
+			if metadata.Instance.TimeToOCMReportingInstalled == 0 {
+				metadata.Instance.SetTimeToOCMReportingInstalled(time.Since(clusterStarted).Seconds())
+			}
+
+			if err := provider.AddProperty(cluster, clusterproperties.Status, healthcheckStatus); err != nil {
+				logger.Printf("error trying to add health-check property to cluster ID %s: %v", cluster.ID(), err)
 				return false, nil
 			}
 
-		}
-
-		if cluster != nil && cluster.State() == spi.ClusterStateReady {
-			// This is the first time that we've entered this section, so we'll consider this the time until OCM has said the cluster is ready
-			if !ocmReady {
-				ocmReady = true
-				if metadata.Instance.TimeToOCMReportingInstalled == 0 {
-					metadata.Instance.SetTimeToOCMReportingInstalled(time.Since(clusterStarted).Seconds())
-				}
-
-				if currentStatus == clusterproperties.StatusUpgrading {
-					err = provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusUpgradeHealthCheck)
-				} else {
-					err = provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusHealthCheck)
-				}
-
-				if err != nil {
-					log.Printf("error trying to add health-check property to cluster ID %s: %v", cluster.ID(), err)
-					return false, nil
-				}
-
-				readinessStarted = time.Now()
-			}
+			readinessStarted = time.Now()
 			return true, nil
 		}
+		logger.Printf("cluster is not ready, state is: %v", cluster.State())
 		return false, nil
 	})
 }
 
-func waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID string, logger *log.Logger, overrideSkipCheck bool) error {
+func waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID string, logger *log.Logger, isUpgrade, overrideSkipCheck bool) error {
 	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
+	if viper.GetBool(config.Tests.SkipClusterHealthChecks) && !overrideSkipCheck {
+		logger.Println("Skipping health checks...")
+		return nil
+	}
 
 	provider, err := providers.ClusterProvider()
 
 	if err != nil {
 		return fmt.Errorf("error getting cluster provisioning client: %v", err)
+	}
+
+	unhealthyStatus := clusterproperties.StatusUnhealthy
+	healthyStatus := clusterproperties.StatusHealthy
+	if isUpgrade {
+		unhealthyStatus = clusterproperties.StatusUpgradeUnhealthy
+		healthyStatus = clusterproperties.StatusUpgradeHealthy
 	}
 
 	installTimeout := viper.GetInt64(config.Cluster.InstallTimeout)
@@ -152,89 +214,69 @@ func waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID string, l
 	cleanRuns := 0
 	errRuns := 0
 
-	if !viper.GetBool(config.Tests.SkipClusterHealthChecks) || overrideSkipCheck {
-		readinessStarted, err := waitForOCMProvisioning(provider, clusterID, installTimeout, logger)
-		if err != nil {
-			return fmt.Errorf("OCM never became ready: %w", err)
+	readinessStarted, err := waitForOCMProvisioning(provider, clusterID, installTimeout, logger, isUpgrade)
+	if err != nil {
+		return fmt.Errorf("OCM never became ready: %w", err)
+	}
+
+	cluster, err := provider.GetCluster(clusterID)
+	if err != nil {
+		return fmt.Errorf("Error fetching cluster details from provider: %w", err)
+	}
+
+	if pollErr := wait.PollImmediate(30*time.Second, time.Duration(installTimeout)*time.Minute, func() (bool, error) {
+		if cluster.State() != spi.ClusterStateReady {
+			logger.Printf("Cluster is not ready, current status '%s'.", cluster.State())
+			return false, nil
 		}
-		pollErr := wait.PollImmediate(30*time.Second, time.Duration(installTimeout)*time.Minute, func() (bool, error) {
-			cluster, err := provider.GetCluster(clusterID)
-			if err != nil {
-				log.Printf("Error fetching cluster details from provider: %s", err)
-				return false, nil
-			}
 
-			metadata.Instance.IncrementHealthcheckIteration()
-			properties := cluster.Properties()
-			currentStatus := properties[clusterproperties.Status]
+		metadata.Instance.IncrementHealthcheckIteration()
+		properties := cluster.Properties()
+		currentStatus := properties[clusterproperties.Status]
 
-			if cluster != nil && cluster.State() == spi.ClusterStateReady {
-				if success, failures, err := PollClusterHealth(clusterID, logger); success {
-					cleanRuns++
-					logger.Printf("Clean run %d/%d...", cleanRuns, cleanRunsNeeded)
-					errRuns = 0
-					if cleanRuns == cleanRunsNeeded {
-						return true, nil
-					}
-					return false, nil
-				} else {
-					if err != nil {
-						errRuns++
-						logger.Printf("Error in PollClusterHealth: %v", err)
-						if errRuns >= errorWindow {
-							if currentStatus == clusterproperties.StatusUpgradeHealthCheck {
-								err = provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusUpgradeUnhealthy)
-							} else {
-								err = provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusUnhealthy)
-							}
-
-							if err != nil {
-								log.Printf("error trying to add unhealthy property to cluster ID %s: %v", clusterID, err)
-								return false, nil
-							}
-						}
-					}
-					cleanRuns = 0
-
-					failureString := strings.Join(failures, ",")
-					if currentStatus != failureString {
-						err = provider.AddProperty(cluster, clusterproperties.Status, failureString)
-						if err != nil {
-							log.Printf("error trying to add property to cluster ID %s: %v", clusterID, err)
-						}
-					}
-
-					return false, nil
-				}
-			} else if cluster == nil {
-				return false, fmt.Errorf("the cluster is null despite there being no error: please check the logs")
-			} else if cluster.State() == spi.ClusterStateError {
-				return false, fmt.Errorf("the installation of cluster '%s' has errored", clusterID)
-			} else {
-				logger.Printf("Cluster is not ready, current status '%s'.", cluster.State())
+		if success, failures, err := PollClusterHealth(clusterID, logger); success {
+			cleanRuns++
+			logger.Printf("Clean run %d/%d...", cleanRuns, cleanRunsNeeded)
+			errRuns = 0
+			if cleanRuns == cleanRunsNeeded {
+				return true, nil
 			}
 			return false, nil
-		})
-		if pollErr == nil {
-    		// polling succeeded and the cluster is healthy
-			if metadata.Instance.TimeToClusterReady == 0 {
-				metadata.Instance.SetTimeToClusterReady(time.Since(readinessStarted).Seconds())
-			} else {
-				metadata.Instance.SetTimeToUpgradedClusterReady(time.Since(readinessStarted).Seconds())
-			}
-
-			if currentStatus == clusterproperties.StatusUpgradeHealthCheck {
-				err = provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusUpgradeHealthy)
-			} else {
-				err = provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusHealthy)
-			}
-
+		} else {
 			if err != nil {
-				log.Printf("error trying to add healthy property to cluster ID %s: %v", cluster.ID(), err)
-				return false, nil
+				errRuns++
+				logger.Printf("Error in PollClusterHealth: %v", err)
+				if errRuns >= errorWindow {
+					if err := provider.AddProperty(cluster, clusterproperties.Status, unhealthyStatus); err != nil {
+						log.Printf("error trying to add unhealthy property to cluster ID %s: %v", clusterID, err)
+					}
+					return false, nil
+				}
 			}
-		}
+			cleanRuns = 0
 
+			failureString := strings.Join(failures, ",")
+			if currentStatus != failureString {
+				err = provider.AddProperty(cluster, clusterproperties.Status, failureString)
+				if err != nil {
+					log.Printf("error trying to add property to cluster ID %s: %v", clusterID, err)
+				}
+			}
+
+			return false, nil
+		}
+	}); pollErr != nil {
+		return fmt.Errorf("failed polling for cluster health: %w", err)
+	}
+	// polling succeeded and the cluster is healthy
+	if metadata.Instance.TimeToClusterReady == 0 {
+		metadata.Instance.SetTimeToClusterReady(time.Since(readinessStarted).Seconds())
+	} else {
+		metadata.Instance.SetTimeToUpgradedClusterReady(time.Since(readinessStarted).Seconds())
+	}
+
+	if err := provider.AddProperty(cluster, clusterproperties.Status, healthyStatus); err != nil {
+		return fmt.Errorf("error trying to add healthy property to cluster ID %s: %w", cluster.ID(), err)
 	}
 	return nil
 }

--- a/pkg/common/cluster/healthchecks/healthcheckjob.go
+++ b/pkg/common/cluster/healthchecks/healthcheckjob.go
@@ -22,50 +22,59 @@ func CheckHealthcheckJob(k8sClient *kubernetes.Clientset, ctx context.Context, l
 	bv1C := k8sClient.BatchV1()
 	namespace := "openshift-monitoring"
 	name := "osd-cluster-ready"
-	jobs, err := bv1C.Jobs(namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return fmt.Errorf("failed listing jobs: %w", err)
-	}
-	for _, job := range jobs.Items {
-		if job.Name != name {
-			continue
-		}
-		if job.Status.Succeeded > 0 {
-			log.Println("Healthcheck job has already succeeded")
-			return nil
-		}
-		log.Println("Healthcheck job has not yet succeeded, watching...")
-	}
-	watcher, err := bv1C.Jobs(namespace).Watch(ctx, metav1.ListOptions{
-		ResourceVersion: jobs.ResourceVersion,
-		FieldSelector:   "metadata.name=osd-cluster-ready",
-	})
-	if err != nil {
-		return fmt.Errorf("failed watching job: %w", err)
-	}
+
 	for {
-		select {
-		case event := <-watcher.ResultChan():
-			switch event.Type {
-			case watch.Added:
-				fallthrough
-			case watch.Modified:
-				job := event.Object.(*batchv1.Job)
-				if job.Status.Succeeded > 0 {
-					return nil
-				}
-				if job.Status.Failed > 0 {
-					return fmt.Errorf("cluster readiness job failed")
-				}
-			case watch.Deleted:
-				return fmt.Errorf("cluster readiness job deleted before becoming ready (this should never happen)")
-			case watch.Error:
-				return fmt.Errorf("watch returned error event: %v", event)
-			default:
-				logger.Printf("Unrecognized event type while watching for healthcheck job updates: %v", event.Type)
-			}
-		case <-ctx.Done():
-			return fmt.Errorf("healtcheck watch context cancelled while still waiting for success")
+		jobs, err := bv1C.Jobs(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("failed listing jobs: %w", err)
 		}
+		for _, job := range jobs.Items {
+			if job.Name != name {
+				continue
+			}
+			if job.Status.Succeeded > 0 {
+				log.Println("Healthcheck job has already succeeded")
+				return nil
+			}
+			log.Println("Healthcheck job has not yet succeeded, watching...")
+		}
+		watcher, err := bv1C.Jobs(namespace).Watch(ctx, metav1.ListOptions{
+			ResourceVersion: jobs.ResourceVersion,
+			FieldSelector:   "metadata.name=osd-cluster-ready",
+		})
+		if err != nil {
+			return fmt.Errorf("failed watching job: %w", err)
+		}
+	resultLoop:
+		for {
+			select {
+			case event, more := <-watcher.ResultChan():
+				switch event.Type {
+				case watch.Added:
+					fallthrough
+				case watch.Modified:
+					job := event.Object.(*batchv1.Job)
+					if job.Status.Succeeded > 0 {
+						return nil
+					}
+					if job.Status.Failed > 0 {
+						return fmt.Errorf("cluster readiness job failed")
+					}
+				case watch.Deleted:
+					return fmt.Errorf("cluster readiness job deleted before becoming ready (this should never happen)")
+				case watch.Error:
+					return fmt.Errorf("watch returned error event: %v", event)
+				default:
+					logger.Printf("Unrecognized event type while watching for healthcheck job updates: %v", event.Type)
+				}
+				if !more {
+					logger.Printf("cluster watch result channel closed prematurely with event: %T %v", event, event)
+					break resultLoop
+				}
+			case <-ctx.Done():
+				return fmt.Errorf("healtcheck watch context cancelled while still waiting for success")
+			}
+		}
+		logger.Println("restarting healthcheck watch")
 	}
 }

--- a/pkg/common/cluster/healthchecks/healthcheckjob.go
+++ b/pkg/common/cluster/healthchecks/healthcheckjob.go
@@ -1,0 +1,71 @@
+package healthchecks
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/openshift/osde2e/pkg/common/logging"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+)
+
+// CheckHealthcheckJob uses the `osd-cluster-ready` healthcheck job to determine cluster readiness. If the cluster
+// is not ready, it will return an error.
+func CheckHealthcheckJob(k8sClient *kubernetes.Clientset, ctx context.Context, logger *log.Logger) error {
+	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
+
+	logger.Print("Checking whether cluster is healthy before proceeding...")
+
+	bv1C := k8sClient.BatchV1()
+	namespace := "openshift-monitoring"
+	name := "osd-cluster-ready"
+	jobs, err := bv1C.Jobs(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed listing jobs: %w", err)
+	}
+	for _, job := range jobs.Items {
+		if job.Name != name {
+			continue
+		}
+		if job.Status.Succeeded > 0 {
+			log.Println("Healthcheck job has already succeeded")
+			return nil
+		}
+		log.Println("Healthcheck job has not yet succeeded, watching...")
+	}
+	watcher, err := bv1C.Jobs(namespace).Watch(ctx, metav1.ListOptions{
+		ResourceVersion: jobs.ResourceVersion,
+		FieldSelector:   "metadata.name=osd-cluster-ready",
+	})
+	if err != nil {
+		return fmt.Errorf("failed watching job: %w", err)
+	}
+	for {
+		select {
+		case event := <-watcher.ResultChan():
+			switch event.Type {
+			case watch.Added:
+				fallthrough
+			case watch.Modified:
+				job := event.Object.(*batchv1.Job)
+				if job.Status.Succeeded > 0 {
+					return nil
+				}
+				if job.Status.Failed > 0 {
+					return fmt.Errorf("cluster readiness job failed")
+				}
+			case watch.Deleted:
+				return fmt.Errorf("cluster readiness job deleted before becoming ready (this should never happen)")
+			case watch.Error:
+				return fmt.Errorf("watch returned error event: %v", event)
+			default:
+				logger.Printf("Unrecognized event type while watching for healthcheck job updates: %v", event.Type)
+			}
+		case <-ctx.Done():
+			return fmt.Errorf("healtcheck watch context cancelled while still waiting for success")
+		}
+	}
+}

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -175,6 +175,12 @@ var Tests = struct {
 	// Env: SKIP_CLUSTER_HEALTH_CHECKS
 	SkipClusterHealthChecks string
 
+	// ClusterHealthChecksTimeout defines the duration for which the harness will
+	// wait for the cluster to indicate it is healthy before cancelling the test
+	// run. This value should be formatted for use with time.ParseDuration.
+	// Env: CLUSTER_HEALTH_CHECKS_TIMEOUT
+	ClusterHealthChecksTimeout string
+
 	// MetricsBucket is the bucket that metrics data will be uploaded to.
 	// Env: METRICS_BUCKET
 	MetricsBucket string
@@ -184,16 +190,17 @@ var Tests = struct {
 	ServiceAccount string
 }{
 
-	PollingTimeout:            "tests.pollingTimeout",
-	GinkgoSkip:                "tests.ginkgoSkip",
-	GinkgoFocus:               "tests.focus",
-	TestsToRun:                "tests.testsToRun",
-	SuppressSkipNotifications: "tests.suppressSkipNotifications",
-	CleanRuns:                 "tests.cleanRuns",
-	OperatorSkip:              "tests.operatorSkip",
-	SkipClusterHealthChecks:   "tests.skipClusterHealthChecks",
-	MetricsBucket:             "tests.metricsBucket",
-	ServiceAccount:            "tests.serviceAccount",
+	PollingTimeout:             "tests.pollingTimeout",
+	GinkgoSkip:                 "tests.ginkgoSkip",
+	GinkgoFocus:                "tests.focus",
+	TestsToRun:                 "tests.testsToRun",
+	SuppressSkipNotifications:  "tests.suppressSkipNotifications",
+	CleanRuns:                  "tests.cleanRuns",
+	OperatorSkip:               "tests.operatorSkip",
+	SkipClusterHealthChecks:    "tests.skipClusterHealthChecks",
+	MetricsBucket:              "tests.metricsBucket",
+	ServiceAccount:             "tests.serviceAccount",
+	ClusterHealthChecksTimeout: "tests.clusterHealthChecksTimeout",
 }
 
 // Cluster config keys.
@@ -536,6 +543,9 @@ func init() {
 
 	viper.SetDefault(Tests.SkipClusterHealthChecks, false)
 	viper.BindEnv(Tests.OperatorSkip, "SKIP_CLUSTER_HEALTH_CHECKS")
+
+	viper.SetDefault(Tests.ClusterHealthChecksTimeout, "2h")
+	viper.BindEnv(Tests.ClusterHealthChecksTimeout, "CLUSTER_HEALTH_CHECKS_TIMEOUT")
 
 	viper.SetDefault(Tests.MetricsBucket, "osde2e-metrics")
 	viper.BindEnv(Tests.MetricsBucket, "METRICS_BUCKET")

--- a/pkg/common/upgrade/upgrade.go
+++ b/pkg/common/upgrade/upgrade.go
@@ -134,7 +134,7 @@ func RunUpgrade() error {
 
 	metadata.Instance.SetTimeToUpgradedCluster(time.Since(upgradeStarted).Seconds())
 
-	if err = cluster.WaitForClusterReady(viper.GetString(config.Cluster.ID), nil); err != nil {
+	if err = cluster.WaitForClusterReadyPostUpgrade(viper.GetString(config.Cluster.ID), nil); err != nil {
 		return fmt.Errorf("failed waiting for cluster ready: %v", err)
 	}
 


### PR DESCRIPTION
I believe that this *finally* resolves SD-CICD 577. Essentially, these changes alter our healthcheck in the following ways:

- waiting for OCM to finish provisioning a cluster has been broken out into its own reusable function
- the different reasons that we might wait on cluster health now have different functions. This allows us to specialize the implementation to use the healthcheck most appropriate for the circumstance
- `WaitForClusterReadyPostInstall` properly waits for OCM and then the healthcheck cron job.