### PR TITLE
fix: update incorrect error message

### DIFF
--- a/pkg/common/cluster/healthchecks/healthcheckjob.go
+++ b/pkg/common/cluster/healthchecks/healthcheckjob.go
@@ -47,7 +47,7 @@ func CheckHealthcheckJob(k8sClient *kubernetes.Clientset, ctx context.Context, l
 func watchJob(bv1C v1.BatchV1Interface, ctx context.Context, namespace, jobname string) error {
 	jobs, err := bv1C.Jobs(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return fmt.Errorf("failed listing jobs and timed out: %w", err)
+		return fmt.Errorf("failed listing jobs: %w", err)
 	}
 	for _, job := range jobs.Items {
 		if job.Name != jobname {


### PR DESCRIPTION
There's no timeout here, this is just an artifact of a previous code structure.

Signed-off-by: Chris Waldon <cwaldon@redhat.com>