### PR TITLE
feat: implement concurrentviper via code generation

### DIFF
--- a/cmd/osde2e/healthcheck/cmd.go
+++ b/cmd/osde2e/healthcheck/cmd.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/osde2e/query/cmd.go
+++ b/cmd/osde2e/query/cmd.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 	"github.com/openshift/osde2e/cmd/osde2e/common"
 	"github.com/openshift/osde2e/pkg/common/config"

--- a/cmd/osde2e/test/cmd.go
+++ b/cmd/osde2e/test/cmd.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
 	"github.com/openshift/osde2e/pkg/e2e"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 	// import suites to be tested
 	_ "github.com/openshift/osde2e/pkg/e2e/addons"

--- a/cmd/osde2ectl/create/cmd.go
+++ b/cmd/osde2ectl/create/cmd.go
@@ -21,7 +21,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/versions"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/osde2ectl/delete/cmd.go
+++ b/cmd/osde2ectl/delete/cmd.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/osde2ectl/extend/cmd.go
+++ b/cmd/osde2ectl/extend/cmd.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/providers"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 var Cmd = &cobra.Command{

--- a/cmd/osde2ectl/healthcheck/cmd.go
+++ b/cmd/osde2ectl/healthcheck/cmd.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 var Cmd = &cobra.Command{

--- a/gen/main.go
+++ b/gen/main.go
@@ -7,7 +7,6 @@ import (
 	"go/format"
 	"go/token"
 	"go/types"
-	"io"
 	"os"
 	"path/filepath"
 

--- a/gen/main.go
+++ b/gen/main.go
@@ -1,0 +1,297 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/token"
+	"go/types"
+	"io"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/tools/go/packages"
+)
+
+var (
+	// the AST node for the output file. This specifies the output package
+	// name and allows us to predeclare the lock file.
+	outputFileNode = &ast.File{
+		Name: &ast.Ident{Name: "concurrentviper"},
+		// the nil at the beginning will be replaced by the import declaration later on
+		Decls: []ast.Decl{&ast.GenDecl{
+			Tok:   token.IMPORT,
+			Specs: []ast.Spec{},
+		}, lockDeclarationNode},
+		Imports: []*ast.ImportSpec{},
+	}
+	// the AST node corresponding to `var l sync.Mutex`
+	lockDeclarationNode = &ast.GenDecl{
+		Tok: token.VAR,
+		Specs: []ast.Spec{
+			&ast.ValueSpec{
+				Names: []*ast.Ident{
+					{
+						Name: "l",
+					},
+				},
+				Type: &ast.SelectorExpr{
+					X: &ast.Ident{
+						Name: "sync",
+					},
+					Sel: &ast.Ident{
+						Name: "Mutex",
+					},
+				},
+			},
+		},
+	}
+
+	// the AST node corresponding to a call to `l.Lock()`
+	lockNode = &ast.ExprStmt{
+		X: &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X: &ast.Ident{
+					Name: "l",
+				},
+				Sel: &ast.Ident{
+					Name: "Lock",
+				},
+			},
+		},
+	}
+	// the AST node corresponding to `defer l.Unlock()`
+	unlockNode = &ast.DeferStmt{
+		Call: &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X: &ast.Ident{
+					Name: "l",
+				},
+				Sel: &ast.Ident{
+					Name: "Unlock",
+				},
+			},
+		},
+	}
+)
+
+// definitionTracker keeps track of what imports are actually needed
+// in our rewritten code.
+type definitionTracker struct {
+	pkg        *packages.Package
+	nameToPath map[string]string
+	needed     map[string]struct{}
+}
+
+func NewDefinitionTracker(pkg *packages.Package) *definitionTracker {
+	d := &definitionTracker{
+		pkg:        pkg,
+		nameToPath: make(map[string]string),
+		needed:     make(map[string]struct{}),
+	}
+	for path, p := range d.pkg.Imports {
+		d.nameToPath[p.Name] = path
+	}
+	return d
+
+}
+
+func (d *definitionTracker) MarkNeeded(pkgName, pkgPath string) {
+	d.nameToPath[pkgName] = pkgPath
+	d.needed[pkgName] = struct{}{}
+}
+
+// RewriteType updates the tracker's internal state to ensure that dependencies
+// of the provided type will be imported, as well as altering the type to be
+// imported properly if it was originally a local variable.
+func (d *definitionTracker) RewriteType(fieldType ast.Expr) ast.Expr {
+	switch t := fieldType.(type) {
+	case *ast.Ident:
+		// if the type is just a single identifier, check if it's defined in viper
+		if packageDefinesType(t, d.pkg) {
+			return &ast.SelectorExpr{
+				X:   &ast.Ident{Name: "viper"},
+				Sel: t,
+			}
+		}
+		return fieldType
+	case *ast.SelectorExpr:
+		// if the type of a parameter is a reference to a type in another
+		// package, make sure we import that package
+		d.needed[t.X.(*ast.Ident).Name] = struct{}{}
+		return fieldType
+	case *ast.StarExpr:
+		// if the type is a pointer, descend and check again
+		t.X = d.RewriteType(t.X)
+		return t
+	case *ast.Ellipsis:
+		// if the type is ...type, descend and check again
+		t.Elt = d.RewriteType(t.Elt)
+		return t
+	case *ast.FuncType:
+		for i := range t.Params.List {
+			t.Params.List[i].Type = d.RewriteType(t.Params.List[i].Type)
+		}
+		if t.Results != nil {
+			for i := range t.Results.List {
+				t.Results.List[i].Type = d.RewriteType(t.Results.List[i].Type)
+			}
+		}
+		return t
+	default:
+		return fieldType
+	}
+}
+
+func (d *definitionTracker) Imports() []ast.Spec {
+	imports := []ast.Spec{}
+
+	// insert import statements for our dependencies
+	for name := range d.needed {
+		imports = append(imports, &ast.ImportSpec{
+			Name: &ast.Ident{Name: name},
+			Path: &ast.BasicLit{
+				Kind:  token.STRING,
+				Value: "\"" + d.nameToPath[name] + "\"",
+			},
+		})
+	}
+	return imports
+}
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), `Usage: %[1]s <output-go-file-path>`, func() string {
+			e, _ := os.Executable()
+			return filepath.Base(e)
+		}())
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	// create output file
+	out, err := os.Create(flag.Arg(0))
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := out.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	// configure and parse input package
+	cfg := &packages.Config{Mode: packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedImports | packages.NeedDeps | packages.NeedExportsFile | packages.NeedTypes | packages.NeedSyntax | packages.NeedTypesInfo | packages.NeedTypesSizes | packages.NeedModule}
+	pkgs, err := packages.Load(cfg, "github.com/spf13/viper")
+	if err != nil {
+		panic(err)
+	}
+	if packages.PrintErrors(pkgs) > 0 {
+		os.Exit(1)
+	}
+
+	// simplify since we are only working with one package
+	pkg := pkgs[0]
+
+	// create useful mapping types to track imports we need
+	tracker := NewDefinitionTracker(pkg)
+	tracker.MarkNeeded("sync", "sync")
+	tracker.MarkNeeded("viper", "github.com/spf13/viper")
+
+	// for each file in the source package
+	for _, f := range pkg.Syntax {
+		// for each top-level declaration in the file
+		for _, decl := range f.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok {
+				// skip if not a function
+				continue
+			}
+			fd.Doc = nil
+			if fd.Recv != nil {
+				// skip if a method instead of a function
+				continue
+			}
+			if !fd.Name.IsExported() {
+				// skip if not exported
+				continue
+			}
+			// redefine function body to be a lock/unlock followed by a call to
+			// the original viper function
+			call := &ast.CallExpr{
+				Fun: &ast.SelectorExpr{
+					X:   &ast.Ident{Name: "viper"},
+					Sel: &ast.Ident{Name: fd.Name.Name},
+				},
+				Args: []ast.Expr{},
+			}
+			expr := ast.Stmt(&ast.ExprStmt{X: call})
+			// if the function returns something, insert a "return"
+			if fd.Type.Results != nil {
+				expr = &ast.ReturnStmt{
+					Results: []ast.Expr{
+						call,
+					},
+				}
+			}
+			// iterate the parameters of the function and insert each one as an argument
+			// to the function call we're generating
+			for _, p := range fd.Type.Params.List {
+				if _, ok := p.Type.(*ast.Ellipsis); ok {
+					// if the last argument is variadic, spread it with `foo...` when calling
+					// the original viper function.
+					call.Ellipsis = token.Pos(1)
+				}
+				for _, n := range p.Names {
+					call.Args = append(call.Args, &ast.Ident{Name: n.Name})
+				}
+				p.Type = tracker.RewriteType(p.Type)
+			}
+			if fd.Type.Results != nil {
+				for _, p := range fd.Type.Results.List {
+					p.Type = tracker.RewriteType(p.Type)
+				}
+			}
+
+			body := &ast.BlockStmt{List: []ast.Stmt{}}
+			body.List = append(body.List, lockNode)
+			body.List = append(body.List, unlockNode)
+			body.List = append(body.List, expr)
+			fd.Body = body
+
+			// insert rewritten function into our list of rewritten functions
+			outputFileNode.Decls = append(outputFileNode.Decls, fd)
+		}
+	}
+
+	// attach these imports to the predeclared import block
+	outputFileNode.Decls[0].(*ast.GenDecl).Specs = tracker.Imports()
+
+	// format our source code into out
+	format.Node(out, pkg.Fset, outputFileNode)
+}
+
+// packageDefinesType checks whether pkg defines a type with the name typeName.
+func packageDefinesType(typeName *ast.Ident, pkg *packages.Package) bool {
+	if types.Universe.Lookup(typeName.Name) != nil {
+		return false
+	}
+	for _, f := range pkg.Syntax {
+	inner:
+		for _, decl := range f.Decls {
+			switch decl := decl.(type) {
+			case *ast.GenDecl:
+				if decl.Tok != token.TYPE {
+					continue inner
+				}
+				for _, s := range decl.Specs {
+					s := s.(*ast.TypeSpec)
+					if s.Name.Name == typeName.Name {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/dgryski/go-gk v0.0.0-20200319235926-a69029f61654 // indirect
 	github.com/dgryski/go-lttb v0.0.0-20180810165845-318fcdf10a77 // indirect
 	github.com/emicklei/go-restful v2.9.6+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/google/go-github/v31 v31.0.0
 	github.com/google/uuid v1.1.1
@@ -23,6 +24,7 @@ require (
 	github.com/joshdk/go-junit v0.0.0-20201221202203-061ee62ada40
 	github.com/kylelemons/godebug v1.1.0
 	github.com/markbates/pkger v0.17.1
+	github.com/mitchellh/mapstructure v1.1.2
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/openshift-online/ocm-sdk-go v0.1.166
@@ -43,6 +45,7 @@ require (
 	github.com/prometheus/common v0.15.0
 	github.com/redhat-cop/must-gather-operator v1.0.0
 	github.com/slack-go/slack v0.6.5
+	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.0
@@ -51,6 +54,7 @@ require (
 	github.com/tsenart/vegeta v12.7.0+incompatible
 	github.com/vmware-tanzu/velero v1.5.0-beta.1.0.20200831161009-1dcaa1bf7512
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
+	golang.org/x/tools v0.0.0-20200616133436-c1934b75d054
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	k8s.io/api v0.20.0
 	k8s.io/apimachinery v0.20.0

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
-	github.com/spf13/viper v1.7.0
+	github.com/spf13/viper v1.7.1
 	github.com/streadway/quantile v0.0.0-20150917103942-b0c588724d25 // indirect
 	github.com/tsenart/go-tsz v0.0.0-20180814235614-0bd30b3df1c3 // indirect
 	github.com/tsenart/vegeta v12.7.0+incompatible
@@ -69,6 +69,7 @@ replace (
 	github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20200521150516-05eb9880269c
 
 	github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v0.15.1
+
 	helm.sh/helm/v3 => helm.sh/helm/v3 v3.1.2
 	k8s.io/api => k8s.io/api v0.19.2
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.19.2

--- a/go.sum
+++ b/go.sum
@@ -694,7 +694,6 @@ github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible/go.mo
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6/go.mod h1:xGMAM8JLi7UkZt1i4FQeQy0R2T8GLUwQhOP5M1gBhy4=
 github.com/helm/helm-2to3 v0.2.0/go.mod h1:jQUVAWB0bM7zNIqKPIfHFzuFSK0kHYovJrjO+hqcvRk=
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
-github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -1193,8 +1192,9 @@ github.com/spf13/viper v1.0.2/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7Sr
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
-github.com/spf13/viper v1.7.0 h1:xVKxvI7ouOI5I+U9s2eeiUfMaWBVoXA3AWskkrqK0VM=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
+github.com/spf13/viper v1.7.1 h1:pM5oEahlgWv/WnHXpgbKz7iLIxRf65tye2Ci+XFK5sk=
+github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/storageos/go-api v0.0.0-20180912212459-343b3eff91fc/go.mod h1:ZrLn+e0ZuF3Y65PNF6dIwbJPZqfmtCXxFm9ckv0agOY=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=

--- a/go.sum
+++ b/go.sum
@@ -541,7 +541,6 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
-github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3 h1:JjCZWpVbqXDqFVmTfYWEVTMIYrL/NPdPSCHPJ0T/raM=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
@@ -1064,7 +1063,6 @@ github.com/prometheus/client_golang v1.2.1/go.mod h1:XMU6Z2MjaRKVu/dC1qupJI9SiNk
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
 github.com/prometheus/client_golang v1.5.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.6.0/go.mod h1:ZLOG9ck3JLRdB5MgO8f+lLTe83AXG6ro35rLTxvnIl4=
-github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.9.0 h1:Rrch9mh17XcxvEu9D9DEpb4isxjGBtcevQjKvxPRQIU=
 github.com/prometheus/client_golang v1.9.0/go.mod h1:FqZLKOZnGdFAhOK4nqGHa7D66IdsO+O441Eve7ptJDU=
@@ -1178,7 +1176,6 @@ github.com/spf13/cobra v0.0.2/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
-github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
@@ -1429,7 +1426,6 @@ golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
@@ -1725,7 +1721,6 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/pkg/common/alert/alert.go
+++ b/pkg/common/alert/alert.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/metrics"
 	"github.com/slack-go/slack"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 // MetricAlerts is an array of LogMetric types with an easier lookup method

--- a/pkg/common/aws/session.go
+++ b/pkg/common/aws/session.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/prometheus/common/log"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 const (

--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -20,7 +20,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/providers"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/util"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/common/cluster/clusterutil_test.go
+++ b/pkg/common/cluster/clusterutil_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/openshift/osde2e/pkg/common/config"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func TestRandomClusterName(t *testing.T) {

--- a/pkg/common/cluster/healthchecks/operators.go
+++ b/pkg/common/cluster/healthchecks/operators.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/logging"
 	"github.com/openshift/osde2e/pkg/common/metadata"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/common/cluster/healthchecks/operators_test.go
+++ b/pkg/common/cluster/healthchecks/operators_test.go
@@ -6,7 +6,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	fakeConfig "github.com/openshift/client-go/config/clientset/versioned/fake"
 	"github.com/openshift/osde2e/pkg/common/config"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/pkg/common/concurrentviper/gen.go
+++ b/pkg/common/concurrentviper/gen.go
@@ -1,5 +1,6 @@
 package concurrentviper
 
-//go:generate go run github.com/openshift/osde2e/gen generated.go
+//go:generate go run ./gen generated.go
+//go:generate go mod tidy
 
 // The above regenerates this package when you run `go generate ./...`

--- a/pkg/common/concurrentviper/gen.go
+++ b/pkg/common/concurrentviper/gen.go
@@ -1,0 +1,5 @@
+package concurrentviper
+
+//go:generate go run github.com/openshift/osde2e/gen generated.go
+
+// The above regenerates this package when you run `go generate ./...`

--- a/pkg/common/concurrentviper/gen.go
+++ b/pkg/common/concurrentviper/gen.go
@@ -1,3 +1,4 @@
+// Package concurrentviper is a generated thread-safe wrapper for github.com/spf13/viper
 package concurrentviper
 
 //go:generate go run ./gen generated.go

--- a/pkg/common/concurrentviper/gen/main.go
+++ b/pkg/common/concurrentviper/gen/main.go
@@ -1,3 +1,6 @@
+/*
+Package main generates a threadsafe version of github.com/spf13/viper
+*/
 package main
 
 import (

--- a/pkg/common/concurrentviper/gen/main.go
+++ b/pkg/common/concurrentviper/gen/main.go
@@ -209,7 +209,6 @@ func main() {
 				// skip if not a function
 				continue
 			}
-			fd.Doc = nil
 			if fd.Recv != nil {
 				// skip if a method instead of a function
 				continue
@@ -218,6 +217,10 @@ func main() {
 				// skip if not exported
 				continue
 			}
+			if fd.Doc == nil {
+				fd.Doc = &ast.CommentGroup{}
+			}
+			fd.Doc.List = append(fd.Doc.List, &ast.Comment{Text: "// This function is safe for concurrent use."})
 			// redefine function body to be a lock/unlock followed by a call to
 			// the original viper function
 			call := &ast.CallExpr{

--- a/pkg/common/concurrentviper/generated.go
+++ b/pkg/common/concurrentviper/generated.go
@@ -1,16 +1,16 @@
 package concurrentviper
 
 import (
-	afero "github.com/spf13/afero"
-	mapstructure "github.com/mitchellh/mapstructure"
-	fsnotify "github.com/fsnotify/fsnotify"
+	time "time"
 	pflag "github.com/spf13/pflag"
 	strings "strings"
+	io "io"
+	viper "github.com/spf13/viper"
+	mapstructure "github.com/mitchellh/mapstructure"
+	fsnotify "github.com/fsnotify/fsnotify"
+	afero "github.com/spf13/afero"
 	os "os"
 	sync "sync"
-	viper "github.com/spf13/viper"
-	time "time"
-	io "io"
 )
 
 var l sync.Mutex

--- a/pkg/common/concurrentviper/generated.go
+++ b/pkg/common/concurrentviper/generated.go
@@ -1,254 +1,468 @@
 package concurrentviper
 
 import (
-	time "time"
-	pflag "github.com/spf13/pflag"
-	strings "strings"
-	io "io"
-	viper "github.com/spf13/viper"
 	mapstructure "github.com/mitchellh/mapstructure"
 	fsnotify "github.com/fsnotify/fsnotify"
+	time "time"
+	strings "strings"
 	afero "github.com/spf13/afero"
-	os "os"
 	sync "sync"
+	viper "github.com/spf13/viper"
+	pflag "github.com/spf13/pflag"
+	io "io"
+	os "os"
 )
 
 var l sync.Mutex
 
+// DecodeHook returns a DecoderConfigOption which overrides the default
+// DecoderConfig.DecodeHook value, the default is:
+//
+//  mapstructure.ComposeDecodeHookFunc(
+//		mapstructure.StringToTimeDurationHookFunc(),
+//		mapstructure.StringToSliceHookFunc(","),
+//	)
+// This function is safe for concurrent use.
 func DecodeHook(hook mapstructure.DecodeHookFunc) viper.DecoderConfigOption {
 	l.Lock()
 	defer l.Unlock()
 	return viper.DecodeHook(hook)
 }
 
+// New returns an initialized Viper instance.
+// This function is safe for concurrent use.
 func New() *viper.Viper { l.Lock(); defer l.Unlock(); return viper.New() }
 
+// KeyDelimiter sets the delimiter used for determining key parts.
+// By default it's value is ".".
+// This function is safe for concurrent use.
 func KeyDelimiter(d string) viper.Option { l.Lock(); defer l.Unlock(); return viper.KeyDelimiter(d) }
 
+// EnvKeyReplacer sets a replacer used for mapping environment variables to internal keys.
+// This function is safe for concurrent use.
 func EnvKeyReplacer(r viper.StringReplacer) viper.Option {
 	l.Lock()
 	defer l.Unlock()
 	return viper.EnvKeyReplacer(r)
 }
 
+// NewWithOptions creates a new Viper instance.
+// This function is safe for concurrent use.
 func NewWithOptions(opts ...viper.Option) *viper.Viper {
 	l.Lock()
 	defer l.Unlock()
 	return viper.NewWithOptions(opts...)
 }
 
+// Reset is intended for testing, will reset all to default settings.
+// In the public interface for the viper package so applications
+// can use it in their testing as well.
+// This function is safe for concurrent use.
 func Reset() { l.Lock(); defer l.Unlock(); viper.Reset() }
-
+// This function is safe for concurrent use.
 func OnConfigChange(run func(in fsnotify.Event)) {
 	l.Lock()
 	defer l.Unlock()
 	viper.OnConfigChange(run)
 }
-
+// This function is safe for concurrent use.
 func WatchConfig() { l.Lock(); defer l.Unlock(); viper.WatchConfig() }
 
+// SetConfigFile explicitly defines the path, name and extension of the config file.
+// Viper will use this and not check any of the config paths.
+// This function is safe for concurrent use.
 func SetConfigFile(in string) { l.Lock(); defer l.Unlock(); viper.SetConfigFile(in) }
 
+// SetEnvPrefix defines a prefix that ENVIRONMENT variables will use.
+// E.g. if your prefix is "spf", the env registry will look for env
+// variables that start with "SPF_".
+// This function is safe for concurrent use.
 func SetEnvPrefix(in string) { l.Lock(); defer l.Unlock(); viper.SetEnvPrefix(in) }
 
+// AllowEmptyEnv tells Viper to consider set,
+// but empty environment variables as valid values instead of falling back.
+// For backward compatibility reasons this is false by default.
+// This function is safe for concurrent use.
 func AllowEmptyEnv(allowEmptyEnv bool) {
 	l.Lock()
 	defer l.Unlock()
 	viper.AllowEmptyEnv(allowEmptyEnv)
 }
 
+// ConfigFileUsed returns the file used to populate the config registry.
+// This function is safe for concurrent use.
 func ConfigFileUsed() string { l.Lock(); defer l.Unlock(); return viper.ConfigFileUsed() }
 
+// AddConfigPath adds a path for Viper to search for the config file in.
+// Can be called multiple times to define multiple search paths.
+// This function is safe for concurrent use.
 func AddConfigPath(in string) { l.Lock(); defer l.Unlock(); viper.AddConfigPath(in) }
 
+// AddRemoteProvider adds a remote configuration source.
+// Remote Providers are searched in the order they are added.
+// provider is a string value: "etcd", "consul" or "firestore" are currently supported.
+// endpoint is the url.  etcd requires http://ip:port  consul requires ip:port
+// path is the path in the k/v store to retrieve configuration
+// To retrieve a config file called myapp.json from /configs/myapp.json
+// you should set path to /configs and set config name (SetConfigName()) to
+// "myapp"
+// This function is safe for concurrent use.
 func AddRemoteProvider(provider, endpoint, path string) error {
 	l.Lock()
 	defer l.Unlock()
 	return viper.AddRemoteProvider(provider, endpoint, path)
 }
 
+// AddSecureRemoteProvider adds a remote configuration source.
+// Secure Remote Providers are searched in the order they are added.
+// provider is a string value: "etcd", "consul" or "firestore" are currently supported.
+// endpoint is the url.  etcd requires http://ip:port  consul requires ip:port
+// secretkeyring is the filepath to your openpgp secret keyring.  e.g. /etc/secrets/myring.gpg
+// path is the path in the k/v store to retrieve configuration
+// To retrieve a config file called myapp.json from /configs/myapp.json
+// you should set path to /configs and set config name (SetConfigName()) to
+// "myapp"
+// Secure Remote Providers are implemented with github.com/bketelsen/crypt
+// This function is safe for concurrent use.
 func AddSecureRemoteProvider(provider, endpoint, path, secretkeyring string) error {
 	l.Lock()
 	defer l.Unlock()
 	return viper.AddSecureRemoteProvider(provider, endpoint, path, secretkeyring)
 }
 
+// SetTypeByDefaultValue enables or disables the inference of a key value's
+// type when the Get function is used based upon a key's default value as
+// opposed to the value returned based on the normal fetch logic.
+//
+// For example, if a key has a default value of []string{} and the same key
+// is set via an environment variable to "a b c", a call to the Get function
+// would return a string slice for the key if the key's type is inferred by
+// the default value and the Get function would return:
+//
+//   []string {"a", "b", "c"}
+//
+// Otherwise the Get function would return:
+//
+//   "a b c"
+// This function is safe for concurrent use.
 func SetTypeByDefaultValue(enable bool) {
 	l.Lock()
 	defer l.Unlock()
 	viper.SetTypeByDefaultValue(enable)
 }
 
+// GetViper gets the global Viper instance.
+// This function is safe for concurrent use.
 func GetViper() *viper.Viper { l.Lock(); defer l.Unlock(); return viper.GetViper() }
 
+// Get can retrieve any value given the key to use.
+// Get is case-insensitive for a key.
+// Get has the behavior of returning the value associated with the first
+// place from where it is set. Viper will check in the following order:
+// override, flag, env, config file, key/value store, default
+//
+// Get returns an interface. For a specific value use one of the Get____ methods.
+// This function is safe for concurrent use.
 func Get(key string) interface{} { l.Lock(); defer l.Unlock(); return viper.Get(key) }
 
+// Sub returns new Viper instance representing a sub tree of this instance.
+// Sub is case-insensitive for a key.
+// This function is safe for concurrent use.
 func Sub(key string) *viper.Viper { l.Lock(); defer l.Unlock(); return viper.Sub(key) }
 
+// GetString returns the value associated with the key as a string.
+// This function is safe for concurrent use.
 func GetString(key string) string { l.Lock(); defer l.Unlock(); return viper.GetString(key) }
 
+// GetBool returns the value associated with the key as a boolean.
+// This function is safe for concurrent use.
 func GetBool(key string) bool { l.Lock(); defer l.Unlock(); return viper.GetBool(key) }
 
+// GetInt returns the value associated with the key as an integer.
+// This function is safe for concurrent use.
 func GetInt(key string) int { l.Lock(); defer l.Unlock(); return viper.GetInt(key) }
 
+// GetInt32 returns the value associated with the key as an integer.
+// This function is safe for concurrent use.
 func GetInt32(key string) int32 { l.Lock(); defer l.Unlock(); return viper.GetInt32(key) }
 
+// GetInt64 returns the value associated with the key as an integer.
+// This function is safe for concurrent use.
 func GetInt64(key string) int64 { l.Lock(); defer l.Unlock(); return viper.GetInt64(key) }
 
+// GetUint returns the value associated with the key as an unsigned integer.
+// This function is safe for concurrent use.
 func GetUint(key string) uint { l.Lock(); defer l.Unlock(); return viper.GetUint(key) }
 
+// GetUint32 returns the value associated with the key as an unsigned integer.
+// This function is safe for concurrent use.
 func GetUint32(key string) uint32 { l.Lock(); defer l.Unlock(); return viper.GetUint32(key) }
 
+// GetUint64 returns the value associated with the key as an unsigned integer.
+// This function is safe for concurrent use.
 func GetUint64(key string) uint64 { l.Lock(); defer l.Unlock(); return viper.GetUint64(key) }
 
+// GetFloat64 returns the value associated with the key as a float64.
+// This function is safe for concurrent use.
 func GetFloat64(key string) float64 { l.Lock(); defer l.Unlock(); return viper.GetFloat64(key) }
 
+// GetTime returns the value associated with the key as time.
+// This function is safe for concurrent use.
 func GetTime(key string) time.Time { l.Lock(); defer l.Unlock(); return viper.GetTime(key) }
 
+// GetDuration returns the value associated with the key as a duration.
+// This function is safe for concurrent use.
 func GetDuration(key string) time.Duration { l.Lock(); defer l.Unlock(); return viper.GetDuration(key) }
 
+// GetIntSlice returns the value associated with the key as a slice of int values.
+// This function is safe for concurrent use.
 func GetIntSlice(key string) []int { l.Lock(); defer l.Unlock(); return viper.GetIntSlice(key) }
 
+// GetStringSlice returns the value associated with the key as a slice of strings.
+// This function is safe for concurrent use.
 func GetStringSlice(key string) []string {
 	l.Lock()
 	defer l.Unlock()
 	return viper.GetStringSlice(key)
 }
 
+// GetStringMap returns the value associated with the key as a map of interfaces.
+// This function is safe for concurrent use.
 func GetStringMap(key string) map[string]interface{} {
 	l.Lock()
 	defer l.Unlock()
 	return viper.GetStringMap(key)
 }
 
+// GetStringMapString returns the value associated with the key as a map of strings.
+// This function is safe for concurrent use.
 func GetStringMapString(key string) map[string]string {
 	l.Lock()
 	defer l.Unlock()
 	return viper.GetStringMapString(key)
 }
 
+// GetStringMapStringSlice returns the value associated with the key as a map to a slice of strings.
+// This function is safe for concurrent use.
 func GetStringMapStringSlice(key string) map[string][]string {
 	l.Lock()
 	defer l.Unlock()
 	return viper.GetStringMapStringSlice(key)
 }
 
+// GetSizeInBytes returns the size of the value associated with the given key
+// in bytes.
+// This function is safe for concurrent use.
 func GetSizeInBytes(key string) uint { l.Lock(); defer l.Unlock(); return viper.GetSizeInBytes(key) }
 
+// UnmarshalKey takes a single key and unmarshals it into a Struct.
+// This function is safe for concurrent use.
 func UnmarshalKey(key string, rawVal interface{}, opts ...viper.DecoderConfigOption) error {
 	l.Lock()
 	defer l.Unlock()
 	return viper.UnmarshalKey(key, rawVal, opts...)
 }
 
+// Unmarshal unmarshals the config into a Struct. Make sure that the tags
+// on the fields of the structure are properly set.
+// This function is safe for concurrent use.
 func Unmarshal(rawVal interface{}, opts ...viper.DecoderConfigOption) error {
 	l.Lock()
 	defer l.Unlock()
 	return viper.Unmarshal(rawVal, opts...)
 }
 
+// UnmarshalExact unmarshals the config into a Struct, erroring if a field is nonexistent
+// in the destination struct.
+// This function is safe for concurrent use.
 func UnmarshalExact(rawVal interface{}, opts ...viper.DecoderConfigOption) error {
 	l.Lock()
 	defer l.Unlock()
 	return viper.UnmarshalExact(rawVal, opts...)
 }
 
+// BindPFlags binds a full flag set to the configuration, using each flag's long
+// name as the config key.
+// This function is safe for concurrent use.
 func BindPFlags(flags *pflag.FlagSet) error {
 	l.Lock()
 	defer l.Unlock()
 	return viper.BindPFlags(flags)
 }
 
+// BindPFlag binds a specific key to a pflag (as used by cobra).
+// Example (where serverCmd is a Cobra instance):
+//
+//	 serverCmd.Flags().Int("port", 1138, "Port to run Application server on")
+//	 Viper.BindPFlag("port", serverCmd.Flags().Lookup("port"))
+//
+// This function is safe for concurrent use.
 func BindPFlag(key string, flag *pflag.Flag) error {
 	l.Lock()
 	defer l.Unlock()
 	return viper.BindPFlag(key, flag)
 }
 
+// BindFlagValues binds a full FlagValue set to the configuration, using each flag's long
+// name as the config key.
+// This function is safe for concurrent use.
 func BindFlagValues(flags viper.FlagValueSet) error {
 	l.Lock()
 	defer l.Unlock()
 	return viper.BindFlagValues(flags)
 }
 
+// BindFlagValue binds a specific key to a FlagValue.
+// This function is safe for concurrent use.
 func BindFlagValue(key string, flag viper.FlagValue) error {
 	l.Lock()
 	defer l.Unlock()
 	return viper.BindFlagValue(key, flag)
 }
 
+// BindEnv binds a Viper key to a ENV variable.
+// ENV variables are case sensitive.
+// If only a key is provided, it will use the env key matching the key, uppercased.
+// EnvPrefix will be used when set when env name is not provided.
+// This function is safe for concurrent use.
 func BindEnv(input ...string) error { l.Lock(); defer l.Unlock(); return viper.BindEnv(input...) }
 
+// IsSet checks to see if the key has been set in any of the data locations.
+// IsSet is case-insensitive for a key.
+// This function is safe for concurrent use.
 func IsSet(key string) bool { l.Lock(); defer l.Unlock(); return viper.IsSet(key) }
 
+// AutomaticEnv has Viper check ENV variables for all.
+// keys set in config, default & flags
+// This function is safe for concurrent use.
 func AutomaticEnv() { l.Lock(); defer l.Unlock(); viper.AutomaticEnv() }
 
+// SetEnvKeyReplacer sets the strings.Replacer on the viper object
+// Useful for mapping an environmental variable to a key that does
+// not match it.
+// This function is safe for concurrent use.
 func SetEnvKeyReplacer(r *strings.Replacer) { l.Lock(); defer l.Unlock(); viper.SetEnvKeyReplacer(r) }
 
+// RegisterAlias creates an alias that provides another accessor for the same key.
+// This enables one to change a name without breaking the application.
+// This function is safe for concurrent use.
 func RegisterAlias(alias string, key string) {
 	l.Lock()
 	defer l.Unlock()
 	viper.RegisterAlias(alias, key)
 }
 
+// InConfig checks to see if the given key (or an alias) is in the config file.
+// This function is safe for concurrent use.
 func InConfig(key string) bool { l.Lock(); defer l.Unlock(); return viper.InConfig(key) }
 
+// SetDefault sets the default value for this key.
+// SetDefault is case-insensitive for a key.
+// Default only used when no value is provided by the user via flag, config or ENV.
+// This function is safe for concurrent use.
 func SetDefault(key string, value interface{}) {
 	l.Lock()
 	defer l.Unlock()
 	viper.SetDefault(key, value)
 }
 
+// Set sets the value for the key in the override register.
+// Set is case-insensitive for a key.
+// Will be used instead of values obtained via
+// flags, config file, ENV, default, or key/value store.
+// This function is safe for concurrent use.
 func Set(key string, value interface{}) { l.Lock(); defer l.Unlock(); viper.Set(key, value) }
 
+// ReadInConfig will discover and load the configuration file from disk
+// and key/value stores, searching in one of the defined paths.
+// This function is safe for concurrent use.
 func ReadInConfig() error { l.Lock(); defer l.Unlock(); return viper.ReadInConfig() }
 
+// MergeInConfig merges a new configuration with an existing config.
+// This function is safe for concurrent use.
 func MergeInConfig() error { l.Lock(); defer l.Unlock(); return viper.MergeInConfig() }
 
+// ReadConfig will read a configuration file, setting existing keys to nil if the
+// key does not exist in the file.
+// This function is safe for concurrent use.
 func ReadConfig(in io.Reader) error { l.Lock(); defer l.Unlock(); return viper.ReadConfig(in) }
 
+// MergeConfig merges a new configuration with an existing config.
+// This function is safe for concurrent use.
 func MergeConfig(in io.Reader) error { l.Lock(); defer l.Unlock(); return viper.MergeConfig(in) }
 
+// MergeConfigMap merges the configuration from the map given with an existing config.
+// Note that the map given may be modified.
+// This function is safe for concurrent use.
 func MergeConfigMap(cfg map[string]interface{}) error {
 	l.Lock()
 	defer l.Unlock()
 	return viper.MergeConfigMap(cfg)
 }
 
+// WriteConfig writes the current configuration to a file.
+// This function is safe for concurrent use.
 func WriteConfig() error { l.Lock(); defer l.Unlock(); return viper.WriteConfig() }
 
+// SafeWriteConfig writes current configuration to file only if the file does not exist.
+// This function is safe for concurrent use.
 func SafeWriteConfig() error { l.Lock(); defer l.Unlock(); return viper.SafeWriteConfig() }
 
+// WriteConfigAs writes current configuration to a given filename.
+// This function is safe for concurrent use.
 func WriteConfigAs(filename string) error {
 	l.Lock()
 	defer l.Unlock()
 	return viper.WriteConfigAs(filename)
 }
 
+// SafeWriteConfigAs writes current configuration to a given filename if it does not exist.
+// This function is safe for concurrent use.
 func SafeWriteConfigAs(filename string) error {
 	l.Lock()
 	defer l.Unlock()
 	return viper.SafeWriteConfigAs(filename)
 }
 
+// ReadRemoteConfig attempts to get configuration from a remote source
+// and read it in the remote configuration registry.
+// This function is safe for concurrent use.
 func ReadRemoteConfig() error { l.Lock(); defer l.Unlock(); return viper.ReadRemoteConfig() }
-
+// This function is safe for concurrent use.
 func WatchRemoteConfig() error { l.Lock(); defer l.Unlock(); return viper.WatchRemoteConfig() }
 
+// AllKeys returns all keys holding a value, regardless of where they are set.
+// Nested keys are returned with a v.keyDelim separator
+// This function is safe for concurrent use.
 func AllKeys() []string { l.Lock(); defer l.Unlock(); return viper.AllKeys() }
 
+// AllSettings merges all settings and returns them as a map[string]interface{}.
+// This function is safe for concurrent use.
 func AllSettings() map[string]interface{} { l.Lock(); defer l.Unlock(); return viper.AllSettings() }
 
+// SetFs sets the filesystem to use to read configuration.
+// This function is safe for concurrent use.
 func SetFs(fs afero.Fs) { l.Lock(); defer l.Unlock(); viper.SetFs(fs) }
 
+// SetConfigName sets name for the config file.
+// Does not include extension.
+// This function is safe for concurrent use.
 func SetConfigName(in string) { l.Lock(); defer l.Unlock(); viper.SetConfigName(in) }
 
+// SetConfigType sets the type of the configuration returned by the
+// remote source, e.g. "json".
+// This function is safe for concurrent use.
 func SetConfigType(in string) { l.Lock(); defer l.Unlock(); viper.SetConfigType(in) }
 
+// SetConfigPermissions sets the permissions for the config file.
+// This function is safe for concurrent use.
 func SetConfigPermissions(perm os.FileMode) {
 	l.Lock()
 	defer l.Unlock()
 	viper.SetConfigPermissions(perm)
 }
 
+// Debug prints all configuration registries for debugging
+// purposes.
+// This function is safe for concurrent use.
 func Debug() { l.Lock(); defer l.Unlock(); viper.Debug() }

--- a/pkg/common/concurrentviper/generated.go
+++ b/pkg/common/concurrentviper/generated.go
@@ -1,0 +1,254 @@
+package concurrentviper
+
+import (
+	afero "github.com/spf13/afero"
+	mapstructure "github.com/mitchellh/mapstructure"
+	fsnotify "github.com/fsnotify/fsnotify"
+	pflag "github.com/spf13/pflag"
+	strings "strings"
+	os "os"
+	sync "sync"
+	viper "github.com/spf13/viper"
+	time "time"
+	io "io"
+)
+
+var l sync.Mutex
+
+func DecodeHook(hook mapstructure.DecodeHookFunc) viper.DecoderConfigOption {
+	l.Lock()
+	defer l.Unlock()
+	return viper.DecodeHook(hook)
+}
+
+func New() *viper.Viper { l.Lock(); defer l.Unlock(); return viper.New() }
+
+func KeyDelimiter(d string) viper.Option { l.Lock(); defer l.Unlock(); return viper.KeyDelimiter(d) }
+
+func EnvKeyReplacer(r viper.StringReplacer) viper.Option {
+	l.Lock()
+	defer l.Unlock()
+	return viper.EnvKeyReplacer(r)
+}
+
+func NewWithOptions(opts ...viper.Option) *viper.Viper {
+	l.Lock()
+	defer l.Unlock()
+	return viper.NewWithOptions(opts...)
+}
+
+func Reset() { l.Lock(); defer l.Unlock(); viper.Reset() }
+
+func OnConfigChange(run func(in fsnotify.Event)) {
+	l.Lock()
+	defer l.Unlock()
+	viper.OnConfigChange(run)
+}
+
+func WatchConfig() { l.Lock(); defer l.Unlock(); viper.WatchConfig() }
+
+func SetConfigFile(in string) { l.Lock(); defer l.Unlock(); viper.SetConfigFile(in) }
+
+func SetEnvPrefix(in string) { l.Lock(); defer l.Unlock(); viper.SetEnvPrefix(in) }
+
+func AllowEmptyEnv(allowEmptyEnv bool) {
+	l.Lock()
+	defer l.Unlock()
+	viper.AllowEmptyEnv(allowEmptyEnv)
+}
+
+func ConfigFileUsed() string { l.Lock(); defer l.Unlock(); return viper.ConfigFileUsed() }
+
+func AddConfigPath(in string) { l.Lock(); defer l.Unlock(); viper.AddConfigPath(in) }
+
+func AddRemoteProvider(provider, endpoint, path string) error {
+	l.Lock()
+	defer l.Unlock()
+	return viper.AddRemoteProvider(provider, endpoint, path)
+}
+
+func AddSecureRemoteProvider(provider, endpoint, path, secretkeyring string) error {
+	l.Lock()
+	defer l.Unlock()
+	return viper.AddSecureRemoteProvider(provider, endpoint, path, secretkeyring)
+}
+
+func SetTypeByDefaultValue(enable bool) {
+	l.Lock()
+	defer l.Unlock()
+	viper.SetTypeByDefaultValue(enable)
+}
+
+func GetViper() *viper.Viper { l.Lock(); defer l.Unlock(); return viper.GetViper() }
+
+func Get(key string) interface{} { l.Lock(); defer l.Unlock(); return viper.Get(key) }
+
+func Sub(key string) *viper.Viper { l.Lock(); defer l.Unlock(); return viper.Sub(key) }
+
+func GetString(key string) string { l.Lock(); defer l.Unlock(); return viper.GetString(key) }
+
+func GetBool(key string) bool { l.Lock(); defer l.Unlock(); return viper.GetBool(key) }
+
+func GetInt(key string) int { l.Lock(); defer l.Unlock(); return viper.GetInt(key) }
+
+func GetInt32(key string) int32 { l.Lock(); defer l.Unlock(); return viper.GetInt32(key) }
+
+func GetInt64(key string) int64 { l.Lock(); defer l.Unlock(); return viper.GetInt64(key) }
+
+func GetUint(key string) uint { l.Lock(); defer l.Unlock(); return viper.GetUint(key) }
+
+func GetUint32(key string) uint32 { l.Lock(); defer l.Unlock(); return viper.GetUint32(key) }
+
+func GetUint64(key string) uint64 { l.Lock(); defer l.Unlock(); return viper.GetUint64(key) }
+
+func GetFloat64(key string) float64 { l.Lock(); defer l.Unlock(); return viper.GetFloat64(key) }
+
+func GetTime(key string) time.Time { l.Lock(); defer l.Unlock(); return viper.GetTime(key) }
+
+func GetDuration(key string) time.Duration { l.Lock(); defer l.Unlock(); return viper.GetDuration(key) }
+
+func GetIntSlice(key string) []int { l.Lock(); defer l.Unlock(); return viper.GetIntSlice(key) }
+
+func GetStringSlice(key string) []string {
+	l.Lock()
+	defer l.Unlock()
+	return viper.GetStringSlice(key)
+}
+
+func GetStringMap(key string) map[string]interface{} {
+	l.Lock()
+	defer l.Unlock()
+	return viper.GetStringMap(key)
+}
+
+func GetStringMapString(key string) map[string]string {
+	l.Lock()
+	defer l.Unlock()
+	return viper.GetStringMapString(key)
+}
+
+func GetStringMapStringSlice(key string) map[string][]string {
+	l.Lock()
+	defer l.Unlock()
+	return viper.GetStringMapStringSlice(key)
+}
+
+func GetSizeInBytes(key string) uint { l.Lock(); defer l.Unlock(); return viper.GetSizeInBytes(key) }
+
+func UnmarshalKey(key string, rawVal interface{}, opts ...viper.DecoderConfigOption) error {
+	l.Lock()
+	defer l.Unlock()
+	return viper.UnmarshalKey(key, rawVal, opts...)
+}
+
+func Unmarshal(rawVal interface{}, opts ...viper.DecoderConfigOption) error {
+	l.Lock()
+	defer l.Unlock()
+	return viper.Unmarshal(rawVal, opts...)
+}
+
+func UnmarshalExact(rawVal interface{}, opts ...viper.DecoderConfigOption) error {
+	l.Lock()
+	defer l.Unlock()
+	return viper.UnmarshalExact(rawVal, opts...)
+}
+
+func BindPFlags(flags *pflag.FlagSet) error {
+	l.Lock()
+	defer l.Unlock()
+	return viper.BindPFlags(flags)
+}
+
+func BindPFlag(key string, flag *pflag.Flag) error {
+	l.Lock()
+	defer l.Unlock()
+	return viper.BindPFlag(key, flag)
+}
+
+func BindFlagValues(flags viper.FlagValueSet) error {
+	l.Lock()
+	defer l.Unlock()
+	return viper.BindFlagValues(flags)
+}
+
+func BindFlagValue(key string, flag viper.FlagValue) error {
+	l.Lock()
+	defer l.Unlock()
+	return viper.BindFlagValue(key, flag)
+}
+
+func BindEnv(input ...string) error { l.Lock(); defer l.Unlock(); return viper.BindEnv(input...) }
+
+func IsSet(key string) bool { l.Lock(); defer l.Unlock(); return viper.IsSet(key) }
+
+func AutomaticEnv() { l.Lock(); defer l.Unlock(); viper.AutomaticEnv() }
+
+func SetEnvKeyReplacer(r *strings.Replacer) { l.Lock(); defer l.Unlock(); viper.SetEnvKeyReplacer(r) }
+
+func RegisterAlias(alias string, key string) {
+	l.Lock()
+	defer l.Unlock()
+	viper.RegisterAlias(alias, key)
+}
+
+func InConfig(key string) bool { l.Lock(); defer l.Unlock(); return viper.InConfig(key) }
+
+func SetDefault(key string, value interface{}) {
+	l.Lock()
+	defer l.Unlock()
+	viper.SetDefault(key, value)
+}
+
+func Set(key string, value interface{}) { l.Lock(); defer l.Unlock(); viper.Set(key, value) }
+
+func ReadInConfig() error { l.Lock(); defer l.Unlock(); return viper.ReadInConfig() }
+
+func MergeInConfig() error { l.Lock(); defer l.Unlock(); return viper.MergeInConfig() }
+
+func ReadConfig(in io.Reader) error { l.Lock(); defer l.Unlock(); return viper.ReadConfig(in) }
+
+func MergeConfig(in io.Reader) error { l.Lock(); defer l.Unlock(); return viper.MergeConfig(in) }
+
+func MergeConfigMap(cfg map[string]interface{}) error {
+	l.Lock()
+	defer l.Unlock()
+	return viper.MergeConfigMap(cfg)
+}
+
+func WriteConfig() error { l.Lock(); defer l.Unlock(); return viper.WriteConfig() }
+
+func SafeWriteConfig() error { l.Lock(); defer l.Unlock(); return viper.SafeWriteConfig() }
+
+func WriteConfigAs(filename string) error {
+	l.Lock()
+	defer l.Unlock()
+	return viper.WriteConfigAs(filename)
+}
+
+func SafeWriteConfigAs(filename string) error {
+	l.Lock()
+	defer l.Unlock()
+	return viper.SafeWriteConfigAs(filename)
+}
+
+func ReadRemoteConfig() error { l.Lock(); defer l.Unlock(); return viper.ReadRemoteConfig() }
+
+func WatchRemoteConfig() error { l.Lock(); defer l.Unlock(); return viper.WatchRemoteConfig() }
+
+func AllKeys() []string { l.Lock(); defer l.Unlock(); return viper.AllKeys() }
+
+func AllSettings() map[string]interface{} { l.Lock(); defer l.Unlock(); return viper.AllSettings() }
+
+func SetFs(fs afero.Fs) { l.Lock(); defer l.Unlock(); viper.SetFs(fs) }
+
+func SetConfigName(in string) { l.Lock(); defer l.Unlock(); viper.SetConfigName(in) }
+
+func SetConfigType(in string) { l.Lock(); defer l.Unlock(); viper.SetConfigType(in) }
+
+func SetConfigPermissions(perm os.FileMode) {
+	l.Lock()
+	defer l.Unlock()
+	viper.SetConfigPermissions(perm)
+}
+
+func Debug() { l.Lock(); defer l.Unlock(); viper.Debug() }

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 const (

--- a/pkg/common/config/log_metrics.go
+++ b/pkg/common/config/log_metrics.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 // LogMetrics is an array of LogMetric types with an easier lookup method

--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 	configv1 "github.com/openshift/api/config/v1"
 	projectv1 "github.com/openshift/api/project/v1"

--- a/pkg/common/helper/runner.go
+++ b/pkg/common/helper/runner.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/runner"

--- a/pkg/common/load/load.go
+++ b/pkg/common/load/load.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/markbates/pkger"
 	"github.com/openshift/osde2e/pkg/common/config"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 const (

--- a/pkg/common/prometheus/connect.go
+++ b/pkg/common/prometheus/connect.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/prometheus/client_golang/api"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 // CreateClient will create a Prometheus client.

--- a/pkg/common/providers/crc/config.go
+++ b/pkg/common/providers/crc/config.go
@@ -1,7 +1,7 @@
 package crc
 
 import (
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 const (

--- a/pkg/common/providers/crc/crc.go
+++ b/pkg/common/providers/crc/crc.go
@@ -19,7 +19,7 @@ import (
 	"github.com/code-ready/crc/pkg/crc/validation"
 	"github.com/code-ready/crc/pkg/crc/version"
 	"github.com/openshift/osde2e/pkg/common/spi"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	// Specifically using this for YAMLToJSON

--- a/pkg/common/providers/getprovider.go
+++ b/pkg/common/providers/getprovider.go
@@ -3,7 +3,7 @@ package providers
 import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 // ClusterProvider returns the provisioner configured by the config object.

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -13,7 +13,7 @@ import (
 	"github.com/markbates/pkger"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 const (

--- a/pkg/common/providers/mock/mock_test.go
+++ b/pkg/common/providers/mock/mock_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/openshift/osde2e/pkg/common/spi"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"k8s.io/client-go/tools/clientcmd"
 )
 

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -18,7 +18,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/clusterproperties"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 

--- a/pkg/common/providers/ocmprovider/config.go
+++ b/pkg/common/providers/ocmprovider/config.go
@@ -2,7 +2,7 @@ package ocmprovider
 
 import (
 	"github.com/openshift/osde2e/pkg/common/config"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 const (

--- a/pkg/common/providers/ocmprovider/flavour.go
+++ b/pkg/common/providers/ocmprovider/flavour.go
@@ -5,7 +5,7 @@ import (
 	"math/rand"
 	"strings"
 
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func getFlavour() string {

--- a/pkg/common/providers/ocmprovider/ocm.go
+++ b/pkg/common/providers/ocmprovider/ocm.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/openshift/osde2e/pkg/common/spi"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 	ocm "github.com/openshift-online/ocm-sdk-go"
 	ocmerr "github.com/openshift-online/ocm-sdk-go/errors"

--- a/pkg/common/providers/ocmprovider/quota.go
+++ b/pkg/common/providers/ocmprovider/quota.go
@@ -8,7 +8,7 @@ import (
 	accounts "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
 	"github.com/openshift/osde2e/pkg/common/config"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 const (

--- a/pkg/common/providers/ocmprovider/retryer.go
+++ b/pkg/common/providers/ocmprovider/retryer.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/adamliesko/retry"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 var ocmOnce = sync.Once{}

--- a/pkg/common/providers/ocmprovider/versions.go
+++ b/pkg/common/providers/ocmprovider/versions.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/util"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 const (

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/util"
 	"github.com/openshift/rosa/pkg/cluster"
 	"github.com/openshift/rosa/pkg/ocm/versions"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 // IsValidClusterName validates the clustername prior to proceeding with it

--- a/pkg/common/providers/rosaprovider/config.go
+++ b/pkg/common/providers/rosaprovider/config.go
@@ -2,7 +2,7 @@ package rosaprovider
 
 import (
 	"github.com/openshift/osde2e/pkg/common/config"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 const (

--- a/pkg/common/providers/rosaprovider/rosa.go
+++ b/pkg/common/providers/rosaprovider/rosa.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
 	"github.com/openshift/osde2e/pkg/common/spi"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func init() {

--- a/pkg/common/providers/rosaprovider/util.go
+++ b/pkg/common/providers/rosaprovider/util.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 // At the moment, rosa requires AWS sessions to be set globally. To get around that, we'll use this

--- a/pkg/common/runner/service.go
+++ b/pkg/common/runner/service.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/emicklei/go-restful/log"
 	"github.com/openshift/osde2e/pkg/common/config"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 	"github.com/hashicorp/go-multierror"
 	kubev1 "k8s.io/api/core/v1"

--- a/pkg/common/upgrade/managed.go
+++ b/pkg/common/upgrade/managed.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/openshift/osde2e/pkg/common/cluster/healthchecks"
 	"github.com/openshift/osde2e/pkg/common/util"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/common/upgrade/upgrade.go
+++ b/pkg/common/upgrade/upgrade.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/common/versions/installselectors/delta_release_from_default.go
+++ b/pkg/common/versions/installselectors/delta_release_from_default.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func init() {

--- a/pkg/common/versions/installselectors/delta_release_from_default_test.go
+++ b/pkg/common/versions/installselectors/delta_release_from_default_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func TestDeltaReleaseFromDefaultVersionSelectVersion(t *testing.T) {

--- a/pkg/common/versions/installselectors/latest_version_selector.go
+++ b/pkg/common/versions/installselectors/latest_version_selector.go
@@ -7,7 +7,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/versions/common"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func init() {

--- a/pkg/common/versions/installselectors/latest_y_from_default_selector.go
+++ b/pkg/common/versions/installselectors/latest_y_from_default_selector.go
@@ -7,7 +7,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/versions/common"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func init() {

--- a/pkg/common/versions/installselectors/latest_z_from_default_selector.go
+++ b/pkg/common/versions/installselectors/latest_z_from_default_selector.go
@@ -7,7 +7,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/versions/common"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func init() {

--- a/pkg/common/versions/installselectors/middle_cluster_image_set.go
+++ b/pkg/common/versions/installselectors/middle_cluster_image_set.go
@@ -5,7 +5,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/versions/common"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func init() {

--- a/pkg/common/versions/installselectors/next_version_after_prod_default.go
+++ b/pkg/common/versions/installselectors/next_version_after_prod_default.go
@@ -7,7 +7,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/versions/common"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func init() {

--- a/pkg/common/versions/installselectors/oldest_cluster_image_set.go
+++ b/pkg/common/versions/installselectors/oldest_cluster_image_set.go
@@ -5,7 +5,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/versions/common"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func init() {

--- a/pkg/common/versions/installselectors/specific_image.go
+++ b/pkg/common/versions/installselectors/specific_image.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/versions/common"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func init() {

--- a/pkg/common/versions/installselectors/specific_image_test.go
+++ b/pkg/common/versions/installselectors/specific_image_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func TestSpecificImages(t *testing.T) {

--- a/pkg/common/versions/installselectors/specific_nightlies.go
+++ b/pkg/common/versions/installselectors/specific_nightlies.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/versions/common"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func init() {

--- a/pkg/common/versions/installselectors/specific_nightlies_test.go
+++ b/pkg/common/versions/installselectors/specific_nightlies_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func TestSpecificNightlies(t *testing.T) {

--- a/pkg/common/versions/upgradeselectors/latest_version_selector.go
+++ b/pkg/common/versions/upgradeselectors/latest_version_selector.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func init() {

--- a/pkg/common/versions/upgradeselectors/latest_y_selector.go
+++ b/pkg/common/versions/upgradeselectors/latest_y_selector.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func init() {

--- a/pkg/common/versions/upgradeselectors/latest_z_selector.go
+++ b/pkg/common/versions/upgradeselectors/latest_z_selector.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func init() {

--- a/pkg/common/versions/version_selector.go
+++ b/pkg/common/versions/version_selector.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/util"
 	"github.com/openshift/osde2e/pkg/common/versions/installselectors"
 	"github.com/openshift/osde2e/pkg/common/versions/upgradeselectors"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 // GetVersionForInstall will get a version based upon available configuration options.

--- a/pkg/common/versions/version_setup.go
+++ b/pkg/common/versions/version_setup.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/providers"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/util"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 

--- a/pkg/debug/diff.go
+++ b/pkg/debug/diff.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/go-github/v31/github"
 	"github.com/kylelemons/godebug/diff"
 	"github.com/openshift/osde2e/pkg/common/config"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/e2e/addons/addon_test_harness.go
+++ b/pkg/e2e/addons/addon_test_harness.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/onsi/ginkgo"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -25,7 +25,7 @@ import (
 	ginkgoConfig "github.com/onsi/ginkgo/config"
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/onsi/gomega"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/aws"

--- a/pkg/e2e/e2e_test.go
+++ b/pkg/e2e/e2e_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/events"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func TestNoHiveLogs(t *testing.T) {

--- a/pkg/e2e/metrics.go
+++ b/pkg/e2e/metrics.go
@@ -22,7 +22,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/expfmt"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 const (

--- a/pkg/e2e/metrics_test.go
+++ b/pkg/e2e/metrics_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/metadata"
 	"github.com/openshift/osde2e/pkg/common/providers/mock"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func TestProcessJUnitXMLFile(t *testing.T) {

--- a/pkg/e2e/operators/certman.go
+++ b/pkg/e2e/operators/certman.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/pkg/e2e/operators/cloudingress/installed.go
+++ b/pkg/e2e/operators/cloudingress/installed.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 	"github.com/openshift/osde2e/pkg/common/config"
 	appsv1 "k8s.io/api/apps/v1"

--- a/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/e2e/operators/operators.go
+++ b/pkg/e2e/operators/operators.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 func checkClusterServiceVersion(h *helper.H, namespace, name string) {

--- a/pkg/e2e/operators/prunejob.go
+++ b/pkg/e2e/operators/prunejob.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unstruct "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/e2e/osd/daemonsets.go
+++ b/pkg/e2e/osd/daemonsets.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/util"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/e2e/osd/dedicatedadmin.go
+++ b/pkg/e2e/osd/dedicatedadmin.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/e2e/osd/nodelabels.go
+++ b/pkg/e2e/osd/nodelabels.go
@@ -8,7 +8,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/e2e/osd/ocm.go
+++ b/pkg/e2e/osd/ocm.go
@@ -6,7 +6,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/providers"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 var ocmTestName string = "[Suite: e2e] [OSD] OCM"

--- a/pkg/e2e/osd/privileged.go
+++ b/pkg/e2e/osd/privileged.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/util"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/e2e/scale/mastervertical.go
+++ b/pkg/e2e/scale/mastervertical.go
@@ -3,7 +3,7 @@ package scale
 import (
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	kubev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/osde2e/pkg/common/alert"

--- a/pkg/e2e/scale/scale.go
+++ b/pkg/e2e/scale/scale.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/markbates/pkger"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	kubev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/osde2e/pkg/common/config"

--- a/pkg/e2e/state/alerts.go
+++ b/pkg/e2e/state/alerts.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/osde2e/pkg/common/alert"

--- a/pkg/e2e/verify/hiveownership_webhook.go
+++ b/pkg/e2e/verify/hiveownership_webhook.go
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/osde2e/pkg/common/helper"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/e2e/verify/identity_webhook.go
+++ b/pkg/e2e/verify/identity_webhook.go
@@ -10,7 +10,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/util"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 )

--- a/pkg/e2e/verify/namespace_webhook.go
+++ b/pkg/e2e/verify/namespace_webhook.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/openshift/osde2e/pkg/common/helper"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/pkg/e2e/verify/prom_exporters.go
+++ b/pkg/e2e/verify/prom_exporters.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/cluster"

--- a/pkg/e2e/verify/regularuser_webhook.go
+++ b/pkg/e2e/verify/regularuser_webhook.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 )

--- a/pkg/e2e/verify/user_webhook.go
+++ b/pkg/e2e/verify/user_webhook.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 	userv1 "github.com/openshift/api/user/v1"
 	"github.com/openshift/osde2e/pkg/common/alert"

--- a/pkg/e2e/version.go
+++ b/pkg/e2e/version.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/util"
 	"github.com/openshift/osde2e/pkg/common/versions"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 

--- a/pkg/e2e/workloads/redmine/redmine.go
+++ b/pkg/e2e/workloads/redmine/redmine.go
@@ -13,7 +13,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/cluster/healthchecks"
 	"github.com/openshift/osde2e/pkg/common/config"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/pkg/metrics/client.go
+++ b/pkg/metrics/client.go
@@ -17,7 +17,7 @@ import (
 	"github.com/prometheus/client_golang/api"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 const (

--- a/pkg/reporting/config.go
+++ b/pkg/reporting/config.go
@@ -1,6 +1,6 @@
 package reporting
 
-import "github.com/spf13/viper"
+import viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 const (
 	// SlackWebhook for pushing reports to slack

--- a/pkg/reporting/report_to_slack.go
+++ b/pkg/reporting/report_to_slack.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/slack-go/slack"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 // SendReportToSlack will send the weather report to slack

--- a/pkg/reporting/reporters/weather/config.go
+++ b/pkg/reporting/reporters/weather/config.go
@@ -1,6 +1,6 @@
 package weather
 
-import "github.com/spf13/viper"
+import viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 const (
 	StartOfTimeWindowInHours = "reporting.weather.startOfTimeWindowInHours"

--- a/pkg/reporting/reporters/weather/weather_reporter.go
+++ b/pkg/reporting/reporters/weather/weather_reporter.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift/osde2e/pkg/metrics"
 	"github.com/openshift/osde2e/pkg/reporting/spi"
 	"github.com/openshift/osde2e/pkg/reporting/templates"
-	"github.com/spf13/viper"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 // Intermediary structs


### PR DESCRIPTION
This PR creates a thread-safe version of viper for us to use via code generation from the official viper package. We're occasionally crashing due to races within viper, so this seems like the best way forward (upstream viper doesn't seem interested in supporting concurrent use).