### PR TITLE
Fix for prometheus pod check

### DIFF
--- a/pkg/e2e/state/prometheus.go
+++ b/pkg/e2e/state/prometheus.go
@@ -42,7 +42,7 @@ var _ = ginkgo.Describe(clusterStateInformingName, func() {
 			names, podNum := verify.GetPodNames("prometheus-operator", list, h)
 			if podNum > 0 {
 				for _, value := range names {
-					if strings.HasPrefix("prometheus-k8s-", value) {
+					if strings.HasPrefix(value, "prometheus-k8s-") {
 						podCount += 1
 					}
 				}
@@ -55,6 +55,7 @@ var _ = ginkgo.Describe(clusterStateInformingName, func() {
 		Expect(poderr).NotTo(HaveOccurred())
 
 		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+
 		r := h.Runner(cmd)
 		r.Name = "collect-prometheus"
 


### PR DESCRIPTION
Added a minor fix for the wait poll check (to see if prometheus pods are up) that happens before the collect-prometheus pod tries to extract data from prometheus.