### PR TITLE
Poll the roles and rolebinding instead of a one-time check

### DIFF
--- a/pkg/e2e/operators/operators.go
+++ b/pkg/e2e/operators/operators.go
@@ -145,15 +145,17 @@ func checkRole(h *helper.H, namespace string, roles []string) {
 func checkRolesWithNamePrefix(h *helper.H, namespace string, prefix string, count int) {
 	ginkgo.Context("roles with prefix", func() {
 		ginkgo.It("should exist", func() {
-			rolesList, err := h.Kube().RbacV1().Roles(namespace).List(context.TODO(), metav1.ListOptions{})
-			Expect(err).NotTo(HaveOccurred(), "failed to get roles in namespace %s", namespace)
-			var roleCount int
-			for _, r := range rolesList.Items {
-				if strings.HasPrefix(r.Name, prefix) {
-					roleCount++
+			Eventually(func() int {
+				rolesList, err := h.Kube().RbacV1().Roles(namespace).List(context.TODO(), metav1.ListOptions{})
+				Expect(err).NotTo(HaveOccurred(), "failed to get roles in namespace %s", namespace)
+				var roleCount int
+				for _, r := range rolesList.Items {
+					if strings.HasPrefix(r.Name, prefix) {
+						roleCount++
+					}
 				}
-			}
-			Expect(roleCount).To(BeNumerically(">=", count))
+				return roleCount
+			}, "10m", "30s").Should(BeNumerically(">=", count))
 		}, viper.GetFloat64(config.Tests.PollingTimeout))
 	})
 }
@@ -161,15 +163,17 @@ func checkRolesWithNamePrefix(h *helper.H, namespace string, prefix string, coun
 func checkRoleBindingsWithNamePrefix(h *helper.H, namespace string, prefix string, count int) {
 	ginkgo.Context("roles with prefix", func() {
 		ginkgo.It("should exist", func() {
-			roleBindings, err := h.Kube().RbacV1().RoleBindings(namespace).List(context.TODO(), metav1.ListOptions{})
-			Expect(err).NotTo(HaveOccurred(), "failed to get roles in namespace %s", namespace)
-			var roleCount int
-			for _, r := range roleBindings.Items {
-				if strings.HasPrefix(r.Name, prefix) {
-					roleCount++
+			Eventually(func() int {
+				roleBindings, err := h.Kube().RbacV1().RoleBindings(namespace).List(context.TODO(), metav1.ListOptions{})
+				Expect(err).NotTo(HaveOccurred(), "failed to get roles in namespace %s", namespace)
+				var roleCount int
+				for _, r := range roleBindings.Items {
+					if strings.HasPrefix(r.Name, prefix) {
+						roleCount++
+					}
 				}
-			}
-			Expect(roleCount).To(BeNumerically(">=", count))
+				return roleCount
+			}, "10m", "30s").Should(BeNumerically(">=", count))
 		}, viper.GetFloat64(config.Tests.PollingTimeout))
 	})
 }


### PR DESCRIPTION
Even the presence of the CSV is verified before this test the CSV might be in the `Pending` state. It might take some time for the resources to be provisioned by the `catalog-operator` and `olm-operator`.