### PR TITLE
SDCICD-624: Pass through non-osde2e secrets into test cluster for addon testing

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -65,6 +65,10 @@ const (
 
 	// Default network provider for OSD
 	DefaultNetworkProvider = "OpenShiftSDN"
+
+	// NonOSDe2eSecrets is an internal-only Viper Key.
+	// End users should not be using this key, there may be unforeseen consequences.
+	NonOSDe2eSecrets = "nonOSDe2eSecrets"
 )
 
 // This is a config key to secret file mapping. We will attempt to read in from secret files before loading anything else.


### PR DESCRIPTION
This will insert any non-OSDe2e-specific secrets specified by Addon Authors into the test cluster under the `osde2e-ci-secrets` namespace as a secret named `ci-secrets`