### PR TITLE
SDCICD-616, 617, 618 -- Hibernation support for CICD

### DIFF
--- a/pkg/common/cluster/healthchecks/pod_predicates.go
+++ b/pkg/common/cluster/healthchecks/pod_predicates.go
@@ -43,3 +43,9 @@ func matchingNS(pod kubev1.Pod, ns string) bool {
 	return pod.Namespace == ns
 }
 
+func IsNotControlledByJob(pod kubev1.Pod) bool {
+	if len(pod.OwnerReferences) > 0 {
+		return pod.OwnerReferences[0].Kind != "Job"
+	}
+	return true
+}

--- a/pkg/common/cluster/healthchecks/pods.go
+++ b/pkg/common/cluster/healthchecks/pods.go
@@ -50,6 +50,7 @@ func CheckPodHealth(podClient v1.CoreV1Interface, logger *log.Logger, ns string,
 		IsNotReadinessPod,
 		IsNotRunning,
 		IsNotCompleted,
+		IsNotControlledByJob,
 	}
 	podlist, err := checkPods(podClient, logger, filters...)
 	if err != nil {

--- a/pkg/common/clusterproperties/statuses.go
+++ b/pkg/common/clusterproperties/statuses.go
@@ -33,4 +33,10 @@ const (
 
 	// StatusCompleted represents the cluster having finished its CI work and awaiting teardown.
 	StatusCompleted = "completed"
+
+	// StatusCompletedPassing represents the cluster having finished its CI and tests having passed
+	StatusCompletedPassing = "completed-passing"
+
+	// StatusCompletedFailing represents the cluster having finished its CI and tests having failed
+	StatusCompletedFailing = "completed-failing"
 )

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -311,6 +311,12 @@ var Cluster = struct {
 	// HibernateAfterUse will tell the provider to attempt to hibernate the cluster after
 	// the test run, assuming the provider supports hibernation
 	HibernateAfterUse string
+
+	// Passing tracks the internal status of the tests: Pass or Fail
+	Passing string
+
+	// Reused tracks whether this cluster's test run used a new or recycled cluster
+	Reused string
 }{
 	MultiAZ:                             "cluster.multiAZ",
 	Channel:                             "cluster.channel",
@@ -339,6 +345,8 @@ var Cluster = struct {
 	ImageContentSource:                  "cluster.imageContentSource",
 	InstallConfig:                       "cluster.installConfig",
 	HibernateAfterUse:                   "cluster.hibernateAfterUse",
+	Passing:                             "cluster.passing",
+	Reused:                              "cluster.rused",
 }
 
 // CloudProvider config keys.
@@ -573,7 +581,7 @@ func init() {
 	viper.SetDefault(Cluster.DestroyAfterTest, false)
 	viper.BindEnv(Cluster.DestroyAfterTest, "DESTROY_CLUSTER")
 
-	viper.SetDefault(Cluster.ExpiryInMinutes, 360)
+	viper.SetDefault(Cluster.ExpiryInMinutes, 1440)
 	viper.BindEnv(Cluster.ExpiryInMinutes, "CLUSTER_EXPIRY_IN_MINUTES")
 
 	viper.SetDefault(Cluster.AfterTestWait, 60)
@@ -634,6 +642,9 @@ func init() {
 
 	viper.SetDefault(Cluster.HibernateAfterUse, true)
 	viper.BindEnv(Cluster.HibernateAfterUse, "HIBERNATE_AFTER_USE")
+
+	viper.SetDefault(Cluster.Reused, false)
+	viper.SetDefault(Cluster.Passing, false)
 
 	// ----- Cloud Provider -----
 	viper.SetDefault(CloudProvider.CloudProviderID, "aws")

--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -135,20 +135,25 @@ func (h *H) Cleanup() {
 	var err error
 
 	h.restConfig, err = clientcmd.RESTConfigFromKubeConfig([]byte(viper.GetString(config.Kubeconfig.Contents)))
-	Expect(err).ShouldNot(HaveOccurred(), "failed to configure client")
+	if err != nil {
+		log.Printf("Error setting Cleanup() restConfig: %s", err.Error())
+		return
+	}
 
 	// Set the SA back to the default. This is required for cleanup in case other helper calls switched SAs
 	h.SetServiceAccount(viper.GetString(config.Tests.ServiceAccount))
-
-	project := viper.GetString(config.Project)
-	if h.proj == nil && project != "" {
-		log.Printf("Setting project name to %s", project)
-		h.proj, err = h.Project().ProjectV1().Projects().Get(context.TODO(), project, metav1.GetOptions{})
-		Expect(err).ShouldNot(HaveOccurred(), "failed to retrieve project")
-		Expect(h.proj).ShouldNot(BeNil())
-
-		err = h.cleanup(h.CurrentProject())
-		Expect(err).ShouldNot(HaveOccurred(), "could not delete project '%s'", h.proj)
+	projects, err := h.Project().ProjectV1().Projects().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		log.Printf("Error listing existing projects in Cleanup(): %s", err.Error())
+	}
+	for _, project := range projects.Items {
+		if strings.Contains(project.Name, "osde2e-") {
+			log.Printf("Deleting project `%s`", project.Name)
+			err = h.Project().ProjectV1().Projects().Delete(context.TODO(), project.Name, metav1.DeleteOptions{})
+			if err != nil {
+				log.Printf("Error deleting project `%s` in Cleanup(): %s", project.Name, err.Error())
+			}
+		}
 	}
 
 	h.restConfig = nil
@@ -355,10 +360,9 @@ func (h *H) GetClusterVersion() (*configv1.ClusterVersion, error) {
 
 // WithToken returns helper with a given bearer token
 func (h *H) WithToken(token string) *H {
-        config := rest.AnonymousClientConfig(h.restConfig)
-        config.BearerToken = token
-        return &H{
-                restConfig: config,
-        }
+	config := rest.AnonymousClientConfig(h.restConfig)
+	config.BearerToken = token
+	return &H{
+		restConfig: config,
+	}
 }
-

--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -153,6 +153,10 @@ func (h *H) Cleanup() {
 			if err != nil {
 				log.Printf("Error deleting project `%s` in Cleanup(): %s", project.Name, err.Error())
 			}
+			err = h.Kube().CoreV1().ServiceAccounts("dedicated-admin").Delete(context.TODO(), project.Name, metav1.DeleteOptions{})
+			if err != nil {
+				log.Printf("Error deleting dedicated-admin serviceaccount for '%s': %v", project.Name, err)
+			}
 		}
 	}
 

--- a/pkg/common/helper/projects.go
+++ b/pkg/common/helper/projects.go
@@ -3,6 +3,7 @@ package helper
 import (
 	"context"
 	"fmt"
+
 	"github.com/openshift/osde2e/pkg/common/runner"
 
 	projectv1 "github.com/openshift/api/project/v1"
@@ -16,20 +17,6 @@ func (h *H) createProject(suffix string) (*projectv1.Project, error) {
 		},
 	}
 	return h.Project().ProjectV1().Projects().Create(context.TODO(), proj, metav1.CreateOptions{})
-}
-
-func (h *H) cleanup(projectName string) error {
-	err := h.Project().ProjectV1().Projects().Delete(context.TODO(), projectName, metav1.DeleteOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to cleanup project '%s': %v", projectName, err)
-	}
-
-	err = h.Kube().CoreV1().ServiceAccounts("dedicated-admin").Delete(context.TODO(), h.CurrentProject(), metav1.DeleteOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to cleanup sa '%s': %v", projectName, err)
-	}
-
-	return nil
 }
 
 func (h *H) inspect(projectName string) error {

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -222,7 +222,7 @@ func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 }
 
 func (o *OCMProvider) findRecycledCluster(cluster *v1.Cluster) string {
-	query := fmt.Sprintf("properties.InstalledVersion='%s' and properties.UpgradeVersion='' and properties.Status='%s'", cluster.Version().ID(), "completed-passing")
+	query := fmt.Sprintf("properties.InstalledVersion='%s' and properties.UpgradeVersion='' and properties.Status like '%s%%'", cluster.Version().ID(), "completed-")
 
 	listResponse, err := o.conn.ClustersMgmt().V1().Clusters().List().Search(query).Send()
 	if err == nil && listResponse.Total() > 0 {


### PR DESCRIPTION
This is a small'ish PR with large-implications.

1. Upon Cluster creation, see if there are any `completed-passing` clusters that have the same version
2. If yes, re-use the cluster. If hibernated, resume the cluster and wait. If not, create a new cluster.
3. If all tests are passing (this logic is up for debate), set it to `completed-passing` so it can be reused -- otherwise, flag it `completed-failing`
4. Regardless of results, hibernate the cluster

There are conditions where a cluster could come up and trigger a (cron) job, which will fail during the wake-up phase. Because of this, we delete any Errored pods owned by Jobs after 10 minutes and before we begin health-checking.

Note: Once [SDA-4063](https://issues.redhat.com/browse/SDA-4063) has been resolved, we will need a follow-up PR updating the types instead of hard-coding the text-value of the codes. 

/hold 
Hold till [SDA-4070](https://issues.redhat.com/browse/SDA-4070) is merged