### PR TITLE
Removed HTTP call which may not be running on-cluster

### DIFF
--- a/pkg/e2e/operators/osdmetricsexporter.go
+++ b/pkg/e2e/operators/osdmetricsexporter.go
@@ -2,9 +2,6 @@ package operators
 
 import (
 	"context"
-	"fmt"
-	"net/http"
-
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
@@ -46,7 +43,6 @@ var _ = ginkgo.Describe(osdMetricsExporterBasicTest, func() {
 
 func checkService(h *helper.H, namespace string, name string, port int) {
 	pollTimeout := viper.GetFloat64(config.Tests.PollingTimeout)
-	serviceEndpoint := fmt.Sprintf("http://%s.%s:%d/metrics", name, namespace, port)
 	ginkgo.Context("service", func() {
 		ginkgo.It(
 			"should exist",
@@ -58,16 +54,6 @@ func checkService(h *helper.H, namespace string, name string, port int) {
 					}
 					return true
 				}, "30m", "1m").Should(BeTrue())
-			},
-			pollTimeout,
-		)
-		ginkgo.It(
-			"should return response",
-			func() {
-				Eventually(func() (*http.Response, error) {
-					response, err := http.Get(serviceEndpoint)
-					return response, err
-				}, "30m", "1m").Should(HaveHTTPStatus(http.StatusOK))
 			},
 			pollTimeout,
 		)


### PR DESCRIPTION
It appears the test don't actually run on the test cluster but instead from a separate location. While writing this test I initially assumed that the test binary would run in the cluster and added an HTTP call to verify that an endpoint is up and running. This PR removes that test.