### PR TITLE
SDCICD-641: Preserve metadata.json during failed cluster installation

### DIFF
--- a/ci/create-ocp-cluster.sh
+++ b/ci/create-ocp-cluster.sh
@@ -37,8 +37,16 @@ chmod +x oc
 
 chmod +x openshift-install
 
-./openshift-install create cluster --dir=./installer/ --log-level info
+{
+    ./openshift-install create cluster --dir=./installer/ --log-level info &&
 
-cp "${INSTALLER_CONFIG}" "${SHARED_DIR}"
-cp ./installer/metadata.json "${SHARED_DIR}"
-cp ./installer/auth/kubeconfig "${SHARED_DIR}"
+    cp "${INSTALLER_CONFIG}" "${SHARED_DIR}"
+    cp ./installer/metadata.json "${SHARED_DIR}"
+    cp ./installer/auth/kubeconfig "${SHARED_DIR}"
+    echo "Copied installer files."
+} || {
+    cp "${INSTALLER_CONFIG}" "${SHARED_DIR}"
+    cp ./installer/metadata.json "${SHARED_DIR}"
+    echo "Error creating cluster.";
+    exit 1;
+}

--- a/ci/create-ocp-cluster.sh
+++ b/ci/create-ocp-cluster.sh
@@ -39,10 +39,7 @@ chmod +x openshift-install
 
 {
     ./openshift-install create cluster --dir=./installer/ --log-level info &&
-
-    cp "${INSTALLER_CONFIG}" "${SHARED_DIR}"
-    cp ./installer/metadata.json "${SHARED_DIR}"
-    cp ./installer/auth/kubeconfig "${SHARED_DIR}"
+    cp "${INSTALLER_CONFIG}" ./installer/metadata.json ./installer/auth/kubeconfig "${SHARED_DIR}" &&
     echo "Copied installer files."
 } || {
     cp "${INSTALLER_CONFIG}" "${SHARED_DIR}"

--- a/ci/create-ocp-cluster.sh
+++ b/ci/create-ocp-cluster.sh
@@ -42,8 +42,7 @@ chmod +x openshift-install
     cp "${INSTALLER_CONFIG}" ./installer/metadata.json ./installer/auth/kubeconfig "${SHARED_DIR}" &&
     echo "Copied installer files."
 } || {
-    cp "${INSTALLER_CONFIG}" "${SHARED_DIR}"
-    cp ./installer/metadata.json "${SHARED_DIR}"
+    cp "${INSTALLER_CONFIG}" ./installer/metadata.json "${SHARED_DIR}" &&
     echo "Error creating cluster.";
     exit 1;
 }


### PR DESCRIPTION
metadata.json is created during a openshift-install operation, but when the install-step fails, metadata.json isn't preserved. When this happens, the destroy-step doesn't have any knowledge of the cluster or resources created and thus can't clean up resources from a failed installation.

This will trap any error during cluster creation and, if it occurs, still copy the metadata.json and install-config into the shared directory for the destroy-step to work its magic. 