### PR TITLE
fix: do not open pd alerts for informing suite failures

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -496,6 +496,10 @@ PD info: %v`, jobName, jobURL, event)); err != nil {
 	}
 	// open an alert for each failing test
 	for _, name := range failingTests {
+		if strings.Contains(name, "informing") {
+			// skip informing suite failures, as they do not warrant CI watcher investigation
+			continue
+		}
 		if _, err := pdc.FireAlert(pd.V2Payload{
 			Summary:  name + " failed",
 			Severity: "info",


### PR DESCRIPTION
Signed-off-by: Chris Waldon <cwaldon@redhat.com>