### PR TITLE
SDCICD-581 / 647: Surface exit codes from RunTests, exit(130) if an issue with version selection

### DIFF
--- a/pkg/common/versions/version_selector.go
+++ b/pkg/common/versions/version_selector.go
@@ -7,12 +7,12 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/util"
 	"github.com/openshift/osde2e/pkg/common/versions/installselectors"
 	"github.com/openshift/osde2e/pkg/common/versions/upgradeselectors"
-	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
 // GetVersionForInstall will get a version based upon available configuration options.
@@ -36,7 +36,11 @@ func GetVersionForInstall(versionList *spi.VersionList) (*semver.Version, string
 
 	v, selector, err := selectedVersionSelector.SelectVersion(versionList)
 	if err != nil {
-		return v, selector, fmt.Errorf("could not select a version from versionlist %v: %w", versionList, err)
+		log.Printf("No valid install version found for selector `%s`", selector)
+		for _, vers := range versionList.AvailableVersions() {
+			log.Printf("%s - Default? %v", vers.Version().Original(), vers.Default())
+		}
+		return nil, selector, nil
 
 	}
 

--- a/pkg/common/versions/version_setup.go
+++ b/pkg/common/versions/version_setup.go
@@ -7,12 +7,12 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/metadata"
 	"github.com/openshift/osde2e/pkg/common/providers"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/util"
-	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -91,7 +91,7 @@ func setupVersion(versionList *spi.VersionList) (*semver.Version, string, error)
 				log.Printf("Unable to get the %s.", versionType)
 			}
 		} else {
-			return nil, versionType, fmt.Errorf("error finding default cluster version: %v", err)
+			return nil, versionType, nil
 		}
 	} else {
 		var err error

--- a/pkg/e2e/version.go
+++ b/pkg/e2e/version.go
@@ -7,12 +7,12 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/metadata"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/util"
 	"github.com/openshift/osde2e/pkg/common/versions"
-	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -38,7 +38,6 @@ func ChooseVersions() (err error) {
 
 			clusterVersion, versionSelector, err = setupVersion(versionList)
 			if err != nil {
-				log.Printf("Error setting up version: %s", err.Error())
 				if versionSelector == "specific image" {
 					log.Printf("Waiting for %s CIS to sync with the Release Controller", viper.GetString(config.Cluster.ReleaseImageLatest))
 					return false, nil
@@ -86,7 +85,7 @@ func setupVersion(versionList *spi.VersionList) (*semver.Version, string, error)
 				log.Printf("Unable to get the %s.", versionType)
 			}
 		} else {
-			return nil, versionType, fmt.Errorf("error finding default cluster version: %v", err)
+			return nil, versionType, nil
 		}
 	} else {
 		var err error


### PR DESCRIPTION
This PR allows us to provide an exit code we want `osde2e test` to use during `RunTests` / `runGinkgoTests`. 

In addition, it updates version selection/errors to exit(130) when an issue arrises during version selection. 