### PR TITLE
fix(es): Prevent cluster claim conflicts, add flag preventing recycled clusters

### DIFF
--- a/pkg/common/clusterproperties/statuses.go
+++ b/pkg/common/clusterproperties/statuses.go
@@ -39,4 +39,7 @@ const (
 
 	// StatusCompletedFailing represents the cluster having finished its CI and tests having failed
 	StatusCompletedFailing = "completed-failing"
+
+	// StatusResuming represents the cluster having just been woken up
+	StatusResuming = "resuming"
 )

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -312,6 +312,11 @@ var Cluster = struct {
 	// the test run, assuming the provider supports hibernation
 	HibernateAfterUse string
 
+	// UseExistingCluster will allow the test run to use an existing cluster if available
+	// ENV: USE_EXISTING_CLUSTER
+	// Default: True
+	UseExistingCluster string
+
 	// Passing tracks the internal status of the tests: Pass or Fail
 	Passing string
 
@@ -345,6 +350,7 @@ var Cluster = struct {
 	ImageContentSource:                  "cluster.imageContentSource",
 	InstallConfig:                       "cluster.installConfig",
 	HibernateAfterUse:                   "cluster.hibernateAfterUse",
+	UseExistingCluster:                  "cluster.useExistingCluster",
 	Passing:                             "cluster.passing",
 	Reused:                              "cluster.rused",
 }
@@ -642,6 +648,9 @@ func init() {
 
 	viper.SetDefault(Cluster.HibernateAfterUse, true)
 	viper.BindEnv(Cluster.HibernateAfterUse, "HIBERNATE_AFTER_USE")
+
+	viper.SetDefault(Cluster.UseExistingCluster, true)
+	viper.BindEnv(Cluster.UseExistingCluster, "USE_EXISTING_CLUSTER")
 
 	viper.SetDefault(Cluster.Reused, false)
 	viper.SetDefault(Cluster.Passing, false)

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -616,6 +616,7 @@ func cleanupAfterE2E(h *helper.H) (errors []error) {
 				}
 
 				err = provider.AddProperty(cluster, clusterproperties.Status, clusterStatus)
+				err = provider.AddProperty(cluster, clusterproperties.JobID, "")
 				if err != nil {
 					log.Printf("Failed setting completed status: %v", err)
 				}


### PR DESCRIPTION
Once we retrieve a cluster, we should immediately tag it with the current Job ID before doing any other operation. 

We should then validate via a second GET whether the Job ID is the same as the current job. If not, recuuuuuurse. 

Additionally, there is now a flag to allow Recycled Clusters for a job (default: True) which means some jobs we can set to always require a fresh cluster. 