### PR TITLE
An overly-bloated PR that I apologize for

### DIFF
--- a/cmd/osde2ectl/expire/cmd.go
+++ b/cmd/osde2ectl/expire/cmd.go
@@ -1,0 +1,104 @@
+package expire
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/openshift/osde2e/cmd/osde2e/common"
+	"github.com/openshift/osde2e/cmd/osde2e/helpers"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/providers"
+	"github.com/openshift/osde2e/pkg/common/spi"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "expire",
+	Short: "Expire the expiry time of a cluster made by osde2e",
+	Long:  "Expire the expiry time of a CI cluster with the help of flags.",
+	Args:  cobra.OnlyValidArgs,
+	RunE:  run,
+}
+
+var provider spi.Provider
+
+var args struct {
+	clusterID       string
+	hours           uint64
+	minutes         uint64
+	seconds         uint64
+	configString    string
+	customConfig    string
+	secretLocations string
+}
+
+func init() {
+	pfs := Cmd.PersistentFlags()
+
+	pfs.StringVar(
+		&args.configString,
+		"configs",
+		"",
+		"A comma separated list of built in configs to use",
+	)
+
+	Cmd.RegisterFlagCompletionFunc("configs", helpers.ConfigComplete)
+	pfs.StringVar(
+		&args.customConfig,
+		"custom-config",
+		"",
+		"Custom config file for osde2e",
+	)
+
+	pfs.StringVar(
+		&args.secretLocations,
+		"secret-locations",
+		"",
+		"A comma separated list of possible secret directory locations for loading secret configs.",
+	)
+
+	pfs.StringVarP(
+		&args.clusterID,
+		"cluster-id",
+		"i",
+		"",
+		"Existing OCM cluster ID to expire expiry time.",
+	)
+
+	viper.BindPFlag(config.Cluster.ID, Cmd.PersistentFlags().Lookup("cluster-id"))
+}
+
+func run(cmd *cobra.Command, argv []string) error {
+
+	var err error
+
+	if err := common.LoadConfigs(args.configString, args.customConfig, args.secretLocations); err != nil {
+		return fmt.Errorf("error loading initial state: %v", err)
+	}
+
+	viper.BindPFlag(config.Cluster.ID, cmd.PersistentFlags().Lookup("cluster-id"))
+
+	clusterID := viper.GetString(config.Cluster.ID)
+
+	if provider, err = providers.ClusterProvider(); err != nil {
+		return fmt.Errorf("could not setup cluster provider: %v", err)
+	}
+
+	cluster, err := provider.GetCluster(clusterID)
+
+	if err != nil {
+		return fmt.Errorf("error retrieving cluster information: %v", err)
+	}
+
+	if properties := cluster.Properties(); properties["MadeByOSDe2e"] != "true" {
+		return fmt.Errorf("Cluster was not created by osde2e")
+	}
+
+	if err = provider.Expire(clusterID); err != nil {
+		return fmt.Errorf("error expireing cluster expiry time: %s", err.Error())
+	}
+
+	log.Print("Expireed cluster expiry time.....")
+	return nil
+}

--- a/cmd/osde2ectl/main.go
+++ b/cmd/osde2ectl/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openshift/osde2e/cmd/osde2ectl/create"
 	"github.com/openshift/osde2e/cmd/osde2ectl/delete"
+	"github.com/openshift/osde2e/cmd/osde2ectl/expire"
 	"github.com/openshift/osde2e/cmd/osde2ectl/extend"
 	"github.com/openshift/osde2e/cmd/osde2ectl/get"
 	"github.com/openshift/osde2e/cmd/osde2ectl/healthcheck"
@@ -28,6 +29,7 @@ func init() {
 	root.AddCommand(list.Cmd)
 	root.AddCommand(get.Cmd)
 	root.AddCommand(extend.Cmd)
+	root.AddCommand(expire.Cmd)
 	root.AddCommand(healthcheck.Cmd)
 
 }

--- a/pkg/common/providers/crc/crc.go
+++ b/pkg/common/providers/crc/crc.go
@@ -296,6 +296,11 @@ func (m *Provider) ExtendExpiry(clusterID string, hours uint64, minutes uint64, 
 	return fmt.Errorf("ExtendExpiry is unsupported by CRC clusters")
 }
 
+// Expire CRCs an extend cluster expiry operation.
+func (m *Provider) Expire(clusterID string) error {
+	return fmt.Errorf("Expire is unsupported by CRC clusters")
+}
+
 // AddProperty CRCs an add new cluster property operation.
 func (m *Provider) AddProperty(cluster *spi.Cluster, tag string, value string) error {
 	// Noop for now and just note it.

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -262,6 +262,11 @@ func (m *MockProvider) ExtendExpiry(clusterID string, hours uint64, minutes uint
 	return fmt.Errorf("ExtendExpiry is unsupported by mock clusters")
 }
 
+// Expire mocks an expire cluster expiry operation.
+func (m *MockProvider) Expire(clusterID string) error {
+	return fmt.Errorf("Expire is unsupported by mock clusters")
+}
+
 // AddProperty mocks an add new cluster property operation.
 func (m *MockProvider) AddProperty(cluster *spi.Cluster, tag string, value string) error {
 	return fmt.Errorf("AddProperty is unsupported by mock clusters")

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -199,7 +199,7 @@ func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 
 	var resp *v1.ClustersAddResponse
 
-	if viper.GetBool(config.Cluster.UseExistingCluster) {
+	if viper.GetBool(config.Cluster.UseExistingCluster) && viper.GetString(config.Addons.IDs) == "" {
 		if clusterID := o.findRecycledCluster(cluster); clusterID != "" {
 			return clusterID, nil
 		}

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -64,6 +64,7 @@ func (o *OCMProvider) IsValidClusterName(clusterName string) (bool, error) {
 }
 
 // LaunchCluster setups an new cluster using the OSD API and returns it's ID.
+// nolint:gocyclo
 func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 	flavourID := getFlavour()
 	if flavourID == "" {
@@ -242,6 +243,11 @@ func (o *OCMProvider) findRecycledCluster(cluster *v1.Cluster) string {
 		}
 
 		err = o.AddProperty(spiRecycledCluster, clusterproperties.JobID, viper.GetString(config.JobID))
+		if err != nil {
+			log.Printf("Error adding property to cluster: %s", err.Error())
+			return ""
+		}
+		err = o.AddProperty(spiRecycledCluster, clusterproperties.JobName, viper.GetString(config.JobName))
 		if err != nil {
 			log.Printf("Error adding property to cluster: %s", err.Error())
 			return ""
@@ -439,6 +445,7 @@ func (o *OCMProvider) GenerateProperties() (map[string]string, error) {
 	provisionshardID := viper.GetString(config.Cluster.ProvisionShardID)
 
 	properties := map[string]string{
+		clusterproperties.JobName:          viper.GetString(config.JobName),
 		clusterproperties.JobID:            viper.GetString(config.JobID),
 		clusterproperties.MadeByOSDe2e:     "true",
 		clusterproperties.OwnedBy:          username,

--- a/pkg/common/providers/rosaprovider/wrapped_calls.go
+++ b/pkg/common/providers/rosaprovider/wrapped_calls.go
@@ -73,6 +73,11 @@ func (m *ROSAProvider) ExtendExpiry(clusterID string, hours uint64, minutes uint
 	return m.ocmProvider.ExtendExpiry(clusterID, hours, minutes, seconds)
 }
 
+// Expire will call Expire from the OCM provider.
+func (m *ROSAProvider) Expire(clusterID string) error {
+	return m.ocmProvider.Expire(clusterID)
+}
+
 // AddProperty will call AddProperty from the OCM provider.
 func (m *ROSAProvider) AddProperty(cluster *spi.Cluster, tag string, value string) error {
 	return m.ocmProvider.AddProperty(cluster, tag, value)

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -113,6 +113,9 @@ type Provider interface {
 	//ExtendExpiry extends the expiration time of an existing cluster.
 	ExtendExpiry(clusterID string, hours uint64, minutes uint64, seconds uint64) error
 
+	//Expire sets the expiration of an existing cluster to the current time.
+	Expire(clusterID string) error
+
 	// AddProperty adds a new property to the properties field of an existing cluster.
 	AddProperty(cluster *Cluster, tag string, value string) error
 

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -622,6 +622,7 @@ func cleanupAfterE2E(h *helper.H) (errors []error) {
 
 				err = provider.AddProperty(cluster, clusterproperties.Status, clusterStatus)
 				err = provider.AddProperty(cluster, clusterproperties.JobID, "")
+				err = provider.AddProperty(cluster, clusterproperties.JobName, "")
 				if err != nil {
 					log.Printf("Failed setting completed status: %v", err)
 				}
@@ -677,7 +678,7 @@ func cleanupAfterE2E(h *helper.H) (errors []error) {
 					log.Printf("Error extending cluster expiration: %s", err.Error())
 				}
 			} else {
-				// If the cluster hasn't been recycled, and the tests passed: Extend it 24h
+				// If the cluster hasn't been recycled, and the cluster isn't errored: Extend it 24h
 				if err := provider.ExtendExpiry(viper.GetString(config.Cluster.ID), 18, 0, 0); err != nil {
 					log.Printf("Error extending cluster expiration: %s", err.Error())
 				}

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -93,7 +93,6 @@ func beforeSuite() bool {
 	// Skip provisioning if we already have a kubeconfig
 	var err error
 	if viper.GetString(config.Kubeconfig.Contents) == "" {
-
 		cluster, err := clusterutil.ProvisionCluster(nil)
 		events.HandleErrorWithEvents(err, events.InstallSuccessful, events.InstallFailed)
 		if err != nil {
@@ -670,10 +669,18 @@ func cleanupAfterE2E(h *helper.H) (errors []error) {
 		log.Printf(msg, viper.GetString(config.Cluster.ID))
 
 		// Current default expiration is 6 hours.
-		// If the cluster hasn't been recycled, and the tests passed: Extend it 24h
-		if !viper.GetBool(config.Cluster.Reused) && clusterStatus != clusterproperties.StatusCompletedError {
-			if err := provider.ExtendExpiry(viper.GetString(config.Cluster.ID), 18, 0, 0); err != nil {
-				log.Printf("Error extending cluster expiration: %s", err.Error())
+		// If this cluster has addons, we don't want to extend the expiration
+		if !viper.GetBool(config.Cluster.Reused) && clusterStatus != clusterproperties.StatusCompletedError && viper.GetString(config.Addons.IDs) == "" {
+			if viper.GetString(config.Cluster.InstallSpecificNightly) != "" {
+				// For release-specific jobs, we want a shorter expiration for these: No more than 12h
+				if err := provider.ExtendExpiry(viper.GetString(config.Cluster.ID), 6, 0, 0); err != nil {
+					log.Printf("Error extending cluster expiration: %s", err.Error())
+				}
+			} else {
+				// If the cluster hasn't been recycled, and the tests passed: Extend it 24h
+				if err := provider.ExtendExpiry(viper.GetString(config.Cluster.ID), 18, 0, 0); err != nil {
+					log.Printf("Error extending cluster expiration: %s", err.Error())
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Apologies up front -- reviewing each commit might make more sense. 

1. Adds "expire" command to osde2ectl -- it will set the expiration timestamp to be now+1min
2. Makes `osde2ectl list` a lot more.... useful. Output example:

```
NAME           OWNER    ID                                 CLOUD     STATE          STATUS                VERSION                                        JOB_ID                   JOB
osde2e-momta   root     1jovh44rpvj38v7nhtf9jivnn55a082c   aws       ready          provisioning          4.7.4                                          -1                       
osde2e-rxain   root     1jovv8i379uaeaougb0mmcmrb9mvieqv   aws       ready          provisioning          4.7.4                                          -1                       
osde2e-2yaup   prow     1kp7fhe8j1m9vlt2cl7g9ujvkcuc698p   aws       ready          healthy               4.7.9-candidate                                1394986318789873664      osde2e-prod-rosa-e2e-default
osde2e-96qlj   prow     1kp97knmdgi55t0lrnnv922d0acjnviu   aws       hibernating    completed-passing     4.8.0-fc.3-candidate                                                    osde2e-prod-aws-e2e-upgrade-prod-minus-three-to-next
osde2e-7ssie   prow     1kpavvdqea63n0j96rks9hqjq5s6bhh3   aws       hibernating    completed-failing     4.6.25-candidate                                                        osde2e-prod-aws-e2e-middle-imageset
```
3. Tweak extending the expiration of clusters based on the job type
4. Do not allow an addon test to use a recycled cluster