### PR TITLE
SDCICD-665: Pass env var in runner pods

### DIFF
--- a/pkg/common/runner/pod.go
+++ b/pkg/common/runner/pod.go
@@ -135,6 +135,10 @@ func (r *Runner) createPod() (pod *kubev1.Pod, err error) {
 		if container.Name == "" || container.Name == r.Name {
 			pod.Spec.Containers[i].Name = r.Name
 			pod.Spec.Containers[i].Image = r.ImageName
+			pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, kubev1.EnvVar{
+				Name:  "OSDE2E",
+				Value: "true",
+			})
 
 			// run command in pod if, present
 			if len(r.Cmd) != 0 {


### PR DESCRIPTION
In any runner pods, we will now pass "OSDE2E=true"