### PR TITLE
SDCICD-672: Fix race condition grabbing expiring clusters

### DIFF
--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -240,6 +240,11 @@ func (o *OCMProvider) FindRecycledCluster(originalVersion, cloudProvider, produc
 	if err == nil && listResponse.Total() > 0 {
 		log.Printf("We've found %d matching clusters to reuse", listResponse.Total())
 		recycledCluster := listResponse.Items().Slice()[rand.Intn(listResponse.Total())]
+
+		if recycledCluster.ExpirationTimestamp().Before(time.Now().Add(4 * time.Hour)) {
+			return o.FindRecycledCluster(originalVersion, cloudProvider, product)
+		}
+
 		spiRecycledCluster, err := o.ocmToSPICluster(recycledCluster)
 		if err != nil {
 			log.Printf("Error converting recycled cluster to an SPI Cluster: %s", err.Error())

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -242,6 +242,11 @@ func (o *OCMProvider) FindRecycledCluster(originalVersion, cloudProvider, produc
 		recycledCluster := listResponse.Items().Slice()[rand.Intn(listResponse.Total())]
 
 		if recycledCluster.ExpirationTimestamp().Before(time.Now().Add(4 * time.Hour)) {
+			// If this cluster is the only available cluster, trigger a new cluster
+			if listResponse.Items().Len() == 1 {
+				return ""
+			}
+			// Otherwise, try and grab a different existing cluster
 			return o.FindRecycledCluster(originalVersion, cloudProvider, product)
 		}
 


### PR DESCRIPTION
There are instances where we have grabbed a cluster that will expire mid-test. This should prevent that by only ever grabbing a cluster that expires 4+ hours after the current time. 