### PR TITLE
SDCICD-673: Add time between the apply and checking for pod state

### DIFF
--- a/assets/addons/addon-runner.template
+++ b/assets/addons/addon-runner.template
@@ -55,6 +55,8 @@ oc create configmap push-results-{{.Suffix}} --from-file=push-results.sh
 
 oc apply -f workload.yaml
 
+sleep 5
+
 set +e
 
 while oc get job/{{.JobName}} -o=jsonpath='{.status}' | grep -q active; do sleep 1; done


### PR DESCRIPTION
There may be instances where we check for the state of a pod's containers before the pod has been created. 

Infamous words ring true: "If there's a race condition, just add another sleep to it."