### PR TITLE
fix: grab correct error string for test entries in db

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -880,7 +880,7 @@ func runTestsInPhase(phase string, description string, dryrun bool) (bool, []db.
 							},
 							Error: func() string {
 								if test.Error != nil {
-									return err.Error()
+									return test.Error.Error()
 								}
 								return ""
 							}(),


### PR DESCRIPTION
This ought to prevent segfaults like this:

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/osde2e-stage-rosa-e2e-upgrade-to-latest/1402460567825813504#1:build-log.txt%3A7120

Signed-off-by: Chris Waldon <cwaldon@redhat.com>