### PR TITLE
Sync entries from MCC MUO ConfigMap

### DIFF
--- a/assets/upgrades/config.template
+++ b/assets/upgrades/config.template
@@ -6,10 +6,9 @@ maintenance:
   controlPlaneTime: {{ .ControlPlaneTime }}
   ignoredAlerts:
   controlPlaneCriticals:
-  - etcdMembersDown
-  - KubeDeploymentReplicasMismatch
+  # ClusterOperatorDown - OSD-6330
   - ClusterOperatorDown
-  - MachineWithNoRunningPhase
+  # ClusterOperatorDown - OSD-6330
   - ClusterOperatorDegraded
 scale:
   timeOut: {{ .ScaleTimeout }}
@@ -24,9 +23,18 @@ healthCheck:
   - MetricsClientSendFailingSRE
   - UpgradeNodeScalingFailedSRE
   - UpgradeClusterCheckFailedSRE
+  - PrometheusRuleFailures
+  - CannotRetrieveUpdates
+  - FluentdNodeDown
 verification:
   ignoredNamespaces:
   - openshift-logging
+  - openshift-redhat-marketplace
+  - openshift-operators
+  - openshift-customer-monitoring
+  - openshift-route-monitoring-operator
+  - openshift-user-workload-monitoring
+  - openshift-pipelines
   namespacePrefixesToCheck:
   - openshift
   - kube


### PR DESCRIPTION
Based on PR https://github.com/openshift/managed-cluster-config/pull/853, adding entries in MUO Configmap with more entries for ignoring namespaces. Also, based on latest MCC configmap [file](https://github.com/openshift/managed-cluster-config/blob/master/deploy/managed-upgrade-operator-config/10-managed-upgrade-operator-configmap.yaml), changed the entries of some of the alerts to be ignored during control plane upgrade.

