### PR TITLE
Changing summary job url to prow.ci.openshift.org

### DIFF
--- a/assets/reports/weather-report/markdown.template
+++ b/assets/reports/weather-report/markdown.template
@@ -3,11 +3,11 @@
 ## Summary
 
 {{range .Jobs}}
-* [{{.Name}}](#{{.Name}}) (Pass Rate: {{.PassRate}}) ([Job](https://prow.svc.ci.openshift.org/?job={{.Name}})){{end}}
+* [{{.Name}}](#{{.Name}}) (Pass Rate: {{.PassRate}}) ([Job](https://prow.ci.openshift.org/?job={{.Name}})){{end}}
 
 {{range .Jobs}}
 ## {{.Name}}
-Job: [link](https://prow.svc.ci.openshift.org/?job={{.Name}})
+Job: [link](https://prow.ci.openshift.org/?job={{.Name}})
 
 Viability: {{.Viable}}
 

--- a/assets/reports/weather-report/sd-report.template
+++ b/assets/reports/weather-report/sd-report.template
@@ -9,7 +9,7 @@ summary = "{{.Summary}}"
 
 | Job Name | Pass Rate | More detail |
 |----------|-----------|-------------|
-{{range .Jobs}}|[{{.Name}}](https://prow.svc.ci.openshift.org/?job={{.Name}})| <span style="color:{{.Color}};">{{printf "%.2f%%" .PassRate}}</span>|[More Detail](#{{.Name}})|
+{{range .Jobs}}|[{{.Name}}](https://prow.ci.openshift.org/?job={{.Name}})| <span style="color:{{.Color}};">{{printf "%.2f%%" .PassRate}}</span>|[More Detail](#{{.Name}})|
 {{end}}
 {{range .Jobs}}
 {{ $jobScope := . }}


### PR DESCRIPTION
Summary job URLs open with `https://prow.svc.ci.openshift.org` by default which does not open. The URL with `https://prow.ci.openshift.org` works fine for it. This PR changes those default URLs being opened.

Example of faulty URLs opened by default: 
Summary Job: https://prow.svc.ci.openshift.org/?job=osde2e-prod-aws-e2e-default 