### PR TITLE
Fix naming of RMO namespace in MUO config

### DIFF
--- a/assets/upgrades/config.template
+++ b/assets/upgrades/config.template
@@ -31,6 +31,6 @@ healthCheck:
   - openshift-redhat-marketplace
   - openshift-operators
   - openshift-customer-monitoring
-  - openshift-route-monitoring-operator                                                                                                                                      
+  - openshift-route-monitor-operator                                                                                                                                      
   - openshift-user-workload-monitoring
   - openshift-pipelines


### PR DESCRIPTION
This PR corrects the mistaken naming of the `openshift-route-monitor-namespace` for being ignored by the `managed-upgrade-operator` when checking active alerts pre-upgrade.
