### PR TITLE
debug: log stack traces immediately before all calls to BeforeEach

### DIFF
--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"runtime"
 	"strings"
 	"sync"
 	"text/template"
@@ -44,6 +45,9 @@ func Init() *H {
 // New instantiates a helper function to be used within a Ginkgo Test block
 func New() *H {
 	h := Init()
+	var stackTrace [4096]byte
+	written := runtime.Stack(stackTrace[:], true)
+	log.Println("Before BeforeEach:", string(stackTrace[:written]))
 	ginkgo.BeforeEach(h.SetupWrapper)
 
 	return h

--- a/pkg/e2e/operators/customdomains.go
+++ b/pkg/e2e/operators/customdomains.go
@@ -10,9 +10,11 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"log"
 	"math/big"
 	"net"
 	"net/http"
+	"runtime"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -59,6 +61,9 @@ var _ = ginkgo.Describe(customDomainsOperatorTestName, func() {
 			testInstanceName = "test-customdomain-" + time.Now().Format("20060102-150405-") + fmt.Sprint(time.Now().Nanosecond()/1000000) + "-" + fmt.Sprint(ginkgo.GinkgoParallelNode())
 			testDomain       *customdomainv1alpha1.CustomDomain
 		)
+		var stackTrace [4096]byte
+		written := runtime.Stack(stackTrace[:], true)
+		log.Println("Before BeforeEach:", string(stackTrace[:written]))
 
 		ginkgo.BeforeEach(func() {
 			ginkgo.By("Logging in as a dedicated-admin")

--- a/pkg/e2e/operators/managedupgrade.go
+++ b/pkg/e2e/operators/managedupgrade.go
@@ -3,7 +3,9 @@ package operators
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
+	stdruntime "runtime"
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -59,6 +61,9 @@ var _ = ginkgo.Describe(managedUpgradeOperatorTestName, func() {
 			err            error
 		)
 
+		var stackTrace [4096]byte
+		written := stdruntime.Stack(stackTrace[:], true)
+		log.Println("Before BeforeEach:", string(stackTrace[:written]))
 		ginkgo.BeforeEach(func() {
 			clusterVersion, err = getClusterVersion(h)
 		})

--- a/pkg/e2e/verify/oauth_tokens.go
+++ b/pkg/e2e/verify/oauth_tokens.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
+	"runtime"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -31,6 +33,9 @@ var _ = ginkgo.Describe(oauthTokensTestName, func() {
 
 		var oauthcfg *configv1.OAuth
 
+		var stackTrace [4096]byte
+		written := runtime.Stack(stackTrace[:], true)
+		log.Println("Before BeforeEach:", string(stackTrace[:written]))
 		ginkgo.BeforeEach(func() {
 			var err error
 			oauthcfg, err = h.Cfg().ConfigV1().OAuths().Get(context.TODO(), "cluster", metav1.GetOptions{})
@@ -56,6 +61,9 @@ var _ = ginkgo.Describe(oauthTokensTestName, func() {
 		var user *userv1.User
 		var client *oauthv1.OAuthClient
 
+		var stackTrace [4096]byte
+		written := runtime.Stack(stackTrace[:], true)
+		log.Println("Before BeforeEach:", string(stackTrace[:written]))
 		ginkgo.BeforeEach(func() {
 			user, _ = createUser("osde2e-token-user-"+util.RandomStr(5), nil, nil, h)
 			Expect(user).ToNot(BeNil())


### PR DESCRIPTION
/assign @jeefy 

This should make it somewhat easier to find the code path that is failing our upgrade tests, albeit at the cost of very noisy logging.