### PR TITLE
Replace quota_summary validation with SKU quota validation

### DIFF
--- a/pkg/common/providers/crc/crc.go
+++ b/pkg/common/providers/crc/crc.go
@@ -214,7 +214,7 @@ func (m *Provider) ClusterKubeconfig(clusterID string) ([]byte, error) {
 }
 
 // CheckQuota CRCs a check quota operation.
-func (m *Provider) CheckQuota(flavour string) (bool, error) {
+func (m *Provider) CheckQuota(sku string) (bool, error) {
 	if len(m.clusters) > 0 {
 		return false, fmt.Errorf("only one CRC cluster may be used at a time")
 	}

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -170,7 +170,7 @@ func (m *MockProvider) ClusterKubeconfig(clusterID string) ([]byte, error) {
 }
 
 // CheckQuota mocks a check quota operation.
-func (m *MockProvider) CheckQuota(flavour string) (bool, error) {
+func (m *MockProvider) CheckQuota(sku string) (bool, error) {
 	if m.env == "fail" {
 		return false, fmt.Errorf("failed to get versions: Some fake error")
 	}

--- a/pkg/common/providers/mock/mock_test.go
+++ b/pkg/common/providers/mock/mock_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/Masterminds/semver"
-	"github.com/openshift/osde2e/pkg/common/spi"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/spi"
 	"k8s.io/client-go/tools/clientcmd"
 )
 

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -67,15 +67,17 @@ func (o *OCMProvider) IsValidClusterName(clusterName string) (bool, error) {
 // nolint:gocyclo
 func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 	flavourID := getFlavour()
-	if flavourID == "" {
-		return "", fmt.Errorf("No flavour has been selected")
-	}
-
-	// check that enough quota exists for this test if creating cluster
-	if enoughQuota, err := o.CheckQuota(flavourID); err != nil {
-		log.Printf("Failed to check if enough quota is available: %v", err)
-	} else if !enoughQuota {
-		return "", fmt.Errorf("currently not enough quota exists to run this test")
+	skuID := getSKU()
+	if skuID != "" {
+		// check that enough quota exists for this test if creating cluster
+		if enoughQuota, err := o.CheckQuota(skuID); err != nil {
+			log.Printf("Failed to check if enough quota is available: %v", err)
+		} else if !enoughQuota {
+			return "", fmt.Errorf("currently not enough quota exists to run this test")
+		}
+	} else {
+		// If no SKU specified, just continue on with no validation, but log it
+		log.Printf("No SKU specified, will not check if enough quota is available.")
 	}
 
 	multiAZ := viper.GetBool(config.Cluster.MultiAZ)

--- a/pkg/common/providers/ocmprovider/config.go
+++ b/pkg/common/providers/ocmprovider/config.go
@@ -1,8 +1,8 @@
 package ocmprovider
 
 import (
-	"github.com/openshift/osde2e/pkg/common/config"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 )
 
 const (
@@ -26,6 +26,9 @@ const (
 
 	// Flavour is an OCM cluster descriptor for cluster defaults
 	Flavour = "ocm.flavour"
+
+	// SKU Rule ID is an identifier for a SKU that OCM can provision
+	Sku = "ocm.skuRule"
 
 	// AdditionalLabels is used to add more specific labels to a cluster in OCM.
 	AdditionalLabels = "ocm.additionalLabels"
@@ -62,6 +65,9 @@ func init() {
 
 	viper.SetDefault(Flavour, "osd-4")
 	viper.BindEnv(Flavour, "OCM_FLAVOUR")
+
+	viper.SetDefault(Sku, "")
+	viper.BindEnv(Sku, "OCM_SKU")
 
 	viper.BindEnv(AdditionalLabels, "OCM_ADDITIONAL_LABELS")
 

--- a/pkg/common/providers/ocmprovider/sku.go
+++ b/pkg/common/providers/ocmprovider/sku.go
@@ -1,0 +1,30 @@
+package ocmprovider
+
+import (
+	"log"
+	"math/rand"
+	"strings"
+
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+)
+
+func getSKU() string {
+	var skuID string
+	// Retrieve SKU based on config
+	// If multiple flavours are supplied in a comma-delimited list
+	// select one at random and will override the config with the
+	// flavor selected for all future calls
+	skus := strings.Split(viper.GetString(Sku), ",")
+	skuLength := len(skus)
+	switch skuLength {
+	case 0:
+		skuID = ""
+	case 1:
+		skuID = skus[0]
+	default:
+		skuID = skus[rand.Intn(skuLength)]
+	}
+	log.Printf("Using SKU: %s", skuID)
+
+	return skuID
+}

--- a/pkg/common/providers/rosaprovider/wrapped_calls.go
+++ b/pkg/common/providers/rosaprovider/wrapped_calls.go
@@ -34,8 +34,8 @@ func (m *ROSAProvider) ClusterKubeconfig(clusterID string) ([]byte, error) {
 }
 
 // CheckQuota will call CheckQuota from the OCM provider.
-func (m *ROSAProvider) CheckQuota(flavour string) (bool, error) {
-	return m.ocmProvider.CheckQuota(flavour)
+func (m *ROSAProvider) CheckQuota(sku string) (bool, error) {
+	return m.ocmProvider.CheckQuota(sku)
 }
 
 // InstallAddons will call InstallAddons from the OCM provider.

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -62,7 +62,7 @@ type Provider interface {
 	//
 	// To prevent a provisioning attempt, OSDe2e will first check the quota first. This quota
 	// is currently expected to be configured by the global config object.
-	CheckQuota(flavour string) (bool, error)
+	CheckQuota(sku string) (bool, error)
 
 	// InstallAddons will install addons onto the cluster.
 	//


### PR DESCRIPTION
This PR removes validation of available quota through the `resource_quota` endpoint and replaces it with validation of SKU quota using `quota_cost`.

`resource_quota` has been deprecated as a API endpoint in SDB-1979. As a result of this, cluster creation in Staging currently fails as the endpoint returns empty data.

If no SKU is specified (via the `OCM_SKU` environment variable or `ocm.skuRule` viper config), cluster creation **proceeds** with no quota validation taking place.


