### PR TITLE
OSD-7652 Make E2E more resilient to upgrade failures

### DIFF
--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -1219,6 +1219,12 @@ func (o *OCMProvider) GetUpgradePolicyID(clusterID string) (string, error) {
 		return "", listResp.Error()
 	}
 
+	if listResp.Items().Len() < 1 {
+		// Don't treat this as an error (because it may not be), just return nothing
+		log.Printf("No upgrade policies currently exist on the provider.")
+		return "", nil
+	}
+
 	policyID := listResp.Items().Get(0).ID()
 	if policyID == "" {
 		return "", fmt.Errorf("failed to get the policy ID")


### PR DESCRIPTION
### Overview

This PR introduces improved handling of managed upgrades to enable OSDE2E to better detect cases of an upgrade failing to start (culminating in the OCM provider cancelling the upgrade altogether), and passing that error back up the chain.

### Background 

Presently in cases where the `managed-upgrade-operator` fails to initiate a control plane upgrade within a configurable time window, the operator reports this as a failed upgrade to OCM and the upgrade is cancelled, resulting in the eventual deletion of the `UpgradeConfig` CR on-cluster. `OSDE2E` does not currently handle this situation in a nice way, and will wait the full three hours hoping that the situation will resolve itself (but it won't). This will often exhaust the total Prow job time, resulting in no reporting at all for jobs such as these. 

This PR addresses that behaviour by enabling OSDE2E to detect such a situation in both the `UpgradeConfig` and the OCM provider.

Additionally, some timings have been tweaked to improve the overall response time of E2E to irregular conditions:

- E2E clusters will check-in with OCM for upgrade policy changes every 15 minutes
- The upgrade window in which an upgrade must commence after being scheduled (Before being treated as a "failed" upgrade) has been reduced from 120 minutes to 30 minutes.

### Tested 

 - [x] Successfully tested an OSDE2E-driven upgrade with an existing cluster.

### Refs

[OSD-7652](https://issues.redhat.com/browse/OSD-7652)