### PR TITLE
Add configurable list of projects to inspect on cleanup

### DIFF
--- a/configs/inspect-namespaces.yaml
+++ b/configs/inspect-namespaces.yaml
@@ -1,0 +1,2 @@
+cluster:
+  inspectNamespaces: openshift-managed-upgrade-operator,openshift-velero,openshift-build-test,openshift-sre-pruning,openshift-cloud-ingress-operator,openshift-rbac-permissions,openshift-route-monitor-operator,openshift-validation-webhook,openshift-backplane,openshift-custom-domains-operator,openshift-must-gather-operator,openshift-splunk-forwarder-operator,openshift-sre-sshd,openshift-rbac-permissions

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -29,7 +29,7 @@ Some environment variables commonly used for pipelines under osde2e are indicate
 |DELTA_RELEASE_FROM_DEFAULT| DeltaReleaseFromDefault will select the cluster image set that is the given number of releases from the current default in either direction.|
 |NEXT_RELEASE_AFTER_PROD_DEFAULT|  NextReleaseAfterProdDefault will select the cluster image set that the given number of releases away from the the production default.|
 |CLEAN_CHECK_RUNS| CleanCheckRuns lets us set the number of osd-verify checks we want to run before deeming a cluster "healthy"|
- 
+|INSPECT_NAMESPACES| InspectNamespaces is a comma-delimeted list of namespaces to perform an `oc adm inspect` on during E2E cleanup|
 
 ### ROSA cluster related:-
  

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -326,6 +326,9 @@ var Cluster = struct {
 
 	// Reused tracks whether this cluster's test run used a new or recycled cluster
 	Reused string
+
+	// InspectNamespaces is a comma-delimited list of namespaces to perform an inspect on during test cleanup
+	InspectNamespaces string
 }{
 	MultiAZ:                             "cluster.multiAZ",
 	Channel:                             "cluster.channel",
@@ -357,6 +360,7 @@ var Cluster = struct {
 	UseExistingCluster:                  "cluster.useExistingCluster",
 	Passing:                             "cluster.passing",
 	Reused:                              "cluster.rused",
+	InspectNamespaces:                   "cluster.inspectNamespaces",
 }
 
 // CloudProvider config keys.
@@ -686,6 +690,9 @@ func init() {
 
 	viper.SetDefault(Cluster.Reused, false)
 	viper.SetDefault(Cluster.Passing, false)
+
+	viper.SetDefault(Cluster.InspectNamespaces, "")
+	viper.BindEnv(Cluster.InspectNamespaces, "INSPECT_NAMESPACES")
 
 	// ----- Cloud Provider -----
 	viper.SetDefault(CloudProvider.CloudProviderID, "aws")

--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -349,9 +349,18 @@ func (h *H) InspectState() {
 		h.proj, err = h.Project().ProjectV1().Projects().Get(context.TODO(), project, metav1.GetOptions{})
 		Expect(err).ShouldNot(HaveOccurred(), "failed to retrieve project")
 		Expect(h.proj).ShouldNot(BeNil())
-
 	}
-	err = h.inspect(h.CurrentProject())
+
+	// Always inspect the E2E project
+	inspectProjects := []string{h.CurrentProject()}
+
+	// Add any additional configured projects to inspect
+	projectsToInspectStr := viper.GetString(config.Cluster.InspectNamespaces)
+	if projectsToInspectStr != "" {
+		inspectProjects = append(inspectProjects, strings.Split(projectsToInspectStr, ",")...)
+	}
+
+	err = h.inspect(inspectProjects)
 	Expect(err).ShouldNot(HaveOccurred(), "could not inspect project '%s'", h.proj)
 }
 

--- a/pkg/common/helper/projects.go
+++ b/pkg/common/helper/projects.go
@@ -3,6 +3,7 @@ package helper
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/openshift/osde2e/pkg/common/runner"
@@ -41,11 +42,17 @@ func (h *H) createProject(suffix string) (*projectv1.Project, error) {
 	return project, err
 }
 
-func (h *H) inspect(projectName string) error {
+func (h *H) inspect(projects []string) error {
 	inspectTimeoutInSeconds := 200
 	h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
-	r := h.Runner(fmt.Sprintf("oc adm inspect ns/%v --dest-dir=%v", projectName, runner.DefaultRunner.OutputDir))
-	r.Name = "osde2e-project"
+
+	// add "ns/" prefix to each project
+	for i, project := range projects {
+		projects[i] = "ns/" + project
+	}
+	projectsArg := strings.Join(projects, " ")
+	r := h.Runner(fmt.Sprintf("oc adm inspect %v --dest-dir=%v", projectsArg, runner.DefaultRunner.OutputDir))
+	r.Name = "must-gather-additional-projects"
 	r.Tarball = true
 	stopCh := make(chan struct{})
 

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -579,7 +579,7 @@ func cleanupAfterE2E(h *helper.H) (errors []error) {
 		}
 	}
 
-	log.Print("Gathering Test Project State...")
+	log.Print("Gathering Project States...")
 	h.InspectState()
 
 	log.Print("Gathering OLM State...")


### PR DESCRIPTION
# Background
Presently during clean-up, E2E performs a `must-gather` on the cluster and an additional `oc adm inspect` on the `osde2e-xxxx` project it creates. However, neither of these include information on OSD operators which are installed as part of the cluster, which means useful information to troubleshoot failing tests is lost.

# Goal of PR
This PR adds a new configuration parameter defining a list of project namespaces that OSDE2E will perform an `oc adm inspect` on during E2E clean-up. This parameter is available as the `INSPECT_NAMESPACES` environment variable or the `cluster.inspectNamespaces` viper configuration parameter.

The gathered project output is build up in the `must-gather-additional-projects.tar.gz` in the test output dir.

A configuration of additional OSD projects has been added as `configs/inspect-namespaces.yaml`.

By default _no_ additional namespaces besides the OSDE2E project namespace are gathered.

# Changes to existing E2E operations

 The previous `osde2e-project.tar.gz`, which contained the `oc adm inspect` of the OSDE2E project namespace, is now part of the `must-gather-additional-projects.tar.gz` file which this PR generates.