### PR TITLE
Increase PollingTimeout to 60s

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -353,7 +353,7 @@ func init() {
 	viper.BindEnv(Kubeconfig.Path, "TEST_KUBECONFIG")
 
 	// ----- Tests -----
-	viper.SetDefault(Tests.PollingTimeout, 30)
+	viper.SetDefault(Tests.PollingTimeout, 60)
 	viper.BindEnv(Tests.PollingTimeout, "POLLING_TIMEOUT")
 
 	viper.BindEnv(Tests.GinkgoSkip, "GINKGO_SKIP")


### PR DESCRIPTION
We have a number of cases where webhook tests are timing out (OSD-7451,
OSD-7452, OSD-7547, et al) where the osde2e framework itself appears to
be responsible. Increasing the timeout here is a "try it and see"
approach.

Signed-off-by: Lisa Seelye <lisa@users.noreply.github.com>