### PR TITLE
Ignore PruningCronjobErrorSRE during upgrades

### DIFF
--- a/assets/upgrades/config.template
+++ b/assets/upgrades/config.template
@@ -26,6 +26,7 @@ healthCheck:
   - PrometheusRuleFailures
   - CannotRetrieveUpdates
   - FluentdNodeDown
+  - PruningCronjobErrorSRE
   ignoredNamespaces:
   - openshift-logging
   - openshift-redhat-marketplace


### PR DESCRIPTION
I've been observing this alert hitching up E2E upgrades quite a bit lately, and there's no reason in my mind why the `managed-upgrade-operator` should really be treating this as an alert worthy of blocking upgrade commencement or completion.

This PR will add the alert to the ignore list so that it's no longer causing upgrades to get stuck either pre or post upgrade.

I'm unsure why the alert is firing is firing at all in E2E world - unfortunately at the moment with the `managed-upgrade-operator` upgrade never finishing due to the alert, it's difficult to catch in the wild due to the lack of a must-gather from the E2E job. My suspicion is maybe one of the SRE pruning E2E tests is colliding or causing inadvertent issues. 

I have also submitted a PR for `managed-upgrade-operator` to ignore this alert in production: https://github.com/openshift/managed-cluster-config/pull/882

And created a ticket for tracking: OSD-7774.