### PR TITLE
Permit URL Op errors due to flaky network connections

### DIFF
--- a/pkg/e2e/operators/customdomains.go
+++ b/pkg/e2e/operators/customdomains.go
@@ -374,11 +374,9 @@ var _ = ginkgo.Describe(customDomainsOperatorTestName, func() {
 					}
 					// Check for URL DNS error
 					if urlError, ok := err.(*url.Error); ok {
-						if opError, ok := urlError.Err.(*net.OpError); ok {
-							if dnsError, ok := opError.Err.(*net.DNSError); ok && dnsError.IsNotFound {
-								// do not abort on flaky DNS responses
-								return false, nil
-							}
+						if _, ok := urlError.Err.(*net.OpError); ok {
+							// do not abort on flaky network operations
+							return false, nil
 						}
 					}
 					// Unhandled error


### PR DESCRIPTION
More stability improvements to catch flaky connection time outs to allow the pollImediate to continue trying.

https://issues.redhat.com/browse/OSD-7472