### PR TITLE
Introduce Addon polling timeout configuration

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -114,7 +114,7 @@ Some environment variables commonly used for pipelines under osde2e are indicate
 |ADDON_TEST_USER| TestUser is the OpenShift user that the tests will run as. If "%s" is detected in the TestUser string, it will evaluate that as the project namespace. Ex. "system:serviceaccount:%s:dedicated-admin" . Evaluated : "system:serviceaccount:osde2e-abc123:dedicated-admin"|
 |ADDON_RUN_CLEANUP| RunCleanup is a boolean to specify whether the testHarnesses should have a separate cleanup phase. This phase would run at the end of all e2e testing|
 |ADDON_CLEANUP_HARNESSES| CleanupHarnesses is a comma separated list of container images that will clean up any artifacts created after test harnesses have run|
- 
+|ADDON_POLLING_TIMEOUT| PollingTimeout defines in seconds the amount of time to wait for an add-on test job to finish before timing it out|
  
 ### Prometheus related:-
 

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -445,6 +445,11 @@ var Addons = struct {
 	// SkipAddonList is a boolean to indicate whether the listing of addons has to be disabled or not.
 	// Env: SKIP_ADDON_LIST
 	SkipAddonList string
+
+	// PollingTimeout is how long (in seconds) to wait for the add-on test to complete running.
+	// Env: ADDON_POLLING_TIMEOUT
+	PollingTimeout string
+
 }{
 	IDsAtCreation:    "addons.idsAtCreation",
 	IDs:              "addons.ids",
@@ -455,6 +460,7 @@ var Addons = struct {
 	SlackChannel:     "addons.slackChannel",
 	SkipAddonList:    "addons.skipAddonlist",
 	Parameters:       "addons.parameters",
+	PollingTimeout:   "addons.pollingTimeout",
 }
 
 // Scale config keys.
@@ -743,6 +749,9 @@ func init() {
 
 	viper.SetDefault(Addons.SkipAddonList, false)
 	viper.BindEnv(Addons.SkipAddonList, "SKIP_ADDON_LIST")
+
+	viper.SetDefault(Addons.PollingTimeout, 3600)
+	viper.BindEnv(Addons.PollingTimeout, "ADDON_POLLING_TIMEOUT")
 
 	// ----- Scale -----
 	viper.SetDefault(Scale.WorkloadsRepository, "https://github.com/openshift-scale/workloads")

--- a/pkg/e2e/addons/addon_test_harness.go
+++ b/pkg/e2e/addons/addon_test_harness.go
@@ -18,13 +18,8 @@ var _ = ginkgo.Describe("[Suite: addons] Addon Test Harness", func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 
-	addonTimeoutInSeconds := float64(viper.GetFloat64(config.Tests.PollingTimeout))
+	addonTimeoutInSeconds := float64(viper.GetFloat64(config.Addons.PollingTimeout))
 	log.Printf("addon timeout is %v", addonTimeoutInSeconds)
-	if addonTimeoutInSeconds == 30 {
-		// 30s is too short of a time for addons. So override the default with
-		// a new default of 60m (3600s)
-		addonTimeoutInSeconds = 3600
-	}
 	ginkgo.It("should run until completion", func() {
 		h.SetServiceAccount(viper.GetString(config.Addons.TestUser))
 		harnesses := strings.Split(viper.GetString(config.Addons.TestHarnesses), ",")


### PR DESCRIPTION
PR #883 increased the polling timeout default to 60s, but this breaks some code in the add-on testing which relies on that default being 30 in order to bump the polling timeout to an hour.

This PR introduces an `ADDON_POLLING_TIMEOUT` configuration which defaults to 1h.
