### PR TITLE
SRE elevates with backplane-cluster-admin

### DIFF
--- a/pkg/e2e/operators/mustgather.go
+++ b/pkg/e2e/operators/mustgather.go
@@ -55,12 +55,12 @@ var _ = ginkgo.Describe(mustGatherOperatorTest, func() {
 		})
 	})
 
-	ginkgo.Context("as Members of SRE", func() {
+	ginkgo.Context("as an elevated SRE", func() {
 		mg := generateMustGather(h, "bar-example")
 		ginkgo.It("can manage MustGather CRs in openshift-must-gather-operator namespace", func() {
-			err := createMustGather(h, mg, operatorNamespace, "dummy@redhat.com", "osd-sre-cluster-admins")
+			err := createMustGather(h, mg, operatorNamespace, "backplane-cluster-admin", "")
 			Expect(err).NotTo(HaveOccurred())
-			err = deleteMustGather(h, mg.Name, operatorNamespace, "dummy@redhat.com", "osd-sre-cluster-admins")
+			err = deleteMustGather(h, mg.Name, operatorNamespace, "backplane-cluster-admin", "")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
Error-ing test from some backplane changes - https://redhat.pagerduty.com/incidents/P2D8HJY
`osd-sre-cluster-admins` no longer exists