### PR TITLE
Pin ARO e2e to the current deployed ARO RP version

### DIFF
--- a/ci/aro-e2e-tests.sh
+++ b/ci/aro-e2e-tests.sh
@@ -10,6 +10,9 @@ export AZURE_CLIENT_ID="$(cat /usr/local/osde2e-credentials/aro-app-id)"
 export AZURE_CLIENT_SECRET="$(cat /usr/local/osde2e-credentials/aro-password)"
 export AZURE_TENANT_ID="$(cat /usr/local/osde2e-credentials/aro-tenant)"
 export AZURE_SUBSCRIPTION_ID="$(cat /usr/local/osde2e-credentials/aro-subscription)"
+
+RP_COMMIT=$(curl --silent https://arorpversion.blob.core.windows.net/rpversion/$LOCATION)
 git clone https://github.com/Azure/ARO-RP.git
 cd ARO-RP
+git checkout $RP_COMMIT
 make test-e2e


### PR DESCRIPTION
Sometimes our (ARO) e2e tests rely on code in master but not currently deployed to production yet.  This should fix failed e2e tests that run which currently don't have the feature enabled or released in production.  