### PR TITLE
[OSD-7617] Implements e2e tests for cloud-ingress-operator

### DIFF
--- a/pkg/e2e/operators/cloudingress/certificate.go
+++ b/pkg/e2e/operators/cloudingress/certificate.go
@@ -1,0 +1,74 @@
+package cloudingress
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/constants"
+	"github.com/openshift/osde2e/pkg/common/helper"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// tests
+var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+	h := helper.New()
+	var originalCert string
+	ginkgo.Context("publishingstrategy-certificate", func() {
+		ginkgo.It("IngressController should be patched when update Certificate", func() {
+			log.Print("Gonna update Certificate")
+			ingress1, _ := getingressController(h, "default")
+			originalCert = string(ingress1.Spec.DefaultCertificate.Name)
+			updateCertificate(h, "foo-bar")
+			time.Sleep(time.Duration(60) * time.Second)
+			log.Print("Updated the certificate in Publishingstrategy")
+			ingress, _ := getingressController(h, "default")
+
+			temp := (int64(1))
+			Expect(string(ingress.Spec.DefaultCertificate.Name)).To(Equal("foo-bar"))
+			Expect(ingress.Generation == temp).To(Equal(false))
+			Expect(ingress.Annotations["Owner"]).To(Equal("cloud-ingress-operator"))
+			log.Print("Ok Done with the test")
+		})
+		ginkgo.It("IngressController should be patched when return the original Certificate", func() {
+			log.Print("Gonna return the origin certificate")
+			updateCertificate(h, originalCert)
+			time.Sleep(time.Duration(60) * time.Second)
+			log.Print("Updated the certificate in Publishingstrategy")
+			ingress, _ := getingressController(h, "default")
+			temp := (int64(1))
+			Expect(string(ingress.Spec.DefaultCertificate.Name)).To(Equal(originalCert))
+			Expect(ingress.Generation == temp).To(Equal(false))
+			Expect(ingress.Annotations["Owner"]).To(Equal("cloud-ingress-operator"))
+			log.Print("Ok Done with the test")
+		})
+	})
+})
+
+func updateCertificate(h *helper.H, newName string) {
+	var err error
+	PublishingStrategyInstance, ps := getPublishingStrategy(h)
+
+	// Grab the current list of Application Ingresses from the Publishing Strategy
+	AppIngress := PublishingStrategyInstance.Spec.ApplicationIngress
+	name := newName
+	// Find the default router and update its scheme
+	for i, v := range AppIngress {
+		if v.Default == true {
+			AppIngress[i].Certificate.Name = name
+		}
+	}
+
+	PublishingStrategyInstance.Spec.ApplicationIngress = AppIngress
+
+	ps.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&PublishingStrategyInstance)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Update the publishingstrategy
+	ps, err = h.Dynamic().Resource(schema.GroupVersionResource{Group: "cloudingress.managed.openshift.io", Version: "v1alpha1", Resource: "publishingstrategies"}).Namespace(OperatorNamespace).Update(context.TODO(), ps, metav1.UpdateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/pkg/e2e/operators/cloudingress/deletetapps2.go
+++ b/pkg/e2e/operators/cloudingress/deletetapps2.go
@@ -1,0 +1,138 @@
+package cloudingress
+
+import (
+	"context"
+	"log"
+	"strings"
+
+	"time"
+
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1"
+	"github.com/openshift/osde2e/pkg/common/constants"
+	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/e2e/operators"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+	h := helper.New()
+	ginkgo.Context("Delete apps2 ingresscontroller", func() {
+		ginkgo.It("Should not be able to delete the ApplicationIngress that doesn't belong to CIO", func() {
+			//1. create a secondaryIngress that does belong to cloud-ingress-operator
+			secondaryIngress := secondaryIngress(h)
+
+			//only create the secondary ingress if it doesn't exist already in the publishing strategy
+			if _, exists, _ := appIngressExits(h, false, secondaryIngress.DNSName); !exists {
+				addAppIngress(h, secondaryIngress)
+			}
+			time.Sleep(time.Duration(30) * time.Second)
+			log.Print("Created a secondary ingress")
+			// from DNSName app-e2e-apps.cluster.mfvz.s1.devshift.org,
+			// the ingresscontroller name is app-e2e-apps: everything before the first period
+			ingressControllerName := strings.Split(secondaryIngress.DNSName, ".")[0]
+			log.Print("Got ingresscontroller Name")
+			// check that the ingresscontroller app-e2e-apps was created
+			ingressControllerExists(h, ingressControllerName, true)
+			log.Printf("Check to see of the ingressControllerExists")
+			// check if the secondary router is created
+			// the created router name should be router-app-e2e-apps
+			deploymentName := "router-" + ingressControllerName
+			deployment, err := operators.PollDeployment(h, "openshift-ingress", deploymentName)
+			log.Print("Check to see if the secondary router exists")
+			Expect(err).ToNot(HaveOccurred(), "failed fetching deployment")
+			Expect(deployment).NotTo(BeNil(), "deployment is nil")
+
+			// wait 1 minute for all routers to start
+
+			time.Sleep(time.Duration(60) * time.Second)
+			//2.delete the annotation
+			apps2Ingress, _ := getingressController(h, ingressControllerName)
+			log.Printf("The ingresscontroller object annotation currently is: %+v\n", apps2Ingress.ObjectMeta.Annotations)
+			newAnnotations := updateAnnotation(h, ingressControllerName, "Owner", "cloud-ingress-operator")
+			apps2Ingress = newAnnotations
+			log.Printf("Deleted the Annotation. This ingresscontroller should not belong to CIO anymore. the object's annotation now looks like: %+v\n", apps2Ingress.ObjectMeta.Annotations)
+			//3. Delete secondaryIngress in publishingstrategy
+			removeIngressController(h, ingressControllerName)
+			log.Print("Try to delete the secondaryIngress that doesn't contains the annotation")
+			time.Sleep(time.Duration(360) * time.Second)
+			// check that the ingresscontroller app-e2e-apps was deleted
+			ingressControllerExists(h, ingressControllerName, true)
+			log.Print("Gonna clean up now")
+			apps2Ingress = updateAnnotation(h, ingressControllerName, "Owner", "cloud-ingress-operator")
+			log.Print("Added the Annotations back to IngressOperator")
+			removeIngressController(h, ingressControllerName)
+			log.Print("Called removeIngressController ")
+			ingressControllerExists(h, ingressControllerName, false)
+			log.Print("ingressControllerExist shouldn't throw any errors")
+		})
+	})
+})
+
+func removeIngressController(h *helper.H, name string) {
+	_, exists, index := appIngressExits(h, false, name)
+	// only remove the secondary ingress if it already exist in the publishing strategy
+	if exists {
+		removeAppIngress(h, index)
+		//wait 2 minute for all resources to be deleted
+		time.Sleep(time.Duration(120) * time.Second)
+	}
+}
+func updateAnnotation(h *helper.H, name string, annotation1 string, annotation2 string) operatorv1.IngressController {
+	var ingressController operatorv1.IngressController
+	log.Print("Gonna start the annotation deletion process")
+	ingresscontroller, err := h.Dynamic().Resource(schema.GroupVersionResource{Group: "operator.openshift.io", Version: "v1", Resource: "ingresscontrollers"}).Namespace("openshift-ingress-operator").Get(context.TODO(), name, metav1.GetOptions{})
+	log.Print("Getting the ingressController object")
+	Expect(err).NotTo(HaveOccurred())
+
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(ingresscontroller.Object, &ingressController)
+	Expect(err).NotTo(HaveOccurred())
+
+	temp := ingressController.ObjectMeta
+	//if annotation exists, delete it
+	if temp.Annotations[annotation1] == annotation2 {
+		delete(temp.Annotations, annotation1)
+		ingressController.ObjectMeta = temp
+		ingresscontroller.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&ingressController)
+		Expect(err).NotTo(HaveOccurred())
+
+		ingresscontroller, err = h.Dynamic().Resource(schema.GroupVersionResource{Group: "operator.openshift.io", Version: "v1", Resource: "ingresscontrollers"}).Namespace("openshift-ingress-operator").Update(context.TODO(), ingresscontroller, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+	} else {
+		//if there's no annotation, add it
+		annotation := map[string]string{
+			annotation1: annotation2,
+		}
+		ingressController.ObjectMeta.Annotations = annotation
+		log.Printf("Set the IngressController Annotations to now: %+v", ingressController.ObjectMeta.Annotations)
+		ingresscontroller.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&ingressController)
+		Expect(err).NotTo(HaveOccurred())
+
+		ingresscontroller, err = h.Dynamic().Resource(schema.GroupVersionResource{Group: "operator.openshift.io", Version: "v1", Resource: "ingresscontrollers"}).Namespace("openshift-ingress-operator").Update(context.TODO(), ingresscontroller, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		updatePublishingStrategy(h, ingressController, name)
+	}
+	return ingressController
+}
+
+func updatePublishingStrategy(h *helper.H, ingressController operatorv1.IngressController, name string) {
+	log.Print("Gonna update the PublishingStrategy")
+	var err error
+	PublishingStrategyInstance, ps := getPublishingStrategy(h)
+	log.Print("Adding the IngressController back to the publishingstrategy")
+	var AppIngress cloudingressv1alpha1.ApplicationIngress
+	//AppIngress.Listening = ingressController.Spec.EndpointPublishingStrategy.LoadBalancer.Scope
+	AppIngress.Default = false
+	AppIngress.DNSName = name
+	PublishingStrategyInstance.Spec.ApplicationIngress = append(PublishingStrategyInstance.Spec.ApplicationIngress, AppIngress)
+	ps.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&PublishingStrategyInstance)
+	Expect(err).NotTo(HaveOccurred())
+	log.Print("Updated the publishingstrategy. should be able to delete this ingresscontroller")
+	// Update the publishingstrategy
+	ps, err = h.Dynamic().Resource(schema.GroupVersionResource{Group: "cloudingress.managed.openshift.io", Version: "v1alpha1", Resource: "publishingstrategies"}).Namespace(OperatorNamespace).Update(context.TODO(), ps, metav1.UpdateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/pkg/e2e/operators/cloudingress/dnsname.go
+++ b/pkg/e2e/operators/cloudingress/dnsname.go
@@ -1,0 +1,72 @@
+package cloudingress
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/constants"
+	"github.com/openshift/osde2e/pkg/common/helper"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// tests
+var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+	h := helper.New()
+	var dnsnameOriginal string
+	ginkgo.Context("publishingstrategy-dnsname", func() {
+		ginkgo.It("IngressController should be patched when update dnsname", func() {
+			log.Print("Grab the original name")
+			ingress1, _ := getingressController(h, "default")
+			dnsnameOriginal = string(ingress1.Spec.Domain)
+			log.Print(" the Domain name is \n", dnsnameOriginal)
+			updateDnsName(h, "foo")
+
+			time.Sleep(time.Duration(60) * time.Second)
+			log.Print("Updated the DnsName in Publishingstrategy")
+			ingress, _ := getingressController(h, "default")
+			temp := (int64(1))
+			log.Print("Updated the DnsName in Publishingstrategy, now the DNSName should be : ")
+			Expect(ingress.Generation == temp).To(Equal(false))
+			Expect(ingress.Annotations["Owner"]).To(Equal("cloud-ingress-operator"))
+			log.Print("Ok Done with the test")
+		})
+		ginkgo.It("IngressController should be patched when return to the original dnsname", func() {
+			updateDnsName(h, dnsnameOriginal)
+
+			time.Sleep(time.Duration(60) * time.Second)
+			log.Print("returned the original  the DnsName in Publishingstrategy")
+			ingress, _ := getingressController(h, "default")
+			temp := (int64(1))
+			Expect(string(ingress.Spec.Domain)).To(Equal(dnsnameOriginal))
+			Expect(ingress.Generation == temp).To(Equal(false))
+			Expect(ingress.Annotations["Owner"]).To(Equal("cloud-ingress-operator"))
+			log.Print("Ok Done with the test")
+		})
+	})
+})
+
+func updateDnsName(h *helper.H, newName string) {
+	var err error
+	PublishingStrategyInstance, ps := getPublishingStrategy(h)
+	AppIngress := PublishingStrategyInstance.Spec.ApplicationIngress
+
+	for i, v := range AppIngress {
+		if v.Default == true {
+			AppIngress[i].DNSName = newName
+		}
+	}
+
+	PublishingStrategyInstance.Spec.ApplicationIngress = AppIngress
+
+	ps.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&PublishingStrategyInstance)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Update the publishingstrategy
+	ps, err = h.Dynamic().Resource(schema.GroupVersionResource{Group: "cloudingress.managed.openshift.io", Version: "v1alpha1", Resource: "publishingstrategies"}).Namespace(OperatorNamespace).Update(context.TODO(), ps, metav1.UpdateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/pkg/e2e/operators/cloudingress/public_private.go
+++ b/pkg/e2e/operators/cloudingress/public_private.go
@@ -7,13 +7,14 @@ import (
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1"
 
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -49,11 +50,16 @@ var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 				return false, nil
 			})
 			Expect(err).NotTo(HaveOccurred())
+
+			ingress, _ := getingressController(h, "default")
+			Expect(string(ingress.Spec.EndpointPublishingStrategy.LoadBalancer.Scope)).To(Equal("Internal"))
+			Expect(ingress.Annotations["Owner"]).To(Equal("cloud-ingress-operator"))
+			temp := (int64(1))
+			Expect(ingress.Generation).To(Equal(temp))
 		})
+
 		ginkgo.It("should be able to toggle the default applicationingress from private to public", func() {
-
 			updateApplicationIngress(h, "external")
-
 			//wait for router-default service loadbalancer to NOT have an annotation indicating its scheme is internal
 			err := wait.PollImmediate(10*time.Second, 5*time.Minute, func() (bool, error) {
 				service, err := h.Kube().CoreV1().Services("openshift-ingress").Get(context.TODO(), "router-default", metav1.GetOptions{})
@@ -65,10 +71,19 @@ var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 					log.Printf("router-default service in openshift-ingress namespace successfully switched to public")
 					return true, nil
 				}
+
 				log.Printf("Waiting for router-default service in openshift-ingress namespace to be public")
 				return false, nil
 			})
 			Expect(err).NotTo(HaveOccurred())
+
+			ingress_controller, exists, _ := appIngressExits(h, true, "")
+			ingress, _ := getingressController(h, "default")
+			temp := (int64(1))
+			Expect(exists).To(BeTrue())
+			Expect(string(ingress_controller.Listening)).To(Equal("external"))
+			Expect(ingress.Annotations["Owner"]).To(Equal("cloud-ingress-operator"))
+			Expect(ingress.Generation).To(Equal(temp))
 		})
 	})
 })
@@ -103,6 +118,17 @@ func updateApplicationIngress(h *helper.H, lbscheme string) {
 	// Update the publishingstrategy
 	ps, err = h.Dynamic().Resource(schema.GroupVersionResource{Group: "cloudingress.managed.openshift.io", Version: "v1alpha1", Resource: "publishingstrategies"}).Namespace(OperatorNamespace).Update(context.TODO(), ps, metav1.UpdateOptions{})
 	Expect(err).NotTo(HaveOccurred())
+}
+
+func getingressController(h *helper.H, name string) (operatorv1.IngressController, *unstructured.Unstructured) {
+	var ingressController operatorv1.IngressController
+	ingresscontroller, err := h.Dynamic().Resource(schema.GroupVersionResource{Group: "operator.openshift.io", Version: "v1", Resource: "ingresscontrollers"}).Namespace("openshift-ingress-operator").Get(context.TODO(), name, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(ingresscontroller.Object, &ingressController)
+	Expect(err).NotTo(HaveOccurred())
+
+	return ingressController, ingresscontroller
 }
 
 // common setup and utils are in cloudingress.go

--- a/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
+++ b/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
@@ -39,6 +39,8 @@ var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 			err := addPublishingstrategy(h, ps)
 			Expect(apierrors.IsForbidden(err)).To(BeTrue())
 
+			//ingress, _ := getingressController(h, "default")
+			//Expect(ingress.Annotations["Owner"]).To(Equal("cloud-ingress-operator"))
 		})
 
 		ginkgo.It("cluster admin should be allowed to manage publishingstrategies CR", func() {
@@ -49,8 +51,11 @@ var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 				publishingstrategyCleanup(h, publishingstrategyName)
 			}()
 			Expect(err).NotTo(HaveOccurred())
-
+			//check the annotation for owned ingress
+			//ingress, _ := getingressController(h, "default")
+			//Expect(ingress.Annotations["Owner"]).To(Equal("cloud-ingress-operator"))
 		})
+
 	})
 
 })

--- a/pkg/e2e/operators/cloudingress/routeSelector.go
+++ b/pkg/e2e/operators/cloudingress/routeSelector.go
@@ -1,0 +1,142 @@
+package cloudingress
+
+import (
+	"context"
+	"log"
+	"reflect"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/constants"
+	"github.com/openshift/osde2e/pkg/common/helper"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// tests
+var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+	h := helper.New()
+
+	ginkgo.Context("publishingstrategy-route-selector", func() {
+		ginkgo.It("IngressController should be patched when update routeSelector matchLabels", func() {
+			log.Print("Gonna Update the RouteSelector to add MatchLabels")
+			updateMatchLabels(h, "tier", "frontend")
+
+			time.Sleep(time.Duration(60) * time.Second)
+			log.Print("Updated the RouteSelector in Publishingstrategy")
+			ingress, _ := getingressController(h, "default")
+			temp := (int64(1))
+			Expect(string(ingress.Spec.RouteSelector.MatchLabels["tier"])).To(Equal("frontend"))
+			Expect(ingress.Generation == temp).To(Equal(false))
+			Expect(ingress.Annotations["Owner"]).To(Equal("cloud-ingress-operator"))
+			log.Print("Ok Done with the test")
+		})
+		ginkgo.It("IngressController should be patched when update routeSelector matchExpressions", func() {
+			log.Print("Gonna Update the RouteSelector to add MatchExpressions")
+			updateMatchExpressions(h, "foo", "In", "bar")
+
+			time.Sleep(time.Duration(60) * time.Second)
+			log.Print("Updated the RouteSelector.MatchExpressions in Publishingstrategy")
+			ingress, _ := getingressController(h, "default")
+			temp := (int64(1))
+			//tempVal := []string{"bar"}
+			//tempOp := metav1.LabelSelectorOperator("In")
+			//temp1 := metav1.LabelSelectorRequirement{"foo", tempOp, tempVal}
+			expectedExpressions := []metav1.LabelSelectorRequirement{
+				{"foo", metav1.LabelSelectorOperator("In"), []string{"bar"}},
+			}
+			for j := range ingress.Spec.RouteSelector.MatchExpressions {
+				Expect(reflect.DeepEqual(ingress.Spec.RouteSelector.MatchExpressions[j], expectedExpressions)).To(BeTrue())
+			}
+			Expect(ingress.Generation == temp).To(Equal(false))
+			Expect(ingress.Annotations["Owner"]).To(Equal("cloud-ingress-operator"))
+			log.Print("Ok Done with the test")
+		})
+		ginkgo.It("IngressController should be patched when reset matchLabels and matchExpressions", func() {
+			log.Print("Gonna reset the matchLabels and matchExpressions to empty now")
+			resetRouteSelector(h)
+			time.Sleep(time.Duration(60) * time.Second)
+
+			log.Print("Reset RouteSelector")
+
+			ingress, _ := getingressController(h, "default")
+			temp := (int64(1))
+			Expect(ingress.Spec.RouteSelector.MatchLabels).To(BeNil())
+			Expect(ingress.Spec.RouteSelector.MatchExpressions).To(BeNil())
+			Expect(ingress.Generation == temp).To(Equal(false))
+			Expect(ingress.Annotations["Owner"]).To(Equal("cloud-ingress-operator"))
+
+		})
+	})
+})
+
+func updateMatchLabels(h *helper.H, tier string, routeS string) {
+	var err error
+	PublishingStrategyInstance, ps := getPublishingStrategy(h)
+
+	// Grab the current list of Application Ingresses from the Publishing Strategy
+	AppIngress := PublishingStrategyInstance.Spec.ApplicationIngress
+	temp := map[string]string{
+		tier: routeS,
+	}
+	// Find the default router and update its scheme
+	for i, v := range AppIngress {
+		if v.Default == true {
+			AppIngress[i].RouteSelector.MatchLabels = temp
+		}
+	}
+
+	PublishingStrategyInstance.Spec.ApplicationIngress = AppIngress
+
+	ps.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&PublishingStrategyInstance)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Update the publishingstrategy
+	ps, err = h.Dynamic().Resource(schema.GroupVersionResource{Group: "cloudingress.managed.openshift.io", Version: "v1alpha1", Resource: "publishingstrategies"}).Namespace(OperatorNamespace).Update(context.TODO(), ps, metav1.UpdateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func updateMatchExpressions(h *helper.H, key string, operator string, values string) {
+	var err error
+	PublishingStrategyInstance, ps := getPublishingStrategy(h)
+	// Grab the current list of Application Ingresses from the Publishing Strategy
+	AppIngress := PublishingStrategyInstance.Spec.ApplicationIngress
+	// Find the default router and update its scheme
+	tempVal := []string{values}
+	tempOp := metav1.LabelSelectorOperator(operator)
+	temp := metav1.LabelSelectorRequirement{key, tempOp, tempVal}
+	for i, v := range AppIngress {
+		if v.Default == true {
+			AppIngress[i].RouteSelector.MatchExpressions = []metav1.LabelSelectorRequirement{temp}
+		}
+	}
+	PublishingStrategyInstance.Spec.ApplicationIngress = AppIngress
+	ps.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&PublishingStrategyInstance)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Update the publishingstrategy
+	ps, err = h.Dynamic().Resource(schema.GroupVersionResource{Group: "cloudingress.managed.openshift.io", Version: "v1alpha1", Resource: "publishingstrategies"}).Namespace(OperatorNamespace).Update(context.TODO(), ps, metav1.UpdateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}
+func resetRouteSelector(h *helper.H) {
+	var err error
+	PublishingStrategyInstance, ps := getPublishingStrategy(h)
+	// Grab the current list of Application Ingresses from the Publishing Strategy
+	AppIngress := PublishingStrategyInstance.Spec.ApplicationIngress
+	// Find the default router and update its scheme
+	for i, v := range AppIngress {
+		if v.Default == true {
+			AppIngress[i].RouteSelector.MatchExpressions = append(AppIngress[i].RouteSelector.MatchExpressions[:i], AppIngress[i].RouteSelector.MatchExpressions[i+1:]...)
+			delete(AppIngress[i].RouteSelector.MatchLabels, "tier")
+		}
+	}
+	PublishingStrategyInstance.Spec.ApplicationIngress = AppIngress
+	ps.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&PublishingStrategyInstance)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Update the publishingstrategy
+	ps, err = h.Dynamic().Resource(schema.GroupVersionResource{Group: "cloudingress.managed.openshift.io", Version: "v1alpha1", Resource: "publishingstrategies"}).Namespace(OperatorNamespace).Update(context.TODO(), ps, metav1.UpdateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/pkg/e2e/operators/cloudingress/secondary_router.go
+++ b/pkg/e2e/operators/cloudingress/secondary_router.go
@@ -52,7 +52,9 @@ var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 			// the created router name should be router-app-e2e-apps
 			deploymentName := "router-" + ingressControllerName
 			deployment, err := operators.PollDeployment(h, "openshift-ingress", deploymentName)
+			ingress, _ := getingressController(h, ingressControllerName)
 
+			Expect(ingress.Annotations["Owner"]).To(Equal("cloud-ingress-operator"))
 			Expect(err).ToNot(HaveOccurred(), "failed fetching deployment")
 			Expect(deployment).NotTo(BeNil(), "deployment is nil")
 			Expect(deployment.Status.ReadyReplicas).To(BeNumerically("==", deployment.Status.Replicas))
@@ -69,16 +71,16 @@ var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 				time.Sleep(time.Duration(120) * time.Second)
 			}
 
-			ingressControllerName := strings.Split(secondaryIngress.DNSName, ".")[0]
+			ingressControllerName := strings.Split(secondaryIngress.DNSName, ".")[1]
 			// check that the ingresscontroller app-e2e-apps was deleted
 			ingressControllerExists(h, ingressControllerName, false)
 		})
 	})
-
 })
 
 // appIngressExits returns the appIngress matching the criteria if it exists
 func appIngressExits(h *helper.H, isdefault bool, dnsname string) (appIngress cloudingressv1alpha1.ApplicationIngress, exists bool, index int) {
+
 	PublishingStrategyInstance, _ := getPublishingStrategy(h)
 
 	// Grab the current list of Application Ingresses from the Publishing Strategy


### PR DESCRIPTION
PR implements @lnguyen1401's e2e tests for the cloud-ingress-operator

e2e tests implemented:
    default ingresscontroller should get deleted and recreated with desired result if publishinstrategy.spec.applicationIngress.listening changes.
    1. Change publishinstrategy.spec.applicationIngress.listening to Internal
    2. check if the Generation == 1, which means it has been deleted and recreated
    3. Change publishinstrategy.spec.applicationIngress.listening to External
    4. check if the Generation == 1, which means it has been deleted and recreated
    default ingresscontroller should get deleted and recreated with desired result if publishinstrategy.spec.applicationIngress.dnsName changes
    1. Change dnsName
    2. check if the Generation == 1, which means it has been deleted and recreated
    3. return dnsName to the original name
    4. check if the Generation == 1, which means it has been deleted and recreated
    Default ingresscontroller should be patched and NOT deleted if publishinstrategy.spec.applicationIngress.certificate changes.
    1. change certificate name
    2. check if the Generation > 1, which means it has been patched
    3. change the certificate name to the original
    4. check if the Generation > 1, which means it has been patched
    Default ingresscontroller should be patched and NOT deleted if publishinstrategy.spec.applicationIngress.routeSelector changes
    1. change routeSelector name
    2. check if the Generation > 1, which means it has been patched
    3. change the routeSelector name to the original
    4. check if the Generation > 1, which means it has been patched
    every ingresscontroller created by the cloud-ingress-operator should have an annotation “Owner: cloud-ingress-operator”
    remove the annotation from apps2 ingresscontroller, then delete apps2 from publishingstrategy, apps2 ingresscontroller should not get deleted. This is because we only want to watch the ingress that we (CIO) owns. (app2 is in secondary router)
    1. remove "cloud-ingress-controller" annotation from apps2 ingresscontroller -> this makes apps2 ingresscontroller not belong to the publishingstrategy anymore
    2. remove apps2 from publishingstrategy -> normally id the ingresscontroller belongs to the publishing strategy, it would delete the ingresscontroller. but since apps2 doesn't belong to the publishingstrategy anymore, it shouldn't be deleted.
    3. clean up the test secondary ingresscontroller: re-add "owner: cloud-ingress-operator" back to the apps2 ingresscontroller. re-add apps2 ingresscontroller to publishingstrategy. this makes the CIO able to delete the apps ingresscontroller for clean-up purpose.
    
REF:  https://issues.redhat.com/browse/OSD-7617
