### PR TITLE
OSD-8744 Ignore prom-exporter secret check on STS clusters

### DIFF
--- a/pkg/e2e/verify/prom_exporters.go
+++ b/pkg/e2e/verify/prom_exporters.go
@@ -54,11 +54,13 @@ var _ = ginkgo.Describe(promExportersTestname, func() {
 		},
 	}
 
-	var secretsToCheck = map[string][]string{
-		awsProvider: []string{
+	var secretsToCheck = map[string][]string{}
+	if !viper.GetBool("rosa.STS") {
+		// Only check AWS provider secrets for non-STS clusters
+		secretsToCheck[awsProvider] = []string{
 			"sre-ebs-iops-reporter-aws-credentials",
 			"sre-stuck-ebs-vols-aws-credentials",
-		},
+		}
 	}
 
 	var roleBindingsToCheck = map[string][]string{


### PR DESCRIPTION
This PR addresses [OSD-8744](https://issues.redhat.com/browse/OSD-8744) which identified failing tests in our `osde2e-*-rosa-sts-e2e-default` jobs. The secrets that the `prom_exporters` test were checking for will not exist on STS clusters, so the test has been revised to not check for these secrets if the test cluster is STS.
