### PR TITLE
Improve secret loading for OSDe2e`

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -815,7 +815,7 @@ func PostProcess() {
 // RegisterSecret will register the secret filename that will be used for the corresponding Viper string.
 func RegisterSecret(key string, secretFileName string) {
 	keyToSecretMappingMutex.Lock()
-	keyToSecretMapping[key] = secretFileName
+	keyToSecretMapping[secretFileName] = key
 	keyToSecretMappingMutex.Unlock()
 }
 

--- a/pkg/common/load/load.go
+++ b/pkg/common/load/load.go
@@ -63,7 +63,7 @@ func Configs(configs []string, customConfig string, secretLocations []string) er
 	// 4. Secrets. These will override all previous entries.
 	if len(secretLocations) > 0 {
 		secrets := config.GetAllSecrets()
-		for key, secretFilename := range secrets {
+		for secretFilename, key := range secrets {
 			loadSecretFileIntoKey(key, secretFilename, secretLocations)
 		}
 

--- a/pkg/common/providers/ocmprovider/config.go
+++ b/pkg/common/providers/ocmprovider/config.go
@@ -74,9 +74,12 @@ func init() {
 	viper.SetDefault(CCS, false)
 	viper.BindEnv(CCS, "OCM_CCS")
 
-	viper.BindEnv(AWSAccount, "OCM_AWS_ACCOUNT")
-	viper.BindEnv(AWSAccessKey, "OCM_AWS_ACCESS_KEY")
-	viper.BindEnv(AWSSecretKey, "OCM_AWS_SECRET_KEY")
+	viper.BindEnv(AWSAccount, "OCM_AWS_ACCOUNT", "AWS_ACCOUNT")
+	viper.BindEnv(AWSAccessKey, "OCM_AWS_ACCESS_KEY", "AWS_ACCESS_KEY_ID")
+	viper.BindEnv(AWSSecretKey, "OCM_AWS_SECRET_KEY", "AWS_SECRET_ACCESS_KEY")
+
+	config.RegisterSecret(AWSAccessKey, "aws-access-key-id")
+	config.RegisterSecret(AWSSecretKey, "aws-secret-access-key")
 
 	config.RegisterSecret(AWSAccount, "ocm-aws-account")
 	config.RegisterSecret(AWSAccessKey, "ocm-aws-access-key")

--- a/pkg/common/providers/rosaprovider/config.go
+++ b/pkg/common/providers/rosaprovider/config.go
@@ -45,13 +45,13 @@ func init() {
 	viper.SetDefault(Env, "prod")
 	viper.BindEnv(Env, "ROSA_ENV")
 
-	viper.BindEnv(AWSAccessKeyID, "ROSA_AWS_ACCESS_KEY_ID")
+	viper.BindEnv(AWSAccessKeyID, "ROSA_AWS_ACCESS_KEY_ID", "AWS_ACCESS_KEY_ID")
 	config.RegisterSecret(AWSAccessKeyID, "rosa-aws-access-key")
 
-	viper.BindEnv(AWSSecretAccessKey, "ROSA_AWS_SECRET_ACCESS_KEY")
+	viper.BindEnv(AWSSecretAccessKey, "ROSA_AWS_SECRET_ACCESS_KEY", "AWS_SECRET_ACCESS_KEY")
 	config.RegisterSecret(AWSSecretAccessKey, "rosa-aws-secret-access-key")
 
-	viper.BindEnv(AWSRegion, "ROSA_AWS_REGION")
+	viper.BindEnv(AWSRegion, "ROSA_AWS_REGION", "AWS_REGION")
 	config.RegisterSecret(AWSRegion, "rosa-aws-region")
 
 	viper.BindEnv(MachineCIDR, "ROSA_MACHINE_CIDR")


### PR DESCRIPTION
This allows you to set multiple possible locations for a single viper variable.

```
config.RegisterSecret(AWSAccessKey, "aws-access-key-id")
config.RegisterSecret(AWSAccessKey, "ocm-aws-access-key")
```

Would now work, allowing you to look at multiple locations for the same variable/secret to load.