### PR TITLE
Remove use of map causing secret loading to fail when specifying multiple secret locations

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -10,6 +10,11 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 )
 
+type Secret struct {
+	FileLocation string
+	Key          string
+}
+
 const (
 	// Provider is what provider to use to create/delete clusters.
 	// Env: PROVIDER
@@ -81,7 +86,8 @@ const (
 )
 
 // This is a config key to secret file mapping. We will attempt to read in from secret files before loading anything else.
-var keyToSecretMapping = map[string]string{}
+
+var keyToSecretMapping = []Secret{}
 var keyToSecretMappingMutex = sync.Mutex{}
 
 // This is a list of OSD-specific namespaces to include in the post-E2E cleanup must-gather
@@ -815,11 +821,14 @@ func PostProcess() {
 // RegisterSecret will register the secret filename that will be used for the corresponding Viper string.
 func RegisterSecret(key string, secretFileName string) {
 	keyToSecretMappingMutex.Lock()
-	keyToSecretMapping[secretFileName] = key
+	keyToSecretMapping = append(keyToSecretMapping, Secret{
+		Key:          key,
+		FileLocation: secretFileName,
+	})
 	keyToSecretMappingMutex.Unlock()
 }
 
 // GetAllSecrets will return Viper config keys and their corresponding secret filenames.
-func GetAllSecrets() map[string]string {
+func GetAllSecrets() []Secret {
 	return keyToSecretMapping
 }

--- a/pkg/common/load/load.go
+++ b/pkg/common/load/load.go
@@ -63,8 +63,8 @@ func Configs(configs []string, customConfig string, secretLocations []string) er
 	// 4. Secrets. These will override all previous entries.
 	if len(secretLocations) > 0 {
 		secrets := config.GetAllSecrets()
-		for secretFilename, key := range secrets {
-			loadSecretFileIntoKey(key, secretFilename, secretLocations)
+		for _, secret := range secrets {
+			loadSecretFileIntoKey(secret.Key, secret.FileLocation, secretLocations)
 		}
 
 		for _, folder := range secretLocations {


### PR DESCRIPTION
We recently added the ability to call RegisterSecret multiple times for a (viper) key.

Using a map is probably the wrong call since we want to load things in the order that they're registered. This should fix some of the odd behavior we've seen with addons loading secrets. 

/assign @mrsantamaria