### PR TITLE
Change PagerDuty Token variable

### DIFF
--- a/cmd/ci-watcher-report/README.md
+++ b/cmd/ci-watcher-report/README.md
@@ -4,12 +4,12 @@ This CLI prints a report of active issues that fall within the scope of the CI W
 
 It will print the pagerduty incidents, their alert counts, their status, the names of pipelines that generated them, a link to the PD incident, and any notes attached to the incident.
 
-To use it, you must supply the `PAGERDUTY_TOKEN` environment variable set to your own PD token.
+To use it, you must supply the `PAGERDUTY_API_TOKEN` environment variable set to your own PD token.
 
 A sample usage:
 
 ```sh
-$ PAGERDUTY_TOKEN=(pass tokens/pagerduty/cwaldon) go run ./cmd/ci-watcher-report/
+$ PAGERDUTY_API_TOKEN=(pass tokens/pagerduty/cwaldon) go run ./cmd/ci-watcher-report/
 [Suite: operators] [OSD] Splunk Forwarder Operator Operator Upgrade should upgrade from the replaced version failed
 23  acknowledged
 osde2e-prod-aws-e2e-next

--- a/cmd/ci-watcher-report/main.go
+++ b/cmd/ci-watcher-report/main.go
@@ -83,7 +83,7 @@ func run() error {
 
 %[1]s
 
-You must set the $PAGERDUTY_TOKEN environment variable to your
+You must set the $PAGERDUTY_API_TOKEN environment variable to your
 personal pagerduty token in order for the report to be generated.
 `, os.Args[0])
 		flag.PrintDefaults()


### PR DESCRIPTION
As per the [documentation](https://github.com/openshift/osde2e/tree/main/cmd/ci-watcher-report), exporting the PagerDuty token as variable `PAGERDUTY_TOKEN` results in below error:
```bash
failed listing incidents: failed listing incidents: failed listing incidents: HTTP response with status code 401 does not contain Content-Type: application/json
exit status 1
```

However, as from [code](https://github.com/openshift/osde2e/blob/main/pkg/common/config/config.go#L784-L786) I came across the variable `PAGERDUTY_API_TOKEN` which works fine. Thus, raised this PR to refer to that var name instead.