### PR TITLE
Use the correct label selector for finding prometheus pods

### DIFF
--- a/pkg/e2e/state/prometheus.go
+++ b/pkg/e2e/state/prometheus.go
@@ -35,7 +35,7 @@ var _ = ginkgo.Describe(clusterStateInformingName, func() {
 		// ensure prometheus pods are up before trying to extract data
 		poderr := wait.PollImmediate(2*time.Second, 5*time.Minute, func() (bool, error) {
 			podCount := 0
-			list, listerr := verify.FilterPods("openshift-monitoring", "app=prometheus", h)
+			list, listerr := verify.FilterPods("openshift-monitoring", "app.kubernetes.io/name=prometheus", h)
 			if listerr != nil {
 				return false, listerr
 			}

--- a/pkg/e2e/verify/sccs.go
+++ b/pkg/e2e/verify/sccs.go
@@ -61,13 +61,13 @@ var _ = ginkgo.Describe(dedicatedAdminSccTestName, func() {
 			Expect(err).NotTo(HaveOccurred())
 			log.Printf("Error:(%v)", err)
 			//Deleting all prometheus pods
-			list, _ := FilterPods("openshift-monitoring", "app=prometheus", h)
+			list, _ := FilterPods("openshift-monitoring", "app.kubernetes.io/name=prometheus", h)
 			names, _ := GetPodNames(list, h)
 			log.Printf("Names of pods:(%v)", names)
 			numPrometheusPods := deletePods(names, "openshift-monitoring", h)
 			//Verifying the same number of running prometheus pods has come up
 			err = wait.PollImmediate(2*time.Second, 3*time.Minute, func() (bool, error) {
-				pollList, _ := FilterPods("openshift-monitoring", "app=prometheus", h)
+				pollList, _ := FilterPods("openshift-monitoring", "app.kubernetes.io/name=prometheus", h)
 				if !AllDifferentPods(list, pollList) {
 					return false, nil
 				}


### PR DESCRIPTION
The `cluster-monitoring-operator` has deprecated the `app=prometheus` label, so it is no longer a reliable way of finding Prometheus pods as of 4.10. [0]

Use `app.kubernetes.io/name=prometheus` instead to find the pods.

[0] https://github.com/openshift/cluster-monitoring-operator/commit/8596875ad058723dcc7719bf37ecdc5d2234c442

