### PR TITLE
SDCICD-706: wait for a latestCSV status before moving forward or fail

### DIFF
--- a/pkg/e2e/operators/operators.go
+++ b/pkg/e2e/operators/operators.go
@@ -255,7 +255,7 @@ func checkUpgrade(h *helper.H, subNamespace string, subName string, packageName 
 				}
 				return false, nil
 			})
-			Expect(pollErr).NotTo(HaveOccurred(), fmt.Sprintf("failed trying to get Subscription %s in %s namespace: %s", subName, subNamespace, err.Error()))
+			Expect(pollErr).NotTo(HaveOccurred(), fmt.Sprintf("failed trying to get Subscription %s in %s namespace: %v", subName, subNamespace, err))
 
 			// Get the N-1 version of the CSV to test an upgrade from
 			previousCSV, err := getReplacesCSV(h, subNamespace, packageName, regServiceName)


### PR DESCRIPTION
This should cause the checkUpgrade function to fail if a latestCSV isn't returned within 5 minutes of looking at an operator's subscription. 