### PR TITLE
Ignore recently-created pods in health check

### DIFF
--- a/pkg/common/cluster/healthchecks/pods.go
+++ b/pkg/common/cluster/healthchecks/pods.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/openshift/osde2e/pkg/common/logging"
 	kubev1 "k8s.io/api/core/v1"
@@ -29,6 +30,7 @@ func (p *PodErrorTracker) NewPodErrorTracker(threshold int) *PodErrorTracker {
 // returns the list of pending pods if any exist.
 func CheckClusterPodHealth(podClient v1.CoreV1Interface, logger *log.Logger) ([]kubev1.Pod, error) {
 	filters := []PodPredicate{
+		IsOlderThan(1 * time.Minute),
 		IsClusterPod,
 		IsNotReadinessPod,
 		IsNotRunning,
@@ -45,6 +47,7 @@ func CheckClusterPodHealth(podClient v1.CoreV1Interface, logger *log.Logger) ([]
 // CheckPodHealth attempts to look at the state of all pods and returns true if things are healthy.
 func CheckPodHealth(podClient v1.CoreV1Interface, logger *log.Logger, ns string, podPrefixes ...string) (bool, error) {
 	filters := []PodPredicate{
+		IsOlderThan(1 * time.Minute),
 		MatchesNamespace(ns),
 		MatchesNames(podPrefixes...),
 		IsNotReadinessPod,


### PR DESCRIPTION
This PR excludes new (< 1 minute old) pods from the health check when looking for not-running pods.

Sometimes frequently-running jobs (ie. `osd-delete-backplane-serviceaccounts`) will regularly cause the health-check to restart due to unfortunate timing of the job spawning right as the health check runs. 

The PR adds a new pod predicate which will only consider pods with a creation timestamp older than a particular time duration, currently hard-coded at NOW()-1 minute. This should cut down on the number of times the health-check has to restart for reasons that will very likely self-resolve.


