### PR TITLE
Clean up stale grpcurl-query pods if they exist

### DIFF
--- a/assets/registry/replaces.template
+++ b/assets/registry/replaces.template
@@ -1,5 +1,7 @@
 REGISTRY_QUERY_FILE="{{.OutputDir}}/registry.json"
 
+oc delete pod --ignore-not-found=true -n {{.Namespace}} grpcurl-query
+
 oc run grpcurl-query -n {{.Namespace}} --quiet --rm=true --restart=Never --attach=true \
     --image=quay.io/rogbas/grpcurl -- -plaintext -d \
     '{"pkgName":"{{.PackageName}}","channelName":"{{.PackageChannel}}"}' \


### PR DESCRIPTION
This PR attempts to clean up a stale `grpcurl-query` pod before creating a new one, to reduce the number of failed `should update from previous version` operator tests that occur.

I have observed that our PR check cluster(s) get impacted by stale or leftover `grpcurl-query` pods that are spawned as part of the test to verify operator version upgrades ([example](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_osde2e/944/pull-ci-openshift-osde2e-main-verify/1469980786529669120)). Even though the `oc run` command for the pod has `--rm=true` on it, somehow they're not being cleaned up. Once they're not cleaned up, the `should update..` test will fail forever until someone manually cleans up the leftover pods.

So this PR will delete any leftover pod before running a new one.