### PR TITLE
Update Splunk Forwarder Operator Owners

### DIFF
--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -21,8 +21,8 @@ var splunkForwarderBlocking string = "[Suite: operators] [OSD] Splunk Forwarder 
 var splunkForwarderInforming string = "[Suite: informing] [OSD] Splunk Forwarder Operator"
 
 func init() {
-	alert.RegisterGinkgoAlert(splunkForwarderBlocking, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
-	alert.RegisterGinkgoAlert(splunkForwarderInforming, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
+	alert.RegisterGinkgoAlert(splunkForwarderBlocking, "SD-SREP", "@srep-security-team", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
+	alert.RegisterGinkgoAlert(splunkForwarderInforming, "SD-SREP", "@srep-security-team", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
 // Blocking SplunkForwarder Signal


### PR DESCRIPTION
This updates the Splunk Forwarder Operator owners to the security team.

https://issues.redhat.com/browse/OSD-9340