### PR TITLE
Handle workload tests more reliably

### DIFF
--- a/pkg/e2e/workloads/redmine/redmine.go
+++ b/pkg/e2e/workloads/redmine/redmine.go
@@ -12,14 +12,21 @@ import (
 
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/cluster/healthchecks"
-	"github.com/openshift/osde2e/pkg/common/config"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	// Service name for the Redmine front-end
+	redmineSvcName = "redmine-frontend"
+	// Service port for the Redmine front-end
+	redmineSvcPort = "3000"
 )
 
 // Specify where the YAML definitions are for the workloads.
@@ -115,6 +122,7 @@ func createWorkload(h *helper.H) error {
 
 func doTest(h *helper.H) {
 
+
 	// track if error occurs
 	var err error
 
@@ -122,30 +130,15 @@ func doTest(h *helper.H) {
 	interval := 5
 
 	// convert time.Duration type
-	timeoutDuration := time.Duration(viper.GetFloat64(config.Tests.PollingTimeout)) * time.Minute
+	timeoutDuration := time.Duration(viper.GetFloat64(config.Tests.PollingTimeout)) * time.Second
 	intervalDuration := time.Duration(interval) * time.Second
 
-	start := time.Now()
-
-Loop:
-	for {
-		_, err = h.Kube().CoreV1().Services(h.CurrentProject()).ProxyGet("http", "redmine-frontend", "3000", "/", nil).DoRaw(context.TODO())
-		elapsed := time.Since(start)
-
-		switch {
-		case err == nil:
-			// Success
-			break Loop
-		default:
-			if elapsed < timeoutDuration {
-				log.Printf("Waiting %v for application to load", (timeoutDuration - elapsed))
-				time.Sleep(intervalDuration)
-			} else {
-				err = fmt.Errorf("failed to check service before timeout")
-				break Loop
-			}
+	err = wait.PollImmediate(intervalDuration, timeoutDuration, func() (bool, error) {
+		_, err = h.Kube().CoreV1().Services(h.CurrentProject()).ProxyGet("http", redmineSvcName, redmineSvcPort, "/", nil).DoRaw(context.TODO())
+		if err == nil {
+			return true, nil
 		}
-	}
-
+		return false, nil
+	})
 	Expect(err).NotTo(HaveOccurred(), "unable to access front end of app")
 }


### PR DESCRIPTION
This PR improves the reliability of the `guestbook` workload test and does a general tidy-up of both the `redmine` and `guestbook` workload tests.

I've been observing that the `guestbook` workload test has been failing regularly in E2E lately, after taking a closer look it seems that it makes one attempt to contact the service and if it doesn't respond then the test fails. The test should take into account that the service might take a little while to become ready, though.

So this introduces a minute-long loop of polling the service.

The `redmine` test already had this logic in place, but I noticed it was implemented in a way that could be greatly simplified by just throwing it in a `wait.PollImmediate` block - so I refactored both.

Change has been successfully tested on a staging cluster.