### PR TITLE
Apply appropriate timeouts for the encrypted_storage and fips tests

### DIFF
--- a/pkg/e2e/verify/fips.go
+++ b/pkg/e2e/verify/fips.go
@@ -134,6 +134,6 @@ var _ = ginkgo.Describe(fipsTestName, func() {
 				return false, err
 			})
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error waiting for pods to become ready: %v", err))
-		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
+		}, float64(fipsTestPollDuration*2))
 	})
 })


### PR DESCRIPTION
Updates timeouts for the `FIPS` and `Encrypted Storage` tests in the `e2e` suite. 

Renames the polling constants in the `Encrypted Storage` test to be less generic and reduces the timeout to 10 minutes.