### PR TITLE
ginkgov2 update test timeouts

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -91,7 +91,7 @@ Some environment variables commonly used for pipelines under osde2e are indicate
 
 | Environment variable | Usage |
 | --------------| ------------------------|  
-|POLLING_TIMEOUT| PollingTimeout is how long (in mimutes) to wait for an object to be created before failing the test.|
+|POLLING_TIMEOUT| PollingTimeout is how long (in seconds) to wait for an object to be created before failing the test.|
 |GINKGO_SKIP| GinkgoSkip is a regex passed to Ginkgo that skips any test suites matching the regex. ex. "Operator"|
 |GINKGO_FOCUS| GinkgoFocus is a regex passed to Ginkgo that focus on any test suites matching the regex. ex. "Operator"|
 |TESTS_TO_RUN| TestsToRun is a list of files which should be executed as part of a test suite|

--- a/pkg/e2e/operators/certman.go
+++ b/pkg/e2e/operators/certman.go
@@ -8,8 +8,6 @@ import (
 	. "github.com/onsi/gomega"
 	osv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/osde2e/pkg/common/alert"
-	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/util"
 	v1 "k8s.io/api/core/v1"
@@ -32,8 +30,10 @@ var _ = ginkgo.Describe(certmanOperatorTestName, func() {
 		var err error
 		var apiserver *osv1.APIServer
 
+		// Waiting period to wait for certman resources to appear
+		pollingDuration := 15 * time.Minute
 		util.GinkgoIt("certificate secret exist under openshift-config namespace", func() {
-			wait.PollImmediate(30*time.Second, 15*time.Minute, func() (bool, error) {
+			wait.PollImmediate(30*time.Second, pollingDuration, func() (bool, error) {
 				listOpts := metav1.ListOptions{
 					LabelSelector: "certificate_request",
 				}
@@ -49,10 +49,10 @@ var _ = ginkgo.Describe(certmanOperatorTestName, func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(secrets.Items)).Should(Equal(1))
-		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
+		}, pollingDuration.Seconds())
 
 		util.GinkgoIt("certificate secret should be applied to apiserver object", func() {
-			wait.PollImmediate(30*time.Second, 15*time.Minute, func() (bool, error) {
+			wait.PollImmediate(30*time.Second, pollingDuration, func() (bool, error) {
 				getOpts := metav1.GetOptions{}
 				apiserver, err = h.Cfg().ConfigV1().APIServers().Get(context.TODO(), "cluster", getOpts)
 				if err != nil {
@@ -66,6 +66,6 @@ var _ = ginkgo.Describe(certmanOperatorTestName, func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(apiserver.Spec.ServingCerts.NamedCertificates)).Should(BeNumerically(">", 0))
 			Expect(apiserver.Spec.ServingCerts.NamedCertificates[0].ServingCertificate.Name).Should(Equal(secretName))
-		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
+		}, pollingDuration.Seconds())
 	})
 })

--- a/pkg/e2e/operators/cloudingress/certificate.go
+++ b/pkg/e2e/operators/cloudingress/certificate.go
@@ -17,24 +17,30 @@ import (
 var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 	h := helper.New()
 	var originalCert string
+
+	// How long to wait for IngressController changes
+	pollingDuration := 120 * time.Second
 	ginkgo.Context("publishingstrategy-certificate", func() {
 		ginkgo.It("IngressController should be patched when update Certificate", func() {
 			ingress1, _ := getingressController(h, "default")
 			originalCert = string(ingress1.Spec.DefaultCertificate.Name)
 			updateCertificate(h, "foo-bar")
-			time.Sleep(time.Duration(120) * time.Second)
+			time.Sleep(pollingDuration)
 			ingress, _ := getingressController(h, "default")
 
 			Expect(string(ingress.Spec.DefaultCertificate.Name)).To(Equal("foo-bar"))
+			Expect(ingress.Generation == int64(1)).To(Equal(false))
 			Expect(ingress.Annotations["Owner"]).To(Equal("cloud-ingress-operator"))
-		})
+		}, pollingDuration.Seconds())
+
 		ginkgo.It("IngressController should be patched when return the original Certificate", func() {
 			updateCertificate(h, originalCert)
-			time.Sleep(time.Duration(120) * time.Second)
+			time.Sleep(pollingDuration)
 			ingress, _ := getingressController(h, "default")
 			Expect(string(ingress.Spec.DefaultCertificate.Name)).To(Equal(originalCert))
+			Expect(ingress.Generation == int64(1)).To(Equal(false))
 			Expect(ingress.Annotations["Owner"]).To(Equal("cloud-ingress-operator"))
-		})
+		}, pollingDuration.Seconds())
 	})
 })
 

--- a/pkg/e2e/operators/cloudingress/deletetapps2.go
+++ b/pkg/e2e/operators/cloudingress/deletetapps2.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	operatorv1 "github.com/openshift/api/operator/v1"
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/e2e/operators"
+
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,25 +44,21 @@ var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 			deployment, err := operators.PollDeployment(h, "openshift-ingress", deploymentName)
 			Expect(err).ToNot(HaveOccurred(), "failed fetching deployment")
 			Expect(deployment).NotTo(BeNil(), "deployment is nil")
-			time.Sleep(time.Duration(120) * time.Second)
 
 			//2.delete the annotation
 			apps2Ingress, _ := getingressController(h, ingressControllerName)
 			log.Printf("The ingresscontroller object annotation : %+v\n", apps2Ingress.ObjectMeta.Annotations)
 			newAnnotations := updateAnnotation(h, ingressControllerName, "Owner", "cloud-ingress-operator")
 			apps2Ingress = newAnnotations
-			time.Sleep(time.Duration(120) * time.Second)
-
 			//3. Delete secondaryIngress in publishingstrategy
 			removeIngressController(h, ingressControllerName)
-			time.Sleep(time.Duration(120) * time.Second)
 			Expect(err).NotTo(HaveOccurred())
 			// check that the ingresscontroller app-e2e-apps was deleted
 			ingressControllerExists(h, ingressControllerName, true)
 			apps2Ingress = updateAnnotation(h, ingressControllerName, "Owner", "cloud-ingress-operator")
 			removeIngressController(h, ingressControllerName)
 			ingressControllerExists(h, ingressControllerName, false)
-		})
+		}, (10 * time.Minute).Seconds())
 	})
 })
 

--- a/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
@@ -44,9 +44,11 @@ var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 //testHostnameResolves Confirms hostname on the cluster resolves
 func testHostnameResolves(h *helper.H) {
 	var err error
+
+	hostnameResolvePollDuration := 15 * time.Minute
 	ginkgo.Context("rh-api-test", func() {
 		util.GinkgoIt("hostname should resolve", func() {
-			wait.PollImmediate(30*time.Second, 15*time.Minute, func() (bool, error) {
+			wait.PollImmediate(30*time.Second, hostnameResolvePollDuration, func() (bool, error) {
 
 				getOpts := metav1.GetOptions{}
 				apiserver, err := h.Cfg().ConfigV1().APIServers().Get(context.TODO(), "cluster", getOpts)
@@ -71,7 +73,7 @@ func testHostnameResolves(h *helper.H) {
 				return true, nil
 			})
 			Expect(err).NotTo(HaveOccurred())
-		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
+		}, (hostnameResolvePollDuration + 1 * time.Minute).Seconds())
 	})
 }
 
@@ -129,7 +131,7 @@ func testCIDRBlockUpdates(h *helper.H) {
 			res := reflect.DeepEqual(CIDRBlock, rhAPIService.Spec.LoadBalancerSourceRanges)
 			Expect(res).Should(BeTrue())
 
-		}, float64(60*time.Second))
+		}, viper.GetFloat64(config.Tests.PollingTimeout))
 	})
 }
 

--- a/pkg/e2e/operators/cloudingress/secondary_router.go
+++ b/pkg/e2e/operators/cloudingress/secondary_router.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -31,6 +32,10 @@ var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 
 	h := helper.New()
 	ginkgo.Context("secondary router", func() {
+
+		// How long to wait for resources to be created
+		pollingDuration := 2 * time.Minute
+
 		util.GinkgoIt("should be created when added to publishingstrategy ", func() {
 
 			secondaryIngress := secondaryIngress(h)
@@ -39,7 +44,7 @@ var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 			if _, exists, _ := appIngressExits(h, false, secondaryIngress.DNSName); !exists {
 				addAppIngress(h, secondaryIngress)
 				// wait 2 minute for all resources to be created
-				time.Sleep(time.Duration(120) * time.Second)
+				time.Sleep(pollingDuration)
 			}
 
 			// from DNSName app-e2e-apps.cluster.mfvz.s1.devshift.org,
@@ -59,7 +64,7 @@ var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 			Expect(err).ToNot(HaveOccurred(), "failed fetching deployment")
 			Expect(deployment).NotTo(BeNil(), "deployment is nil")
 			Expect(deployment.Status.ReadyReplicas).To(BeNumerically("==", deployment.Status.Replicas))
-		})
+		}, pollingDuration.Seconds() + viper.GetFloat64(config.Tests.PollingTimeout))
 
 		util.GinkgoIt("should be deleted when removed from publishingstrategy", func() {
 			secondaryIngress := secondaryIngress(h)
@@ -69,13 +74,13 @@ var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 			if exists {
 				removeAppIngress(h, index)
 				// wait 2 minute for all resources to be deleted
-				time.Sleep(time.Duration(120) * time.Second)
+				time.Sleep(pollingDuration)
 			}
 			Expect(len(strings.Split(secondaryIngress.DNSName, "."))).To(BeNumerically(">", 1))
 			ingressControllerName := strings.Split(secondaryIngress.DNSName, ".")[1]
 			// check that the ingresscontroller app-e2e-apps was deleted
 			ingressControllerExists(h, ingressControllerName, false)
-		})
+		}, pollingDuration.Seconds() + viper.GetFloat64(config.Tests.PollingTimeout))
 	})
 })
 

--- a/pkg/e2e/osd/rebalance_infra_nodes.go
+++ b/pkg/e2e/osd/rebalance_infra_nodes.go
@@ -10,6 +10,8 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/util"
 	batchv1 "k8s.io/api/batch/v1"
@@ -158,7 +160,7 @@ var _ = ginkgo.Describe(rebalanceInfraNodesTestName, func() {
 				podsNumber = checkPodsBalance(h, splunkNamespace, "name", "splunk-heavy-forwarder", node.Name)
 				Expect(podsNumber).To(BeNumerically("<=", 1))
 			}
-		})
+		}, podSucceededTimeout.Seconds()+viper.GetFloat64(config.Tests.PollingTimeout))
 	})
 })
 

--- a/pkg/e2e/verify/sccs.go
+++ b/pkg/e2e/verify/sccs.go
@@ -28,6 +28,8 @@ var _ = ginkgo.Describe(dedicatedAdminSccTestName, func() {
 	h := helper.New()
 
 	workloadDir := "/assets/workloads/e2e/scc"
+	// How long to wait for prometheus pods to restart
+	prometheusRestartPollingDuration := 3 * time.Minute
 
 	ginkgo.Context("Dedicated Admin permissions", func() {
 
@@ -67,7 +69,7 @@ var _ = ginkgo.Describe(dedicatedAdminSccTestName, func() {
 			log.Printf("Names of pods:(%v)", names)
 			numPrometheusPods := deletePods(names, "openshift-monitoring", h)
 			//Verifying the same number of running prometheus pods has come up
-			err = wait.PollImmediate(2*time.Second, 3*time.Minute, func() (bool, error) {
+			err = wait.PollImmediate(2*time.Second, prometheusRestartPollingDuration, func() (bool, error) {
 				pollList, _ := FilterPods("openshift-monitoring", "app.kubernetes.io/name=prometheus", h)
 				if !AllDifferentPods(list, pollList) {
 					return false, nil
@@ -79,7 +81,7 @@ var _ = ginkgo.Describe(dedicatedAdminSccTestName, func() {
 				return false, nil
 			})
 			Expect(err).NotTo(HaveOccurred())
-		}, float64(60*time.Second))
+		}, (prometheusRestartPollingDuration + 30 * time.Second).Seconds())
 	})
 })
 

--- a/pkg/e2e/verify/storage.go
+++ b/pkg/e2e/verify/storage.go
@@ -11,6 +11,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift/osde2e/pkg/common/alert"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/util"
 	corev1 "k8s.io/api/core/v1"
@@ -75,7 +77,7 @@ var _ = ginkgo.Describe(storageTestName, func() {
 
 			}
 
-		}, float64(60*time.Second))
+		}, podStartTimeout.Seconds() + viper.GetFloat64(config.Tests.PollingTimeout))
 
 	})
 

--- a/pkg/e2e/workloads/guestbook/guestbook.go
+++ b/pkg/e2e/workloads/guestbook/guestbook.go
@@ -48,6 +48,7 @@ var _ = ginkgo.Describe(testName, func() {
 	// used for verifying creation of workload pods
 	podPrefixes := []string{"frontend", "redis-master", "redis-slave"}
 
+  workloadPollDuration := 5 * time.Minute
 	util.GinkgoIt("should get created in the cluster", func() {
 
 		// Does this workload exist? If so, this must be a repeat run.
@@ -86,7 +87,7 @@ var _ = ginkgo.Describe(testName, func() {
 			time.Sleep(3 * time.Second)
 
 			// Wait for all pods to come up healthy
-			err = wait.PollImmediate(15*time.Second, 5*time.Minute, func() (bool, error) {
+			err = wait.PollImmediate(15*time.Second, workloadPollDuration, func() (bool, error) {
 				// This is pretty basic. Are all the pods up? Cool.
 				if check, err := healthchecks.CheckPodHealth(h.Kube().CoreV1(), nil, h.CurrentProject(), podPrefixes...); !check || err != nil {
 					return false, nil
@@ -101,7 +102,7 @@ var _ = ginkgo.Describe(testName, func() {
 			h.AddWorkload(workloadName, h.CurrentProject())
 		}
 
-	})
+	}, (workloadPollDuration + (30 * time.Second)).Seconds())
 })
 
 func doTest(h *helper.H) {


### PR DESCRIPTION
This PR follows up on #936 by

- adding sensible default timeouts to tests that didn't have any
- updating the timeouts in existing tests where the timeouts were too small for what the test is actually doing
