### PR TITLE
update the mhc and inhibition tests for ginkgo v2

### DIFF
--- a/pkg/e2e/osd/inhibitions.go
+++ b/pkg/e2e/osd/inhibitions.go
@@ -102,7 +102,7 @@ var _ = ginkgo.Describe(inhibitionsTestName, func() {
 
 			Expect(rulePresent).To(Equal(test.expectedPresent), test.name)
 		}
-	})
+	}, float64(30))
 
 	util.GinkgoIt("inhibits ClusterOperatorDegraded", func() {
 		// define an IdP that will cause the authentication operator to degrade
@@ -185,7 +185,7 @@ var _ = ginkgo.Describe(inhibitionsTestName, func() {
 		}
 		Expect(operatorDownAlertPresent).To(BeTrue())
 		Expect(operatorDegradedAlertPresent).To(BeFalse())
-	}, float64(60*time.Second))
+	}, float64(720))
 })
 
 func cleanup(h *helper.H) {

--- a/pkg/e2e/osd/machinehealthcheck.go
+++ b/pkg/e2e/osd/machinehealthcheck.go
@@ -53,7 +53,7 @@ var _ = ginkgo.Describe(machineHealthTestName, func() {
 				},
 			),
 		))
-	})
+	}, float64(500))
 
 	util.GinkgoIt("worker MHC should exist", func() {
 		mhc, err := h.Machine().MachineV1beta1().MachineHealthChecks(machineAPINamespace).Get(context.TODO(), "srep-worker-healthcheck", metav1.GetOptions{})
@@ -79,7 +79,7 @@ var _ = ginkgo.Describe(machineHealthTestName, func() {
 				},
 			),
 		))
-	})
+	}, float64(500))
 
 	util.GinkgoIt("should replace unhealthy nodes", func() {
 		r := h.Runner("chroot /host -- systemctl stop kubelet")


### PR DESCRIPTION
using
https://onsi.github.io/ginkgo/MIGRATING_TO_V2#removed-async-testing as a
guide