### PR TITLE
Increasing pods.go timeout to 30 minutes

### DIFF
--- a/pkg/e2e/verify/pods.go
+++ b/pkg/e2e/verify/pods.go
@@ -68,7 +68,7 @@ var _ = ginkgo.Describe(podsTestName, func() {
 		msg := "only %f%% of Pods ready, need %f%%. Not ready: %s"
 		Expect(err).NotTo(HaveOccurred(), msg, curRatio, requiredRatio, listPodPhases(notReady))
 		Expect(curRatio).Should(Equal(requiredRatio), msg, curRatio, requiredRatio, listPodPhases(notReady))
-	}, float64(800))
+	}, float64(1800))
 
 	util.GinkgoIt("should not be Failed", func() {
 		list, err := h.Kube().CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})


### PR DESCRIPTION
Pods go is attempting to check that all pods for the cluster are up. Increasing this timeout to 30 minutes in order for the Cluster to fully spin up and update if needed. 