### PR TITLE
[OSD-8942] add ocm agent e2e test

### DIFF
--- a/pkg/e2e/operators/ocmagent.go
+++ b/pkg/e2e/operators/ocmagent.go
@@ -1,0 +1,37 @@
+package operators
+
+import (
+	"github.com/onsi/ginkgo/v2"
+	"github.com/openshift/osde2e/pkg/common/alert"
+	"github.com/openshift/osde2e/pkg/common/helper"
+)
+
+var (
+	ocmAgentTestPrefix = "[Suite: operators] [OSD] OCM Agent Operator"
+	ocmAgentBasicTest  = ocmAgentTestPrefix + " Basic Test"
+)
+
+func init() {
+	alert.RegisterGinkgoAlert(ocmAgentBasicTest, "SD_SREP", "@sre-platform-team-v1alpha1", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
+}
+
+var _ = ginkgo.Describe(ocmAgentBasicTest, func() {
+	var (
+		operatorNamespace = "openshift-ocm-agent-operator"
+		operatorName      = "ocm-agent-operator"
+		clusterRoles      = []string{
+			"ocm-agent-operator",
+		}
+		clusterRoleBindings = []string{
+			"ocm-agent-operator",
+		}
+		// servicePort = 8081
+	)
+	h := helper.New()
+	checkClusterServiceVersion(h, operatorNamespace, operatorName)
+	checkDeployment(h, operatorNamespace, operatorName, 1)
+	checkClusterRoles(h, clusterRoles, true)
+	checkClusterRoleBindings(h, clusterRoleBindings, true)
+	// checkService(h, operatorNamespace, operatorName, servicePort)
+	// checkUpgrade(helper.New(), operatorNamespace, operatorName, operatorName, "ocm-agent-operator-registry")
+})

--- a/pkg/e2e/operators/ocmagent.go
+++ b/pkg/e2e/operators/ocmagent.go
@@ -12,7 +12,7 @@ var (
 )
 
 func init() {
-	alert.RegisterGinkgoAlert(ocmAgentBasicTest, "SD_SREP", "@sre-platform-team-v1alpha1", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
+	alert.RegisterGinkgoAlert(ocmAgentBasicTest, "SD_SREP", "@ocm-agent-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
 var _ = ginkgo.Describe(ocmAgentBasicTest, func() {

--- a/pkg/e2e/operators/ocmagent.go
+++ b/pkg/e2e/operators/ocmagent.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	ocmAgentTestPrefix = "[Suite: operators] [OSD] OCM Agent Operator"
+	ocmAgentTestPrefix = "[Suite: informing] [OSD] OCM Agent Operator"
 	ocmAgentBasicTest  = ocmAgentTestPrefix + " Basic Test"
 )
 

--- a/pkg/e2e/operators/operators.go
+++ b/pkg/e2e/operators/operators.go
@@ -239,8 +239,8 @@ func checkUpgrade(h *helper.H, subNamespace string, subName string, packageName 
 
 	ginkgo.Context("Operator Upgrade", func() {
 
-    installPlanPollingDuration := 5 * time.Minute
-    upgradePollingDuration := 15 * time.Minute
+		installPlanPollingDuration := 5 * time.Minute
+		upgradePollingDuration := 15 * time.Minute
 
 		util.GinkgoIt("should upgrade from the replaced version", func() {
 
@@ -318,6 +318,25 @@ func checkUpgrade(h *helper.H, subNamespace string, subName string, packageName 
 
 		}, upgradePollingDuration.Seconds()+installPlanPollingDuration.Seconds()+
 			float64(viper.GetFloat64(config.Tests.PollingTimeout)))
+	})
+}
+
+func checkService(h *helper.H, namespace string, name string, port int) {
+	pollTimeout := viper.GetFloat64(config.Tests.PollingTimeout)
+	ginkgo.Context("service", func() {
+		util.GinkgoIt(
+			"should exist",
+			func() {
+				Eventually(func() bool {
+					_, err := h.Kube().CoreV1().Services(namespace).Get(context.Background(), name, metav1.GetOptions{})
+					if err != nil {
+						return false
+					}
+					return true
+				}, "30m", "1m").Should(BeTrue())
+			},
+			pollTimeout,
+		)
 	})
 }
 

--- a/pkg/e2e/operators/osdmetricsexporter.go
+++ b/pkg/e2e/operators/osdmetricsexporter.go
@@ -1,16 +1,9 @@
 package operators
 
 import (
-	"context"
-
 	"github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
-	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
-	"github.com/openshift/osde2e/pkg/common/util"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -42,22 +35,3 @@ var _ = ginkgo.Describe(osdMetricsExporterBasicTest, func() {
 	checkService(h, operatorNamespace, operatorName, servicePort)
 	checkUpgrade(helper.New(), operatorNamespace, operatorName, operatorName, "osd-metrics-exporter-registry")
 })
-
-func checkService(h *helper.H, namespace string, name string, port int) {
-	pollTimeout := viper.GetFloat64(config.Tests.PollingTimeout)
-	ginkgo.Context("service", func() {
-		util.GinkgoIt(
-			"should exist",
-			func() {
-				Eventually(func() bool {
-					_, err := h.Kube().CoreV1().Services(namespace).Get(context.Background(), name, metav1.GetOptions{})
-					if err != nil {
-						return false
-					}
-					return true
-				}, "30m", "1m").Should(BeTrue())
-			},
-			pollTimeout,
-		)
-	})
-}


### PR DESCRIPTION
This PR adds initial tests for ocm agent operator as per [OSD-8942](https://issues.redhat.com/browse/OSD-8942). 

Currently `checkService` and `checkUpgrade` tests are disabled and pending investigation    
For reference here's a list of available checks in osde2e (some may not apply to this operator)
```
func checkClusterServiceVersion
func checkConfigMapLockfile
func checkDeployment
func checkPod
func checkServiceAccounts
func checkClusterRoles
func checkClusterRoleBindings
func checkRole
func checkRolesWithNamePrefix
func checkRoleBindingsWithNamePrefix
func checkRoleBindings
func checkSecrets
func checkUpgrade
func checkService
func CheckUpgrade
func CheckPod
```

As part of this PR I've also [updated](https://github.com/openshift/ops-sop/pull/1730/files) testing sop which can be referenced for testing https://github.com/openshift/ops-sop/blob/master/v4/knowledge_base/run-osde2e-tests.md

To test:
```
export POLLING_TIMEOUT=30             # wait for an object to be created before failing the test.
export MUST_GATHER=false              # don't run a Must-Gather process upon completion of the tests.
export HIBERNATE_AFTER_USE=false      # don't hibernate the cluster

./out/osde2e test --cluster-id ${MY_CLUSTERID} -e stage --configs stage --kube-config=${MY_KUBECONFIG} --focus-tests='.*Agent'
```` 

Any feedback is welcome