### PR TITLE
Sdcicd 752 fixdes

### DIFF
--- a/ci/create-aro-cluster-ovn.sh
+++ b/ci/create-aro-cluster-ovn.sh
@@ -87,7 +87,7 @@ az network vnet subnet update \
     --disable-private-link-service-network-policies true
 
 
-CREATE_CMD="az aro create --resource-group \"$RESOURCEGROUP_NAME\" --name \"$CLUSTER_NAME\" --vnet aro-vnet --master-subnet master-subnet --worker-subnet worker-subnet --disk-encryption-set \"$DES_ID\" --master-encryption-at-host --worker-encryption-at-host "
+CREATE_CMD="az aro create --resource-group \"$RESOURCEGROUP_NAME\" --name \"$CLUSTER_NAME\" --vnet aro-vnet --master-subnet master-subnet --worker-subnet worker-subnet --disk-encryption-set \"$DES_ID\" --master-encryption-at-host --worker-encryption-at-host --sdn-type OVNKubernetes "
 
 if [ "$PULL_SECRET_FILE" != "" ];
 then


### PR DESCRIPTION
[SDCICD-752](https://issues.redhat.com/browse/SDCICD-752)
Fixes Disk Encryption Set issues in e2e tests.
Adds a new shell script creating the ARO cluster with the OVN-Kubernetes SDN.

Requires a new secret "des-id"
