### PR TITLE
Add a way to specify the ADDON_PARAMETERS in secret as addon-parameters 

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -767,6 +767,7 @@ func InitViper() {
 
 	viper.SetDefault(Addons.Parameters, "{}")
 	viper.BindEnv(Addons.Parameters, "ADDON_PARAMETERS")
+	RegisterSecret(Addons.Parameters, "addon-parameters")
 
 	viper.SetDefault(Addons.SkipAddonList, false)
 	viper.BindEnv(Addons.SkipAddonList, "SKIP_ADDON_LIST")


### PR DESCRIPTION
Provides a way to specify addon-parameters in vault - in case the parameters contain secret, so it can't be specified in GH repo.
