### PR TITLE
[OHSS-10367] Handle edge case for standalone pod resources

### DIFF
--- a/pkg/common/cluster/healthchecks/pods.go
+++ b/pkg/common/cluster/healthchecks/pods.go
@@ -88,6 +88,10 @@ func checkPods(podClient v1.CoreV1Interface, logger *log.Logger, filters ...PodP
 	cronJobName := ""
 	for _, pod := range pods.Items {
 		if pod.ObjectMeta.Labels["job-name"] == "" {
+			// Completed pod not associated with a job, e.g. a standalone pod
+			if pod.Status.Phase == kubev1.PodSucceeded {
+				continue
+			}
 			if pod.Status.Phase != kubev1.PodPending {
 				return nil, fmt.Errorf("pod %s in unexpected phase %s: reason: %s message: %s", pod.GetName(), pod.Status.Phase, pod.Status.Reason, pod.Status.Message)
 			}

--- a/pkg/common/cluster/healthchecks/pods_test.go
+++ b/pkg/common/cluster/healthchecks/pods_test.go
@@ -42,6 +42,7 @@ func TestCheckPodHealth(t *testing.T) {
 		{"no pods", 0, true, nil},
 		{"single pod failed", 0, true, []runtime.Object{pod("a", ns1, map[string]string{"job-name": "image-pruner-123"}, v1.PodFailed)}},
 		{"single pod without job-name label failed", 0, true, []runtime.Object{pod("a", ns1, map[string]string{}, v1.PodFailed)}},
+		{"single pod without job-name label succeeded", 0, false, []runtime.Object{pod("a", ns1, map[string]string{}, v1.PodSucceeded)}},
 		{"pod is pending beyond specified threshold", 1, false, []runtime.Object{pod("a", ns1, map[string]string{"job-name": "image-pruner-123"}, v1.PodPending)}},
 		{"single pod running", 0, false, []runtime.Object{pod("a", ns1, map[string]string{"job-name": "image-pruner-123"}, v1.PodRunning)}},
 		{"single pod succeeded", 0, false, []runtime.Object{pod("a", ns1, map[string]string{"job-name": "image-pruner-123"}, v1.PodSucceeded)}},


### PR DESCRIPTION
The compliance operator currently creates [standalone pod resources not associated with a job/cronjob](https://github.com/openshift/compliance-operator/blob/78f9bc867a8a3d67566fa59ab70d11accb98d6b6/pkg/controller/compliancescan/aggregator.go#L24), which end up in a `Succeeded` state, however by way of `osd-cluster-ready`, the following error appears since it calls this checkPods function:

```
2022/03/16 12:40:36 Error(s) running health checks: 1 error occurred:
        * pod aggregator-pod-ocp4-moderate in unexpected phase Succeeded: reason:  message:
```

Currently we only allow "Succeeded" pods if it's associated with a job/cronjob, but a standalone pod is another way it could end up in a succeeded state.