### PR TITLE
[OHSS-10367] CheckClusterPodHealth was incorrectly passing non-pending pods along

### DIFF
--- a/pkg/common/cluster/healthchecks/pod_predicates.go
+++ b/pkg/common/cluster/healthchecks/pod_predicates.go
@@ -1,8 +1,9 @@
 package healthchecks
 
 import (
-	kubev1 "k8s.io/api/core/v1"
 	"time"
+
+	kubev1 "k8s.io/api/core/v1"
 )
 
 type PodPredicate func(kubev1.Pod) bool

--- a/pkg/common/cluster/healthchecks/pods_test.go
+++ b/pkg/common/cluster/healthchecks/pods_test.go
@@ -1,7 +1,10 @@
 package healthchecks
 
 import (
+	"strconv"
+	"strings"
 	"testing"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -9,9 +12,18 @@ import (
 	kubernetes "k8s.io/client-go/kubernetes/fake"
 )
 
+const (
+	ns1 = "openshift-1"
+	ns2 = "openshift-2"
+)
+
 func pod(name, namespace string, label map[string]string, phase v1.PodPhase) *v1.Pod {
-	return &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: label},
+	mockPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    label,
+		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
@@ -25,34 +37,77 @@ func pod(name, namespace string, label map[string]string, phase v1.PodPhase) *v1
 			Reason:  "pod reason",
 		},
 	}
+
+	// If we set a job-name label, set the timestamp based on the job number to
+	// simulate a cronJob and also populate OwnerReferences
+	if val, ok := label["job-name"]; ok {
+		jobNumber, err := strconv.Atoi(label["job-name"][strings.LastIndex(label["job-name"], "-")+1:])
+		if err != nil {
+			jobNumber = 0
+		}
+		mockPod.ObjectMeta.CreationTimestamp.Time = time.Unix(0, 0).Add(time.Duration(jobNumber) * time.Second)
+
+		mockPod.OwnerReferences = append(mockPod.OwnerReferences, metav1.OwnerReference{
+			APIVersion: "batch/v1",
+			Kind:       "Job",
+			Name:       val,
+		})
+	}
+
+	return mockPod
 }
+
 func TestCheckPodHealth(t *testing.T) {
-	const (
-		ns1 = "openshift-1"
-		ns2 = "openshift-2"
-	)
 	var tests = []struct {
 		description    string
 		expectedLength int
 		expectedError  bool
 		objs           []runtime.Object
 	}{
-		{"two pods bad, one pod good with same label in the same namespace", 0, false, []runtime.Object{pod("a", ns1, map[string]string{"job-name": "image-pruner-123"}, v1.PodFailed), pod("b", ns1, map[string]string{"job-name": "image-pruner-124"}, v1.PodFailed), pod("c", ns1, map[string]string{"job-name": "image-pruner-125"}, v1.PodSucceeded)}},
-		{"one pod bad, one pod good with same label in the same namespace. One pod bad with different label and namespace", 0, true, []runtime.Object{pod("a", ns1, map[string]string{"job-name": "image-pruner-123"}, v1.PodFailed), pod("b", ns1, map[string]string{"job-name": "image-pruner-124"}, v1.PodSucceeded), pod("c", ns1, map[string]string{"job-name": "new-image-pruner-124"}, v1.PodFailed)}},
-		{"no pods", 0, true, nil},
-		{"single pod failed", 0, true, []runtime.Object{pod("a", ns1, map[string]string{"job-name": "image-pruner-123"}, v1.PodFailed)}},
-		{"single pod without job-name label failed", 0, true, []runtime.Object{pod("a", ns1, map[string]string{}, v1.PodFailed)}},
-		{"single pod without job-name label succeeded", 0, false, []runtime.Object{pod("a", ns1, map[string]string{}, v1.PodSucceeded)}},
-		{"pod is pending beyond specified threshold", 1, false, []runtime.Object{pod("a", ns1, map[string]string{"job-name": "image-pruner-123"}, v1.PodPending)}},
-		{"single pod running", 0, false, []runtime.Object{pod("a", ns1, map[string]string{"job-name": "image-pruner-123"}, v1.PodRunning)}},
-		{"single pod succeeded", 0, false, []runtime.Object{pod("a", ns1, map[string]string{"job-name": "image-pruner-123"}, v1.PodSucceeded)}},
-		{"single pod failed bad namespace", 0, false, []runtime.Object{pod("a", "foobar", map[string]string{"job-name": "image-pruner-123"}, v1.PodFailed)}},
-		{"one pod good one pod bad same namespace", 0, true, []runtime.Object{pod("a", ns1, map[string]string{"job-name": "image-pruner-123"}, v1.PodFailed), pod("b", ns1, map[string]string{"job-name": "image-pruner-124"}, v1.PodRunning)}},
-		{"one pod good one pod pending same namespace", 0, false, []runtime.Object{pod("a", ns1, map[string]string{"job-name": "image-pruner-123"}, v1.PodPending), pod("b", ns1, map[string]string{"job-name": "image-pruner-124"}, v1.PodRunning)}},
-		{"one pod good one pod bad diff namespace", 0, true, []runtime.Object{pod("a", ns1, map[string]string{"job-name": "image-pruner-123"}, v1.PodFailed), pod("b", ns2, map[string]string{"job-name": "image-pruner-124"}, v1.PodRunning)}},
-		{"two succeeded pods diff namespace", 0, false, []runtime.Object{pod("a", ns1, map[string]string{"job-name": "image-pruner-123"}, v1.PodSucceeded), pod("b", ns2, map[string]string{"job-name": "image-pruner-124"}, v1.PodSucceeded)}},
-		{"one pod good, one pod bad diff namespace", 0, true, []runtime.Object{pod("a", ns1, map[string]string{"job-name": "image-pruner-123"}, v1.PodSucceeded), pod("b", ns2, map[string]string{"job-name": "image-pruner-124"}, v1.PodFailed)}},
-		{"two running pods diff namespace", 0, false, []runtime.Object{pod("a", ns1, map[string]string{"job-name": "image-pruner-123"}, v1.PodRunning), pod("b", ns2, map[string]string{"job-name": "image-pruner-124"}, v1.PodRunning)}},
+		{
+			description:    "no pods",
+			expectedLength: 0,
+			expectedError:  true,
+			objs:           nil,
+		},
+		{
+			description:    "single pod failed",
+			expectedLength: 0,
+			expectedError:  true,
+			objs: []runtime.Object{
+				pod("a", ns1, map[string]string{}, v1.PodFailed),
+			},
+		},
+		{
+			description:    "single pod pending",
+			expectedLength: 1,
+			expectedError:  false,
+			objs: []runtime.Object{
+				pod("a", ns1, map[string]string{}, v1.PodPending),
+			},
+		},
+		{
+			description:    "healthy pods",
+			expectedLength: 0,
+			expectedError:  false,
+			objs: []runtime.Object{
+				pod("running", ns1, map[string]string{}, v1.PodRunning),
+				pod("completed", ns2, map[string]string{}, v1.PodSucceeded),
+				pod("failed-first-run", ns1, map[string]string{"job-name": "test-job-122"}, v1.PodFailed),
+				pod("but-completed-second-run", ns1, map[string]string{"job-name": "test-job-123"}, v1.PodSucceeded),
+				pod("worked-first-try", ns2, map[string]string{"job-name": "other-job-456"}, v1.PodSucceeded),
+			},
+		},
+		{
+			description:    "currently unhealthy cronjob pods",
+			expectedLength: 0,
+			expectedError:  true,
+			objs: []runtime.Object{
+				pod("complted-first-run", ns1, map[string]string{"job-name": "test-job-122"}, v1.PodSucceeded),
+				pod("but-failed-second-run", ns1, map[string]string{"job-name": "test-job-124"}, v1.PodFailed),
+				pod("and-failed-again-run", ns1, map[string]string{"job-name": "test-job-125"}, v1.PodFailed),
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -67,5 +122,63 @@ func TestCheckPodHealth(t *testing.T) {
 		if (err != nil && test.expectedError == false) || (err == nil && test.expectedError == true) {
 			t.Errorf("%v: Expected error doesn't match returned value (%v, %v)", test.description, test.expectedError, err)
 		}
+	}
+}
+
+func TestCheckJobPods(t *testing.T) {
+	tests := []struct {
+		description         string
+		expectError         bool
+		expectedPendingPods int
+		pods                []v1.Pod
+	}{
+		{
+			description:         "one successful job pod",
+			expectError:         false,
+			expectedPendingPods: 0,
+			pods: []v1.Pod{
+				*pod("a", ns1, map[string]string{"job-name": "image-pruner-124"}, v1.PodSucceeded),
+			},
+		},
+		{
+			description:         "initially failed, but finally successful cronjob pods",
+			expectError:         false,
+			expectedPendingPods: 0,
+			pods: []v1.Pod{
+				*pod("a", ns1, map[string]string{"job-name": "image-pruner-124"}, v1.PodFailed),
+				*pod("b", ns1, map[string]string{"job-name": "image-pruner-125"}, v1.PodFailed),
+				*pod("c", ns1, map[string]string{"job-name": "image-pruner-126"}, v1.PodSucceeded),
+			},
+		},
+		{
+			description:         "completed, but then pending cronjob pods",
+			expectError:         false,
+			expectedPendingPods: 1,
+			pods: []v1.Pod{
+				*pod("a", ns1, map[string]string{"job-name": "image-pruner-124"}, v1.PodSucceeded),
+				*pod("b", ns1, map[string]string{"job-name": "image-pruner-125"}, v1.PodPending),
+			},
+		},
+		{
+			description:         "not a job pod",
+			expectError:         true,
+			expectedPendingPods: 0,
+			pods: []v1.Pod{
+				*pod("a", ns1, map[string]string{}, v1.PodSucceeded),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		pendingPods, err := checkJobPods(test.pods, nil)
+
+		if len(pendingPods) != test.expectedPendingPods {
+			t.Errorf("%s: expected %v pending pods, got %v", test.description, test.expectedPendingPods, len(pendingPods))
+		}
+
+		if (err != nil && test.expectError == false) || (err == nil && test.expectError == true) {
+			t.Errorf("%s: expected error %v, got %v", test.description, test.expectError, err)
+		}
+		t.Log(test.description)
 	}
 }


### PR DESCRIPTION
In #940 a PodPredicate for filtering `Completed` pods was removed in order to implement smarter CronJob pod health checks (returning healthy even previously unhealthy CronJob pods, if the most recent one is healthy). However, there was a [bug](https://github.com/openshift/osde2e/compare/main...mjlshen:image-pruner-bugfix?expand=1#diff-140e0200e3dd96daa38c05e5a3877f19ec4b3b11337d50db24ac917f619b2020L133-R160) which resulted in `Completed` job pods to be forwarded along via https://github.com/openshift/osde2e/blob/main/pkg/common/cluster/clusterutil.go#L454-L465 to `CheckPendingPods`. That function does no further checks on the status of the pod, so it's important to only send pending pods to it.

By breaking out the smarter CronJob pod health check to its own function, CheckJobPods, it can be individually tested. By doing so I found other assumptions, such as pods being already sorted, resulting in bugs that I fixed by sorting the CronJob pods by their creation timestamp.