### PR TITLE
Allow dependabot to run tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  labels:
+    - "dependencies"
+    - "ok-to-test"
   open-pull-requests-limit: 10


### PR DESCRIPTION
Always allow dependabot to run CI tests