### PR TITLE
Fix misleading log message as completed pods have not been filtered out yet

### DIFF
--- a/pkg/common/cluster/healthchecks/pods.go
+++ b/pkg/common/cluster/healthchecks/pods.go
@@ -80,7 +80,6 @@ func checkPods(podClient v1.CoreV1Interface, logger *log.Logger, filters ...PodP
 	}
 
 	pods := filterPods(list, filters...)
-	logger.Printf("%v pods are currently not running or complete:", len(pods.Items))
 
 	// Keep track of all pending pods that are not associated with a job
 	// and store all pods associated with a job for further analysis
@@ -107,6 +106,7 @@ func checkPods(podClient v1.CoreV1Interface, logger *log.Logger, filters ...PodP
 	if err != nil {
 		return nil, err
 	}
+	logger.Printf("%v pods are currently not running or complete:", len(pendingPods)+len(pendingJobPods))
 
 	return append(pendingPods, pendingJobPods...), nil
 }


### PR DESCRIPTION
Completed pods get filtered out by logic after the existing line and before the moved line.

Currently this will log that "X number of pods are not running or complete", but will include completed pods, which causes confusion