### PR TITLE
Assert full configuration of MHCs

### DIFF
--- a/pkg/e2e/osd/machinehealthcheck.go
+++ b/pkg/e2e/osd/machinehealthcheck.go
@@ -34,38 +34,30 @@ var _ = ginkgo.Describe(machineHealthTestName, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// verify there's an MHC for infra nodes
-		Expect(mhc.Spec.Selector.MatchExpressions).To(SatisfyAll(
-			ContainElement(
-				metav1.LabelSelectorRequirement{
-					Key:      "machine.openshift.io/cluster-api-machine-role",
-					Operator: metav1.LabelSelectorOpIn,
-					Values:   []string{"infra"},
-				},
-			),
-			ContainElement(
-				metav1.LabelSelectorRequirement{
-					Key:      "machine.openshift.io/cluster-api-machineset",
-					Operator: metav1.LabelSelectorOpExists,
-				},
-			),
+		Expect(mhc.Spec.Selector.MatchExpressions).To(ConsistOf(
+			metav1.LabelSelectorRequirement{
+				Key:      "machine.openshift.io/cluster-api-machine-role",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"infra"},
+			},
+			metav1.LabelSelectorRequirement{
+				Key:      "machine.openshift.io/cluster-api-machineset",
+				Operator: metav1.LabelSelectorOpExists,
+			},
 		))
 
 		// verify the unhealthy conditions are on all nodes
-		Expect(mhc.Spec.UnhealthyConditions).To(SatisfyAll(
-			ContainElement(
-				machineV1beta1.UnhealthyCondition{
-					Type:    corev1.NodeReady,
-					Status:  corev1.ConditionFalse,
-					Timeout: "480s",
-				},
-			),
-			ContainElement(
-				machineV1beta1.UnhealthyCondition{
-					Type:    corev1.NodeReady,
-					Status:  corev1.ConditionUnknown,
-					Timeout: "480s",
-				},
-			),
+		Expect(mhc.Spec.UnhealthyConditions).To(ConsistOf(
+			machineV1beta1.UnhealthyCondition{
+				Type:    corev1.NodeReady,
+				Status:  corev1.ConditionFalse,
+				Timeout: "480s",
+			},
+			machineV1beta1.UnhealthyCondition{
+				Type:    corev1.NodeReady,
+				Status:  corev1.ConditionUnknown,
+				Timeout: "480s",
+			},
 		))
 	}, float64(500))
 
@@ -74,38 +66,30 @@ var _ = ginkgo.Describe(machineHealthTestName, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// verify there's an MHC for worker nodes
-		Expect(mhc.Spec.Selector.MatchExpressions).To(SatisfyAll(
-			ContainElement(
-				metav1.LabelSelectorRequirement{
-					Key:      "machine.openshift.io/cluster-api-machine-role",
-					Operator: metav1.LabelSelectorOpNotIn,
-					Values:   []string{"infra", "master"},
-				},
-			),
-			ContainElement(
-				metav1.LabelSelectorRequirement{
-					Key:      "machine.openshift.io/cluster-api-machineset",
-					Operator: metav1.LabelSelectorOpExists,
-				},
-			),
+		Expect(mhc.Spec.Selector.MatchExpressions).To(ConsistOf(
+			metav1.LabelSelectorRequirement{
+				Key:      "machine.openshift.io/cluster-api-machine-role",
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{"infra", "master"},
+			},
+			metav1.LabelSelectorRequirement{
+				Key:      "machine.openshift.io/cluster-api-machineset",
+				Operator: metav1.LabelSelectorOpExists,
+			},
 		))
 
 		// verify the unhealthy conditions are on all nodes
-		Expect(mhc.Spec.UnhealthyConditions).To(SatisfyAll(
-			ContainElement(
-				machineV1beta1.UnhealthyCondition{
-					Type:    corev1.NodeReady,
-					Status:  corev1.ConditionFalse,
-					Timeout: "480s",
-				},
-			),
-			ContainElement(
-				machineV1beta1.UnhealthyCondition{
-					Type:    corev1.NodeReady,
-					Status:  corev1.ConditionUnknown,
-					Timeout: "480s",
-				},
-			),
+		Expect(mhc.Spec.UnhealthyConditions).To(ConsistOf(
+			machineV1beta1.UnhealthyCondition{
+				Type:    corev1.NodeReady,
+				Status:  corev1.ConditionFalse,
+				Timeout: "480s",
+			},
+			machineV1beta1.UnhealthyCondition{
+				Type:    corev1.NodeReady,
+				Status:  corev1.ConditionUnknown,
+				Timeout: "480s",
+			},
 		))
 	}, float64(500))
 


### PR DESCRIPTION
We know exactly what the configuration should look like, including length, so use `ConsistOf` as the matcher. This may help deflake this test.