### PR TITLE
SDCICD-772 allow ReleaseAccepted as a valid CVO condition

### DIFF
--- a/pkg/common/cluster/healthchecks/clusterversionoperator_test.go
+++ b/pkg/common/cluster/healthchecks/clusterversionoperator_test.go
@@ -46,6 +46,12 @@ func clusterVersion() *configv1.ClusterVersion {
 					Reason:  "Available",
 					Message: "Available",
 				},
+				{
+					Type:    "ReleaseAccepted",
+					Status:	 configv1.ConditionTrue,
+					Reason:	 "Available",
+					Message: "Available",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
In recent E2E runs I observed clusters began failing the cluster health check due to the presence of a new `ReleaseAccepted` condition in CVO which was `true`.

This condition is valid to be true and is not an indication of an unhealthy cluster. This PR allows that condition to be in a `true` state without failing the health check.

The original code that did the analysis of CVO conditions seemed quite confusing to me, so I've tried to refactor and comment it a little to make it read a little cleaner as to what it was trying to do. One omission I noticed in the original code is that it seemed to not care about any situation where 'Available' could be 'False', which seems somewhat wrong to me. So the revised logic is:

- if `Available` is false, that's an unhealthy CVO (hopefully there's not an intentional reason this was being ignored)
- if any condition other than `<list of conditions which can be true>` is true, then that's an unhealthy CVO

(I've consciously avoided updating the `go.mod` dependencies to allow parts of this code to be written nicer, ie. referring to the actual `ClusterVersionConditionStatusType` variables rather than raw strings, to reduce the risk involved in pushing this change out ASAP)

Refs [SDCICD-772](https://issues.redhat.com//browse/SDCICD-772)