### PR TITLE
osd-8474 e2e test added for GCP CIO load balancer reconcile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/adamliesko/retry v0.0.0-20200123222335-86c8baac277d
 	github.com/antlr/antlr4 v0.0.0-20200209180723-1177c0b58d07
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
-	github.com/aws/aws-sdk-go v1.42.46
+	github.com/aws/aws-sdk-go v1.43.21
 	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b // indirect
 	github.com/cenkalti/backoff/v4 v4.1.0 // indirect
 	github.com/code-ready/crc v1.10.0
@@ -46,6 +46,7 @@ require (
 	github.com/openshift/custom-domains-operator v0.0.0-20210423153044-6e7655fbdecf
 	github.com/openshift/machine-api-operator v0.2.1-0.20200529045911-d19e8d007f7c
 	github.com/openshift/managed-upgrade-operator v0.0.0-20210728104325-95212635e5e1
+	github.com/openshift/origin v0.0.0-20160503220234-8f127d736703
 	github.com/openshift/rosa v1.1.12
 	github.com/openshift/route-monitor-operator v0.0.0-20210309123726-229da76cc133
 	github.com/openshift/splunk-forwarder-operator v0.0.0-20201112162206-2f454770b6c0
@@ -68,7 +69,8 @@ require (
 	github.com/tsenart/go-tsz v0.0.0-20180814235614-0bd30b3df1c3 // indirect
 	github.com/tsenart/vegeta v12.7.0+incompatible
 	github.com/vmware-tanzu/velero v1.5.0-beta.1.0.20200831161009-1dcaa1bf7512
-	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
+	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/tools v0.1.10
 	google.golang.org/api v0.67.0
 	google.golang.org/genproto v0.0.0-20220126215142-9970aeb2e350

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/aws/aws-sdk-go v1.28.2/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.34.16/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.37.14/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.39.3/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
-github.com/aws/aws-sdk-go v1.42.46 h1:Uehqm39VwQ+t0T7PeoFfsT1SjYRmazuTd9LMdN1JszE=
-github.com/aws/aws-sdk-go v1.42.46/go.mod h1:OGr6lGMAKGlG9CVrYnWYDKIyb829c6EVBRjxqjmPepc=
+github.com/aws/aws-sdk-go v1.43.21 h1:E4S2eX3d2gKJyI/ISrcIrSwXwqjIvCK85gtBMt4sAPE=
+github.com/aws/aws-sdk-go v1.43.21/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/awslabs/goformation/v4 v4.11.0/go.mod h1:GcJULxCJfloT+3pbqCluXftdEK2AD/UqpS3hkaaBntg=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
@@ -1463,6 +1463,7 @@ github.com/openshift/managed-upgrade-operator v0.0.0-20210728104325-95212635e5e1
 github.com/openshift/managed-upgrade-operator v0.0.0-20210728104325-95212635e5e1/go.mod h1:M9KpCngTO2/SIFHApXdCECuRjPzDfvxTJ/YQI8hSqac=
 github.com/openshift/operator-custom-metrics v0.3.0/go.mod h1:4k6G9+KHKg6r/ShP8Vi9YFnpJ5fbHPkQsYCUlzMwtYQ=
 github.com/openshift/operator-custom-metrics v0.4.2/go.mod h1:pF8VqYYaJrZo780/ebeMDcaI20ETzJuUSDHGXSzjWwk=
+github.com/openshift/origin v0.0.0-20160503220234-8f127d736703 h1:KLVRXtjLhZHVtrcdnuefaI2Bf182EEiTfEVDHokoyng=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openshift/prom-label-proxy v0.1.1-0.20191016113035-b8153a7f39f1/go.mod h1:p5MuxzsYP1JPsNGwtjtcgRHHlGziCJJfztff91nNixw=
 github.com/openshift/rosa v1.1.12 h1:aPtp/t2/iUjqwWKTjueD3Pm/9Qj80qc4d9RVthTsvPM=
@@ -2091,8 +2092,8 @@ golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210916014120-12bc252f5db8/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211216030914-fe4d6282115f h1:hEYJvxw1lSnWIl8X9ofsYMklzaDs90JI2az5YMd4fPM=
-golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd h1:O7DYs+zxREGLKzKoMQrtrEacpb0ZVXA5rIwylE2Xchk=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180227000427-d7d64896b5ff/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -2259,8 +2260,9 @@ golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27 h1:XDXtA5hveEEV8JB2l7nhMTp3t
 golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.0.0-20210503060354-a79de5458b56 h1:b8jxX3zqjpqb2LklXPzKSGJhzyxCOZSz8ncv8Nv+y7w=
 golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4ajbZsCe5lw1metzhBm9T3x7oIY=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -4,6 +4,7 @@ package helper
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"math/rand"
@@ -12,21 +13,29 @@ import (
 	"text/template"
 	"time"
 
+	"golang.org/x/oauth2/google"
+	computev1 "google.golang.org/api/compute/v1"
+
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 	configv1 "github.com/openshift/api/config/v1"
 	projectv1 "github.com/openshift/api/project/v1"
 	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/util"
+	cloudcredentialv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 )
 
 func init() {
@@ -310,6 +319,82 @@ func (h *H) GetWorkload(name string) (string, bool) {
 	}
 
 	return "", false
+}
+
+func (h *H) GetGCPCreds(ctx context.Context) (*google.Credentials, bool) {
+	testInstanceName := "test-" + time.Now().Format("20060102-150405-") + fmt.Sprint(time.Now().Nanosecond()/1000000) + "-" + fmt.Sprint(ginkgo.GinkgoParallelProcess())
+	providerBytes := bytes.Buffer{}
+	encoder := json.NewEncoder(&providerBytes)
+	encoder.Encode(cloudcredentialv1.GCPProviderSpec{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "GCPProviderSpec",
+			APIVersion: "cloudcredential.openshift.io/v1",
+		},
+		PredefinedRoles: []string{
+			"roles/owner",
+		},
+		SkipServiceCheck: true,
+	})
+	saCredentialReq := &cloudcredentialv1.CredentialsRequest{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "CredentialsRequest",
+			APIVersion: "cloudcredential.openshift.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testInstanceName,
+			Namespace: h.CurrentProject(),
+		},
+		Spec: cloudcredentialv1.CredentialsRequestSpec{
+			SecretRef: corev1.ObjectReference{
+				Name:      testInstanceName,
+				Namespace: h.CurrentProject(),
+			},
+			ProviderSpec: &runtime.RawExtension{
+				Raw:    providerBytes.Bytes(),
+				Object: &cloudcredentialv1.GCPProviderSpec{},
+			},
+		},
+	}
+
+	credentialReqObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(saCredentialReq)
+	if err != nil {
+		return nil, false
+	}
+	_, err = h.Dynamic().Resource(schema.GroupVersionResource{
+		Group:    "cloudcredential.openshift.io",
+		Version:  "v1",
+		Resource: "credentialsrequests",
+	}).Namespace(saCredentialReq.GetNamespace()).Create(context.TODO(), &unstructured.Unstructured{Object: credentialReqObj}, metav1.CreateOptions{})
+
+	wait.PollImmediate(15*time.Second, 5*time.Minute, func() (bool, error) {
+		unstructCredentialReq, _ := h.Dynamic().Resource(schema.GroupVersionResource{
+			Group:    "cloudcredential.openshift.io",
+			Version:  "v1",
+			Resource: "credentialsrequests",
+		}).Namespace(h.CurrentProject()).Get(context.TODO(), saCredentialReq.GetName(), metav1.GetOptions{})
+
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructCredentialReq.UnstructuredContent(), saCredentialReq)
+		if err != nil || !saCredentialReq.Status.Provisioned {
+			return false, err
+		}
+		return true, err
+	})
+
+	saSecret, err := h.Kube().CoreV1().Secrets(saCredentialReq.Spec.SecretRef.Namespace).Get(context.TODO(), saCredentialReq.Spec.SecretRef.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, false
+	}
+	serviceAccountJSON, ok := saSecret.Data["service_account.json"]
+	if !ok {
+		return nil, false
+	}
+	credentials, err := google.CredentialsFromJSON(
+		ctx, serviceAccountJSON,
+		computev1.ComputeScope)
+	if err != nil {
+		return nil, false
+	}
+	return credentials, true
 }
 
 // AddWorkload uniquely appends a workload to the workloads list

--- a/pkg/e2e/operators/cloudingress/rhapi_lb.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_lb.go
@@ -30,7 +30,10 @@ import (
 var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool("rosa.STS") {
-			ginkgo.Skip("for now we skip this suite for STS")
+			ginkgo.Skip("Cluster is STS. For now we skip rh-api LB reconcile test for STS")
+		}
+		if viper.GetBool("ocm.ccs") != true {
+			ginkgo.Skip("Cluster is non-CCS. For now we skip rh-api LB reconcile test for non-CCS.")
 		}
 	})
 
@@ -132,7 +135,7 @@ func testLBDeletion(h *helper.H) {
 					return false, nil
 				})
 				Expect(err).NotTo(HaveOccurred())
-			}, 900)
+			}, 600)
 		}
 
 		if viper.GetString(config.CloudProvider.CloudProviderID) == "gcp" {
@@ -259,7 +262,7 @@ func testLBDeletion(h *helper.H) {
 					return false, nil
 				})
 				Expect(err).NotTo(HaveOccurred())
-			}, 900)
+			}, 600)
 		}
 	})
 }

--- a/pkg/e2e/operators/cloudingress/rhapi_lb.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_lb.go
@@ -8,10 +8,12 @@ import (
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/origin/Godeps/_workspace/src/github.com/emicklei/go-restful/log"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -19,15 +21,16 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/elb"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	computev1 "google.golang.org/api/compute/v1"
+
+	"google.golang.org/api/option"
 )
 
-var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool("rosa.STS") {
 			ginkgo.Skip("for now we skip this suite for STS")
-		}
-		if viper.GetString(config.CloudProvider.CloudProviderID) != "aws" {
-			ginkgo.Skip("for now we only support aws provider")
 		}
 	})
 
@@ -35,8 +38,29 @@ var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 	testLBDeletion(h)
 })
 
-// getLBForService retrieves the loadbalancer name associated with a service of type LoadBalancer
-func getLBForService(h *helper.H, namespace string, service string) (string, error) {
+// Get forwarding rule for rh-api load balancer in GCP
+func getGCPForwardingRuleForIP(computeService *computev1.Service, oldLBIP string, project string, region string) (*computev1.ForwardingRule, error) {
+	listCall := computeService.ForwardingRules.List(project, region)
+	response, err := listCall.Do()
+	var oldLB *computev1.ForwardingRule
+	if err != nil {
+		return nil, err
+	}
+
+	for _, lb := range response.Items {
+		// This list of forwardingrules (LBs) includes any service LBs
+		// for application routers so check the IP to identify
+		// the rh-api LB.
+		if lb.IPAddress == oldLBIP {
+			oldLB = lb
+		}
+	}
+
+	return oldLB, nil
+}
+
+// getLBForService retrieves the load balancer name or IP associated with a service of type LoadBalancer
+func getLBForService(h *helper.H, namespace string, service string, idtype string) (string, error) {
 	svc, err := h.Kube().CoreV1().Services(namespace).Get(context.TODO(), service, metav1.GetOptions{})
 	if err != nil {
 		return "", err
@@ -50,21 +74,28 @@ func getLBForService(h *helper.H, namespace string, service string) (string, err
 		// the LB wasn't created yet
 		return "", nil
 	}
+
+	if idtype == "ip" {
+		return ingressList[0].IP, nil
+	}
+
 	return ingressList[0].Hostname[0:32], nil
 }
 
-// testLBDeletion deletes the loadbalancer of rh-api service and ensures that cloud-ingress-operator recreates it
+// testLBDeletion deletes the load balancer of rh-api service and ensures that cloud-ingress-operator recreates it
 func testLBDeletion(h *helper.H) {
-	ginkgo.Context("rh-api-test", func() {
-		ginkgo.It("Manually deleted LB should be recreated", func() {
+	ginkgo.Context("rh-api-lb-test", func() {
+
 			if viper.GetString(config.CloudProvider.CloudProviderID) == "aws" {
+			util.GinkgoIt("manually deleted LB should be recreated in AWS", func() {
 				awsAccessKey := viper.GetString("ocm.aws.accessKey")
 				awsSecretKey := viper.GetString("ocm.aws.secretKey")
 				awsRegion := viper.GetString(config.CloudProvider.Region)
 
 				// getLoadBalancer name currently associated with rh-api service
-				oldLBName, err := getLBForService(h, "openshift-kube-apiserver", "rh-api")
+				oldLBName, err := getLBForService(h, "openshift-kube-apiserver", "rh-api", "hostname")
 				Expect(err).NotTo(HaveOccurred())
+				log.Printf("Old LB name %s ",oldLBName)
 
 				// delete the load balancer in aws
 				awsSession, err := session.NewSession(aws.NewConfig().WithCredentials(credentials.NewStaticCredentials(awsAccessKey, awsSecretKey, "")).WithRegion(awsRegion))
@@ -75,25 +106,160 @@ func testLBDeletion(h *helper.H) {
 					LoadBalancerName: aws.String(oldLBName),
 				}
 
-				_, err = lb.DeleteLoadBalancer(input)
+				_ , err = lb.DeleteLoadBalancer(input)
+
 				Expect(err).NotTo(HaveOccurred())
+				log.Printf("Old LB deleted" )
+
 
 				// wait for the new LB to be created
 				err = wait.PollImmediate(15*time.Second, 5*time.Minute, func() (bool, error) {
-					newLBName, err := getLBForService(h, "openshift-kube-apiserver", "rh-api")
+					newLBName, err := getLBForService(h, "openshift-kube-apiserver", "rh-api", "hostname")
+					log.Printf("Looking for new LB")
+
 					if err != nil || newLBName == "" {
 						// either we couldn't retrieve the LB name, or it wasn't created yet
+						log.Printf("LB not found yet")
 						return false, nil
 					}
 					if newLBName != oldLBName {
 						// the LB was successfully recreated
+						log.Printf("New LB found. LB name: %s",newLBName)
 						return true, nil
 					}
 					// the rh-api svc hasn't been deleted yet
+					log.Printf("rh-api service not deleted yet")
 					return false, nil
 				})
 				Expect(err).NotTo(HaveOccurred())
+			}, 900)
+		}
+
+		if viper.GetString(config.CloudProvider.CloudProviderID) == "gcp" {
+			util.GinkgoIt("manually deleted LB should be recreated in GCP", func() {
+
+				region := viper.GetString("cloudProvider.region")
+				ctx := context.TODO()
+
+				ginkgo.By("Getting rh-api IP")
+				oldLBIP, err := getLBForService(h, "openshift-kube-apiserver", "rh-api", "ip")
+				Expect(err).NotTo(HaveOccurred())
+				log.Printf("old LB IP:  %s ", oldLBIP)
+
+				ginkgo.By("Getting GCP creds")
+				gcpCreds, status := h.GetGCPCreds(ctx)
+				Expect(status).To(BeTrue())
+				project := gcpCreds.ProjectID
+
+				ginkgo.By("Initializing GCP compute service")
+				computeService, err := computev1.NewService(ctx, option.WithCredentials(gcpCreds), option.WithScopes("https://www.googleapis.com/auth/compute"))
+				Expect(err).NotTo(HaveOccurred())
+
+				ginkgo.By("Getting GCP forwarding rule for rh-api")
+				oldLB, err := getGCPForwardingRuleForIP(computeService, oldLBIP, project, region)
+				Expect(err).NotTo(HaveOccurred())
+
+				//There's no single command to delete a load balancer in GCP
+				//Delete all GCP resources related to rh-api LB setup
+				ginkgo.By("Deleting rh-api load balancer related resources in GCP")
+				if oldLB == nil {
+					log.Printf("GCP forwarding rule for rh-api does not exist; Skipping deletion ")
+				} else {
+					log.Printf("Old lb name:  %s ", oldLB.Name)
+					_, err = computeService.ForwardingRules.Get(project, region, oldLB.Name).Do()
+					if err != nil {
+						log.Printf("GCP forwarding rule for rh-api not found! ")
+					} else {
+						ginkgo.By("Deleting GCP forwarding rule for rh-api")
+						_, err = computeService.ForwardingRules.Delete(project, region, oldLB.Name).Do()
+						if err != nil {
+							log.Printf("Error deleting forwarding rule ")
+						}
+					}
+
+					ginkgo.By("Deleting GCP backend service rule for rh-api")
+					_, err = computeService.BackendServices.Get(project, oldLB.Name).Do()
+					if err != nil {
+						log.Printf("GCP backend service already deleted. ")
+					} else {
+						_, err = computeService.BackendServices.Delete(project, oldLB.Name).Do()
+						if err != nil {
+							log.Printf("Error deleting backend service ")
+						}
+					}
+
+					ginkgo.By("Deleting GCP health check for rh-api ")
+					_, err = computeService.HealthChecks.Get(project, oldLB.Name).Do()
+					if err != nil {
+						log.Printf("GCP health check already deleted ")
+					} else {
+						_, err = computeService.HealthChecks.Delete(project, oldLB.Name).Do()
+						if err != nil {
+							log.Printf("Error deleting health check ")
+						}
+					}
+
+					ginkgo.By("Deleting GCP target pool for rh-api ")
+					_, err = computeService.TargetPools.Get(project, region, oldLB.Name).Do()
+					if err != nil {
+						log.Printf("GCP target pool already deleted ")
+					} else {
+						_, err = computeService.TargetPools.Delete(project, region, oldLB.Name).Do()
+						if err != nil {
+							log.Printf("Error deleting target pool ")
+						}
+					}
+				}
+
+				ginkgo.By("Deleting GCP address for rh-api")
+				_, err = computeService.Addresses.Get(project, region, oldLBIP).Do()
+				if err != nil {
+					log.Printf("GCP IP address already deleted ")
+				} else {
+					_, err = computeService.Addresses.Delete(project, region, oldLBIP).Do()
+					if err != nil {
+						log.Printf("Error deleting address ")
+					}
+				}
+
+				newLBIP := ""
+				// Getting the new LB from GCP
+				err = wait.PollImmediate(15*time.Second, 10*time.Minute, func() (bool, error) {
+						// Getting the newly created IP from rh-api service
+						ginkgo.By("Getting new IP from rh-api service in OCM")
+
+						newLBIP, err = getLBForService(h, "openshift-kube-apiserver", "rh-api", "ip")
+						if (err != nil) || (newLBIP == "") || (newLBIP == oldLBIP) {
+							log.Printf("New rh-api svc not created yet...")
+							return false, nil
+						}else{
+							log.Printf("Found new rh-api svc! ")
+							log.Printf("new lb IP: %s ", newLBIP)
+							return true, nil
 			}
 		})
+				Expect(err).NotTo(HaveOccurred())
+
+				err = wait.PollImmediate(15*time.Second, 10*time.Minute, func() (bool, error) {
+					ginkgo.By("Polling GCP to get new forwarding rule for rh-api")
+					newLB, err := getGCPForwardingRuleForIP(computeService, newLBIP, project, region)
+					if err != nil || newLB == nil {
+						// Either we couldn't retrieve the LB, or it wasn't created yet
+						log.Printf("New forwarding rule not found yet...")
+						return false, nil
+					}
+					log.Printf("new lb name: %s ", newLB.Name)
+
+					if newLB.Name != oldLB.Name {
+						// A new LB was successfully recreated in GCP
+						return true, nil
+					}
+					// rh-api lb hasn't been deleted yet
+					log.Printf("Old forwarding rule not deleted yet...")
+					return false, nil
+				})
+				Expect(err).NotTo(HaveOccurred())
+			}, 900)
+		}
 	})
 }


### PR DESCRIPTION
Squashed version of https://github.com/openshift/osde2e/pull/1078 

jira https://issues.redhat.com/browse/OSD-8474

Following [OSD-8431](https://issues.redhat.com/browse/OSD-8431), tests need to be added to ensure the code logic is correct.

Done Criteria:

e2e test to delete the rh-api lb on a live cluster and ensure that the lb is recreated in GCP