### PR TITLE
OSD-10981 Handle case when job names are 63 characters long

### DIFF
--- a/ci/prow_pr_check.sh
+++ b/ci/prow_pr_check.sh
@@ -16,7 +16,7 @@ set -eo pipefail
 
     make build
 
-    CLUSTER_ID=1rhqf9e62793ffs2hko7ch8f59mfs2gl \
+    CLUSTER_ID=1rkd1isdn7ojkd9u06renmulm63rnvut \
     GINKGO_SKIP="Must Gather Operator" \
     OCM_CCS="true" \
     ./out/osde2e test --configs=prod,aws,pr-check,e2e-suite --secret-locations=/usr/local/osde2e-common,/usr/local/osde2e-credentials,/usr/local/sd-cicd-aws-prod

--- a/pkg/common/cluster/healthchecks/pods_test.go
+++ b/pkg/common/cluster/healthchecks/pods_test.go
@@ -93,6 +93,7 @@ func TestCheckPodHealth(t *testing.T) {
 			objs: []runtime.Object{
 				pod("running", ns1, map[string]string{}, v1.PodRunning),
 				pod("completed", ns2, map[string]string{}, v1.PodSucceeded),
+				pod("long-job-name", ns2, map[string]string{"job-name": "thisisalongjobnamethatisawhoppingsixtythreecharacterslongtotest"}, v1.PodSucceeded),
 				pod("failed-first-run", ns1, map[string]string{"job-name": "test-job-122"}, v1.PodFailed),
 				pod("but-completed-second-run", ns1, map[string]string{"job-name": "test-job-123"}, v1.PodSucceeded),
 				pod("worked-first-try", ns2, map[string]string{"job-name": "other-job-456"}, v1.PodSucceeded),


### PR DESCRIPTION
`openshift-marketplace` commonly creates jobs that are 63 characters long, like `c50a055663942c74bda6a897a5331c076ec93c668b2fcc4b5a2c5e0acd6326f`, which was not being handled correctly by the pod healthcheck logic, causing osd-cluster-ready to fail.