### PR TITLE
[OHSS-10233] Initial FedRAMP configuration file

### DIFF
--- a/configs/fedramp.yaml
+++ b/configs/fedramp.yaml
@@ -1,0 +1,11 @@
+tests:
+  enableFips: true
+  testsToRun:
+  - '\[Suite\: service-definition\]'
+  - '\[Suite\: app-builds\]'
+  - '\[Suite\: e2e\] FIPS'
+  - '\[Suite\: e2e\] Encrypted Storage'
+  - '\[Suite\: e2e\] ImageStreams'
+  - '\[Suite\: e2e\] \[OSD\] namespace validating webhook'
+  - '\[Suite\: e2e\] \[OSD\] OAuth tokens'
+  - '\[Suite: informing\] \[OSD\] pod validating webhook'


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/OSD-10233

This sets up a config file for manual runs(for now) inside the FedRAMP environment. This is the initial config and we will most likely be expanding it with more tests as time goes on and the fedramp env matures some.