### PR TITLE
Remove clusterwide pod healthcheck

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -451,19 +451,6 @@ func PollClusterHealth(clusterID string, logger *log.Logger) (status bool, failu
 			clusterHealthy = false
 		}
 
-		if podlist, err := healthchecks.CheckClusterPodHealth(kubeClient.CoreV1(), logger); (podlist == nil) && err != nil {
-			healthErr = multierror.Append(healthErr, err)
-			failures = append(failures, "pod")
-			clusterHealthy = false
-		} else {
-			err := podErrorTracker.CheckPendingPods(podlist)
-			if err != nil {
-				healthErr = multierror.Append(healthErr, err)
-				failures = append(failures, "pod")
-				clusterHealthy = false
-			}
-		}
-
 		if check, err := healthchecks.CheckCerts(kubeClient.CoreV1(), logger); !check || err != nil {
 			healthErr = multierror.Append(healthErr, err)
 			failures = append(failures, "cert")

--- a/pkg/common/cluster/healthchecks/pods.go
+++ b/pkg/common/cluster/healthchecks/pods.go
@@ -27,25 +27,6 @@ func (p *PodErrorTracker) NewPodErrorTracker(threshold int) *PodErrorTracker {
 	return p
 }
 
-// CheckClusterPodHealth attempts to look at the state of all internal cluster pods and
-// returns the list of pending pods if any exist.
-func CheckClusterPodHealth(podClient v1.CoreV1Interface, logger *log.Logger) ([]kubev1.Pod, error) {
-	// We are not filtering IsNotCompleted due to an attempt to mark clusters healthy
-	// if a CronJob's latest pod is Completed, even if previous runs may have failed.
-	filters := []PodPredicate{
-		IsOlderThan(1 * time.Minute),
-		IsClusterPod,
-		IsNotReadinessPod,
-		IsNotRunning,
-	}
-	podlist, err := checkPods(podClient, logger, filters...)
-	if err != nil {
-		return nil, err
-	}
-
-	return podlist, err
-}
-
 // CheckPodHealth attempts to look at the state of all pods and returns true if things are healthy.
 func CheckPodHealth(podClient v1.CoreV1Interface, logger *log.Logger, ns string, podPrefixes ...string) (bool, error) {
 	filters := []PodPredicate{


### PR DESCRIPTION
This removes the `CheckClusterPodHealth` check.

We check other things in `PollClusterHealth` like the state of nodes, clusteroperators, daemonsets/replicasets. These things provide us with a clearer signal, than static pod configurations.