### PR TITLE
Double the number of dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,4 +7,4 @@ updates:
   labels:
     - "dependencies"
     - "ok-to-test"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 20


### PR DESCRIPTION
There's a number of dependabot PRs that are open but aren't going to be merged quickly due to dependency conflicts. This is preventing other checks for things that are more important (like the ocm sdk).

This doubles the max number of dependabot PRs open

/assign @MrSantamaria 