### PR TITLE
OSD-8788 Add proxy test suite and day-2 add-proxy test

### DIFF
--- a/cmd/osde2e/test/cmd.go
+++ b/cmd/osde2e/test/cmd.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/openshift/osde2e/pkg/e2e/operators"
 	_ "github.com/openshift/osde2e/pkg/e2e/operators/cloudingress"
 	_ "github.com/openshift/osde2e/pkg/e2e/osd"
+	_ "github.com/openshift/osde2e/pkg/e2e/proxy"
 	_ "github.com/openshift/osde2e/pkg/e2e/scale"
 	_ "github.com/openshift/osde2e/pkg/e2e/state"
 	_ "github.com/openshift/osde2e/pkg/e2e/verify"

--- a/configs/proxy-suite.yaml
+++ b/configs/proxy-suite.yaml
@@ -1,0 +1,3 @@
+tests:
+    testsToRun:
+    - '\[Suite\: proxy\]'

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -125,6 +125,13 @@ Some environment variables commonly used for pipelines under osde2e are indicate
 |PROMETHEUS_ADDRESS| Address of the Prometheus instance to connect to.|
 |PROMETHEUS_BEARER_TOKEN| Token needed for communicating with Prometheus.|
  
+### Proxy related:-
+
+| Environment variable | Usage |
+| --------------| ------------------------| 
+|TEST_HTTP_PROXY| Address of the HTTP Proxy to be added to a cluster. |
+|TEST_HTTPS_PROXY| Address of the HTTPS Proxy to be added to a cluster.|
+|USER_CA_BUNDLE| PEM-encoded CA Bundle to be added as the cluster's additional trusted CA. If prefixed by an @ symbol, the value will be treated as a filesystem path that the content is loaded from.|
 
 
 ## Command Line Flags for osde2e

--- a/pkg/common/providers/crc/crc.go
+++ b/pkg/common/providers/crc/crc.go
@@ -347,3 +347,18 @@ func (o *Provider) Hibernate(id string) bool {
 	log.Println("Hibernation not supported in CRC Provider")
 	return true
 }
+
+// AddClusterProxy adds a proxy to a cluster
+func (m *Provider) AddClusterProxy(clusterId string, httpsProxy string, httpProxy string, userCABundle string) error {
+	return fmt.Errorf("proxies not supported in CRC Provider")
+}
+
+// RemoveClusterProxy removes a proxy from a cluster
+func (m *Provider) RemoveClusterProxy(clusterId string) error {
+	return fmt.Errorf("proxies not supported in CRC Provider")
+}
+
+// RemoveUserCABundle removes a CA Bundle from a cluster
+func (m *Provider) RemoveUserCABundle(clusterId string) error {
+	return fmt.Errorf("proxies not supported in CRC Provider")
+}

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -308,3 +308,18 @@ func (o *MockProvider) Hibernate(id string) bool {
 	log.Println("Hibernation not supported in Mock Provider")
 	return true
 }
+
+// AddClusterProxy adds a proxy to a cluster
+func (m *MockProvider) AddClusterProxy(clusterId string, httpsProxy string, httpProxy string, userCABundle string) error {
+	return fmt.Errorf("proxies not supported in Mock Provider")
+}
+
+// RemoveClusterProxy removes a proxy from a cluster
+func (m *MockProvider) RemoveClusterProxy(clusterId string) error {
+	return fmt.Errorf("proxies not supported in Mock Provider")
+}
+
+// RemoveUserCABundle removes a CA Bundle from a cluster
+func (m *MockProvider) RemoveUserCABundle(clusterId string) error {
+	return fmt.Errorf("proxies not supported in Mock Provider")
+}

--- a/pkg/common/providers/ocmprovider/proxy.go
+++ b/pkg/common/providers/ocmprovider/proxy.go
@@ -1,0 +1,80 @@
+package ocmprovider
+
+import (
+	"fmt"
+	"log"
+
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+type ClusterWideProxy struct {
+	Enabled                   bool
+	HTTPProxy                 string
+	HTTPSProxy                string
+	AdditionalTrustBundle     string
+}
+
+// AddClusterProxy sets the cluster proxy configuration for the supplied cluster
+func (o *OCMProvider) AddClusterProxy(clusterId string, httpsProxy string, httpProxy string, userCABundle string) error {
+
+	clusterBuilder := cmv1.NewCluster()
+
+	clusterProxyBuilder := cmv1.NewProxy()
+	clusterProxyBuilder = clusterProxyBuilder.HTTPProxy(httpProxy)
+	clusterProxyBuilder = clusterProxyBuilder.HTTPSProxy(httpsProxy)
+	clusterBuilder = clusterBuilder.Proxy(clusterProxyBuilder)
+	clusterBuilder = clusterBuilder.AdditionalTrustBundle(userCABundle)
+
+	clusterSpec, err := clusterBuilder.Build()
+	if err != nil {
+		return err
+	}
+	return o.updateCluster(clusterId, clusterSpec)
+}
+
+// RemoveClusterProxy removes the cluster proxy configuration for the supplied cluster
+func (o *OCMProvider) RemoveClusterProxy(clusterId string) error {
+
+	clusterBuilder := cmv1.NewCluster()
+
+	clusterProxyBuilder := cmv1.NewProxy()
+	clusterProxyBuilder = clusterProxyBuilder.HTTPProxy("")
+	clusterProxyBuilder = clusterProxyBuilder.HTTPSProxy("")
+	clusterBuilder = clusterBuilder.Proxy(clusterProxyBuilder)
+	clusterBuilder = clusterBuilder.AdditionalTrustBundle("")
+
+	clusterSpec, err := clusterBuilder.Build()
+	if err != nil {
+		return err
+	}
+	return o.updateCluster(clusterId, clusterSpec)
+}
+
+// RemoveUserCABundle removes only the Additional Trusted CA Bundle from the cluster
+func (o *OCMProvider) RemoveUserCABundle(clusterId string) error {
+
+	clusterBuilder := cmv1.NewCluster()
+	clusterBuilder = clusterBuilder.AdditionalTrustBundle("")
+	clusterSpec, err := clusterBuilder.Build()
+	if err != nil {
+		return err
+	}
+	return o.updateCluster(clusterId, clusterSpec)
+}
+
+func (o *OCMProvider) updateCluster(clusterId string, clusterSpec *cmv1.Cluster) error {
+	resp, err := o.conn.ClustersMgmt().V1().Clusters().Cluster(clusterId).Update().Body(clusterSpec).Send()
+	if err != nil {
+		err = fmt.Errorf("couldn't update proxy for cluster '%s': %v", clusterId, err)
+		log.Printf("%v", err)
+		return err
+	}
+
+	if resp != nil && resp.Error() != nil {
+		err = fmt.Errorf("error while trying to update proxy from cluster: %v", resp.Error())
+		log.Printf("%v", err)
+		return resp.Error()
+	}
+
+	return nil
+}

--- a/pkg/common/providers/rosaprovider/wrapped_calls.go
+++ b/pkg/common/providers/rosaprovider/wrapped_calls.go
@@ -112,3 +112,18 @@ func (m *ROSAProvider) Resume(id string) bool {
 func (m *ROSAProvider) Hibernate(id string) bool {
 	return m.ocmProvider.Hibernate(id)
 }
+
+// AddClusterProxy sets the cluster proxy configuration for the supplied cluster
+func (m *ROSAProvider) AddClusterProxy(clusterId string, httpsProxy string, httpProxy string, userCABundle string) error {
+	return m.ocmProvider.AddClusterProxy(clusterId, httpsProxy, httpProxy, userCABundle)
+}
+
+// RemoveClusterProxy removes the cluster proxy configuration for the supplied cluster
+func (m *ROSAProvider) RemoveClusterProxy(clusterId string) error {
+	return m.RemoveClusterProxy(clusterId)
+}
+
+// RemoveUserCABundle removes only the Additional Trusted CA Bundle from the cluster
+func (m *ROSAProvider) RemoveUserCABundle(clusterId string) error {
+	return m.RemoveUserCABundle(clusterId)
+}

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -140,4 +140,14 @@ type Provider interface {
 	// If hibernation is unsupported by the provider, it will log that it's unsupported
 	// but still return True.
 	Resume(clusterID string) bool
+
+	// AddClusterProxy adds a cluster-wide proxy to the cluster.
+	AddClusterProxy(clusterId string, httpsProxy string, httpProxy string, userCABundle string) error
+
+	// RemoveClusterProxy removes the cluster proxy configuration for the supplied cluster
+	RemoveClusterProxy(clusterId string) error
+
+	// RemoveUserCABundle removes only the Additional Trusted CA Bundle from the cluster
+	RemoveUserCABundle(clusterId string) error
+
 }

--- a/pkg/e2e/proxy/postinstall.go
+++ b/pkg/e2e/proxy/postinstall.go
@@ -1,0 +1,122 @@
+package proxy
+
+import (
+	"context"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	configv1 "github.com/openshift/api/config/v1"
+	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/osde2e/pkg/common/alert"
+	"github.com/openshift/osde2e/pkg/common/cluster"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/logging"
+	"github.com/openshift/osde2e/pkg/common/providers"
+	"github.com/openshift/osde2e/pkg/common/util"
+)
+
+var postInstallProxyTestName string = "[Suite: proxy] Post-Install Cluster Proxy"
+
+func init() {
+	alert.RegisterGinkgoAlert(postInstallProxyTestName, "SD-SREP", "@sd-srep-team-hulk", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
+}
+
+var _ = ginkgo.Describe(postInstallProxyTestName, func() {
+	ginkgo.Context("Adding a proxy", func() {
+		// setup helper
+		h := helper.New()
+		// setup logger
+		logger := logging.CreateNewStdLoggerOrUseExistingLogger(nil)
+		// How long to wait for proxy changes to be reflected in the resource
+		proxyConfigSyncDuration := 15 * time.Minute
+		// How long to wait for proxy changes to be applied and cluster to return to health
+		proxyHealthCheckWaitDuration := 45 * time.Minute
+
+		util.GinkgoIt("can add a proxy to the cluster successfully", func() {
+			clusterID := viper.GetString(config.Cluster.ID)
+			clusterProvider, err := providers.ClusterProvider()
+			Expect(err).NotTo(HaveOccurred())
+
+			httpsProxy := viper.GetString(config.Proxy.HttpsProxy)
+			httpProxy := viper.GetString(config.Proxy.HttpProxy)
+			userCABundle := viper.GetString(config.Proxy.UserCABundle)
+
+			logger.Printf("Setting cluster-wide proxy to httpsProxy=%v,httpProxy=%v,settingCA=%v",
+				httpsProxy, httpProxy, userCABundle != "")
+			err = clusterProvider.AddClusterProxy(clusterID, httpsProxy, httpProxy, userCABundle)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Wait to see proxy reflected on the cluster
+			logger.Printf("Validating state of proxy on cluster within %v minutes", proxyConfigSyncDuration.Minutes())
+			err = wait.Poll(30*time.Second, proxyConfigSyncDuration, func() (bool, error) {
+				var proxy *configv1.Proxy
+				var cabundle *v1.ConfigMap
+
+				// Validate state of proxy on-cluster vs what values it should have
+				proxy, err = h.Cfg().ConfigV1().Proxies().Get(context.TODO(), "cluster", metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				if userCABundle != "" {
+					if proxy.Spec.TrustedCA.Name != "user-ca-bundle" {
+						return false, nil
+					}
+					// Check if the ConfigMap exists
+					cabundle, err = h.Kube().CoreV1().ConfigMaps("openshift-config").Get(context.TODO(), "user-ca-bundle", metav1.GetOptions{})
+					// don't treat the cabundle not existing as an error
+					if err != nil && !apierrors.IsNotFound(err) {
+						return false, err
+					}
+					cabundleData, found := cabundle.Data["ca-bundle.crt"]
+					// if the configmap exists, so should this key, and the value should match
+					if !found || strings.TrimSpace(cabundleData) != strings.TrimSpace(userCABundle) {
+						logger.Printf("User CA Bundle still not reflected on cluster")
+						return false, nil
+					}
+				}
+				if httpsProxy != "" {
+					// Check if status reflects the HTTPS Proxy value
+					if proxy.Status.HTTPSProxy != httpsProxy {
+						logger.Printf("HTTPS Proxy still not reflected on cluster")
+						return false, nil
+					}
+				}
+				if httpProxy != "" {
+					// Check if status reflects the HTTPS Proxy value
+					if proxy.Status.HTTPProxy != httpProxy {
+						logger.Printf("HTTP Proxy still not reflected on cluster")
+						return false, nil
+					}
+				}
+				return true, nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// The cluster's proxy and configmap state reflects what we expect
+			// So now, is the cluster still healthy?
+			logger.Printf("Verifying cluster health after proxy addition..")
+			err = wait.PollImmediate(30*time.Second, proxyHealthCheckWaitDuration, func() (bool, error) {
+				isHealthy, failures, _ := cluster.PollClusterHealth(clusterID, logger)
+				if isHealthy {
+					logger.Printf("cluster is healthy after proxy addition\n")
+					return true, nil
+				}
+				log.Printf("cluster is not healthy after proxy addition\n")
+				if len(failures) > 0 {
+					logger.Printf("Currently failing %s health checks", strings.Join(failures, ", "))
+				}
+				return false, nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		}, proxyConfigSyncDuration.Seconds()+proxyHealthCheckWaitDuration.Seconds())
+	})
+})


### PR DESCRIPTION
This PR adds a new test suite `proxy` which will form the bulk of tests relating to epic [SDE-1634](https://issues.redhat.com//browse/SDE-1634) for testing cluster-wide proxy features on OSD/ROSA clusters.

## Configuration parameters introduced
- `TEST_HTTP_PROXY`: Represents the address of a HTTP Proxy to configure the cluster with.
- `TEST_HTTPS_PROXY`: Represents the address of a HTTPS Proxy to configure the cluster with.
- `USER_CA_BUNDLE`: Represents the User CA Bundle to configure the cluster with.
Documentation for all three parameters has been added.

## Tests added
A new test has been added to the `proxy` suite which will use the OCM API to add a proxy to a pre-existing cluster.
The test verifies that:
- the cluster received the requested configuration change correctly
- the cluster successfully passes a cluster health check

## Provider changes
Functions have been added to the OCM and ROSA providers to use the OCM API to define or remove a cluster-wide-proxy from the cluster. 

## To test
To test, one needs to first have built and installed a valid HTTP/HTTPS proxy which will be accessible from the target cluster.

```
export TEST_HTTP_PROXY=<value>
export TEST_HTTPS_PROXY=<value>
export USER_CA_BUNDLE=<value>
out/osde2e test --configs proxy-suite --kube-config $KUBECONFIG -e stage
```

It is safe to run the test without these values set, though doing so will have the same effect as 'removing' the proxy configuration from the cluster.

Refs [OSD-8788](https://issues.redhat.com//browse/OSD-8788)