### PR TITLE
[OSD-11524] enable cluster provision with proxy enabled for osd and rosa

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -35,9 +35,13 @@ Some environment variables commonly used for pipelines under osde2e are indicate
  
 | Environment variable | Usage |
 | --------------| ------------------------| 
-|ROSA_AWS_ACCESS_KEY_ID| AWSAccessKeyID for provisioning clusters|
+|ROSA_ENV| Environment for the e2e testing, default to prod.|
+|ROSA_AWS_ACCESS_KEY_ID| AWSAccessKeyID for provisioning clusters.|
 |ROSA_AWS_SECRET_ACCESS_KEY| AWSSecretAccessKey for provisioning clusters.|
 |ROSA_AWS_REGION| AWSRegion for provisioning clusters.|
+|ROSA_STS| Boolean value to indicate the cluster is STS enabled or not.|
+|ROSA_SUBNET_IDS| A list of subnets used to create the cluster, required for proxy enabled cluster.|
+|ROSA_COMPUTE_NODES| Compute node count for the rosa cluster, default is 2.|
  
  
 ### OCM related:-
@@ -131,7 +135,7 @@ Some environment variables commonly used for pipelines under osde2e are indicate
 | --------------| ------------------------| 
 |TEST_HTTP_PROXY| Address of the HTTP Proxy to be added to a cluster. |
 |TEST_HTTPS_PROXY| Address of the HTTPS Proxy to be added to a cluster.|
-|USER_CA_BUNDLE| PEM-encoded CA Bundle to be added as the cluster's additional trusted CA. If prefixed by an @ symbol, the value will be treated as a filesystem path that the content is loaded from.|
+|USER_CA_BUNDLE| A file contains a PEM-encoded X.509 certificate bundle that will be added to the nodes' trusted certificate store.|
 
 
 ## Command Line Flags for osde2e

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/PagerDuty/go-pagerduty v1.5.1
 	github.com/PuerkitoBio/goquery v1.8.0
 	github.com/adamliesko/retry v0.0.0-20200123222335-86c8baac277d
+	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20220209173558-ad29539cd2e9
 	github.com/aws/aws-sdk-go v1.44.14
 	github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b // indirect
 	github.com/code-ready/crc v1.10.0

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -844,12 +844,6 @@ func PostProcess() {
 		log.Printf("Found an ARTIFACTS directory, using that for the REPORT_DIR.")
 		viper.Set(ReportDir, artifacts)
 	}
-
-	// Load UserCABundle from file if the value indicates a path
-	err := LoadUserCABundle()
-	if err != nil {
-		log.Printf("Unable to load User CA Bundle: %v", err)
-	}
 }
 
 // RegisterSecret will register the secret filename that will be used for the corresponding Viper string.
@@ -876,24 +870,6 @@ func LoadKubeconfig() error {
 			return fmt.Errorf("failed reading '%s' which has been set as the TEST_KUBECONFIG: %v", kubeconfigPath, err)
 		}
 		viper.Set(Kubeconfig.Contents, string(kubeconfigBytes))
-	}
-	return nil
-}
-
-// LoadUserCABundle will, given a path to a user CA bundle, attempt to load it into the Viper config
-func LoadUserCABundle() error {
-	userCABundlePath := viper.GetString(Proxy.UserCABundle)
-	if strings.HasPrefix(userCABundlePath, "@") {
-		userCABundlePath = userCABundlePath[1:]
-		data, err := ioutil.ReadFile(userCABundlePath)
-		if err != nil {
-			return fmt.Errorf(
-				"can't read userCABundle file '%s': %w",
-				userCABundlePath, err,
-			)
-		}
-		userCABundle := strings.TrimSpace(string(data))
-		viper.Set(Proxy.UserCABundle, userCABundle)
 	}
 	return nil
 }

--- a/pkg/common/providers/crc/crc.go
+++ b/pkg/common/providers/crc/crc.go
@@ -362,3 +362,8 @@ func (m *Provider) RemoveClusterProxy(clusterId string) error {
 func (m *Provider) RemoveUserCABundle(clusterId string) error {
 	return fmt.Errorf("proxies not supported in CRC Provider")
 }
+
+// LoadUserCaBundleData loads CA contents from CA cert file
+func (m *Provider) LoadUserCaBundleData(file string) (string, error) {
+	return "", fmt.Errorf("proxies not supported in CRC Provider")
+}

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -323,3 +323,8 @@ func (m *MockProvider) RemoveClusterProxy(clusterId string) error {
 func (m *MockProvider) RemoveUserCABundle(clusterId string) error {
 	return fmt.Errorf("proxies not supported in Mock Provider")
 }
+
+// LoadUserCaBundleData loads CA contents from CA cert file
+func (m *MockProvider) LoadUserCaBundleData(file string) (string, error) {
+	return "", fmt.Errorf("proxies not supported in Mock Provider")
+}

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -184,6 +184,22 @@ func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 					availabilityZones := GetAvailabilityZones(subnetworks, subnetIDs)
 					nodeBuilder.AvailabilityZones(availabilityZones...)
 				}
+				proxy := v1.NewProxy()
+				if userCaBundle := viper.GetString(config.Proxy.UserCABundle); userCaBundle != "" {
+					userCaBundleData, err := o.LoadUserCaBundleData(userCaBundle)
+					if err != nil {
+						return "", fmt.Errorf("error loading CA contents: %v", err)
+					}
+					newCluster = newCluster.AdditionalTrustBundle(userCaBundleData)
+				}
+				if httpProxy := viper.GetString(config.Proxy.HttpProxy); httpProxy != "" {
+					proxy = proxy.HTTPProxy(httpProxy)
+					newCluster = newCluster.Proxy(proxy)
+				}
+				if httpsProxy := viper.GetString(config.Proxy.HttpsProxy); httpsProxy != "" {
+					proxy = proxy.HTTPSProxy(httpsProxy)
+					newCluster = newCluster.Proxy(proxy)
+				}
 			} else {
 				var err error
 				var ccsUser string

--- a/pkg/common/providers/ocmprovider/ocm.go
+++ b/pkg/common/providers/ocmprovider/ocm.go
@@ -4,8 +4,8 @@ package ocmprovider
 import (
 	"fmt"
 
-	"github.com/openshift/osde2e/pkg/common/spi"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/spi"
 
 	ocm "github.com/openshift-online/ocm-sdk-go"
 	ocmerr "github.com/openshift-online/ocm-sdk-go/errors"

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -68,6 +68,7 @@ func (m *ROSAProvider) IsValidClusterName(clusterName string) (bool, error) {
 }
 
 // LaunchCluster will provision an AWS cluster.
+// nolint:gocyclo
 func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 	// Calculate an expiration date for the cluster so that it will be automatically deleted if
 	// we happen to forget to do it:
@@ -120,6 +121,19 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 		"--service-cidr", viper.GetString(ServiceCIDR),
 		"--pod-cidr", viper.GetString(PodCIDR),
 		"--host-prefix", viper.GetString(HostPrefix),
+	}
+	if viper.GetString(SubnetIDs) != "" {
+		subnetIDs := viper.GetString(SubnetIDs)
+		createClusterArgs = append(createClusterArgs, "--subnet-ids", subnetIDs)
+		if httpProxy := viper.GetString(config.Proxy.HttpProxy); httpProxy != "" {
+			createClusterArgs = append(createClusterArgs, "--http-proxy", httpProxy)
+		}
+		if httpsProxy := viper.GetString(config.Proxy.HttpsProxy); httpsProxy != "" {
+			createClusterArgs = append(createClusterArgs, "--https-proxy", httpsProxy)
+		}
+		if userCaBundle := viper.GetString(config.Proxy.UserCABundle); userCaBundle != "" {
+			createClusterArgs = append(createClusterArgs, "--additional-trust-bundle-file", userCaBundle)
+		}
 	}
 	if viper.GetBool(config.Cluster.MultiAZ) {
 		createClusterArgs = append(createClusterArgs, "--multi-az")

--- a/pkg/common/providers/rosaprovider/config.go
+++ b/pkg/common/providers/rosaprovider/config.go
@@ -41,6 +41,9 @@ const (
 
 	// STS is a boolean tracking whether or not this cluster should be provisioned using the STS workflow
 	STS = "rosa.STS"
+
+	// SubnetIDs is comma-separated list of strings to specify the subnets for cluster provision
+	SubnetIDs = "rosa.subnetIDs"
 )
 
 func init() {
@@ -74,4 +77,6 @@ func init() {
 
 	viper.BindEnv(STS, "ROSA_STS")
 	viper.SetDefault(STS, false)
+
+	viper.BindEnv(SubnetIDs, "ROSA_SUBNET_IDS")
 }

--- a/pkg/common/providers/rosaprovider/wrapped_calls.go
+++ b/pkg/common/providers/rosaprovider/wrapped_calls.go
@@ -127,3 +127,7 @@ func (m *ROSAProvider) RemoveClusterProxy(clusterId string) error {
 func (m *ROSAProvider) RemoveUserCABundle(clusterId string) error {
 	return m.RemoveUserCABundle(clusterId)
 }
+
+func (m *ROSAProvider) LoadUserCaBundleData(file string) (string, error) {
+	return m.LoadUserCaBundleData(file)
+}

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -150,4 +150,6 @@ type Provider interface {
 	// RemoveUserCABundle removes only the Additional Trusted CA Bundle from the cluster
 	RemoveUserCABundle(clusterId string) error
 
+	// LoadUserCaBundleData loads CA contents from CA cert file
+	LoadUserCaBundleData(file string) (string, error)
 }

--- a/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
@@ -73,7 +73,7 @@ func testHostnameResolves(h *helper.H) {
 				return true, nil
 			})
 			Expect(err).NotTo(HaveOccurred())
-		}, (hostnameResolvePollDuration + 1 * time.Minute).Seconds())
+		}, (hostnameResolvePollDuration + 1*time.Minute).Seconds())
 	})
 }
 
@@ -117,7 +117,7 @@ func testCIDRBlockUpdates(h *helper.H) {
 			Expect(err).NotTo(HaveOccurred())
 
 			//Create a service Object
-			rhAPIService := &corev1.Service{}
+			var rhAPIService *corev1.Service
 
 			// wait 30 secs for apiserver to reconcile
 			time.Sleep(30 * time.Second)

--- a/pkg/e2e/osd/dedicatedadmin.go
+++ b/pkg/e2e/osd/dedicatedadmin.go
@@ -327,7 +327,7 @@ func manageSecrets(nsList []string, h *helper.H) error {
 
 		// check 'create' permission
 		secrets := h.Kube().CoreV1().Secrets(ns)
-		dummySecret, err := secrets.Create(context.TODO(), &corev1.Secret{
+		_, err := secrets.Create(context.TODO(), &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      newSecretName,
 				Namespace: ns,
@@ -336,7 +336,7 @@ func manageSecrets(nsList []string, h *helper.H) error {
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to create secret %s in namespace %s", newSecretName, ns))
 
 		// check 'get' permission
-		dummySecret, err = secrets.Get(context.TODO(), newSecretName, metav1.GetOptions{})
+		dummySecret, err := secrets.Get(context.TODO(), newSecretName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to get secret %s in namespace %s", newSecretName, ns))
 
 		// check 'list' permission

--- a/pkg/e2e/proxy/postinstall.go
+++ b/pkg/e2e/proxy/postinstall.go
@@ -50,6 +50,8 @@ var _ = ginkgo.Describe(postInstallProxyTestName, func() {
 			httpsProxy := viper.GetString(config.Proxy.HttpsProxy)
 			httpProxy := viper.GetString(config.Proxy.HttpProxy)
 			userCABundle := viper.GetString(config.Proxy.UserCABundle)
+			userCABundleData, err := clusterProvider.LoadUserCaBundleData(userCABundle)
+			Expect(err).NotTo(HaveOccurred())
 
 			logger.Printf("Setting cluster-wide proxy to httpsProxy=%v,httpProxy=%v,settingCA=%v",
 				httpsProxy, httpProxy, userCABundle != "")
@@ -78,7 +80,7 @@ var _ = ginkgo.Describe(postInstallProxyTestName, func() {
 					}
 					cabundleData, found := cabundle.Data["ca-bundle.crt"]
 					// if the configmap exists, so should this key, and the value should match
-					if !found || strings.TrimSpace(cabundleData) != strings.TrimSpace(userCABundle) {
+					if !found || strings.TrimSpace(cabundleData) != strings.TrimSpace(userCABundleData) {
 						logger.Printf("User CA Bundle still not reflected on cluster")
 						return false, nil
 					}


### PR DESCRIPTION
Append the proxy related parameters to the ocm and rosa provider.

To test with OSD cluster:
```
export OCM_CCS=true
export OCM_AWS_ACCOUNT=$AWS_ACCOUNT_ID
export OCM_AWS_ACCESS_KEY=$AWS_ACCESS_KEY_ID
export OCM_AWS_SECRET_KEY=$AWS_SECRET_ACCESS_KEY
export CLOUD_PROVIDER_ID=aws
export OCM_AWS_VPC_SUBNET_IDS=subnet-052ad08ae5fd1b9bd,subnet-0b73c8670379ea008
export TEST_HTTP_PROXY=<test http proxy server>
export TEST_HTTPS_PROXY=<test https proxy server>
export USER_CA_BUNDLE=@ca.pem
export CLOUD_PROVIDER_REGION=us-east-1
export OCM_TOKEN=$(ocm token)

./osde2e test --configs stage -e stage --focus-tests "RBAC Operator"
```
The cluster will be created as 
```
$ ocm describe cluster 1s8f9ur5jq5s83bqe7cuigsfbvgbbdon

ID:			1s8f9ur5jq5s83bqe7cuigsfbvgbbdon
External ID:		a6ca850e-6dd2-4512-8ab6-aac96763c338
Name:			osde2e-qtfoz
State:			installing
API URL:		
API Listening:		external
Console URL:		
Masters:		3
Infra:			2
Computes:		2
Product:		osd
Provider:		aws
Version:		
Region:			us-east-1
Multi-az:		false
CCS:			true
Subnet IDs:		[subnet-052ad08ae5fd1b9bd subnet-0b73c8670379ea008]
PrivateLink:		false
STS:			false
Existing VPC:		true
Channel Group:		candidate
Cluster Admin:		true
Organization:		Red Hat OpenShift Online
Creator:		bmeng_sre.openshift
Email:			bmeng@redhat.com
Created:		2022-05-17T06:38:53Z
Expiration:		2022-05-17T12:38:51Z
Shard:			-------
HTTPProxy:	        http://<proxy_server_ip>:3128
HTTPSProxy:	        http://<proxy_server_ip>:3128
AdditionalTrustBundle:  REDACTED

```

To test with ROSA cluster:
```
export PROVIDER=rosa
export ROSA_AWS_ACCESS_KEY_ID=$AWS_ACCOUNT_ID
export ROSA_AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
export ROSA_AWS_REGION=us-east-1
export ROSA_SUBNET_IDS=$OCM_AWS_VPC_SUBNET_IDS 
export ROSA_ENV=stage
export TEST_HTTP_PROXY=<test http proxy server>
export TEST_HTTPS_PROXY=<test https proxy server>
export USER_CA_BUNDLE=ca.pem               <-----------------------------------  direct file path here

./osde2e test --configs stage -e stage --focus-tests "RBAC Operator"
```
The rosa cluster will be created as:
```
I: Creating cluster 'osde2e-6pi5h'
I: To view a list of clusters and their status, run 'rosa list clusters'
I: Cluster 'osde2e-6pi5h' has been created.
I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
Name:                       osde2e-6pi5h
ID:                         1s8gi65jsijjrt0r0ds51mro6ruro5v7
External ID:                
OpenShift Version:          
Channel Group:              candidate
DNS:                        REDACTED
AWS Account:                537136174241
API URL:                    
Console URL:                
Region:                     us-east-1
Multi-AZ:                   false
Nodes:
 - Control plane:           3
 - Infra:                   2
 - Compute:                 2
Network:
 - Service CIDR:            172.30.0.0/16
 - Machine CIDR:            10.0.0.0/16
 - Pod CIDR:                10.128.0.0/14
 - Host Prefix:             /23
Proxy:
 - HTTPProxy:               http://<proxy_server_ip>:3128
 - HTTPSProxy:              http://<proxy_server_ip>:3128
Additional trust bundle:    REDACTED
State:                      validating 
Private:                    No
Created:                    May 17 2022 08:04:41 UTC
Details Page:              REDACTED

```