### PR TITLE
Only gather project/olm state if must-gather is enabled

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -572,14 +572,14 @@ func cleanupAfterE2E(h *helper.H) (errors []error) {
 				h.WriteResults(gatherResults)
 			}
 		}
+
+		log.Print("Gathering Project States...")
+		h.InspectState()
+
+		log.Print("Gathering OLM State...")
+		h.InspectOLM()
 	}
-
-	log.Print("Gathering Project States...")
-	h.InspectState()
-
-	log.Print("Gathering OLM State...")
-	h.InspectOLM()
-
+	
 	log.Print("Gathering Cluster State...")
 	clusterState := h.GetClusterState()
 	stateResults := make(map[string][]byte, len(clusterState))


### PR DESCRIPTION
The `oc adm inspect` routines to gather `osde2e-*` project state and `openshift-*` project states are must-gather-like things, and are time consuming to execute at the end of a job. If someone has deliberately disabled the must-gather collection for a job, it is almost assured that they don't want to be gathering this data either.

Therefore, this PR moves those two actions under the control of the Must Gather viper config.
