### PR TITLE
Add control config param for proxy-based installs

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -30,6 +30,7 @@ Some environment variables commonly used for pipelines under osde2e are indicate
 |NEXT_RELEASE_AFTER_PROD_DEFAULT|  NextReleaseAfterProdDefault will select the cluster image set that the given number of releases away from the the production default.|
 |CLEAN_CHECK_RUNS| CleanCheckRuns lets us set the number of osd-verify checks we want to run before deeming a cluster "healthy"|
 |INSPECT_NAMESPACES| InspectNamespaces is a comma-delimeted list of namespaces to perform an `oc adm inspect` on during E2E cleanup|
+|USE_PROXY_FOR_INSTALL| UseProxyForInstall will use a cluster-wide proxy for the cluster installation, provided that cluster proxy configuration is also supplied.|
 
 ### ROSA cluster related:-
  

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -362,6 +362,9 @@ var Cluster = struct {
 
 	// InspectNamespaces is a comma-delimited list of namespaces to perform an inspect on during test cleanup
 	InspectNamespaces string
+
+	// UseProxyForInstall will attempt to use a cluster-wide proxy for cluster installation, provided that a cluster-wide proxy config is supplied
+	UseProxyForInstall string
 }{
 	MultiAZ:                             "cluster.multiAZ",
 	Channel:                             "cluster.channel",
@@ -370,6 +373,7 @@ var Cluster = struct {
 	AfterTestWait:                       "cluster.afterTestWait",
 	InstallTimeout:                      "cluster.installTimeout",
 	ReleaseImageLatest:                  "cluster.releaseImageLatest",
+	UseProxyForInstall:                  "cluster.useProxyForInstall",
 	UseLatestVersionForInstall:          "cluster.useLatestVersionForInstall",
 	UseMiddleClusterImageSetForInstall:  "cluster.useMiddleClusterVersionForInstall",
 	UseOldestClusterImageSetForInstall:  "cluster.useOldestClusterVersionForInstall",
@@ -686,6 +690,9 @@ func InitViper() {
 	viper.BindEnv(Cluster.InstallTimeout, "CLUSTER_UP_TIMEOUT")
 
 	viper.BindEnv(Cluster.ReleaseImageLatest, "RELEASE_IMAGE_LATEST")
+
+	viper.SetDefault(Cluster.UseProxyForInstall, false)
+	viper.BindEnv(Cluster.UseProxyForInstall, "USE_PROXY_FOR_INSTALL")
 
 	viper.SetDefault(Cluster.UseLatestVersionForInstall, false)
 	viper.BindEnv(Cluster.UseLatestVersionForInstall, "USE_LATEST_VERSION_FOR_INSTALL")

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -184,21 +184,23 @@ func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 					availabilityZones := GetAvailabilityZones(subnetworks, subnetIDs)
 					nodeBuilder.AvailabilityZones(availabilityZones...)
 				}
-				proxy := v1.NewProxy()
-				if userCaBundle := viper.GetString(config.Proxy.UserCABundle); userCaBundle != "" {
-					userCaBundleData, err := o.LoadUserCaBundleData(userCaBundle)
-					if err != nil {
-						return "", fmt.Errorf("error loading CA contents: %v", err)
+				if viper.GetBool(config.Cluster.UseProxyForInstall) {
+					proxy := v1.NewProxy()
+					if userCaBundle := viper.GetString(config.Proxy.UserCABundle); userCaBundle != "" {
+						userCaBundleData, err := o.LoadUserCaBundleData(userCaBundle)
+						if err != nil {
+							return "", fmt.Errorf("error loading CA contents: %v", err)
+						}
+						newCluster = newCluster.AdditionalTrustBundle(userCaBundleData)
 					}
-					newCluster = newCluster.AdditionalTrustBundle(userCaBundleData)
-				}
-				if httpProxy := viper.GetString(config.Proxy.HttpProxy); httpProxy != "" {
-					proxy = proxy.HTTPProxy(httpProxy)
-					newCluster = newCluster.Proxy(proxy)
-				}
-				if httpsProxy := viper.GetString(config.Proxy.HttpsProxy); httpsProxy != "" {
-					proxy = proxy.HTTPSProxy(httpsProxy)
-					newCluster = newCluster.Proxy(proxy)
+					if httpProxy := viper.GetString(config.Proxy.HttpProxy); httpProxy != "" {
+						proxy = proxy.HTTPProxy(httpProxy)
+						newCluster = newCluster.Proxy(proxy)
+					}
+					if httpsProxy := viper.GetString(config.Proxy.HttpsProxy); httpsProxy != "" {
+						proxy = proxy.HTTPSProxy(httpsProxy)
+						newCluster = newCluster.Proxy(proxy)
+					}
 				}
 			} else {
 				var err error

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -125,14 +125,16 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 	if viper.GetString(SubnetIDs) != "" {
 		subnetIDs := viper.GetString(SubnetIDs)
 		createClusterArgs = append(createClusterArgs, "--subnet-ids", subnetIDs)
-		if httpProxy := viper.GetString(config.Proxy.HttpProxy); httpProxy != "" {
-			createClusterArgs = append(createClusterArgs, "--http-proxy", httpProxy)
-		}
-		if httpsProxy := viper.GetString(config.Proxy.HttpsProxy); httpsProxy != "" {
-			createClusterArgs = append(createClusterArgs, "--https-proxy", httpsProxy)
-		}
-		if userCaBundle := viper.GetString(config.Proxy.UserCABundle); userCaBundle != "" {
-			createClusterArgs = append(createClusterArgs, "--additional-trust-bundle-file", userCaBundle)
+		if viper.GetBool(config.Cluster.UseProxyForInstall) {
+			if httpProxy := viper.GetString(config.Proxy.HttpProxy); httpProxy != "" {
+				createClusterArgs = append(createClusterArgs, "--http-proxy", httpProxy)
+			}
+			if httpsProxy := viper.GetString(config.Proxy.HttpsProxy); httpsProxy != "" {
+				createClusterArgs = append(createClusterArgs, "--https-proxy", httpsProxy)
+			}
+			if userCaBundle := viper.GetString(config.Proxy.UserCABundle); userCaBundle != "" {
+				createClusterArgs = append(createClusterArgs, "--additional-trust-bundle-file", userCaBundle)
+			}
 		}
 	}
 	if viper.GetBool(config.Cluster.MultiAZ) {

--- a/pkg/e2e/proxy/postinstall.go
+++ b/pkg/e2e/proxy/postinstall.go
@@ -25,155 +25,167 @@ import (
 	"github.com/openshift/osde2e/pkg/common/util"
 )
 
-var postInstallProxyTestName string = "[Suite: proxy] Post-Install Cluster Proxy"
+var (
+	postInstallProxyTestName string = "[Suite: proxy] Post-Install Cluster Proxy"
+	logger = logging.CreateNewStdLoggerOrUseExistingLogger(nil)
+)
+
+const (
+	// How long to wait for proxy changes to be reflected in the resource
+	proxyConfigSyncDuration = 15 * time.Minute
+	// How long to wait for proxy changes to be applied and cluster to return to health
+	proxyHealthCheckWaitDuration = 45 * time.Minute
+)
 
 func init() {
 	alert.RegisterGinkgoAlert(postInstallProxyTestName, "SD-SREP", "@sd-srep-team-hulk", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
 var _ = ginkgo.Describe(postInstallProxyTestName, func() {
-	// setup helper
-	h := helper.New()
-	// setup logger
-	logger := logging.CreateNewStdLoggerOrUseExistingLogger(nil)
-	// How long to wait for proxy changes to be reflected in the resource
-	proxyConfigSyncDuration := 15 * time.Minute
-	// How long to wait for proxy changes to be applied and cluster to return to health
-	proxyHealthCheckWaitDuration := 45 * time.Minute
-
-	ginkgo.Context("Adding proxy", func() {
-		util.GinkgoIt("can add a proxy to the cluster successfully", func() {
-			clusterID := viper.GetString(config.Cluster.ID)
-			clusterProvider, err := providers.ClusterProvider()
-			Expect(err).NotTo(HaveOccurred())
-
-			httpsProxy := viper.GetString(config.Proxy.HttpsProxy)
-			httpProxy := viper.GetString(config.Proxy.HttpProxy)
-			userCABundle := viper.GetString(config.Proxy.UserCABundle)
-			userCABundleData, err := clusterProvider.LoadUserCaBundleData(userCABundle)
-			Expect(err).NotTo(HaveOccurred())
-
-			logger.Printf("Setting cluster-wide proxy to httpsProxy=%v,httpProxy=%v,settingCA=%v",
-				httpsProxy, httpProxy, userCABundle != "")
-			err = clusterProvider.AddClusterProxy(clusterID, httpsProxy, httpProxy, userCABundle)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Wait to see proxy reflected on the cluster
-			logger.Printf("Validating state of proxy on cluster within %v minutes", proxyConfigSyncDuration.Minutes())
-			err = wait.Poll(30*time.Second, proxyConfigSyncDuration, func() (bool, error) {
-				var proxy *configv1.Proxy
-				var cabundle *v1.ConfigMap
-
-				// Validate state of proxy on-cluster vs what values it should have
-				proxy, err = h.Cfg().ConfigV1().Proxies().Get(context.TODO(), "cluster", metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				if userCABundle != "" {
-					if proxy.Spec.TrustedCA.Name != "user-ca-bundle" {
-						return false, nil
-					}
-					// Check if the ConfigMap exists
-					cabundle, err = h.Kube().CoreV1().ConfigMaps("openshift-config").Get(context.TODO(), "user-ca-bundle", metav1.GetOptions{})
-					// don't treat the cabundle not existing as an error
-					if err != nil && !apierrors.IsNotFound(err) {
-						return false, err
-					}
-					cabundleData, found := cabundle.Data["ca-bundle.crt"]
-					// if the configmap exists, so should this key, and the value should match
-					if !found || strings.TrimSpace(cabundleData) != strings.TrimSpace(userCABundleData) {
-						logger.Printf("User CA Bundle still not reflected on cluster")
-						return false, nil
-					}
-				}
-				if httpsProxy != "" {
-					// Check if status reflects the HTTPS Proxy value
-					if proxy.Status.HTTPSProxy != httpsProxy {
-						logger.Printf("HTTPS Proxy still not reflected on cluster")
-						return false, nil
-					}
-				}
-				if httpProxy != "" {
-					// Check if status reflects the HTTPS Proxy value
-					if proxy.Status.HTTPProxy != httpProxy {
-						logger.Printf("HTTP Proxy still not reflected on cluster")
-						return false, nil
-					}
-				}
-				return true, nil
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			// The cluster's proxy and configmap state reflects what we expect
-			// So now, is the cluster still healthy?
-			logger.Printf("Verifying cluster health after proxy addition..")
-			err = wait.PollImmediate(30*time.Second, proxyHealthCheckWaitDuration, func() (bool, error) {
-				isHealthy, failures, _ := cluster.PollClusterHealth(clusterID, logger)
-				if isHealthy {
-					logger.Printf("cluster is healthy after proxy addition\n")
-					return true, nil
-				}
-				log.Printf("cluster is not healthy after proxy addition\n")
-				if len(failures) > 0 {
-					logger.Printf("Currently failing %s health checks", strings.Join(failures, ", "))
-				}
-				return false, nil
-			})
-			Expect(err).NotTo(HaveOccurred())
-		}, proxyConfigSyncDuration.Seconds()+proxyHealthCheckWaitDuration.Seconds())
-	})
-
-	ginkgo.Context("Removing proxy", func() {
-		util.GinkgoIt("can remove proxy from the cluster successfully", func() {
-			clusterID := viper.GetString(config.Cluster.ID)
-			clusterProvider, err := providers.ClusterProvider()
-			Expect(err).NotTo(HaveOccurred())
-
-			err = clusterProvider.RemoveClusterProxy(clusterID)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Wait to see proxy reflected on the cluster
-			logger.Printf("Validating state of proxy on cluster within %v minutes", proxyConfigSyncDuration.Minutes())
-			err = wait.Poll(30*time.Second, proxyConfigSyncDuration, func() (bool, error) {
-				var proxy *configv1.Proxy
-
-				// Validate state of proxy on-cluster vs what values it should have
-				proxy, err = h.Cfg().ConfigV1().Proxies().Get(context.TODO(), "cluster", metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				if proxy.Spec.HTTPProxy != "" || proxy.Status.HTTPProxy != "" {
-					return false, nil
-				}
-				if proxy.Spec.HTTPSProxy != "" || proxy.Status.HTTPSProxy != "" {
-					return false, nil
-				}
-
-				_, err = h.Kube().CoreV1().ConfigMaps("openshift-config").Get(context.TODO(), "user-ca-bundle", metav1.GetOptions{})
-				if !apierrors.IsNotFound(err) {
-					return false, nil
-				}
-				if proxy.Spec.TrustedCA.Name != "" {
-					return false, nil
-				}
-
-				return true, nil
-			})
-			Expect(err).NotTo(HaveOccurred())
-			// The cluster's proxy and configmap state reflects what we expect
-			// So now, is the cluster still healthy?
-			logger.Printf("Verifying cluster health after proxy removed..")
-			err = wait.PollImmediate(30*time.Second, proxyHealthCheckWaitDuration, func() (bool, error) {
-				isHealthy, failures, _ := cluster.PollClusterHealth(clusterID, logger)
-				if isHealthy {
-					logger.Printf("cluster is healthy after proxy removed\n")
-					return true, nil
-				}
-				log.Printf("cluster is not healthy after proxy removed\n")
-				if len(failures) > 0 {
-					logger.Printf("Currently failing %s health checks", strings.Join(failures, ", "))
-				}
-				return false, nil
-			})
-			Expect(err).NotTo(HaveOccurred())
-		}, proxyConfigSyncDuration.Seconds()+proxyHealthCheckWaitDuration.Seconds())
+	ginkgo.Context("Day 2 Configuration", func() {
+		testAddProxy()
+		testRemoveProxy()
 	})
 })
+
+func testAddProxy()  {
+	util.GinkgoIt("can add a proxy to the cluster successfully", func() {
+		// setup helper
+		h := helper.New()
+
+		clusterID := viper.GetString(config.Cluster.ID)
+		clusterProvider, err := providers.ClusterProvider()
+		Expect(err).NotTo(HaveOccurred())
+
+		httpsProxy := viper.GetString(config.Proxy.HttpsProxy)
+		httpProxy := viper.GetString(config.Proxy.HttpProxy)
+		userCABundle := viper.GetString(config.Proxy.UserCABundle)
+		userCABundleData, err := clusterProvider.LoadUserCaBundleData(userCABundle)
+		Expect(err).NotTo(HaveOccurred())
+
+		logger.Printf("Setting cluster-wide proxy to httpsProxy=%v,httpProxy=%v,settingCA=%v",
+			httpsProxy, httpProxy, userCABundle != "")
+		err = clusterProvider.AddClusterProxy(clusterID, httpsProxy, httpProxy, userCABundle)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Wait to see proxy reflected on the cluster
+		logger.Printf("Validating state of proxy on cluster within %v minutes", proxyConfigSyncDuration.Minutes())
+		err = wait.Poll(30*time.Second, proxyConfigSyncDuration, func() (bool, error) {
+			var proxy *configv1.Proxy
+			var cabundle *v1.ConfigMap
+
+			// Validate state of proxy on-cluster vs what values it should have
+			proxy, err = h.Cfg().ConfigV1().Proxies().Get(context.TODO(), "cluster", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			if userCABundle != "" {
+				if proxy.Spec.TrustedCA.Name != "user-ca-bundle" {
+					return false, nil
+				}
+				// Check if the ConfigMap exists
+				cabundle, err = h.Kube().CoreV1().ConfigMaps("openshift-config").Get(context.TODO(), "user-ca-bundle", metav1.GetOptions{})
+				// don't treat the cabundle not existing as an error
+				if err != nil && !apierrors.IsNotFound(err) {
+					return false, err
+				}
+				cabundleData, found := cabundle.Data["ca-bundle.crt"]
+				// if the configmap exists, so should this key, and the value should match
+				if !found || strings.TrimSpace(cabundleData) != strings.TrimSpace(userCABundleData) {
+					logger.Printf("User CA Bundle still not reflected on cluster")
+					return false, nil
+				}
+			}
+			if httpsProxy != "" {
+				// Check if status reflects the HTTPS Proxy value
+				if proxy.Status.HTTPSProxy != httpsProxy {
+					logger.Printf("HTTPS Proxy still not reflected on cluster")
+					return false, nil
+				}
+			}
+			if httpProxy != "" {
+				// Check if status reflects the HTTPS Proxy value
+				if proxy.Status.HTTPProxy != httpProxy {
+					logger.Printf("HTTP Proxy still not reflected on cluster")
+					return false, nil
+				}
+			}
+			return true, nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// The cluster's proxy and configmap state reflects what we expect
+		// So now, is the cluster still healthy?
+		logger.Printf("Verifying cluster health after proxy addition..")
+		err = wait.PollImmediate(30*time.Second, proxyHealthCheckWaitDuration, func() (bool, error) {
+			isHealthy, failures, _ := cluster.PollClusterHealth(clusterID, logger)
+			if isHealthy {
+				logger.Printf("cluster is healthy after proxy addition\n")
+				return true, nil
+			}
+			log.Printf("cluster is not healthy after proxy addition\n")
+			if len(failures) > 0 {
+				logger.Printf("Currently failing %s health checks", strings.Join(failures, ", "))
+			}
+			return false, nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	}, proxyConfigSyncDuration.Seconds()+proxyHealthCheckWaitDuration.Seconds())
+}
+
+func testRemoveProxy() {
+	util.GinkgoIt("can remove proxy from the cluster successfully", func() {
+		// setup helper
+		h := helper.New()
+
+		clusterID := viper.GetString(config.Cluster.ID)
+		clusterProvider, err := providers.ClusterProvider()
+		Expect(err).NotTo(HaveOccurred())
+
+		err = clusterProvider.RemoveClusterProxy(clusterID)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Wait to see proxy reflected on the cluster
+		logger.Printf("Validating state of proxy on cluster within %v minutes", proxyConfigSyncDuration.Minutes())
+		err = wait.Poll(30*time.Second, proxyConfigSyncDuration, func() (bool, error) {
+			var proxy *configv1.Proxy
+
+			// Validate state of proxy on-cluster vs what values it should have
+			proxy, err = h.Cfg().ConfigV1().Proxies().Get(context.TODO(), "cluster", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			if proxy.Spec.HTTPProxy != "" || proxy.Status.HTTPProxy != "" {
+				return false, nil
+			}
+			if proxy.Spec.HTTPSProxy != "" || proxy.Status.HTTPSProxy != "" {
+				return false, nil
+			}
+
+			_, err = h.Kube().CoreV1().ConfigMaps("openshift-config").Get(context.TODO(), "user-ca-bundle", metav1.GetOptions{})
+			if !apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			if proxy.Spec.TrustedCA.Name != "" {
+				return false, nil
+			}
+
+			return true, nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+		// The cluster's proxy and configmap state reflects what we expect
+		// So now, is the cluster still healthy?
+		logger.Printf("Verifying cluster health after proxy removed..")
+		err = wait.PollImmediate(30*time.Second, proxyHealthCheckWaitDuration, func() (bool, error) {
+			isHealthy, failures, _ := cluster.PollClusterHealth(clusterID, logger)
+			if isHealthy {
+				logger.Printf("cluster is healthy after proxy removed\n")
+				return true, nil
+			}
+			log.Printf("cluster is not healthy after proxy removed\n")
+			if len(failures) > 0 {
+				logger.Printf("Currently failing %s health checks", strings.Join(failures, ", "))
+			}
+			return false, nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	}, proxyConfigSyncDuration.Seconds()+proxyHealthCheckWaitDuration.Seconds())
+}


### PR DESCRIPTION
This PR has two goals:
- Add a configuration parameter (`USE_PROXY_FOR_INSTALL`) that controls whether to conduct a proxy-based cluster install. This is being done so that the "Day 2" proxy suite can use the Proxy configuration parameters without the cluster having been installed with a proxy.
- Transform the "Day 2" proxy suite into a test that executes the Add Proxy feature followed by the Remove Proxy one. This is so that we can guarantee that the Add Proxy feature is executed and runs successfully before the Remove Proxy feature is tested.

This has been successfully tested in a staging cluster.