### PR TITLE
Fix code panic in ROSA day-2 proxy calls

### DIFF
--- a/pkg/common/providers/rosaprovider/wrapped_calls.go
+++ b/pkg/common/providers/rosaprovider/wrapped_calls.go
@@ -120,14 +120,14 @@ func (m *ROSAProvider) AddClusterProxy(clusterId string, httpsProxy string, http
 
 // RemoveClusterProxy removes the cluster proxy configuration for the supplied cluster
 func (m *ROSAProvider) RemoveClusterProxy(clusterId string) error {
-	return m.RemoveClusterProxy(clusterId)
+	return m.ocmProvider.RemoveClusterProxy(clusterId)
 }
 
 // RemoveUserCABundle removes only the Additional Trusted CA Bundle from the cluster
 func (m *ROSAProvider) RemoveUserCABundle(clusterId string) error {
-	return m.RemoveUserCABundle(clusterId)
+	return m.ocmProvider.RemoveUserCABundle(clusterId)
 }
 
 func (m *ROSAProvider) LoadUserCaBundleData(file string) (string, error) {
-	return m.LoadUserCaBundleData(file)
+	return m.ocmProvider.LoadUserCaBundleData(file)
 }


### PR DESCRIPTION
This addresses what looks like a code panic bug in the ROSA provider's OCM-wrapped proxy calls. These functions in their pre-PR state would appear to just be calling themselves over and over and probably blow the stack. They should be using the `ocmProvider`, as is the `wrapped_call` file's intended purpose.