### PR TITLE
Updating dependabot to Fridays 9am MST

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: weekly
+    - cron: '0 15 * * 5'
   labels:
     - "dependencies"
     - "ok-to-test"


### PR DESCRIPTION
The weekly tag is weekly based on Pr creation instead of just once a week.