### PR TITLE
Clean up security groups orphaned by AWS LB deletion test

### DIFF
--- a/pkg/e2e/operators/cloudingress/rhapi_lb.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_lb.go
@@ -146,7 +146,7 @@ func deleteSecGroupReferencesToOrphans(awsSession *session.Session, orphanSecGro
 func testLBDeletion(h *helper.H) {
 	ginkgo.Context("rh-api-lb-test", func() {
 
-			if viper.GetString(config.CloudProvider.CloudProviderID) == "aws" {
+		if viper.GetString(config.CloudProvider.CloudProviderID) == "aws" {
 			util.GinkgoIt("manually deleted LB should be recreated in AWS", func() {
 				awsAccessKey := viper.GetString("ocm.aws.accessKey")
 				awsSecretKey := viper.GetString("ocm.aws.secretKey")
@@ -155,7 +155,7 @@ func testLBDeletion(h *helper.H) {
 				// getLoadBalancer name currently associated with rh-api service
 				oldLBName, err := getLBForService(h, "openshift-kube-apiserver", "rh-api", "hostname")
 				Expect(err).NotTo(HaveOccurred())
-				log.Printf("Old LB name %s ",oldLBName)
+				log.Printf("Old LB name %s ", oldLBName)
 
 				// delete the load balancer in aws
 				awsSession, err := session.NewSession(aws.NewConfig().WithCredentials(credentials.NewStaticCredentials(awsAccessKey, awsSecretKey, "")).WithRegion(awsRegion))
@@ -176,7 +176,7 @@ func testLBDeletion(h *helper.H) {
 				_, err = lb.DeleteLoadBalancer(input)
 
 				Expect(err).NotTo(HaveOccurred())
-				log.Printf("Old LB deleted" )
+				log.Printf("Old LB deleted")
 
 				// wait for the new LB to be created
 				err = wait.PollImmediate(15*time.Second, 5*time.Minute, func() (bool, error) {
@@ -190,7 +190,7 @@ func testLBDeletion(h *helper.H) {
 					}
 					if newLBName != oldLBName {
 						// the LB was successfully recreated
-						log.Printf("New LB found. LB name: %s",newLBName)
+						log.Printf("New LB found. LB name: %s", newLBName)
 						return true, nil
 					}
 					// the rh-api svc hasn't been deleted yet

--- a/pkg/e2e/operators/cloudingress/rhapi_lb.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_lb.go
@@ -29,7 +29,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-var _ = ginkgo.Describe(constants.SuiteDummy+TestPrefix, func() {
+var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool("rosa.STS") {
 			ginkgo.Skip("Cluster is STS. For now we skip rh-api LB reconcile test for STS")

--- a/pkg/e2e/operators/cloudingress/rhapi_lb.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_lb.go
@@ -123,12 +123,16 @@ func testLBDeletion(h *helper.H) {
 				log.Printf("Old LB deleted" )
 
 				// delete old LB's security groups, otherwise they'll leak
-				// TODO delete sg (https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.DeleteSecurityGroup)
 				ec2Svc := ec2.New(awsSession)
 				for _, secGroup := range oldLBSecGroups {
-					ec2Svc.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
-						GroupName: aws.String(*secGroup),
+					_, err := ec2Svc.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
+						GroupId: aws.String(*secGroup),
 					})
+					if err != nil {
+						log.Printf("Failed to delete security group %s: %s", *secGroup, err)
+					} else {
+						log.Printf("Deleted orphaned security group %s", *secGroup)
+					}
 				}
 
 				// wait for the new LB to be created

--- a/pkg/e2e/operators/cloudingress/rhapi_lb.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_lb.go
@@ -111,9 +111,11 @@ func testLBDeletion(h *helper.H) {
 				}
 
 				// must store security groups associated with LB so we can delete them
-				oldLBSecGroups := elb.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
-					LoadBalancerNames: [1]*string{aws.String(oldLBName)},
-				})[0].SecurityGroups
+				oldLBDesc, err := lb.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
+					LoadBalancerNames: []*string{aws.String(oldLBName)},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				oldLBSecGroups := oldLBDesc.LoadBalancerDescriptions[0].SecurityGroups
 
 				_, err = lb.DeleteLoadBalancer(input)
 
@@ -124,8 +126,8 @@ func testLBDeletion(h *helper.H) {
 				// TODO delete sg (https://docs.aws.amazon.com/sdk-for-go/api/service/ec2/#EC2.DeleteSecurityGroup)
 				ec2Svc := ec2.New(awsSession)
 				for _, secGroup := range oldLBSecGroups {
-					ec2Svc.DeleteSecurityGroup(&ec2Svc.DeleteSecurityGroupInput{
-						GroupName: aws.String(secGroup),
+					ec2Svc.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
+						GroupName: aws.String(*secGroup),
 					})
 				}
 


### PR DESCRIPTION
The test added in #985 ([OSD-8474](https://issues.redhat.com/browse/OSD-8474)) covering load balancer deletion doesn't currently clean up the security groups left over from deleted load balancers, causing them to become "orphaned" and pile up over time. This PR fixes this bug by recording which security groups are associated with a load balancer pre-deletion, removing any references to said groups (required by AWS in order to delete group), and then deleting these orphan security groups post-LB-recreation.

This PR addresses [OSD-11485](https://issues.redhat.com/browse/OSD-11485), where it was noticed that this bug was causing us to rub up against [AWS's limits](https://docs.aws.amazon.com/vpc/latest/userguide/amazon-vpc-limits.html#vpc-limits-security-groups) on security group quantity.

**Steps to Test**
1. Create a CCS OSD stage cluster, then observe total number of security groups reported by AWS EC2 management console.
2. Run this test: `./out/osde2e test --cluster-id $CLUSTER_ID --skip-health-check --configs "stage" --focus-tests "rh-api-lb-test"`
3. Confirm the test reports "Deleted orphaned security group sg-XYZ"
4. Confirm that total number of security groups reported by AWS EC2 management console hasn't grown since step 1 (i.e., ensure no orphan security groups remain)