### PR TITLE
[WIP] Use the admin-account in MNMO tests.

### DIFF
--- a/pkg/e2e/operators/mnmo.go
+++ b/pkg/e2e/operators/mnmo.go
@@ -17,7 +17,6 @@ import (
 	"github.com/openshift/osde2e/pkg/common/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 )
 
 var mnmoOperatorTestName string = "[Suite: e2e] [OSD] Managed Node Metadata Operator"
@@ -213,14 +212,7 @@ var _ = ginkgo.Describe(mnmoOperatorTestName, ginkgo.Ordered, func() {
 
 		// build the ocm client for this specific cluster
 		clusterClient = ocm.GetConnection().ClustersMgmt().V1().Clusters().Cluster(clusterId)
-
-		// build the cluster client to interact with things on-cluster with
-		h.Impersonate(rest.ImpersonationConfig{
-			UserName: "test-user@redhat.com",
-			Groups: []string{
-				"cluster-admins",
-			},
-		})
+		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
 		// Before everything runs, we need to create a new MachinePoolBuilder to use for OCM
 		machinePoolBuilder = ocmTypes.NewMachinePool().
 			ID(ocmMachinePoolName)

--- a/pkg/e2e/operators/mnmo.go
+++ b/pkg/e2e/operators/mnmo.go
@@ -258,7 +258,7 @@ var _ = ginkgo.Describe(mnmoOperatorTestName, ginkgo.Ordered, func() {
 			}
 			err = waitFor(test, h, machineSetName)
 			Expect(err).NotTo(HaveOccurred())
-		}, 30)
+		}, 60)
 
 		util.GinkgoIt("Updates the label on the Nodes and Machines with a new value", func() {
 			labels := map[string]string{
@@ -288,7 +288,7 @@ var _ = ginkgo.Describe(mnmoOperatorTestName, ginkgo.Ordered, func() {
 			}
 			err = waitFor(test, h, machineSetName)
 			Expect(err).NotTo(HaveOccurred())
-		}, 30)
+		}, 60)
 
 		util.GinkgoIt("Adds a second label to the nodes and machines", func() {
 			labels := map[string]string{
@@ -328,7 +328,7 @@ var _ = ginkgo.Describe(mnmoOperatorTestName, ginkgo.Ordered, func() {
 			}
 			err = waitFor(test, h, machineSetName)
 			Expect(err).NotTo(HaveOccurred())
-		}, 30)
+		}, 60)
 
 		util.GinkgoIt("Removes a single label from the nodes and machines", func() {
 			labels := map[string]string{
@@ -364,7 +364,7 @@ var _ = ginkgo.Describe(mnmoOperatorTestName, ginkgo.Ordered, func() {
 			}
 			err = waitFor(test, h, machineSetName)
 			Expect(err).NotTo(HaveOccurred())
-		}, 30)
+		}, 60)
 
 		util.GinkgoIt("Removes all labels from nodes and machines", func() {
 			labels := map[string]string{}
@@ -392,7 +392,7 @@ var _ = ginkgo.Describe(mnmoOperatorTestName, ginkgo.Ordered, func() {
 			}
 			err = waitFor(test, h, machineSetName)
 			Expect(err).NotTo(HaveOccurred())
-		}, 30)
+		}, 60)
 	})
 
 	ginkgo.Context("When adding a Taint to a MachinePool", ginkgo.Ordered, func() {
@@ -435,7 +435,7 @@ var _ = ginkgo.Describe(mnmoOperatorTestName, ginkgo.Ordered, func() {
 			}
 			err = waitFor(test, h, machineSetName)
 			Expect(err).NotTo(HaveOccurred())
-		}, 30)
+		}, 60)
 
 		util.GinkgoIt("Updates the taint on the Nodes and Machines with a new value", func() {
 			testTaint := ocmTypes.NewTaint().Key(TestTaintKeyOne).Value(TestTaintValueOneUpdated).Effect(TestTaintEffectOne)
@@ -469,7 +469,7 @@ var _ = ginkgo.Describe(mnmoOperatorTestName, ginkgo.Ordered, func() {
 			}
 			err = waitFor(test, h, machineSetName)
 			Expect(err).NotTo(HaveOccurred())
-		}, 30)
+		}, 60)
 
 		util.GinkgoIt("Adds a second taint to the nodes and machines", func() {
 			testTaint := ocmTypes.NewTaint().Key(TestTaintKeyOne).Value(TestTaintValueOneUpdated).Effect(TestTaintEffectOne)
@@ -513,7 +513,7 @@ var _ = ginkgo.Describe(mnmoOperatorTestName, ginkgo.Ordered, func() {
 			}
 			err = waitFor(test, h, machineSetName)
 			Expect(err).NotTo(HaveOccurred())
-		}, 30)
+		}, 60)
 
 		util.GinkgoIt("Removes a single taint from the nodes and machines", func() {
 			testTaintTwo := ocmTypes.NewTaint().Key(TestTaintKeyTwo).Value(TestTaintValueTwo).Effect(TestTaintEffectTwo)
@@ -551,7 +551,7 @@ var _ = ginkgo.Describe(mnmoOperatorTestName, ginkgo.Ordered, func() {
 			}
 			err = waitFor(test, h, machineSetName)
 			Expect(err).NotTo(HaveOccurred())
-		}, 30)
+		}, 60)
 
 		util.GinkgoIt("Removes all taints from nodes and machines", func() {
 			machinePool, err := machinePoolBuilder.Taints().Build()
@@ -584,6 +584,6 @@ var _ = ginkgo.Describe(mnmoOperatorTestName, ginkgo.Ordered, func() {
 			}
 			err = waitFor(test, h, machineSetName)
 			Expect(err).NotTo(HaveOccurred())
-		}, 30)
+		}, 60)
 	})
 })


### PR DESCRIPTION
The account used before did not have permission to get the machinesets,
so the wait-loop would never retrieve the it.