### PR TITLE
Disable cluster-admin publishing strategy test

### DIFF
--- a/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
+++ b/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
@@ -41,17 +41,6 @@ var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 			Expect(apierrors.IsForbidden(err)).To(BeTrue())
 
 		})
-
-		util.GinkgoIt("cluster admin should be allowed to manage publishingstrategies CR", func() {
-			publishingstrategyName := "publishingstrategy-cr-test-2"
-			ps := createPublishingstrategies(publishingstrategyName)
-			err := addPublishingstrategy(h, ps)
-			defer func() {
-				publishingstrategyCleanup(h, publishingstrategyName)
-			}()
-			Expect(err).NotTo(HaveOccurred())
-		})
-
 	})
 
 })
@@ -83,11 +72,4 @@ func addPublishingstrategy(h *helper.H, publishingstrategy cloudingress.Publishi
 		Group: "cloudingress.managed.openshift.io", Version: "v1alpha1", Resource: "publishingstrategies",
 	}).Namespace(OperatorNamespace).Create(context.TODO(), &unstructuredObj, metav1.CreateOptions{})
 	return err
-}
-
-func publishingstrategyCleanup(h *helper.H, publishingstrategyName string) error {
-	return h.Dynamic().Resource(schema.GroupVersionResource{
-		Group: "cloudingress.managed.openshift.io", Version: "v1alpha1", Resource: "publishingstrategies",
-	}).Namespace(OperatorNamespace).Delete(context.TODO(), publishingstrategyName, metav1.DeleteOptions{})
-
 }


### PR DESCRIPTION
* Test doesn't seem to be necessary as cluster-admins shouldn't create publishing strategies themselves
* Publishing strategies should be pushed by OCM
* This test breaks the OpenShift console, resulting in an alert that fails osde2e

Jira: [OSD-11389](https://issues.redhat.com//browse/OSD-11389)