### PR TITLE
Update copy method to avoid ReadOnly disk issues

### DIFF
--- a/pkg/e2e/state/prometheus.go
+++ b/pkg/e2e/state/prometheus.go
@@ -17,7 +17,6 @@ import (
 
 const (
 	// cmd to collect prometheus data
-	promCollectCmd            = "oc exec -n openshift-monitoring prometheus-k8s-0 -c prometheus -- /bin/sh -c \"cp -ruf /prometheus /tmp/ && tar cvzO -C /tmp/prometheus . \""
 	clusterStateInformingName = "[Suite: e2e] Cluster state"
 )
 
@@ -35,7 +34,7 @@ var _ = ginkgo.Describe(clusterStateInformingName, func() {
 		// this command is has specific code to capture and suppress an exit code of
 		// 1 as tar 1.26 will exit 1 if files change while the tar is running, as is
 		// common for a running prometheus instance
-		cmd := promCollectCmd + " > " + runner.DefaultRunner.OutputDir + "/prometheus.tar.gz; err=$? ; if (( $err != 0 )) ; then exit $err ; fi"
+		cmd := "oc cp -c prometheus openshift-monitoring/prometheus-k8s-0:/prometheus /tmp/prometheus && tar -cvzf " + runner.DefaultRunner.OutputDir + "/prometheus.tar.gz -C /tmp/prometheus .; err=$? ; if (( $err != 0 )) ; then exit $err ; fi"
 
 		// ensure prometheus pods are up before trying to extract data
 		poderr := wait.PollImmediate(2*time.Second, prometheusPodStartedDuration, func() (bool, error) {


### PR DESCRIPTION
Completes: https://issues.redhat.com/browse/OSD-12641

---

Refactors the runner pod's command to copy data in `openshift-monitoring/prometheus-k8s-0`'s `/prometheus` directory directly to the runner. This is required for `4.11`, as prometheus's `securityContext` has been updated to include `readOnlyRootFilesystem: true`.