### PR TITLE
Rewrite Operator "CheckUpgrade" test

### DIFF
--- a/pkg/e2e/osd/olm.go
+++ b/pkg/e2e/osd/olm.go
@@ -1,0 +1,43 @@
+package osd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/alert"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var olmTestName string = "[Suite: informing] [OSD] OLM"
+
+const hiveManagedLabel = "hive.openshift.io/managed"
+
+func init() {
+	alert.RegisterGinkgoAlert(olmTestName, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
+}
+
+var _ = ginkgo.Describe(olmTestName, func() {
+	ginkgo.Context("Managed OpenShift Operators", func() {
+		// setup helper
+		h := helper.New()
+
+		util.GinkgoIt("subscriptions are satisfied", func() {
+			subs, err := h.Operator().OperatorsV1alpha1().Subscriptions(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, sub := range subs.Items {
+				if _, ok := sub.Labels[hiveManagedLabel]; ok {
+					// Managed subscriptions must have a CSV successfully installed
+					Expect(sub.Status.CurrentCSV).NotTo(BeEmpty(), fmt.Sprintf("subscription %s currentCSV is empty", sub.Name))
+					Expect(sub.Status.InstalledCSV).NotTo(BeEmpty(), fmt.Sprintf("subscription %s installedCSV is empty", sub.Name))
+				}
+			}
+		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
+	})
+})


### PR DESCRIPTION
## What it does
- Rewrites the operator `checkUpgrade` function to be more resilient to bad Subscription states.
- Introduces a new `informing` test to validate the state of all managed operator subscriptions on the cluster.

## Why
The `should upgrade from the replaced version` operator tests have long been a randomly failing, flaky test in our E2E suite. It finally dawned on me that [BZ1980755](https://bugzilla.redhat.com/show_bug.cgi?id=1980755) could have been the culprit all along. After checking a few must-gathers from runs where the test failed, this theory turned out to be correct.

I have rewritten the `checkUpgrade` test to be able to operate successfully even if a cluster's subscriptions are in a state impacted by BZ1980755. It has been successfully tested on a cluster that is impacted by BZ1980755 and a cluster that is not.

This should finally be the missing link in us achieving solid, flake-free tests in the E2E baseline. :tada: 

Because I don't want to lose insight into if/when this bug is impacting our clusters, I have also introduced a new informing test that verifies the Subscription status of all Hive-managed Subscriptions. 