### PR TITLE
Do not treat postgres port like a secret

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -782,7 +782,6 @@ func init() {
 
 	viper.SetDefault(Database.Port, "5432")
 	viper.BindEnv(Database.Port, "PG_PORT")
-	RegisterSecret(Database.Port, "rds-port")
 
 	viper.SetDefault(Database.DatabaseName, "cicd_test_data")
 	viper.BindEnv(Database.DatabaseName, "PG_DATABASE")


### PR DESCRIPTION
## What it does

No longer treat the RDS postgres DB port as a secret.

## Why / background explanation

We regularly end up with test failures in TestGrid that fail for reasons of being unable to parse the junit xml. [0] [1] [2]

This has been bugging me for a while. The XMLs validated schema checks in `xmllint`. So I ended up writing a simple client to run the xml through TestGrid's parsing function [3], and could then reproduce the error. From there, I was able to hone in on the problem: every junit file that has failed features a test with `XXXX` randomly inserted into the `<testcase>` timestamp.

The reason is because we treat the E2E RDS DB postgres port as a secret. As soon as this number appears in a test artifact file, it is replaced with `XXXX`. Whenever we get a timestamp with the number `5432` in it (which amazingly happens on a near-daily basis) it turns into a bad timestamp which breaks the parsing.

I think we are fine to stop treating the RDS DB port as a secret. Especially giving the anticipatory demise of the RDS DB. I wish I had figured this out like a few months ago. But it was a fun thing to debug.

[0] https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/osde2e-stage-aws-e2e-default/1557245607398084608
[1] https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/osde2e-prod-aws-e2e-default/1556430325687521280
[2] https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/osde2e-prod-aws-e2e-default/1557970235162628096
[3] https://github.com/GoogleCloudPlatform/testgrid/blob/master/metadata/junit/junit.go