### PR TITLE
Increase timeout for SCC RBAC test

### DIFF
--- a/pkg/e2e/verify/sccs.go
+++ b/pkg/e2e/verify/sccs.go
@@ -29,7 +29,7 @@ var _ = ginkgo.Describe(dedicatedAdminSccTestName, func() {
 
 	workloadDir := "/assets/workloads/e2e/scc"
 	// How long to wait for prometheus pods to restart
-	prometheusRestartPollingDuration := 3 * time.Minute
+	prometheusRestartPollingDuration := 4 * time.Minute
 
 	ginkgo.Context("Dedicated Admin permissions", func() {
 
@@ -81,7 +81,7 @@ var _ = ginkgo.Describe(dedicatedAdminSccTestName, func() {
 				return false, nil
 			})
 			Expect(err).NotTo(HaveOccurred())
-		}, (prometheusRestartPollingDuration + 30 * time.Second).Seconds())
+		}, (prometheusRestartPollingDuration + 30*time.Second).Seconds())
 	})
 })
 


### PR DESCRIPTION
## What it does

Increase the timeout for the `new SCC does not break pods` test from 3 minutes to 4 minutes.

## Why?

This is another quite flaky test. My analysis of failed runs has shown that the current 3 minute wait period is just slightly too short. As in, by barely 5-10 seconds each time. The test bounces the Prometheus pods and then waits for them to come back Ready. From checking the must-gathers of failed runs, I can see that it's transitioning to a `ContainersReady` state barely 5 seconds after the test timeout.

By bumping the test timeout by a minute I'm hoping that it addresses this.

A valid question is, "why is it taking 3 minutes for Prometheus to restart?". The answer to which I am not sure, or at least it is difficult to discern that quickly from the events in the namespace via the must-gather.