### PR TITLE
Address Pod Security Admission Failures

### DIFF
--- a/pkg/e2e/verify/namespace_webhook.go
+++ b/pkg/e2e/verify/namespace_webhook.go
@@ -265,9 +265,11 @@ func createNamespace(namespace string, h *helper.H) (*v1.Namespace, error) {
 	}
 
 	log.Printf("Creating namespace for namespace validation webhook (%s)", namespace)
+	labels := map[string]string{"pod-security.kubernetes.io/enforce": "privileged", "pod-security.kubernetes.io/audit": "privileged", "pod-security.kubernetes.io/warn": "privileged", "security.openshift.io/scc.podSecurityLabelSync": "false"}
 	ns = &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
+			Name:   namespace,
+			Labels: labels,
 		},
 	}
 	h.Kube().CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})


### PR DESCRIPTION
### What it does

Adds pod-security labels when creating namespaces

### Why?

TRT is tracking down failed jobs / tests cause by the recent [Pod Security Admission changes](https://docs.openshift.com/container-platform/4.11/authentication/understanding-and-managing-pod-security-admission.html).

A [search](https://search.ci.openshift.org/?search=forbidden%3A+violates+PodSecurity&maxAge=336h&context=1&type=build-log&name=.*ocp-osd.*&excludeName=pull.*&maxMatches=5&maxBytes=20971520&groupBy=job) turned up hits for this project.

```
release-openshift-ocp-osd-aws-nightly-4.12` (all) - 54 runs, 100% failed, 54% of failures match = 54% impact
release-openshift-ocp-osd-gcp-nightly-4.12 (all) - 54 runs, 100% failed, 41% of failures match = 41% impact
```

```
pod Create API error: pods "pvc-tester-8bbqd" is forbidden: violates PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "dummy" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "dummy" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "dummy" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "dummy" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")`

```

This PR is a suggested fix based on a review of the code but please review and close if you have a preferred update / are providing your own fix.
