### PR TITLE
rosaprovider: remove redudant sts cluster setup

### DIFF
--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -17,8 +17,6 @@ import (
 	"github.com/openshift/osde2e/pkg/common/util"
 	accountRoles "github.com/openshift/rosa/cmd/create/accountroles"
 	createCluster "github.com/openshift/rosa/cmd/create/cluster"
-	oidcProvider "github.com/openshift/rosa/cmd/create/oidcprovider"
-	operatorRoles "github.com/openshift/rosa/cmd/create/operatorroles"
 	rosaLogin "github.com/openshift/rosa/cmd/login"
 	"github.com/openshift/rosa/pkg/aws"
 	"github.com/openshift/rosa/pkg/logging"
@@ -254,10 +252,6 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 		return "", fmt.Errorf("failed to get cluster '%s': %v", clusterName, err)
 	}
 
-	if viper.GetBool(STS) {
-		m.stsClusterSetup(cluster)
-	}
-
 	return cluster.ID(), nil
 }
 
@@ -268,25 +262,6 @@ func (m *ROSAProvider) stsAccountSetup(version string) error {
 	newAccountRoles.SetArgs(args)
 	return callAndSetAWSSession(func() error {
 		return newAccountRoles.Execute()
-	})
-}
-
-func (m *ROSAProvider) stsClusterSetup(cluster *v1.Cluster) error {
-	newOperatorRoles := operatorRoles.Cmd
-	newOperatorRoles.SetArgs([]string{"--cluster", cluster.Name(), "--mode", "auto", "--yes"})
-	return callAndSetAWSSession(func() error {
-		err := newOperatorRoles.Execute()
-		if err != nil {
-			return err
-		}
-
-		newOIDCProvider := oidcProvider.Cmd
-		newOIDCProvider.SetArgs([]string{"--cluster", cluster.Name(), "--mode", "auto", "--yes"})
-		err = newOIDCProvider.Execute()
-		if err != nil {
-			return err
-		}
-		return nil
 	})
 }
 


### PR DESCRIPTION
Remove redudant `operator-roles` and `oidc-provider` create command executions as these are already ran when running the create cluster command[1]. This is currently causing a prompt to show (shown below) due to another bug of not enough arguments being supplied to the `create operator-roles` cmd (permission boundary). Since `mode` is set to `auto`, `create cluster` command does the heavy lifting for cluster setup.

```
export CLEAN_CHECK_RUNS="3"
export POLLING_TIMEOUT="5"
export PROVIDER=rosa
export ROSA_STS=true

dlv debug ./cmd/osde2e/ -- test --configs "e2e-suite"
```

```
...
I: Cluster 'osde2e-uqybc' has been created.
...
I: Preparing to create operator roles.
I: Creating roles using 'arn:aws:iam::..:user/osdCcsAdmin'
...
I: Preparing to create OIDC Provider.
I: Creating OIDC provider using 'arn:aws:iam::..:user/osdCcsAdmin'
...
2022/10/25 17:41:55 cluster.go:399: created OCM client
? Permissions boundary ARN (optional): [? for help]
E: Expected a valid policy ARN for permissions boundary: interrupt
...
```

the rosa create cluster command:

```
  2018:
=>2019:		if isSTS {
  2020:			if mode != "" {
  2021:				if !output.HasFlag() || r.Reporter.IsTerminal() {
  2022:					r.Reporter.Infof("Preparing to create operator roles.")
  2023:				}
  2024:				operatorroles.Cmd.Run(operatorroles.Cmd, []string{clusterName, mode, permissionsBoundary})
(dlv) p mode
"auto"
```

https://github.com/openshift/rosa/blob/fc712b47728e902f9504ee0d51410edcfe6f3f2e/cmd/create/cluster/cmd.go#L2034-L2042

[1]: https://github.com/openshift/rosa/blob/master/cmd/create/cluster/cmd.go#L2034-L2042

Signed-off-by: Brady Pratt <bpratt@redhat.com>