### PR TITLE
rosaprovider: replace deprecated arguments

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -42,7 +42,7 @@ Some environment variables commonly used for pipelines under osde2e are indicate
 |ROSA_AWS_REGION| AWSRegion for provisioning clusters.|
 |ROSA_STS| Boolean value to indicate the cluster is STS enabled or not.|
 |ROSA_SUBNET_IDS| A list of subnets used to create the cluster, required for proxy enabled cluster.|
-|ROSA_COMPUTE_NODES| Compute node count for the rosa cluster, default is 2.|
+|ROSA_REPLICAS| Compute node count for the rosa cluster, default is 2.|
  
  
 ### OCM related:-

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -115,7 +115,7 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 		"--version", rosaClusterVersion,
 		"--expiration-time", expiration.Format(time.RFC3339),
 		"--compute-machine-type", viper.GetString(ComputeMachineType),
-		"--compute-nodes", viper.GetString(ComputeNodes),
+		"--replicas", viper.GetString(Replicas),
 		"--machine-cidr", viper.GetString(MachineCIDR),
 		"--service-cidr", viper.GetString(ServiceCIDR),
 		"--pod-cidr", viper.GetString(PodCIDR),
@@ -185,7 +185,7 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 		createClusterArgs = append(createClusterArgs,
 			"--role-arn", fmt.Sprintf("arn:aws:iam::%s:role/ManagedOpenShift-%s-Installer-Role", awsAccountID, majorMinor),
 			"--support-role-arn", fmt.Sprintf("arn:aws:iam::%s:role/ManagedOpenShift-%s-Support-Role", awsAccountID, majorMinor),
-			"--master-iam-role", fmt.Sprintf("arn:aws:iam::%s:role/ManagedOpenShift-%s-ControlPlane-Role", awsAccountID, majorMinor),
+			"--controlplane-iam-role", fmt.Sprintf("arn:aws:iam::%s:role/ManagedOpenShift-%s-ControlPlane-Role", awsAccountID, majorMinor),
 			"--worker-iam-role", fmt.Sprintf("arn:aws:iam::%s:role/ManagedOpenShift-%s-Worker-Role", awsAccountID, majorMinor),
 		)
 

--- a/pkg/common/providers/rosaprovider/config.go
+++ b/pkg/common/providers/rosaprovider/config.go
@@ -33,8 +33,8 @@ const (
 	// ComputeMachineType is instance size of the compute nodes in a cluster.
 	ComputeMachineTypeRegex = "rosa.computeMachineTypeRegex"
 
-	// ComputeNodes is number of compute nodes in a cluster.
-	ComputeNodes = "rosa.computeNodes"
+	// Replicas is number of compute nodes in a cluster.
+	Replicas = "rosa.replicas"
 
 	// HostPrefix is the prefix for the hosts produced by ROSA.
 	HostPrefix = "rosa.hostPrefix"
@@ -69,8 +69,8 @@ func init() {
 	viper.BindEnv(ComputeMachineType, "ROSA_COMPUTE_MACHINE_TYPE")
 	viper.BindEnv(ComputeMachineTypeRegex, "ROSA_COMPUTE_MACHINE_TYPE")
 
-	viper.BindEnv(ComputeNodes, "ROSA_COMPUTE_NODES")
-	viper.SetDefault(ComputeNodes, 2)
+	viper.BindEnv(Replicas, "ROSA_REPLICAS")
+	viper.SetDefault(Replicas, 2)
 
 	viper.BindEnv(HostPrefix, "ROSA_HOST_PREFIX")
 	viper.SetDefault(HostPrefix, 0)


### PR DESCRIPTION
```
Flag --compute-nodes has been deprecated, use --replicas instead
Flag --master-iam-role has been deprecated, use --controlplane-iam-role instead
```

resolves #1340

Signed-off-by: Brady Pratt <bpratt@redhat.com>