### PR TITLE
SDCICD-821 - DestroyAfterTest flag Debug

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -359,7 +359,8 @@ func waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID string, l
 // ClusterConfig returns the rest API config for a given cluster as well as the provider it
 // inferred to discover the config.
 // param clusterID: If specified, Provider will be discovered through OCM. If the empty string,
-// 		assume we are running in a cluster and use in-cluster REST config instead.
+//
+//	assume we are running in a cluster and use in-cluster REST config instead.
 func ClusterConfig(clusterID string) (restConfig *rest.Config, providerType string, err error) {
 	if clusterID == "" {
 		if restConfig, err = rest.InClusterConfig(); err != nil {
@@ -390,7 +391,8 @@ func ClusterConfig(clusterID string) (restConfig *rest.Config, providerType stri
 
 // PollClusterHealth looks at CVO data to determine if a cluster is alive/healthy or not
 // param clusterID: If specified, Provider will be discovered through OCM. If the empty string,
-// 		assume we are running in a cluster and use in-cluster REST config instead.
+//
+//	assume we are running in a cluster and use in-cluster REST config instead.
 func PollClusterHealth(clusterID string, logger *log.Logger) (status bool, failures []string, err error) {
 	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 
@@ -544,6 +546,7 @@ func ProvisionCluster(logger *log.Logger) (*spi.Cluster, error) {
 		if cluster, err = provider.GetCluster(clusterID); err != nil {
 			return nil, fmt.Errorf("could not get cluster after launching: %v", err)
 		}
+
 	} else {
 		logger.Printf("CLUSTER_ID of '%s' was provided, skipping cluster creation and using it instead", clusterID)
 

--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -359,8 +359,7 @@ func waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID string, l
 // ClusterConfig returns the rest API config for a given cluster as well as the provider it
 // inferred to discover the config.
 // param clusterID: If specified, Provider will be discovered through OCM. If the empty string,
-//
-//	assume we are running in a cluster and use in-cluster REST config instead.
+// assume we are running in a cluster and use in-cluster REST config instead.
 func ClusterConfig(clusterID string) (restConfig *rest.Config, providerType string, err error) {
 	if clusterID == "" {
 		if restConfig, err = rest.InClusterConfig(); err != nil {
@@ -391,8 +390,7 @@ func ClusterConfig(clusterID string) (restConfig *rest.Config, providerType stri
 
 // PollClusterHealth looks at CVO data to determine if a cluster is alive/healthy or not
 // param clusterID: If specified, Provider will be discovered through OCM. If the empty string,
-//
-//	assume we are running in a cluster and use in-cluster REST config instead.
+// assume we are running in a cluster and use in-cluster REST config instead.
 func PollClusterHealth(clusterID string, logger *log.Logger) (status bool, failures []string, err error) {
 	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 
@@ -546,7 +544,6 @@ func ProvisionCluster(logger *log.Logger) (*spi.Cluster, error) {
 		if cluster, err = provider.GetCluster(clusterID); err != nil {
 			return nil, fmt.Errorf("could not get cluster after launching: %v", err)
 		}
-
 	} else {
 		logger.Printf("CLUSTER_ID of '%s' was provided, skipping cluster creation and using it instead", clusterID)
 

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -682,7 +682,7 @@ func InitViper() {
 	viper.SetDefault(Cluster.Channel, "candidate")
 	viper.BindEnv(Cluster.Channel, "CHANNEL")
 
-	viper.SetDefault(Cluster.DestroyAfterTest, false)
+	viper.SetDefault(Cluster.DestroyAfterTest, true)
 	viper.BindEnv(Cluster.DestroyAfterTest, "DESTROY_CLUSTER")
 
 	viper.SetDefault(Cluster.ExpiryInMinutes, 360)

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -725,10 +725,13 @@ func InitViper() {
 	viper.SetDefault(Cluster.CleanCheckRuns, 20)
 	viper.BindEnv(Cluster.CleanCheckRuns, "CLEAN_CHECK_RUNS")
 
+	viper.SetDefault(Cluster.ID, "")
 	viper.BindEnv(Cluster.ID, "CLUSTER_ID")
 
+	viper.SetDefault(Cluster.Name, "")
 	viper.BindEnv(Cluster.Name, "CLUSTER_NAME")
 
+	viper.SetDefault(Cluster.Version, "")
 	viper.BindEnv(Cluster.Version, "CLUSTER_VERSION")
 
 	viper.SetDefault(Cluster.EnoughVersionsForOldestOrMiddleTest, true)

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -326,7 +326,6 @@ func runGinkgoTests() (int, error) {
 	log.Printf("Outputting log to build log at %s", buildLogPath)
 
 	// Get the cluster ID now to test against later
-	clusterID := viper.GetString(config.Cluster.ID)
 	providerCfg := viper.GetString(config.Provider)
 	// setup OSD unless Kubeconfig is present
 	if len(viper.GetString(config.Kubeconfig.Path)) > 0 && providerCfg == "mock" {
@@ -526,9 +525,9 @@ func runGinkgoTests() (int, error) {
 	}
 
 	if viper.GetBool(config.Cluster.DestroyAfterTest) {
-		log.Printf("Destroying cluster '%s'...", clusterID)
+		log.Printf("Destroying cluster '%s'...", viper.GetString(config.Cluster.ID))
 
-		if err = provider.DeleteCluster(clusterID); err != nil {
+		if err = provider.DeleteCluster(viper.GetString(config.Cluster.ID)); err != nil {
 			return Failure, fmt.Errorf("error deleting cluster: %s", err.Error())
 		}
 	} else {
@@ -683,7 +682,7 @@ func cleanupAfterE2E(h *helper.H) (errors []error) {
 	// We need a provider to hibernate
 	// We need a cluster to hibernate
 	// We need to check that the test run wants to hibernate after this run
-	if provider != nil && viper.GetString(config.Cluster.ID) != "" && viper.GetBool(config.Cluster.HibernateAfterUse) {
+	if provider != nil && viper.GetString(config.Cluster.ID) != "" && viper.GetBool(config.Cluster.HibernateAfterUse) && !viper.GetBool(config.Cluster.DestroyAfterTest) {
 		msg := "Unable to hibernate %s"
 		if provider.Hibernate(viper.GetString(config.Cluster.ID)) {
 			msg = "Hibernating %s"

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -507,19 +507,6 @@ func runGinkgoTests() (int, error) {
 		}
 	}
 
-	if viper.GetBool(config.Cluster.DestroyAfterTest) {
-		log.Printf("Destroying cluster '%s'...", clusterID)
-
-		if err = provider.DeleteCluster(clusterID); err != nil {
-			return Failure, fmt.Errorf("error deleting cluster: %s", err.Error())
-		}
-	} else {
-		// When using a local kubeconfig, provider might not be set
-		if provider != nil {
-			log.Printf("For debugging, please look for cluster ID %s in environment %s", viper.GetString(config.Cluster.ID), provider.Environment())
-		}
-	}
-
 	if !suiteConfig.DryRun {
 		getLogs()
 
@@ -536,6 +523,19 @@ func runGinkgoTests() (int, error) {
 	if !testsPassed || !upgradeTestsPassed {
 		viper.Set(config.Cluster.Passing, false)
 		return Failure, fmt.Errorf("please inspect logs for more details")
+	}
+
+	if viper.GetBool(config.Cluster.DestroyAfterTest) {
+		log.Printf("Destroying cluster '%s'...", clusterID)
+
+		if err = provider.DeleteCluster(clusterID); err != nil {
+			return Failure, fmt.Errorf("error deleting cluster: %s", err.Error())
+		}
+	} else {
+		// When using a local kubeconfig, provider might not be set
+		if provider != nil {
+			log.Printf("For debugging, please look for cluster ID %s in environment %s", viper.GetString(config.Cluster.ID), provider.Environment())
+		}
 	}
 
 	return Success, nil


### PR DESCRIPTION
The current use of the DestroyAfterTest flag is causing the pipeline to show as failed since it's not exiting gracefully. 
We need to be able to destroy clusters after runs in order to clean up STS resources during the same run as the delete cluster functions won't clean up the Cloud accounts. 