### PR TITLE
go install pkger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ build-quick:
 	go build -o "$(OUT_DIR)" "$(DIR)cmd/..."
 
 pkger:
-	GOFLAGS='' go get github.com/markbates/pkger/cmd/pkger
+	GOFLAGS='' go install github.com/markbates/pkger/cmd/pkger
 	pkger --include $(DIR)assets --include $(DIR)configs
 
 diffproviders.txt:


### PR DESCRIPTION
go get \<binary\> is deprecated

Signed-off-by: Brady Pratt <bpratt@redhat.com>

required for https://github.com/openshift/release/pull/33570

failing for:
```
GOFLAGS='' go get github.com/markbates/pkger/cmd/pkger
pkger --include /go/src/github.com/openshift/osde2e/assets --include /go/src/github.com/openshift/osde2e/configs
make: pkger: Command not found 
```