### PR TITLE
SDCICD-760: remove unneeded sts account setup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/ginkgo/v2 v2.4.0
 	github.com/onsi/gomega v1.24.0
-	github.com/openshift-online/ocm-sdk-go v0.1.288
+	github.com/openshift-online/ocm-sdk-go v0.1.289
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/openshift/client-go v0.0.0-20200827190008-3062137373b5
 	github.com/openshift/cloud-credential-operator v0.0.0-20210525141023-02cc6303cd10
@@ -39,8 +39,7 @@ require (
 	github.com/openshift/custom-domains-operator v0.0.0-20210423153044-6e7655fbdecf
 	github.com/openshift/machine-api-operator v0.2.1-0.20200529045911-d19e8d007f7c
 	github.com/openshift/managed-upgrade-operator v0.0.0-20210728104325-95212635e5e1
-	github.com/openshift/origin v0.0.0-20160503220234-8f127d736703
-	github.com/openshift/rosa v1.2.8
+	github.com/openshift/rosa v1.2.9-0.20221103140620-386b9ce99acb
 	github.com/openshift/route-monitor-operator v0.0.0-20210309123726-229da76cc133
 	github.com/openshift/splunk-forwarder-operator v0.0.0-20201112162206-2f454770b6c0
 	github.com/operator-framework/api v0.3.6

--- a/go.sum
+++ b/go.sum
@@ -1350,8 +1350,8 @@ github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/opencontainers/selinux v1.5.2/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
-github.com/openshift-online/ocm-sdk-go v0.1.288 h1:lhA5YLgGP2m23xiMKIivD/T/J3zt7ee0UWbzDxm6HmU=
-github.com/openshift-online/ocm-sdk-go v0.1.288/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
+github.com/openshift-online/ocm-sdk-go v0.1.289 h1:OU44aAq9LCbXsSeGXJyjDv/h5Q9Jh6gP0kBzJ3fVwIU=
+github.com/openshift-online/ocm-sdk-go v0.1.289/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
 github.com/openshift/api v0.0.0-20200526144822-34f54f12813a h1:riE/kCXnb051RWT/z+DytxKEZ3+JromVDl79rXAKyFY=
 github.com/openshift/api v0.0.0-20200526144822-34f54f12813a/go.mod h1:l6TGeqJ92DrZBuWMNKcot1iZUHfbYSJyBWHGgg6Dn6s=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
@@ -1382,11 +1382,10 @@ github.com/openshift/managed-upgrade-operator v0.0.0-20210728104325-95212635e5e1
 github.com/openshift/managed-upgrade-operator v0.0.0-20210728104325-95212635e5e1/go.mod h1:M9KpCngTO2/SIFHApXdCECuRjPzDfvxTJ/YQI8hSqac=
 github.com/openshift/operator-custom-metrics v0.3.0/go.mod h1:4k6G9+KHKg6r/ShP8Vi9YFnpJ5fbHPkQsYCUlzMwtYQ=
 github.com/openshift/operator-custom-metrics v0.4.2/go.mod h1:pF8VqYYaJrZo780/ebeMDcaI20ETzJuUSDHGXSzjWwk=
-github.com/openshift/origin v0.0.0-20160503220234-8f127d736703 h1:KLVRXtjLhZHVtrcdnuefaI2Bf182EEiTfEVDHokoyng=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openshift/prom-label-proxy v0.1.1-0.20191016113035-b8153a7f39f1/go.mod h1:p5MuxzsYP1JPsNGwtjtcgRHHlGziCJJfztff91nNixw=
-github.com/openshift/rosa v1.2.8 h1:mmszQB45lXurpb1ViKx/tuLlIGujS6AXAviVxTIPFyk=
-github.com/openshift/rosa v1.2.8/go.mod h1:tiogxx7QNQ+ly8tWBCWTTP88cEtu38eHeFgNw1YDZxs=
+github.com/openshift/rosa v1.2.9-0.20221103140620-386b9ce99acb h1:VLE9K+GUZ+TxfQ8HA2DZAlM59Tn33skYj0+Mu29AA2g=
+github.com/openshift/rosa v1.2.9-0.20221103140620-386b9ce99acb/go.mod h1:j1TH8e423AkXuvLOzZPz9cVlD/HUysThWPpwxvaeIyk=
 github.com/openshift/route-monitor-operator v0.0.0-20210309123726-229da76cc133 h1:6Cr5RoyrSgaQ5184W/HX0N5k0t5P8Ru9zD83wR278Us=
 github.com/openshift/route-monitor-operator v0.0.0-20210309123726-229da76cc133/go.mod h1:ZVZAfHAN2JDYWelRwkYhvtkjR6RC1Mp/xH7Mm5n/P5A=
 github.com/openshift/runtime-utils v0.0.0-20200415173359-c45d4ff3f912/go.mod h1:0OXNy7VoqFexkxKqyQbHJLPwn1MFp1/CxRJAgKHM+/o=

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Masterminds/semver"
 	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
-	accountRoles "github.com/openshift/rosa/cmd/create/accountroles"
 	createCluster "github.com/openshift/rosa/cmd/create/cluster"
 	"github.com/openshift/rosa/cmd/dlt/oidcprovider"
 	"github.com/openshift/rosa/cmd/dlt/operatorrole"
@@ -122,6 +121,8 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 		"--service-cidr", viper.GetString(ServiceCIDR),
 		"--pod-cidr", viper.GetString(PodCIDR),
 		"--host-prefix", viper.GetString(HostPrefix),
+		"--mode", "auto",
+		"--yes",
 	}
 	if viper.GetString(SubnetIDs) != "" {
 		subnetIDs := viper.GetString(SubnetIDs)
@@ -148,8 +149,6 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 		)
 	}
 
-	awsAccountID := ""
-
 	err = callAndSetAWSSession(func() error {
 		// Retrieve AWS Account info
 		logger := logging.NewLogger()
@@ -168,8 +167,6 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 			return fmt.Errorf("unable to get IAM credentials: %v", err)
 		}
 
-		awsAccountID = awsCreator.AccountID
-
 		return nil
 	})
 	if err != nil {
@@ -177,24 +174,10 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 	}
 
 	if viper.GetBool(STS) {
-		parsedVersion := semver.MustParse(rosaClusterVersion)
-		majorMinor := fmt.Sprintf("%d.%d", parsedVersion.Major(), parsedVersion.Minor())
-
-		err = m.stsAccountSetup(majorMinor)
-		if err != nil {
-			return "", err
-		}
-		createClusterArgs = append(createClusterArgs,
-			"--role-arn", fmt.Sprintf("arn:aws:iam::%s:role/ManagedOpenShift-%s-Installer-Role", awsAccountID, majorMinor),
-			"--support-role-arn", fmt.Sprintf("arn:aws:iam::%s:role/ManagedOpenShift-%s-Support-Role", awsAccountID, majorMinor),
-			"--controlplane-iam-role", fmt.Sprintf("arn:aws:iam::%s:role/ManagedOpenShift-%s-ControlPlane-Role", awsAccountID, majorMinor),
-			"--worker-iam-role", fmt.Sprintf("arn:aws:iam::%s:role/ManagedOpenShift-%s-Worker-Role", awsAccountID, majorMinor),
-		)
-
+		createClusterArgs = append(createClusterArgs, "--sts")
 	}
 
 	clusterProperties, err := m.ocmProvider.GenerateProperties()
-
 	if err != nil {
 		return "", fmt.Errorf("error generating cluster properties: %v", err)
 	}
@@ -271,16 +254,6 @@ func (m *ROSAProvider) DeleteCluster(clusterID string) error {
 	}
 
 	return nil
-}
-
-func (m *ROSAProvider) stsAccountSetup(version string) error {
-	newAccountRoles := accountRoles.Cmd
-	args := []string{"--version", version, "--prefix", fmt.Sprintf("ManagedOpenShift-%s", version), "--mode", "auto", "--yes"}
-	log.Printf("%v", args)
-	newAccountRoles.SetArgs(args)
-	return callAndSetAWSSession(func() error {
-		return newAccountRoles.Execute()
-	})
 }
 
 func (m *ROSAProvider) stsClusterCleanup(clusterID string) error {

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -173,8 +173,8 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 		return "", err
 	}
 
-	if viper.GetBool(STS) {
-		createClusterArgs = append(createClusterArgs, "--sts")
+	if !viper.GetBool(STS) {
+		createClusterArgs = append(createClusterArgs, "--non-sts")
 	}
 
 	clusterProperties, err := m.ocmProvider.GenerateProperties()

--- a/pkg/e2e/operators/cloudingress/rhapi_lb.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_lb.go
@@ -3,12 +3,12 @@ package cloudingress
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/openshift/origin/Godeps/_workspace/src/github.com/emicklei/go-restful/log"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/constants"


### PR DESCRIPTION
It is no longer needed to create specific roles which will help with the cluttering of the AWS account

Signed-off-by: Brady Pratt <bpratt@redhat.com>

/hold