### PR TITLE
actually use failure threshold for alerts

### DIFF
--- a/pkg/common/alert/alert.go
+++ b/pkg/common/alert/alert.go
@@ -126,7 +126,7 @@ func RegisterGinkgoAlert(test, team, contact, slack, email string, threshold int
 		PrimaryContact:   contact,
 		SlackChannel:     slack,
 		Email:            email,
-		FailureThreshold: 4,
+		FailureThreshold: threshold,
 	}
 	ma.AddAlert(testAlert)
 }


### PR DESCRIPTION
all of the calls to RegisterGinkgoAlert are setting threshold to 4 anyway, so no behavior is changing with this but let's actually use the parameter to set the threshold in case it will be set to something different in the future.

Signed-off-by: Brady Pratt <bpratt@redhat.com>

```
pkg/e2e/openshift/images.go
17:	alert.RegisterGinkgoAlert(imageRegistryTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
18:	alert.RegisterGinkgoAlert(imageEcosystemTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/openshift/app_builds.go
47:	alert.RegisterGinkgoAlert(appBuildsTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/openshift/conformance.go
33:	alert.RegisterGinkgoAlert(conformanceK8sTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
34:	alert.RegisterGinkgoAlert(conformanceOpenshiftTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/openshift/disruptive.go
16:	alert.RegisterGinkgoAlert(disruptiveTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/validation_webhook.go
20:	alert.RegisterGinkgoAlert(validationWebhookTestName, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/storage.go
29:	alert.RegisterGinkgoAlert(storageTestName, "SD-SREP", "Christoph Blecker", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/techpreviewnoupgrade_webhook.go
20:	alert.RegisterGinkgoAlert(techPreviewNoUpgradeWebhookTestName, "SD-SREP", "Tafhim Ul Islam", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/workloads/redmine/redmine.go
42:	alert.RegisterGinkgoAlert(testName, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/check_workloads.go
21:	alert.RegisterGinkgoAlert(onNodesTestName, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/prom_exporters.go
23:	alert.RegisterGinkgoAlert(promExportersTestname, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/sccs.go
24:	alert.RegisterGinkgoAlert(dedicatedAdminSccTestName, "SD-CICD", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/namespace_webhook.go
28:	alert.RegisterGinkgoAlert(namespaceWebhookTestName, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/hiveownership_webhook.go
27:	alert.RegisterGinkgoAlert(hiveownershipWebhookTestName, "SD-SREP", "Boran Seref", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/loadbalancers.go
27:	alert.RegisterGinkgoAlert(loadBalancersTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/routes.go
30:	alert.RegisterGinkgoAlert(routesTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/regularuser_webhook.go
19:	alert.RegisterGinkgoAlert(regularuserWebhookTestName, "SD-SREP", "Max Whittingham", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/user-workload-monitoring.go
27:	alert.RegisterGinkgoAlert(userWorkloadMonitoringTestName, "SD-SREP", "Max Whittingham", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/pods.go
24:	alert.RegisterGinkgoAlert(podsTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/encrypted_storage.go
49:	alert.RegisterGinkgoAlert(encryptedStorageTestName, "SD-SREP", "Trevor Nierman", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/scale/mastervertical.go
23:	alert.RegisterGinkgoAlert(masterVerticalTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/pod_webhook.go
25:	alert.RegisterGinkgoAlert(podWebhookTestName, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/fips.go
31:	alert.RegisterGinkgoAlert(fipsTestName, "SD-SREP", "Trevor Nierman", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/state/alerts.go
36:	alert.RegisterGinkgoAlert(clusterStateTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/verify/imagestreams.go
19:	alert.RegisterGinkgoAlert(imageStreamsTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/scale/performance.go
16:	alert.RegisterGinkgoAlert(performanceTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/operators/routemonitor.go
28:  alert.RegisterGinkgoAlert(routeMonitorOperatorTestName, "SD-SREP", "@sre-platform-team-orange", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/proxy/postinstall.go
41:	alert.RegisterGinkgoAlert(postInstallProxyTestName, "SD-SREP", "@sd-srep-team-hulk", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/scale/nodes_and_pods.go
22:	alert.RegisterGinkgoAlert(nodesPodsTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/osd/ocm.go
29:	alert.RegisterGinkgoAlert(ocmTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/osd/rebalance_infra_nodes.go
35:	alert.RegisterGinkgoAlert(rebalanceInfraNodesTestName, "SD-SREP", "Jing Zhang", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/osd/dedicatedadmin.go
27:	alert.RegisterGinkgoAlert(dedicatedAdminTestName, "SD-SREP", "@dedicated-admin-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/operators/dvo.go
28:	alert.RegisterGinkgoAlert(deploymentValidationOperatorTestName, "SD-SREP", "Ron Green", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/osd/nodelabels.go
19:	alert.RegisterGinkgoAlert(nodeLabelsTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/operators/customdomains.go
53:	alert.RegisterGinkgoAlert(customDomainsOperatorTestName, "SD-SREP", "@custom-domains-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/osd/privileged.go
41:	alert.RegisterGinkgoAlert(privilegedTestname, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/osd/daemonsets.go
22:	alert.RegisterGinkgoAlert(daemonSetsTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/workloads/guestbook/guestbook.go
40:	alert.RegisterGinkgoAlert(testName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/operators/configurealertmanager.go
12:	alert.RegisterGinkgoAlert(configureAlertManagerOperators, "SD-SREP", "@sd-srep-team-thor", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/operators/managedvelero.go
26:	alert.RegisterGinkgoAlert(veleroOperatorTestName, "SD-SREP", "@managed-velero-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/operators/osdmetricsexporter.go
15:	alert.RegisterGinkgoAlert(osdMetricsExporterBasicTest, "SD_SREP", "@sre-platform-team-v1alpha1", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/operators/ocmagent.go
25:	alert.RegisterGinkgoAlert(ocmAgentBasicTest, "SD_SREP", "@ocm-agent-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/operators/rbac.go
25:	alert.RegisterGinkgoAlert(rbacOperatorBlocking, "SD-SREP", "@rbac-permissions-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
26:	alert.RegisterGinkgoAlert(subjectPermissionsTestName, "SD-SREP", "@rbac-permissions-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/osd/machinehealthcheck.go
23:	alert.RegisterGinkgoAlert(machineHealthTestName, "SD-SRE", "Alex Chvatal", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/operators/prunejob.go
26:	alert.RegisterGinkgoAlert(pruneJobsTestName, "SD-SREP", "Haoran Wang", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/operators/certman.go
21:	alert.RegisterGinkgoAlert(certmanOperatorTestName, "SD-SREP", "@certman-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/osd/inhibitions.go
213:	alert.RegisterGinkgoAlert(inhibitionsTestName, "SD-SRE", "Alex Chvatal", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/operators/cloudingress/cloudingress.go
17:	alert.RegisterGinkgoAlert(constants.SuiteInforming+TestPrefix, "SD-SRE", "@sd-sre-aurora-team", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
18:	alert.RegisterGinkgoAlert(constants.SuiteOperators+TestPrefix, "SD-SRE", "@sd-sre-aurora-team", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/operators/mustgather.go
25:	alert.RegisterGinkgoAlert(mustGatherOperatorTest, "SD-SREP", "@sd-sre-aurora-team", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/osd/olm.go
22:	alert.RegisterGinkgoAlert(olmTestName, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/operators/managedupgrade.go
30:	alert.RegisterGinkgoAlert(managedUpgradeOperatorTestName, "SD-SREP", "@managed-upgrade-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

pkg/e2e/operators/splunkforwarder.go
25:	alert.RegisterGinkgoAlert(splunkForwarderBlocking, "SD-SREP", "@srep-security-team", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
26:	alert.RegisterGinkgoAlert(splunkForwarderInforming, "SD-SREP", "@srep-security-team", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
```