### PR TITLE
bump golangci-lint to v1.50.1

### DIFF
--- a/.golang-ci.yml
+++ b/.golang-ci.yml
@@ -8,12 +8,10 @@ run:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - gocyclo
     - govet
     - ineffassign
     - misspell
-    - structcheck
     - unused
 issues:
   exclude:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ifndef $(GOPATH)
 endif
 
 check: shellcheck vipercheck diffproviders.txt diffreporters.txt
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.46.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.50.1
 	(cd "$(DIR)"; golangci-lint run -c .golang-ci.yml ./...)
 	cmp -s diffproviders.txt "$(DIR)pkg/common/providers/providers_generated.go"
 	cmp -s diffreporters.txt "$(DIR)pkg/reporting/reporters/reporters_generated.go"


### PR DESCRIPTION
deadcode and structcheck are both deprecated/abandoned and replaced by unused

Signed-off-by: Brady Pratt <bpratt@redhat.com>