### PR TITLE
allow ginkgo to manage the context

### DIFF
--- a/pkg/common/helper/addons.go
+++ b/pkg/common/helper/addons.go
@@ -16,7 +16,7 @@ import (
 // RunAddonTests will attempt to run the configured addon tests for the current job.
 // It allows you to specify a job name prefix and arguments to a test harness container.
 // It returns the names of test harnesses that failed (empty slice if none failed).
-func (h *H) RunAddonTests(name string, timeout int, harnesses, args []string) (failed []string) {
+func (h *H) RunAddonTests(ctx context.Context, name string, timeout int, harnesses, args []string) (failed []string) {
 	addonTestTemplate, err := templates.LoadTemplate("addons/addon-runner.template")
 
 	if err != nil {
@@ -24,7 +24,7 @@ func (h *H) RunAddonTests(name string, timeout int, harnesses, args []string) (f
 	}
 
 	// We don't know what a test harness may need so let's give them everything.
-	h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+	h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 	for _, harness := range harnesses {
 		// configure tests
 		// setup runner
@@ -87,7 +87,7 @@ func (h *H) RunAddonTests(name string, timeout int, harnesses, args []string) (f
 		Expect(err).NotTo(HaveOccurred())
 
 		// ensure job has not failed
-		job, err := h.Kube().BatchV1().Jobs(r.Namespace).Get(context.TODO(), jobName, metav1.GetOptions{})
+		job, err := h.Kube().BatchV1().Jobs(r.Namespace).Get(ctx, jobName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		if !Expect(job.Status.Failed).Should(BeNumerically("==", 0)) {
 			failed = append(failed, harness)

--- a/pkg/common/helper/endpoints.go
+++ b/pkg/common/helper/endpoints.go
@@ -12,13 +12,13 @@ import (
 )
 
 // WaitForEndpointReady until Endpoint for svc is ready, checking n times and sleeping dur between them.
-func (h *H) WaitForEndpointReady(svc *kubev1.Service, n int, dur time.Duration) error {
+func (h *H) WaitForEndpointReady(ctx context.Context, svc *kubev1.Service, n int, dur time.Duration) error {
 	if svc == nil {
 		return errors.New("svc was nil")
 	}
 
 	for i := 0; i < n; i++ {
-		if endpoints, err := h.Kube().CoreV1().Endpoints(svc.Namespace).Get(context.TODO(), svc.Name, metav1.GetOptions{}); err != nil {
+		if endpoints, err := h.Kube().CoreV1().Endpoints(svc.Namespace).Get(ctx, svc.Name, metav1.GetOptions{}); err != nil {
 			log.Println(err)
 		} else if endpoints != nil {
 			for _, subset := range endpoints.Subsets {

--- a/pkg/common/helper/olm.go
+++ b/pkg/common/helper/olm.go
@@ -1,14 +1,16 @@
 package helper
 
 import (
+	"context"
 	"fmt"
+
 	"github.com/openshift/osde2e/pkg/common/runner"
 )
 
 // InspectOLM inspects the OLM state of the cluster and saves the state to disk for later debugging
-func (h *H) InspectOLM() error {
+func (h *H) InspectOLM(ctx context.Context) error {
 	inspectTimeoutInSeconds := 200
-	h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+	h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 	r := h.Runner(fmt.Sprintf("oc adm inspect --dest-dir=%v -A olm", runner.DefaultRunner.OutputDir))
 	r.Name = "olm-inspect"
 	r.Tarball = true

--- a/pkg/common/helper/pods.go
+++ b/pkg/common/helper/pods.go
@@ -12,10 +12,10 @@ import (
 )
 
 // WaitForPodPhase until in target, checking n times and sleeping dur between them. Last known phase is returned.
-func (h *H) WaitForPodPhase(pod *kubev1.Pod, target kubev1.PodPhase, n int, dur time.Duration) (phase kubev1.PodPhase) {
+func (h *H) WaitForPodPhase(ctx context.Context, pod *kubev1.Pod, target kubev1.PodPhase, n int, dur time.Duration) (phase kubev1.PodPhase) {
 	var err error
 	for i := 0; i < n; i++ {
-		if pod, err = h.Kube().CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{}); err != nil {
+		if pod, err = h.Kube().CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{}); err != nil {
 			log.Println(err)
 		} else if pod != nil {
 			phase = pod.Status.Phase

--- a/pkg/common/helper/projects.go
+++ b/pkg/common/helper/projects.go
@@ -13,21 +13,21 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-func (h *H) createProject(suffix string) (*projectv1.Project, error) {
+func (h *H) createProject(ctx context.Context, suffix string) (*projectv1.Project, error) {
 	proj := &projectv1.Project{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "osde2e-" + suffix,
 		},
 	}
 
-	project, err := h.Project().ProjectV1().Projects().Create(context.TODO(), proj, metav1.CreateOptions{})
+	project, err := h.Project().ProjectV1().Projects().Create(ctx, proj, metav1.CreateOptions{})
 
 	if err != nil {
 		return project, err
 	}
 
 	wait.PollImmediate(5*time.Second, 60*time.Second, func() (done bool, err error) {
-		ns, err := h.Kube().CoreV1().Namespaces().Get(context.TODO(), project.Name, metav1.GetOptions{})
+		ns, err := h.Kube().CoreV1().Namespaces().Get(ctx, project.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -42,12 +42,12 @@ func (h *H) createProject(suffix string) (*projectv1.Project, error) {
 	return project, err
 }
 
-func (h *H) inspect(projects []string) error {
+func (h *H) inspect(ctx context.Context, projects []string) error {
 	inspectTimeoutInSeconds := 200
-	h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+	h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 
 	// Get a list of projects from the cluster
-	clusterProjects, err := h.Project().ProjectV1().Projects().List(context.TODO(), metav1.ListOptions{})
+	clusterProjects, err := h.Project().ProjectV1().Projects().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -58,7 +58,7 @@ func (h *H) inspect(projects []string) error {
 		for _, p := range projects {
 			if clusterProject.Name == p {
 				// Add an 'ns/' prefix for the inspect call
-				inspectProjects = append(inspectProjects, "ns/" + clusterProject.Name)
+				inspectProjects = append(inspectProjects, "ns/"+clusterProject.Name)
 			}
 		}
 	}
@@ -71,12 +71,12 @@ func (h *H) inspect(projects []string) error {
 
 	err = r.Run(inspectTimeoutInSeconds, stopCh)
 	if err != nil {
-		return fmt.Errorf("Error running project inspection: %s", err.Error())
+		return fmt.Errorf("error running project inspection: %s", err.Error())
 	}
 
 	gatherResults, err := r.RetrieveResults()
 	if err != nil {
-		return fmt.Errorf("Error retrieving project inspection results: %s", err.Error())
+		return fmt.Errorf("error retrieving project inspection results: %s", err.Error())
 	}
 
 	h.WriteResults(gatherResults)

--- a/pkg/common/helper/state.go
+++ b/pkg/common/helper/state.go
@@ -72,7 +72,7 @@ var (
 )
 
 // GetClusterState retrieves the current objects in desiredClusterResources and desiredResources.
-func (h *H) GetClusterState() (resources map[schema.GroupVersionResource]*unstructured.UnstructuredList) {
+func (h *H) GetClusterState(ctx context.Context) (resources map[schema.GroupVersionResource]*unstructured.UnstructuredList) {
 	// setup client
 	client := h.Dynamic()
 
@@ -81,7 +81,7 @@ func (h *H) GetClusterState() (resources map[schema.GroupVersionResource]*unstru
 	listOpts := metav1.ListOptions{}
 	// retrieve cluster-wide resources
 	for _, r := range desiredClusterResources {
-		if list, err := client.Resource(r).List(context.TODO(), listOpts); err != nil {
+		if list, err := client.Resource(r).List(ctx, listOpts); err != nil {
 			log.Printf("Encountered error listing getting resource '%s': %v", r, err)
 		} else {
 			resources[r] = list
@@ -90,7 +90,7 @@ func (h *H) GetClusterState() (resources map[schema.GroupVersionResource]*unstru
 
 	// retrieve namespaces resources
 	for _, r := range desiredResources {
-		if list, err := client.Resource(r).Namespace(metav1.NamespaceAll).List(context.TODO(), listOpts); err != nil {
+		if list, err := client.Resource(r).Namespace(metav1.NamespaceAll).List(ctx, listOpts); err != nil {
 			log.Printf("Encountered error listing getting resource '%s': %v", r, err)
 		} else {
 			resources[r] = list

--- a/pkg/common/helper/utilities.go
+++ b/pkg/common/helper/utilities.go
@@ -9,11 +9,11 @@ import (
 )
 
 // WaitTimeoutForDaemonSetInNamespace waits the given timeout duration for the specified ds.
-func (h *H) WaitTimeoutForDaemonSetInNamespace(daemonSetName string, namespace string, timeout time.Duration, poll time.Duration) error {
+func (h *H) WaitTimeoutForDaemonSetInNamespace(ctx context.Context, daemonSetName string, namespace string, timeout time.Duration, poll time.Duration) error {
 
 	return (wait.PollImmediate(poll, timeout, func() (bool, error) {
 
-		if _, err := h.Kube().AppsV1().DaemonSets(namespace).Get(context.TODO(), daemonSetName, metav1.GetOptions{}); err != nil {
+		if _, err := h.Kube().AppsV1().DaemonSets(namespace).Get(ctx, daemonSetName, metav1.GetOptions{}); err != nil {
 			return false, err
 		}
 		return true, nil
@@ -21,10 +21,10 @@ func (h *H) WaitTimeoutForDaemonSetInNamespace(daemonSetName string, namespace s
 }
 
 // WaitTimeoutForServiceInNamespace waits the given timeout duration for the specified service.
-func (h *H) WaitTimeoutForServiceInNamespace(serviceName string, namespace string, timeout time.Duration, poll time.Duration) error {
+func (h *H) WaitTimeoutForServiceInNamespace(ctx context.Context, serviceName string, namespace string, timeout time.Duration, poll time.Duration) error {
 	return (wait.PollImmediate(poll, timeout, func() (bool, error) {
 
-		if _, err := h.Kube().CoreV1().Services(namespace).Get(context.TODO(), serviceName, metav1.GetOptions{}); err != nil {
+		if _, err := h.Kube().CoreV1().Services(namespace).Get(ctx, serviceName, metav1.GetOptions{}); err != nil {
 			return false, err
 		}
 		return true, nil

--- a/pkg/common/util/util.go
+++ b/pkg/common/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"context"
 	"math/rand"
 	"strings"
 	"time"
@@ -38,13 +39,13 @@ func SemverToOpenshiftVersion(version *semver.Version) string {
 }
 
 // GinkgoIt wraps the 2.0 Ginkgo It function to allow for additional functionality.
-func GinkgoIt(text string, body func(), timeout ...float64) bool {
+func GinkgoIt(text string, body func(ctx context.Context), timeout ...float64) bool {
 	defer ginkgo.GinkgoRecover()
-	return ginkgo.It(text, func() {
+	return ginkgo.It(text, func(ctx context.Context) {
 		done := make(chan interface{})
 		go func() {
 			defer ginkgo.GinkgoRecover()
-			body()
+			body(ctx)
 			close(done)
 		}()
 		duration := time.Duration(5) * time.Second

--- a/pkg/common/util/versionutil.go
+++ b/pkg/common/util/versionutil.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"context"
+
 	"github.com/Masterminds/semver"
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -24,23 +26,23 @@ var (
 // ClusterVersionProvider is a type that can return cluster version
 // information. The *helper.H type implements this interface.
 type ClusterVersionProvider interface {
-	GetClusterVersion() (*v1.ClusterVersion, error)
+	GetClusterVersion(context.Context) (*v1.ClusterVersion, error)
 }
 
 // OnSupportedVersionIt runs a ginkgo It() if and only if the cluster version meets the provided constraint.
 // The cluster version is looked up using the provided helper.H.
-func OnSupportedVersionIt(constraints *semver.Constraints, helper ClusterVersionProvider, description string, f func(), timeout float64) {
-	getVersion := func() *semver.Version {
-		ver, err := helper.GetClusterVersion()
+func OnSupportedVersionIt(constraints *semver.Constraints, helper ClusterVersionProvider, description string, f func(context.Context), timeout float64) {
+	getVersion := func(ctx context.Context) *semver.Version {
+		ver, err := helper.GetClusterVersion(ctx)
 		Expect(err).ToNot(HaveOccurred())
 		return semver.MustParse(ver.Status.Desired.Version)
 	}
 
-	GinkgoIt(description, func() {
-		if !constraints.Check(getVersion()) {
+	GinkgoIt(description, func(ctx context.Context) {
+		if !constraints.Check(getVersion(ctx)) {
 			ginkgo.Skip("unsupported version")
 		}
-		f()
+		f(ctx)
 	}, timeout)
 }
 

--- a/pkg/e2e/addons/addon_test_harness.go
+++ b/pkg/e2e/addons/addon_test_harness.go
@@ -1,6 +1,7 @@
 package addons
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -21,10 +22,10 @@ var _ = ginkgo.Describe("[Suite: addons] Addon Test Harness", func() {
 
 	addonTimeoutInSeconds := float64(viper.GetFloat64(config.Addons.PollingTimeout))
 	log.Printf("addon timeout is %v", addonTimeoutInSeconds)
-	util.GinkgoIt("should run until completion", func() {
-		h.SetServiceAccount(viper.GetString(config.Addons.TestUser))
+	util.GinkgoIt("should run until completion", func(ctx context.Context) {
+		h.SetServiceAccount(ctx, viper.GetString(config.Addons.TestUser))
 		harnesses := strings.Split(viper.GetString(config.Addons.TestHarnesses), ",")
-		failed := h.RunAddonTests("addon-tests", int(addonTimeoutInSeconds), harnesses, []string{})
+		failed := h.RunAddonTests(ctx, "addon-tests", int(addonTimeoutInSeconds), harnesses, []string{})
 		if len(failed) > 0 {
 			message := fmt.Sprintf("Addon tests failed: %v", failed)
 			if url, ok := prow.JobURL(); ok {

--- a/pkg/e2e/openshift/app_builds.go
+++ b/pkg/e2e/openshift/app_builds.go
@@ -53,11 +53,11 @@ var _ = ginkgo.Describe(appBuildsTestName, func() {
 	h := helper.New()
 
 	e2eTimeoutInSeconds := 3600
-	util.GinkgoIt("should get created in the cluster", func() {
+	util.GinkgoIt("should get created in the cluster", func(ctx context.Context) {
 
 		namespacesExist := false
 		for _, application := range testApplications {
-			_, err := findAppNamespace(h, application)
+			_, err := findAppNamespace(ctx, h, application)
 			if err == nil {
 				namespacesExist = true
 				break
@@ -71,10 +71,10 @@ var _ = ginkgo.Describe(appBuildsTestName, func() {
 
 			log.Printf("Existing applications detected, will verify rather than build.")
 			for _, applicationName := range testApplications {
-				appNamespace, err := findAppNamespace(h, applicationName)
+				appNamespace, err := findAppNamespace(ctx, h, applicationName)
 				Expect(err).NotTo(HaveOccurred())
 
-				list, err := h.Kube().CoreV1().Pods(appNamespace).List(context.TODO(), metav1.ListOptions{
+				list, err := h.Kube().CoreV1().Pods(appNamespace).List(ctx, metav1.ListOptions{
 					FieldSelector: fmt.Sprintf("status.phase=%s", kubev1.PodFailed),
 				})
 				Expect(err).NotTo(HaveOccurred(), "couldn't list Pods")
@@ -115,10 +115,10 @@ var _ = ginkgo.Describe(appBuildsTestName, func() {
 
 })
 
-func findAppNamespace(h *helper.H, appName string) (string, error) {
+func findAppNamespace(ctx context.Context, h *helper.H, appName string) (string, error) {
 
 	namespaceRegex := regexp.MustCompile("e2e-test-" + appName + "-repo-test-\\w+")
-	namespaceList, err := h.Project().ProjectV1().Projects().List(context.TODO(), metav1.ListOptions{})
+	namespaceList, err := h.Project().ProjectV1().Projects().List(ctx, metav1.ListOptions{})
 	//h.Kube().CoreV1().Namespaces().List()
 	if err != nil {
 		err = fmt.Errorf("failed to fetch namespaces")

--- a/pkg/e2e/openshift/conformance.go
+++ b/pkg/e2e/openshift/conformance.go
@@ -2,6 +2,8 @@
 package openshift
 
 import (
+	"context"
+
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -39,9 +41,9 @@ var _ = ginkgo.Describe(conformanceK8sTestName, func() {
 	h := helper.New()
 
 	e2eTimeoutInSeconds := 7200
-	util.GinkgoIt("should run until completion", func() {
+	util.GinkgoIt("should run until completion", func(ctx context.Context) {
 		// configure tests
-		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 
 		cfg := DefaultE2EConfig
 		cmd := cfg.Cmd()
@@ -74,8 +76,8 @@ var _ = ginkgo.Describe(conformanceOpenshiftTestName, func() {
 	h := helper.New()
 
 	e2eTimeoutInSeconds := 7200
-	util.GinkgoIt("should run until completion", func() {
-		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+	util.GinkgoIt("should run until completion", func(ctx context.Context) {
+		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 		// configure tests
 		cfg := DefaultE2EConfig
 		cfg.Suite = "openshift/conformance/parallel suite"

--- a/pkg/e2e/openshift/disruptive.go
+++ b/pkg/e2e/openshift/disruptive.go
@@ -2,6 +2,8 @@
 package openshift
 
 import (
+	"context"
+
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -22,12 +24,12 @@ var _ = ginkgo.Describe(disruptiveTestName, func() {
 	h := helper.New()
 
 	e2eTimeoutInSeconds := 3600
-	util.GinkgoIt("should run until completion", func() {
+	util.GinkgoIt("should run until completion", func(ctx context.Context) {
 		// configure tests
 		cfg := DefaultE2EConfig
 		cfg.Suite = "openshift/disruptive"
 		cmd := cfg.Cmd()
-		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 
 		// setup runner
 		r := h.Runner(cmd)

--- a/pkg/e2e/openshift/images.go
+++ b/pkg/e2e/openshift/images.go
@@ -2,6 +2,8 @@
 package openshift
 
 import (
+	"context"
+
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -23,8 +25,8 @@ var _ = ginkgo.Describe(imageRegistryTestName, func() {
 	h := helper.New()
 
 	e2eTimeoutInSeconds := 3600
-	util.GinkgoIt("should run until completion", func() {
-		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+	util.GinkgoIt("should run until completion", func(ctx context.Context) {
+		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 		// configure tests
 		cfg := DefaultE2EConfig
 		cfg.Suite = "openshift/image-registry"
@@ -56,13 +58,13 @@ var _ = ginkgo.Describe(imageEcosystemTestName, func() {
 	h := helper.New()
 
 	e2eTimeoutInSeconds := 3600
-	util.GinkgoIt("should run until completion", func() {
+	util.GinkgoIt("should run until completion", func(ctx context.Context) {
 		// configure tests
 		cfg := DefaultE2EConfig
 		cfg.Suite = "openshift/image-ecosystem"
 		cmd := cfg.Cmd()
 
-		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 		// setup runner
 		r := h.Runner(cmd)
 

--- a/pkg/e2e/operators/certman.go
+++ b/pkg/e2e/operators/certman.go
@@ -32,12 +32,12 @@ var _ = ginkgo.Describe(certmanOperatorTestName, func() {
 
 		// Waiting period to wait for certman resources to appear
 		pollingDuration := 15 * time.Minute
-		util.GinkgoIt("certificate secret exist under openshift-config namespace", func() {
+		util.GinkgoIt("certificate secret exist under openshift-config namespace", func(ctx context.Context) {
 			wait.PollImmediate(30*time.Second, pollingDuration, func() (bool, error) {
 				listOpts := metav1.ListOptions{
 					LabelSelector: "certificate_request",
 				}
-				secrets, err = h.Kube().CoreV1().Secrets("openshift-config").List(context.TODO(), listOpts)
+				secrets, err = h.Kube().CoreV1().Secrets("openshift-config").List(ctx, listOpts)
 				if err != nil {
 					return false, err
 				}
@@ -51,10 +51,10 @@ var _ = ginkgo.Describe(certmanOperatorTestName, func() {
 			Expect(len(secrets.Items)).Should(Equal(1))
 		}, pollingDuration.Seconds())
 
-		util.GinkgoIt("certificate secret should be applied to apiserver object", func() {
+		util.GinkgoIt("certificate secret should be applied to apiserver object", func(ctx context.Context) {
 			wait.PollImmediate(30*time.Second, pollingDuration, func() (bool, error) {
 				getOpts := metav1.GetOptions{}
-				apiserver, err = h.Cfg().ConfigV1().APIServers().Get(context.TODO(), "cluster", getOpts)
+				apiserver, err = h.Cfg().ConfigV1().APIServers().Get(ctx, "cluster", getOpts)
 				if err != nil {
 					return false, err
 				}

--- a/pkg/e2e/operators/cloudingress/deletetapps2.go
+++ b/pkg/e2e/operators/cloudingress/deletetapps2.go
@@ -25,51 +25,58 @@ import (
 var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 	h := helper.New()
 	ginkgo.Context("Delete apps2 ingresscontroller", func() {
-		ginkgo.It("Should not be able to delete the ApplicationIngress that doesn't belong to CIO", func() {
-			//1. create a secondaryIngress that does belong to cloud-ingress-operator
-			secondaryIngress := secondaryIngress(h)
+		ginkgo.It(
+			"Should not be able to delete the ApplicationIngress that doesn't belong to CIO",
+			func(ctx context.Context) {
+				// 1. create a secondaryIngress that does belong to cloud-ingress-operator
+				secondaryIngress := secondaryIngress(ctx, h)
 
-			//only create the secondary ingress if it doesn't exist already in the publishing strategy
-			if _, exists, _ := appIngressExits(h, false, secondaryIngress.DNSName); !exists {
-				addAppIngress(h, secondaryIngress)
-			}
-			// from DNSName app-e2e-apps.cluster.mfvz.s1.devshift.org,
-			// the ingresscontroller name is app-e2e-apps: everything before the first period
-			ingressControllerName := strings.Split(secondaryIngress.DNSName, ".")[0]
-			// check that the ingresscontroller app-e2e-apps was created
-			ingressControllerExists(h, ingressControllerName, true)
-			// check if the secondary router is created
-			// the created router name should be router-app-e2e-apps
-			deploymentName := "router-" + ingressControllerName
-			deployment, err := operators.PollDeployment(h, "openshift-ingress", deploymentName)
-			Expect(err).ToNot(HaveOccurred(), "failed fetching deployment")
-			Expect(deployment).NotTo(BeNil(), "deployment is nil")
+				// only create the secondary ingress if it doesn't exist already in the publishing strategy
+				if _, exists, _ := appIngressExits(ctx, h, false, secondaryIngress.DNSName); !exists {
+					addAppIngress(ctx, h, secondaryIngress)
+				}
+				// from DNSName app-e2e-apps.cluster.mfvz.s1.devshift.org,
+				// the ingresscontroller name is app-e2e-apps: everything before the first period
+				ingressControllerName := strings.Split(secondaryIngress.DNSName, ".")[0]
+				// check that the ingresscontroller app-e2e-apps was created
+				ingressControllerExists(ctx, h, ingressControllerName, true)
+				// check if the secondary router is created
+				// the created router name should be router-app-e2e-apps
+				deploymentName := "router-" + ingressControllerName
+				deployment, err := operators.PollDeployment(ctx, h, "openshift-ingress", deploymentName)
+				Expect(err).ToNot(HaveOccurred(), "failed fetching deployment")
+				Expect(deployment).NotTo(BeNil(), "deployment is nil")
 
-			//2.delete the annotation
-			apps2Ingress, _ := getingressController(h, ingressControllerName)
-			log.Printf("The ingresscontroller object annotation : %+v\n", apps2Ingress.ObjectMeta.Annotations)
-			newAnnotations := updateAnnotation(h, ingressControllerName, "Owner", "cloud-ingress-operator")
-			apps2Ingress = newAnnotations
-			//3. Delete secondaryIngress in publishingstrategy
-			removeIngressController(h, ingressControllerName)
-			Expect(err).NotTo(HaveOccurred())
-			// check that the ingresscontroller app-e2e-apps was deleted
-			ingressControllerExists(h, ingressControllerName, true)
-			apps2Ingress = updateAnnotation(h, ingressControllerName, "Owner", "cloud-ingress-operator")
-			removeIngressController(h, ingressControllerName)
-			ingressControllerExists(h, ingressControllerName, false)
-		}, (10 * time.Minute).Seconds())
+				// 2.delete the annotation
+				apps2Ingress, _ := getingressController(ctx, h, ingressControllerName)
+				log.Printf("The ingresscontroller object annotation : %+v\n", apps2Ingress.ObjectMeta.Annotations)
+				newAnnotations := updateAnnotation(ctx, h, ingressControllerName, "Owner", "cloud-ingress-operator")
+				apps2Ingress = newAnnotations
+				// 3. Delete secondaryIngress in publishingstrategy
+				removeIngressController(ctx, h, ingressControllerName)
+				Expect(err).NotTo(HaveOccurred())
+				// check that the ingresscontroller app-e2e-apps was deleted
+				ingressControllerExists(ctx, h, ingressControllerName, true)
+				apps2Ingress = updateAnnotation(ctx, h, ingressControllerName, "Owner", "cloud-ingress-operator")
+				removeIngressController(ctx, h, ingressControllerName)
+				ingressControllerExists(ctx, h, ingressControllerName, false)
+			},
+			(10 * time.Minute).Seconds(),
+		)
 	})
 })
 
-func removeIngressController(h *helper.H, name string) error {
-	_, exists, index := appIngressExits(h, false, name)
+func removeIngressController(ctx context.Context, h *helper.H, name string) error {
+	_, exists, index := appIngressExits(ctx, h, false, name)
 	// only remove the secondary ingress if it already exist in the publishing strategy
 	if exists {
-		removeAppIngress(h, index)
+		removeAppIngress(ctx, h, index)
 	}
 	err := wait.PollImmediate(10*time.Second, 2*time.Minute, func() (bool, error) {
-		_, err := h.Dynamic().Resource(schema.GroupVersionResource{Group: "operator.openshift.io", Version: "v1", Resource: "ingresscontrollers"}).Namespace("openshift-ingress-operator").Get(context.TODO(), name, metav1.GetOptions{})
+		_, err := h.Dynamic().
+			Resource(schema.GroupVersionResource{Group: "operator.openshift.io", Version: "v1", Resource: "ingresscontrollers"}).
+			Namespace("openshift-ingress-operator").
+			Get(ctx, name, metav1.GetOptions{})
 		if k8serrors.IsNotFound(err) {
 			return true, nil
 		}
@@ -77,26 +84,39 @@ func removeIngressController(h *helper.H, name string) error {
 	})
 	return err
 }
-func updateAnnotation(h *helper.H, name string, annotation1 string, annotation2 string) operatorv1.IngressController {
+
+func updateAnnotation(
+	ctx context.Context,
+	h *helper.H,
+	name string,
+	annotation1 string,
+	annotation2 string,
+) operatorv1.IngressController {
 	var ingressController operatorv1.IngressController
-	ingresscontroller, err := h.Dynamic().Resource(schema.GroupVersionResource{Group: "operator.openshift.io", Version: "v1", Resource: "ingresscontrollers"}).Namespace("openshift-ingress-operator").Get(context.TODO(), name, metav1.GetOptions{})
+	ingresscontroller, err := h.Dynamic().
+		Resource(schema.GroupVersionResource{Group: "operator.openshift.io", Version: "v1", Resource: "ingresscontrollers"}).
+		Namespace("openshift-ingress-operator").
+		Get(ctx, name, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(ingresscontroller.Object, &ingressController)
 	Expect(err).NotTo(HaveOccurred())
 
 	temp := ingressController.ObjectMeta
-	//if annotation exists, delete it
+	// if annotation exists, delete it
 	if temp.Annotations[annotation1] == annotation2 {
 		delete(temp.Annotations, annotation1)
 		ingressController.ObjectMeta = temp
 		ingresscontroller.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&ingressController)
 		Expect(err).NotTo(HaveOccurred())
 
-		ingresscontroller, err = h.Dynamic().Resource(schema.GroupVersionResource{Group: "operator.openshift.io", Version: "v1", Resource: "ingresscontrollers"}).Namespace("openshift-ingress-operator").Update(context.TODO(), ingresscontroller, metav1.UpdateOptions{})
+		ingresscontroller, err = h.Dynamic().
+			Resource(schema.GroupVersionResource{Group: "operator.openshift.io", Version: "v1", Resource: "ingresscontrollers"}).
+			Namespace("openshift-ingress-operator").
+			Update(ctx, ingresscontroller, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 	} else {
-		//if there's no annotation, add it
+		// if there's no annotation, add it
 		annotation := map[string]string{
 			annotation1: annotation2,
 		}
@@ -104,24 +124,38 @@ func updateAnnotation(h *helper.H, name string, annotation1 string, annotation2 
 		ingresscontroller.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&ingressController)
 		Expect(err).NotTo(HaveOccurred())
 
-		ingresscontroller, err = h.Dynamic().Resource(schema.GroupVersionResource{Group: "operator.openshift.io", Version: "v1", Resource: "ingresscontrollers"}).Namespace("openshift-ingress-operator").Update(context.TODO(), ingresscontroller, metav1.UpdateOptions{})
+		ingresscontroller, err = h.Dynamic().
+			Resource(schema.GroupVersionResource{Group: "operator.openshift.io", Version: "v1", Resource: "ingresscontrollers"}).
+			Namespace("openshift-ingress-operator").
+			Update(ctx, ingresscontroller, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		updatePublishingStrategy(h, ingressController, name)
+		updatePublishingStrategy(ctx, h, ingressController, name)
 	}
 	return ingressController
 }
 
-func updatePublishingStrategy(h *helper.H, ingressController operatorv1.IngressController, name string) {
+func updatePublishingStrategy(
+	ctx context.Context,
+	h *helper.H,
+	ingressController operatorv1.IngressController,
+	name string,
+) {
 	var err error
-	PublishingStrategyInstance, ps := getPublishingStrategy(h)
+	PublishingStrategyInstance, ps := getPublishingStrategy(ctx, h)
 	var AppIngress cloudingressv1alpha1.ApplicationIngress
-	//AppIngress.Listening = ingressController.Spec.EndpointPublishingStrategy.LoadBalancer.Scope
+	// AppIngress.Listening = ingressController.Spec.EndpointPublishingStrategy.LoadBalancer.Scope
 	AppIngress.Default = false
 	AppIngress.DNSName = name
-	PublishingStrategyInstance.Spec.ApplicationIngress = append(PublishingStrategyInstance.Spec.ApplicationIngress, AppIngress)
+	PublishingStrategyInstance.Spec.ApplicationIngress = append(
+		PublishingStrategyInstance.Spec.ApplicationIngress,
+		AppIngress,
+	)
 	ps.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(&PublishingStrategyInstance)
 	Expect(err).NotTo(HaveOccurred())
 	// Update the publishingstrategy
-	ps, err = h.Dynamic().Resource(schema.GroupVersionResource{Group: "cloudingress.managed.openshift.io", Version: "v1alpha1", Resource: "publishingstrategies"}).Namespace(OperatorNamespace).Update(context.TODO(), ps, metav1.UpdateOptions{})
+	ps, err = h.Dynamic().
+		Resource(schema.GroupVersionResource{Group: "cloudingress.managed.openshift.io", Version: "v1alpha1", Resource: "publishingstrategies"}).
+		Namespace(OperatorNamespace).
+		Update(ctx, ps, metav1.UpdateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 }

--- a/pkg/e2e/operators/cloudingress/dnsname.go
+++ b/pkg/e2e/operators/cloudingress/dnsname.go
@@ -21,28 +21,28 @@ var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 	// How long to wait for IngressController changes
 	pollingDuration := 120 * time.Second
 	ginkgo.Context("publishingstrategy-dnsname", func() {
-		ginkgo.It("IngressController should be patched when update dnsname", func() {
-			ingress1, _ := getingressController(h, "default")
+		ginkgo.It("IngressController should be patched when update dnsname", func(ctx context.Context) {
+			ingress1, _ := getingressController(ctx, h, "default")
 			dnsnameOriginal = string(ingress1.Spec.Domain)
 			log.Print(" the Domain name \n", dnsnameOriginal)
-			updateDnsName(h, "foo")
+			updateDnsName(ctx, h, "foo")
 
-			ingress, _ := getingressController(h, "default")
+			ingress, _ := getingressController(ctx, h, "default")
 			log.Print(" The new Generation is \n", ingress.Generation)
 		}, pollingDuration.Seconds())
 
-		ginkgo.It("IngressController should be patched when return to the original dnsname", func() {
-			updateDnsName(h, dnsnameOriginal)
+		ginkgo.It("IngressController should be patched when return to the original dnsname", func(ctx context.Context) {
+			updateDnsName(ctx, h, dnsnameOriginal)
 
-			ingress, _ := getingressController(h, "default")
+			ingress, _ := getingressController(ctx, h, "default")
 			Expect(string(ingress.Spec.Domain)).To(Equal(dnsnameOriginal))
 		}, pollingDuration.Seconds())
 	})
 })
 
-func updateDnsName(h *helper.H, newName string) {
+func updateDnsName(ctx context.Context, h *helper.H, newName string) {
 	var err error
-	PublishingStrategyInstance, ps := getPublishingStrategy(h)
+	PublishingStrategyInstance, ps := getPublishingStrategy(ctx, h)
 	AppIngress := PublishingStrategyInstance.Spec.ApplicationIngress
 
 	for i, v := range AppIngress {
@@ -57,6 +57,9 @@ func updateDnsName(h *helper.H, newName string) {
 	Expect(err).NotTo(HaveOccurred())
 
 	// Update the publishingstrategy
-	ps, err = h.Dynamic().Resource(schema.GroupVersionResource{Group: "cloudingress.managed.openshift.io", Version: "v1alpha1", Resource: "publishingstrategies"}).Namespace(OperatorNamespace).Update(context.TODO(), ps, metav1.UpdateOptions{})
+	ps, err = h.Dynamic().
+		Resource(schema.GroupVersionResource{Group: "cloudingress.managed.openshift.io", Version: "v1alpha1", Resource: "publishingstrategies"}).
+		Namespace(OperatorNamespace).
+		Update(ctx, ps, metav1.UpdateOptions{})
 	Expect(err).NotTo(HaveOccurred())
 }

--- a/pkg/e2e/operators/cloudingress/installed.go
+++ b/pkg/e2e/operators/cloudingress/installed.go
@@ -34,14 +34,14 @@ var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 
 	// Check that the operator deployment exists in the operator namespace
 	ginkgo.Context("deployment", func() {
-		util.GinkgoIt("should exist", func() {
-			deployment, err := pollDeployment(h, OperatorNamespace, OperatorName)
+		util.GinkgoIt("should exist", func(ctx context.Context) {
+			deployment, err := pollDeployment(ctx, h, OperatorNamespace, OperatorName)
 			Expect(err).ToNot(HaveOccurred(), "failed fetching deployment")
 			Expect(deployment).NotTo(BeNil(), "deployment is nil")
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 
-		util.GinkgoIt("should have all desired replicas ready", func() {
-			deployment, err := pollDeployment(h, OperatorNamespace, OperatorName)
+		util.GinkgoIt("should have all desired replicas ready", func(ctx context.Context) {
+			deployment, err := pollDeployment(ctx, h, OperatorNamespace, OperatorName)
 			Expect(err).ToNot(HaveOccurred(), "failed fetching deployment")
 
 			readyReplicas := deployment.Status.ReadyReplicas
@@ -57,7 +57,7 @@ var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 
 })
 
-func pollDeployment(h *helper.H, namespace, deploymentName string) (*appsv1.Deployment, error) {
+func pollDeployment(ctx context.Context, h *helper.H, namespace, deploymentName string) (*appsv1.Deployment, error) {
 	// pollDeployment polls for a deployment with a timeout
 	// to handle the case when a new cluster is up but the OLM has not yet
 	// finished deploying the operator
@@ -77,7 +77,7 @@ func pollDeployment(h *helper.H, namespace, deploymentName string) (*appsv1.Depl
 
 Loop:
 	for {
-		deployment, err = h.Kube().AppsV1().Deployments(namespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+		deployment, err = h.Kube().AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
 		elapsed := time.Since(start)
 
 		switch {

--- a/pkg/e2e/operators/managedvelero.go
+++ b/pkg/e2e/operators/managedvelero.go
@@ -84,8 +84,8 @@ var _ = ginkgo.Describe(veleroOperatorTestName, func() {
 
 func testDaCRbackups(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be forbidden to edit Backups", func() {
-			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-project")
+		util.GinkgoIt("Access should be forbidden to edit Backups", func(ctx context.Context) {
+			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
 			defer func() {
 				h.Impersonate(rest.ImpersonationConfig{})
 			}()
@@ -95,7 +95,7 @@ func testDaCRbackups(h *helper.H) {
 					Name: "dedicated-admin-backup-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().Backups(h.CurrentProject()).Create(context.TODO(), &backup, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().Backups(h.CurrentProject()).Create(ctx, &backup, metav1.CreateOptions{})
 			Expect(apierrors.IsForbidden(err)).To(BeTrue())
 
 		})
@@ -104,8 +104,8 @@ func testDaCRbackups(h *helper.H) {
 
 func testDaCRrestore(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be forbidden to edit Restore", func() {
-			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-project")
+		util.GinkgoIt("Access should be forbidden to edit Restore", func(ctx context.Context) {
+			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
 			defer func() {
 				h.Impersonate(rest.ImpersonationConfig{})
 			}()
@@ -115,7 +115,7 @@ func testDaCRrestore(h *helper.H) {
 					Name: "dedicated-admin-restore-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().Restores(h.CurrentProject()).Create(context.TODO(), &restore, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().Restores(h.CurrentProject()).Create(ctx, &restore, metav1.CreateOptions{})
 			Expect(apierrors.IsForbidden(err)).To(BeTrue())
 
 		})
@@ -124,8 +124,8 @@ func testDaCRrestore(h *helper.H) {
 
 func testDaCRdeleteBackupRequests(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be forbidden to edit DeleteBackupRequests", func() {
-			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-project")
+		util.GinkgoIt("Access should be forbidden to edit DeleteBackupRequests", func(ctx context.Context) {
+			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
 			defer func() {
 				h.Impersonate(rest.ImpersonationConfig{})
 			}()
@@ -135,7 +135,7 @@ func testDaCRdeleteBackupRequests(h *helper.H) {
 					Name: "dedicated-admin-delete-backup-request-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().DeleteBackupRequests(h.CurrentProject()).Create(context.TODO(), &deleteBackupRequest, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().DeleteBackupRequests(h.CurrentProject()).Create(ctx, &deleteBackupRequest, metav1.CreateOptions{})
 			Expect(apierrors.IsForbidden(err)).To(BeTrue())
 		})
 	})
@@ -143,8 +143,8 @@ func testDaCRdeleteBackupRequests(h *helper.H) {
 
 func testDaCRbackupStorageLocations(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be forbidden to edit BackupStorageLocations", func() {
-			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-project")
+		util.GinkgoIt("Access should be forbidden to edit BackupStorageLocations", func(ctx context.Context) {
+			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
 			defer func() {
 				h.Impersonate(rest.ImpersonationConfig{})
 			}()
@@ -163,7 +163,7 @@ func testDaCRbackupStorageLocations(h *helper.H) {
 					},
 				},
 			}
-			_, err := h.Velero().VeleroV1().BackupStorageLocations(h.CurrentProject()).Create(context.TODO(), &backupStorageLocation, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().BackupStorageLocations(h.CurrentProject()).Create(ctx, &backupStorageLocation, metav1.CreateOptions{})
 			Expect(apierrors.IsForbidden(err)).To(BeTrue())
 		})
 	})
@@ -171,8 +171,8 @@ func testDaCRbackupStorageLocations(h *helper.H) {
 
 func testDaCRdownloadRequests(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be forbidden to edit DownloadRequests", func() {
-			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-project")
+		util.GinkgoIt("Access should be forbidden to edit DownloadRequests", func(ctx context.Context) {
+			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
 			defer func() {
 				h.Impersonate(rest.ImpersonationConfig{})
 			}()
@@ -188,7 +188,7 @@ func testDaCRdownloadRequests(h *helper.H) {
 					},
 				},
 			}
-			_, err := h.Velero().VeleroV1().DownloadRequests(h.CurrentProject()).Create(context.TODO(), &downloadRequest, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().DownloadRequests(h.CurrentProject()).Create(ctx, &downloadRequest, metav1.CreateOptions{})
 			Expect(apierrors.IsForbidden(err)).To(BeTrue())
 		})
 	})
@@ -196,8 +196,8 @@ func testDaCRdownloadRequests(h *helper.H) {
 
 func testDaCRpodVolumeBackup(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be forbidden to edit PodVolumeBackups", func() {
-			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-project")
+		util.GinkgoIt("Access should be forbidden to edit PodVolumeBackups", func(ctx context.Context) {
+			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
 			defer func() {
 				h.Impersonate(rest.ImpersonationConfig{})
 			}()
@@ -207,7 +207,7 @@ func testDaCRpodVolumeBackup(h *helper.H) {
 					Name: "dedicated-admin-pod-volume-backup-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().PodVolumeBackups(h.CurrentProject()).Create(context.TODO(), &podVolumeBackup, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().PodVolumeBackups(h.CurrentProject()).Create(ctx, &podVolumeBackup, metav1.CreateOptions{})
 			Expect(apierrors.IsForbidden(err)).To(BeTrue())
 		})
 	})
@@ -215,8 +215,8 @@ func testDaCRpodVolumeBackup(h *helper.H) {
 
 func testDaCRpodVolumeRestores(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be forbidden to edit PodVolumeRestores", func() {
-			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-project")
+		util.GinkgoIt("Access should be forbidden to edit PodVolumeRestores", func(ctx context.Context) {
+			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
 			defer func() {
 				h.Impersonate(rest.ImpersonationConfig{})
 			}()
@@ -226,7 +226,7 @@ func testDaCRpodVolumeRestores(h *helper.H) {
 					Name: "dedicated-admin-pod-volume-restore-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().PodVolumeRestores(h.CurrentProject()).Create(context.TODO(), &podVolumeRestore, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().PodVolumeRestores(h.CurrentProject()).Create(ctx, &podVolumeRestore, metav1.CreateOptions{})
 			Expect(apierrors.IsForbidden(err)).To(BeTrue())
 		})
 
@@ -235,8 +235,8 @@ func testDaCRpodVolumeRestores(h *helper.H) {
 
 func testDaCRvolumeSnapshotLocation(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be forbidden to edit VolumeSnapshotLocations", func() {
-			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-project")
+		util.GinkgoIt("Access should be forbidden to edit VolumeSnapshotLocations", func(ctx context.Context) {
+			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
 			defer func() {
 				h.Impersonate(rest.ImpersonationConfig{})
 			}()
@@ -246,7 +246,7 @@ func testDaCRvolumeSnapshotLocation(h *helper.H) {
 					Name: "dedicated-admin-volume-snapshot-locations-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().VolumeSnapshotLocations(h.CurrentProject()).Create(context.TODO(), &volumeSnapshotLocation, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().VolumeSnapshotLocations(h.CurrentProject()).Create(ctx, &volumeSnapshotLocation, metav1.CreateOptions{})
 			Expect(apierrors.IsForbidden(err)).To(BeTrue())
 		})
 	})
@@ -254,8 +254,8 @@ func testDaCRvolumeSnapshotLocation(h *helper.H) {
 
 func testDaCRschedules(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be forbidden to edit Schedules", func() {
-			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-project")
+		util.GinkgoIt("Access should be forbidden to edit Schedules", func(ctx context.Context) {
+			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
 			defer func() {
 				h.Impersonate(rest.ImpersonationConfig{})
 			}()
@@ -265,7 +265,7 @@ func testDaCRschedules(h *helper.H) {
 					Name: "dedicated-admin-schedules-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().Schedules(h.CurrentProject()).Create(context.TODO(), &schedules, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().Schedules(h.CurrentProject()).Create(ctx, &schedules, metav1.CreateOptions{})
 			Expect(apierrors.IsForbidden(err)).To(BeTrue())
 		})
 	})
@@ -273,8 +273,8 @@ func testDaCRschedules(h *helper.H) {
 
 func testDaCRserverStatusRequest(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be forbidden to edit ServerStatusRequests", func() {
-			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-project")
+		util.GinkgoIt("Access should be forbidden to edit ServerStatusRequests", func(ctx context.Context) {
+			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
 			defer func() {
 				h.Impersonate(rest.ImpersonationConfig{})
 			}()
@@ -284,7 +284,7 @@ func testDaCRserverStatusRequest(h *helper.H) {
 					Name: "dedicated-admin-server-status-request-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().ServerStatusRequests(h.CurrentProject()).Create(context.TODO(), &serverStatusRequest, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().ServerStatusRequests(h.CurrentProject()).Create(ctx, &serverStatusRequest, metav1.CreateOptions{})
 			Expect(apierrors.IsForbidden(err)).To(BeTrue())
 		})
 	})
@@ -292,8 +292,8 @@ func testDaCRserverStatusRequest(h *helper.H) {
 
 func testDaCRrestricRepository(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be forbidden to edit RestricRepository", func() {
-			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-project")
+		util.GinkgoIt("Access should be forbidden to edit RestricRepository", func(ctx context.Context) {
+			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
 			defer func() {
 				h.Impersonate(rest.ImpersonationConfig{})
 			}()
@@ -303,7 +303,7 @@ func testDaCRrestricRepository(h *helper.H) {
 					Name: "dedicated-admin-restric-repository-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().ResticRepositories(h.CurrentProject()).Create(context.TODO(), &resticRepository, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().ResticRepositories(h.CurrentProject()).Create(ctx, &resticRepository, metav1.CreateOptions{})
 			Expect(apierrors.IsForbidden(err)).To(BeTrue())
 		})
 	})
@@ -313,16 +313,16 @@ func testDaCRrestricRepository(h *helper.H) {
 
 func testCRbackups(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be allowed to edit Backups", func() {
+		util.GinkgoIt("Access should be allowed to edit Backups", func(ctx context.Context) {
 			backup := velerov1.Backup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "admin-backup-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().Backups(h.CurrentProject()).Create(context.TODO(), &backup, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().Backups(h.CurrentProject()).Create(ctx, &backup, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			h.Velero().VeleroV1().Backups(h.CurrentProject()).Delete(context.TODO(), "admin-backup-test", metav1.DeleteOptions{})
+			h.Velero().VeleroV1().Backups(h.CurrentProject()).Delete(ctx, "admin-backup-test", metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 		})
@@ -331,17 +331,17 @@ func testCRbackups(h *helper.H) {
 
 func testCRrestore(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be allowed to edit Restore", func() {
+		util.GinkgoIt("Access should be allowed to edit Restore", func(ctx context.Context) {
 
 			restore := velerov1.Restore{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "restore-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().Restores(h.CurrentProject()).Create(context.TODO(), &restore, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().Restores(h.CurrentProject()).Create(ctx, &restore, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			h.Velero().VeleroV1().Restores(h.CurrentProject()).Delete(context.TODO(), "restore-test", metav1.DeleteOptions{})
+			h.Velero().VeleroV1().Restores(h.CurrentProject()).Delete(ctx, "restore-test", metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 		})
@@ -350,17 +350,17 @@ func testCRrestore(h *helper.H) {
 
 func testCRdeleteBackupRequests(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be allowed to edit DeleteBackupRequests", func() {
+		util.GinkgoIt("Access should be allowed to edit DeleteBackupRequests", func(ctx context.Context) {
 
 			deleteBackupRequest := velerov1.DeleteBackupRequest{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "delete-backup-request-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().DeleteBackupRequests(h.CurrentProject()).Create(context.TODO(), &deleteBackupRequest, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().DeleteBackupRequests(h.CurrentProject()).Create(ctx, &deleteBackupRequest, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			h.Velero().VeleroV1().DeleteBackupRequests(h.CurrentProject()).Delete(context.TODO(), "delete-backup-request-test", metav1.DeleteOptions{})
+			h.Velero().VeleroV1().DeleteBackupRequests(h.CurrentProject()).Delete(ctx, "delete-backup-request-test", metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -368,7 +368,7 @@ func testCRdeleteBackupRequests(h *helper.H) {
 
 func testCRbackupStorageLocations(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be allowed to edit BackupStorageLocations", func() {
+		util.GinkgoIt("Access should be allowed to edit BackupStorageLocations", func(ctx context.Context) {
 
 			backupStorageLocation := velerov1.BackupStorageLocation{
 				ObjectMeta: metav1.ObjectMeta{
@@ -384,10 +384,10 @@ func testCRbackupStorageLocations(h *helper.H) {
 					},
 				},
 			}
-			_, err := h.Velero().VeleroV1().BackupStorageLocations(h.CurrentProject()).Create(context.TODO(), &backupStorageLocation, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().BackupStorageLocations(h.CurrentProject()).Create(ctx, &backupStorageLocation, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			h.Velero().VeleroV1().BackupStorageLocations(h.CurrentProject()).Delete(context.TODO(), "backup-storage-location-test", metav1.DeleteOptions{})
+			h.Velero().VeleroV1().BackupStorageLocations(h.CurrentProject()).Delete(ctx, "backup-storage-location-test", metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 		})
@@ -396,7 +396,7 @@ func testCRbackupStorageLocations(h *helper.H) {
 
 func testCRdownloadRequests(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be allowed to edit DownloadRequests", func() {
+		util.GinkgoIt("Access should be allowed to edit DownloadRequests", func(ctx context.Context) {
 
 			downloadRequest := velerov1.DownloadRequest{
 				ObjectMeta: metav1.ObjectMeta{
@@ -410,10 +410,10 @@ func testCRdownloadRequests(h *helper.H) {
 				},
 			}
 
-			_, err := h.Velero().VeleroV1().DownloadRequests(h.CurrentProject()).Create(context.TODO(), &downloadRequest, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().DownloadRequests(h.CurrentProject()).Create(ctx, &downloadRequest, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			h.Velero().VeleroV1().DownloadRequests(h.CurrentProject()).Delete(context.TODO(), "download-request-test", metav1.DeleteOptions{})
+			h.Velero().VeleroV1().DownloadRequests(h.CurrentProject()).Delete(ctx, "download-request-test", metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 		})
@@ -422,17 +422,17 @@ func testCRdownloadRequests(h *helper.H) {
 
 func testCRpodVolumeBackup(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be allowed to edit PodVolumeBackups", func() {
+		util.GinkgoIt("Access should be allowed to edit PodVolumeBackups", func(ctx context.Context) {
 
 			podVolumeBackup := velerov1.PodVolumeBackup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pod-volume-backup-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().PodVolumeBackups(h.CurrentProject()).Create(context.TODO(), &podVolumeBackup, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().PodVolumeBackups(h.CurrentProject()).Create(ctx, &podVolumeBackup, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			h.Velero().VeleroV1().PodVolumeBackups(h.CurrentProject()).Delete(context.TODO(), "pod-volume-backup-test", metav1.DeleteOptions{})
+			h.Velero().VeleroV1().PodVolumeBackups(h.CurrentProject()).Delete(ctx, "pod-volume-backup-test", metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -440,17 +440,17 @@ func testCRpodVolumeBackup(h *helper.H) {
 
 func testCRpodVolumeRestores(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be allowed to edit PodVolumeRestores", func() {
+		util.GinkgoIt("Access should be allowed to edit PodVolumeRestores", func(ctx context.Context) {
 
 			podVolumeRestore := velerov1.PodVolumeRestore{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pod-volume-restore-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().PodVolumeRestores(h.CurrentProject()).Create(context.TODO(), &podVolumeRestore, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().PodVolumeRestores(h.CurrentProject()).Create(ctx, &podVolumeRestore, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			h.Velero().VeleroV1().PodVolumeRestores(h.CurrentProject()).Delete(context.TODO(), "pod-volume-restore-test", metav1.DeleteOptions{})
+			h.Velero().VeleroV1().PodVolumeRestores(h.CurrentProject()).Delete(ctx, "pod-volume-restore-test", metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -459,17 +459,17 @@ func testCRpodVolumeRestores(h *helper.H) {
 
 func testCRvolumeSnapshotLocation(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be allowed to edit VolumeSnapshotLocations", func() {
+		util.GinkgoIt("Access should be allowed to edit VolumeSnapshotLocations", func(ctx context.Context) {
 
 			volumeSnapshotLocation := velerov1.VolumeSnapshotLocation{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "volume-snapshot-locations-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().VolumeSnapshotLocations(h.CurrentProject()).Create(context.TODO(), &volumeSnapshotLocation, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().VolumeSnapshotLocations(h.CurrentProject()).Create(ctx, &volumeSnapshotLocation, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			h.Velero().VeleroV1().VolumeSnapshotLocations(h.CurrentProject()).Delete(context.TODO(), "volume-snapshot-locations-test", metav1.DeleteOptions{})
+			h.Velero().VeleroV1().VolumeSnapshotLocations(h.CurrentProject()).Delete(ctx, "volume-snapshot-locations-test", metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -477,17 +477,17 @@ func testCRvolumeSnapshotLocation(h *helper.H) {
 
 func testCRschedules(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be allowed to edit Schedules", func() {
+		util.GinkgoIt("Access should be allowed to edit Schedules", func(ctx context.Context) {
 
 			schedules := velerov1.Schedule{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "schedules-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().Schedules(h.CurrentProject()).Create(context.TODO(), &schedules, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().Schedules(h.CurrentProject()).Create(ctx, &schedules, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			h.Velero().VeleroV1().Schedules(h.CurrentProject()).Delete(context.TODO(), "schedules-test", metav1.DeleteOptions{})
+			h.Velero().VeleroV1().Schedules(h.CurrentProject()).Delete(ctx, "schedules-test", metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -495,17 +495,17 @@ func testCRschedules(h *helper.H) {
 
 func testCRserverStatusRequest(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be allowed to edit ServerStatusRequests", func() {
+		util.GinkgoIt("Access should be allowed to edit ServerStatusRequests", func(ctx context.Context) {
 
 			serverStatusRequest := velerov1.ServerStatusRequest{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "server-status-request-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().ServerStatusRequests(h.CurrentProject()).Create(context.TODO(), &serverStatusRequest, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().ServerStatusRequests(h.CurrentProject()).Create(ctx, &serverStatusRequest, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			h.Velero().VeleroV1().ServerStatusRequests(h.CurrentProject()).Delete(context.TODO(), "server-status-request-test", metav1.DeleteOptions{})
+			h.Velero().VeleroV1().ServerStatusRequests(h.CurrentProject()).Delete(ctx, "server-status-request-test", metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -513,17 +513,17 @@ func testCRserverStatusRequest(h *helper.H) {
 
 func testCRrestricRepository(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("Access should be allowed to edit RestricRepository", func() {
+		util.GinkgoIt("Access should be allowed to edit RestricRepository", func(ctx context.Context) {
 
 			resticRepository := velerov1.ResticRepository{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "restric-repository-test",
 				},
 			}
-			_, err := h.Velero().VeleroV1().ResticRepositories(h.CurrentProject()).Create(context.TODO(), &resticRepository, metav1.CreateOptions{})
+			_, err := h.Velero().VeleroV1().ResticRepositories(h.CurrentProject()).Create(ctx, &resticRepository, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			h.Velero().VeleroV1().ResticRepositories(h.CurrentProject()).Delete(context.TODO(), "restric-repository-test", metav1.DeleteOptions{})
+			h.Velero().VeleroV1().ResticRepositories(h.CurrentProject()).Delete(ctx, "restric-repository-test", metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -531,12 +531,12 @@ func testCRrestricRepository(h *helper.H) {
 
 func checkVeleroBackups(h *helper.H) {
 	ginkgo.Context("velero", func() {
-		util.GinkgoIt("backups should be complete", func() {
+		util.GinkgoIt("backups should be complete", func(ctx context.Context) {
 			err := wait.PollImmediate(5*time.Second, 5*time.Minute, func() (bool, error) {
 				us, err := h.Dynamic().Resource(schema.GroupVersionResource{
 					Group:    "velero.io",
 					Version:  "v1",
-					Resource: "backups"}).Namespace(operatorNamespace).List(context.TODO(), metav1.ListOptions{})
+					Resource: "backups"}).Namespace(operatorNamespace).List(ctx, metav1.ListOptions{})
 				if err != nil {
 					return false, fmt.Errorf("Error getting backups: %s", err.Error())
 				}

--- a/pkg/e2e/operators/mustgather.go
+++ b/pkg/e2e/operators/mustgather.go
@@ -48,20 +48,20 @@ var _ = ginkgo.Describe(mustGatherOperatorTest, func() {
 
 	ginkgo.Context("as Members of CEE", func() {
 		mg := generateMustGather(h, "foo-example")
-		util.GinkgoIt("can manage MustGather CRs in openshift-must-gather-operator namespace", func() {
-			err := createMustGather(h, mg, operatorNamespace, "a-dummy-service-account-name", "system:serviceaccounts:openshift-backplane-cee")
+		util.GinkgoIt("can manage MustGather CRs in openshift-must-gather-operator namespace", func(ctx context.Context) {
+			err := createMustGather(ctx, h, mg, operatorNamespace, "a-dummy-service-account-name", "system:serviceaccounts:openshift-backplane-cee")
 			Expect(err).NotTo(HaveOccurred())
-			err = deleteMustGather(h, mg.Name, operatorNamespace, "a-dummy-service-account-name", "system:serviceaccounts:openshift-backplane-cee")
+			err = deleteMustGather(ctx, h, mg.Name, operatorNamespace, "a-dummy-service-account-name", "system:serviceaccounts:openshift-backplane-cee")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
 	ginkgo.Context("as an elevated SRE", func() {
 		mg := generateMustGather(h, "bar-example")
-		util.GinkgoIt("can manage MustGather CRs in openshift-must-gather-operator namespace", func() {
-			err := createMustGather(h, mg, operatorNamespace, "backplane-cluster-admin", "")
+		util.GinkgoIt("can manage MustGather CRs in openshift-must-gather-operator namespace", func(ctx context.Context) {
+			err := createMustGather(ctx, h, mg, operatorNamespace, "backplane-cluster-admin", "")
 			Expect(err).NotTo(HaveOccurred())
-			err = deleteMustGather(h, mg.Name, operatorNamespace, "backplane-cluster-admin", "")
+			err = deleteMustGather(ctx, h, mg.Name, operatorNamespace, "backplane-cluster-admin", "")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -89,19 +89,19 @@ func impersonate(h *helper.H, asUser, userGroup string) dynamic.Interface {
 	return h.Dynamic()
 }
 
-func deleteMustGather(h *helper.H, name, namespace, asUser, userGroup string) (err error) {
+func deleteMustGather(ctx context.Context, h *helper.H, name, namespace, asUser, userGroup string) (err error) {
 	client := impersonate(h, asUser, userGroup)
 
 	err = client.Resource(schema.GroupVersionResource{
 		Group:    "managed.openshift.io",
 		Version:  "v1alpha1",
 		Resource: "mustgathers",
-	}).Namespace(namespace).Delete(context.TODO(), name, v1.DeleteOptions{})
+	}).Namespace(namespace).Delete(ctx, name, v1.DeleteOptions{})
 
 	return err
 }
 
-func createMustGather(h *helper.H, cr *mustgatherv1alpha1.MustGather, namespace, asUser, userGroup string) (err error) {
+func createMustGather(ctx context.Context, h *helper.H, cr *mustgatherv1alpha1.MustGather, namespace, asUser, userGroup string) (err error) {
 	client := impersonate(h, asUser, userGroup)
 
 	// transform the object to unstructured and send via dynamic client
@@ -114,7 +114,7 @@ func createMustGather(h *helper.H, cr *mustgatherv1alpha1.MustGather, namespace,
 		Group:    "managed.openshift.io",
 		Version:  "v1alpha1",
 		Resource: "mustgathers",
-	}).Namespace(namespace).Create(context.TODO(), &unstructured.Unstructured{obj}, v1.CreateOptions{})
+	}).Namespace(namespace).Create(ctx, &unstructured.Unstructured{obj}, v1.CreateOptions{})
 
 	return err
 }

--- a/pkg/e2e/operators/ocmagent.go
+++ b/pkg/e2e/operators/ocmagent.go
@@ -60,15 +60,15 @@ var _ = ginkgo.Describe(ocmAgentBasicTest, func() {
 
 		// Waiting period to wait for OAO resources to be appear once deleted
 		pollingDuration := 600 * time.Second
-		util.GinkgoIt("ocm-agent deployment should be restored when it gets deleted", func() {
+		util.GinkgoIt("ocm-agent deployment should be restored when it gets deleted", func(ctx context.Context) {
 
-			err := deleteDeployment(ocmAgentDeploymentName, operatorNamespace, h)
+			err := deleteDeployment(ctx, ocmAgentDeploymentName, operatorNamespace, h)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = wait.Poll(30*time.Second, 5*time.Minute, func() (bool, error) {
 				obj, err := h.Dynamic().Resource(schema.GroupVersionResource{
 					Group: "apps", Version: "v1", Resource: "deployments",
-				}).Namespace(operatorNamespace).Get(context.TODO(), ocmAgentDeploymentName, metav1.GetOptions{})
+				}).Namespace(operatorNamespace).Get(ctx, ocmAgentDeploymentName, metav1.GetOptions{})
 				if err != nil {
 					return false, fmt.Errorf("unable to retrieve ocm-agent Deployment")
 				}
@@ -81,15 +81,15 @@ var _ = ginkgo.Describe(ocmAgentBasicTest, func() {
 			Expect(err).NotTo(HaveOccurred())
 		}, pollingDuration.Seconds())
 
-		util.GinkgoIt("ocm-agent-config configmap should be restored when it gets deleted", func() {
+		util.GinkgoIt("ocm-agent-config configmap should be restored when it gets deleted", func(ctx context.Context) {
 
-			err := deleteConfigMap(ocmAgentCofigRefName, operatorNamespace, h)
+			err := deleteConfigMap(ctx, ocmAgentCofigRefName, operatorNamespace, h)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = wait.Poll(30*time.Second, 5*time.Minute, func() (bool, error) {
 				obj, err := h.Dynamic().Resource(schema.GroupVersionResource{
 					Group: "", Version: "v1", Resource: "configmaps",
-				}).Namespace(operatorNamespace).Get(context.TODO(), ocmAgentCofigRefName, metav1.GetOptions{})
+				}).Namespace(operatorNamespace).Get(ctx, ocmAgentCofigRefName, metav1.GetOptions{})
 				if err != nil {
 					return false, fmt.Errorf("unable to retrieve ocm-agent-config configmap")
 				}
@@ -102,15 +102,15 @@ var _ = ginkgo.Describe(ocmAgentBasicTest, func() {
 			Expect(err).NotTo(HaveOccurred())
 		}, pollingDuration.Seconds())
 
-		util.GinkgoIt("ocm-agent-token secret should be restored when it gets deleted", func() {
+		util.GinkgoIt("ocm-agent-token secret should be restored when it gets deleted", func(ctx context.Context) {
 
-			err := deleteSecret(ocmAgentTokenRefName, operatorNamespace, h)
+			err := deleteSecret(ctx, ocmAgentTokenRefName, operatorNamespace, h)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = wait.Poll(30*time.Second, 5*time.Minute, func() (bool, error) {
 				obj, err := h.Dynamic().Resource(schema.GroupVersionResource{
 					Group: "", Version: "v1", Resource: "secrets",
-				}).Namespace(operatorNamespace).Get(context.TODO(), ocmAgentTokenRefName, metav1.GetOptions{})
+				}).Namespace(operatorNamespace).Get(ctx, ocmAgentTokenRefName, metav1.GetOptions{})
 				if err != nil {
 					return false, fmt.Errorf("unable to retrieve ocm-agent-token secret")
 				}
@@ -123,15 +123,15 @@ var _ = ginkgo.Describe(ocmAgentBasicTest, func() {
 			Expect(err).NotTo(HaveOccurred())
 		}, pollingDuration.Seconds())
 
-		util.GinkgoIt("ocm-agent-metrics servicemonitor should be restored when it gets deleted", func() {
+		util.GinkgoIt("ocm-agent-metrics servicemonitor should be restored when it gets deleted", func(ctx context.Context) {
 
-			err := deleteServiceMonitor(ocmAgentServiceMonitorName, operatorNamespace, h)
+			err := deleteServiceMonitor(ctx, ocmAgentServiceMonitorName, operatorNamespace, h)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = wait.Poll(30*time.Second, 5*time.Minute, func() (bool, error) {
 				obj, err := h.Dynamic().Resource(schema.GroupVersionResource{
 					Group: "monitoring.coreos.com", Version: "v1", Resource: "servicemonitors",
-				}).Namespace(operatorNamespace).Get(context.TODO(), ocmAgentServiceMonitorName, metav1.GetOptions{})
+				}).Namespace(operatorNamespace).Get(ctx, ocmAgentServiceMonitorName, metav1.GetOptions{})
 				if err != nil {
 					return false, fmt.Errorf("unable to retrieve ocm-agent-metrics servicemonitor")
 				}
@@ -144,15 +144,15 @@ var _ = ginkgo.Describe(ocmAgentBasicTest, func() {
 			Expect(err).NotTo(HaveOccurred())
 		}, pollingDuration.Seconds())
 
-		util.GinkgoIt("ocm-agent service should be restored when it gets deleted", func() {
+		util.GinkgoIt("ocm-agent service should be restored when it gets deleted", func(ctx context.Context) {
 
-			err := deleteService(ocmAgentServiceName, operatorNamespace, h)
+			err := deleteService(ctx, ocmAgentServiceName, operatorNamespace, h)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = wait.Poll(30*time.Second, 5*time.Minute, func() (bool, error) {
 				obj, err := h.Dynamic().Resource(schema.GroupVersionResource{
 					Group: "", Version: "v1", Resource: "services",
-				}).Namespace(operatorNamespace).Get(context.TODO(), ocmAgentServiceName, metav1.GetOptions{})
+				}).Namespace(operatorNamespace).Get(ctx, ocmAgentServiceName, metav1.GetOptions{})
 				if err != nil {
 					return false, fmt.Errorf("unable to retrieve ocm-agent service")
 				}
@@ -165,15 +165,15 @@ var _ = ginkgo.Describe(ocmAgentBasicTest, func() {
 			Expect(err).NotTo(HaveOccurred())
 		}, pollingDuration.Seconds())
 
-		util.GinkgoIt("ocm-agent-allow-only-alertmanager  networkpolicy should restored when it gets deleted", func() {
+		util.GinkgoIt("ocm-agent-allow-only-alertmanager  networkpolicy should restored when it gets deleted", func(ctx context.Context) {
 
-			err := deleteNetworkPolicy(ocmAgentNetworkpolicyName, operatorNamespace, h)
+			err := deleteNetworkPolicy(ctx, ocmAgentNetworkpolicyName, operatorNamespace, h)
 			Expect(err).NotTo(HaveOccurred())
 
 			err = wait.Poll(30*time.Second, 5*time.Minute, func() (bool, error) {
 				obj, err := h.Dynamic().Resource(schema.GroupVersionResource{
 					Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies",
-				}).Namespace(operatorNamespace).Get(context.TODO(), ocmAgentNetworkpolicyName, metav1.GetOptions{})
+				}).Namespace(operatorNamespace).Get(ctx, ocmAgentNetworkpolicyName, metav1.GetOptions{})
 				if err != nil {
 					return false, fmt.Errorf("unable to retrieve ocm-agent-allow-only-alertmanager  networkpolicy")
 				}
@@ -188,38 +188,38 @@ var _ = ginkgo.Describe(ocmAgentBasicTest, func() {
 	})
 })
 
-func deleteDeployment(resourceName string, namespace string, h *helper.H) error {
+func deleteDeployment(ctx context.Context, resourceName string, namespace string, h *helper.H) error {
 	return h.Dynamic().Resource(schema.GroupVersionResource{
 		Group: "apps", Version: "v1", Resource: "deployments",
-	}).Namespace(namespace).Delete(context.TODO(), resourceName, metav1.DeleteOptions{})
+	}).Namespace(namespace).Delete(ctx, resourceName, metav1.DeleteOptions{})
 }
 
-func deleteConfigMap(resourceName string, namespace string, h *helper.H) error {
+func deleteConfigMap(ctx context.Context, resourceName string, namespace string, h *helper.H) error {
 	return h.Dynamic().Resource(schema.GroupVersionResource{
 		Group: "", Version: "v1", Resource: "configmaps",
-	}).Namespace(namespace).Delete(context.TODO(), resourceName, metav1.DeleteOptions{})
+	}).Namespace(namespace).Delete(ctx, resourceName, metav1.DeleteOptions{})
 }
 
-func deleteSecret(resourceName string, namespace string, h *helper.H) error {
+func deleteSecret(ctx context.Context, resourceName string, namespace string, h *helper.H) error {
 	return h.Dynamic().Resource(schema.GroupVersionResource{
 		Group: "", Version: "v1", Resource: "secrets",
-	}).Namespace(namespace).Delete(context.TODO(), resourceName, metav1.DeleteOptions{})
+	}).Namespace(namespace).Delete(ctx, resourceName, metav1.DeleteOptions{})
 }
 
-func deleteService(resourceName string, namespace string, h *helper.H) error {
+func deleteService(ctx context.Context, resourceName string, namespace string, h *helper.H) error {
 	return h.Dynamic().Resource(schema.GroupVersionResource{
 		Group: "", Version: "v1", Resource: "services",
-	}).Namespace(namespace).Delete(context.TODO(), resourceName, metav1.DeleteOptions{})
+	}).Namespace(namespace).Delete(ctx, resourceName, metav1.DeleteOptions{})
 }
 
-func deleteServiceMonitor(resourceName string, namespace string, h *helper.H) error {
+func deleteServiceMonitor(ctx context.Context, resourceName string, namespace string, h *helper.H) error {
 	return h.Dynamic().Resource(schema.GroupVersionResource{
 		Group: "monitoring.coreos.com", Version: "v1", Resource: "servicemonitors",
-	}).Namespace(namespace).Delete(context.TODO(), resourceName, metav1.DeleteOptions{})
+	}).Namespace(namespace).Delete(ctx, resourceName, metav1.DeleteOptions{})
 }
 
-func deleteNetworkPolicy(resourceName string, namespace string, h *helper.H) error {
+func deleteNetworkPolicy(ctx context.Context, resourceName string, namespace string, h *helper.H) error {
 	return h.Dynamic().Resource(schema.GroupVersionResource{
 		Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies",
-	}).Namespace(namespace).Delete(context.TODO(), resourceName, metav1.DeleteOptions{})
+	}).Namespace(namespace).Delete(ctx, resourceName, metav1.DeleteOptions{})
 }

--- a/pkg/e2e/operators/operators.go
+++ b/pkg/e2e/operators/operators.go
@@ -30,9 +30,9 @@ import (
 func checkClusterServiceVersion(h *helper.H, namespace, name string) {
 	// Check that the operator clusterServiceVersion exists
 	ginkgo.Context(fmt.Sprintf("clusterServiceVersion %s/%s", namespace, name), func() {
-		util.GinkgoIt("should be present and in succeeded state", func() {
+		util.GinkgoIt("should be present and in succeeded state", func(ctx context.Context) {
 			Eventually(func() bool {
-				csvList, err := h.Operator().OperatorsV1alpha1().ClusterServiceVersions(namespace).List(context.TODO(), metav1.ListOptions{})
+				csvList, err := h.Operator().OperatorsV1alpha1().ClusterServiceVersions(namespace).List(ctx, metav1.ListOptions{})
 				if err != nil {
 					log.Printf("failed to get CSVs in namespace %s: %v", namespace, err)
 					return false
@@ -51,9 +51,9 @@ func checkClusterServiceVersion(h *helper.H, namespace, name string) {
 func checkConfigMapLockfile(h *helper.H, namespace, operatorLockFile string) {
 	// Check that the operator configmap has been deployed
 	ginkgo.Context("configmaps", func() {
-		util.GinkgoIt("should exist", func() {
+		util.GinkgoIt("should exist", func(ctx context.Context) {
 			// Wait for lockfile to signal operator is active
-			err := pollLockFile(h, namespace, operatorLockFile)
+			err := pollLockFile(ctx, h, namespace, operatorLockFile)
 			Expect(err).ToNot(HaveOccurred(), "failed fetching the configMap lockfile")
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 	})
@@ -62,13 +62,13 @@ func checkConfigMapLockfile(h *helper.H, namespace, operatorLockFile string) {
 func checkDeployment(h *helper.H, namespace string, name string, defaultDesiredReplicas int32) {
 	// Check that the operator deployment exists in the operator namespace
 	ginkgo.Context("deployment", func() {
-		util.GinkgoIt("should exist", func() {
-			deployment, err := pollDeployment(h, namespace, name)
+		util.GinkgoIt("should exist", func(ctx context.Context) {
+			deployment, err := pollDeployment(ctx, h, namespace, name)
 			Expect(err).ToNot(HaveOccurred(), "failed fetching deployment")
 			Expect(deployment).NotTo(BeNil(), "deployment is nil")
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
-		util.GinkgoIt("should have all desired replicas ready", func() {
-			deployment, err := pollDeployment(h, namespace, name)
+		util.GinkgoIt("should have all desired replicas ready", func(ctx context.Context) {
+			deployment, err := pollDeployment(ctx, h, namespace, name)
 			Expect(err).ToNot(HaveOccurred(), "failed fetching deployment")
 
 			readyReplicas := deployment.Status.ReadyReplicas
@@ -87,11 +87,11 @@ func checkPod(h *helper.H, namespace string, name string, gracePeriod int, maxAc
 	// Checks that deployed pods have less than maxAcceptedRestart restarts
 
 	ginkgo.Context("pods", func() {
-		util.GinkgoIt(fmt.Sprintf("should have %v or less restart(s)", maxAcceptedRestart), func() {
+		util.GinkgoIt(fmt.Sprintf("should have %v or less restart(s)", maxAcceptedRestart), func(ctx context.Context) {
 			// wait for graceperiod
 			time.Sleep(time.Duration(gracePeriod) * time.Second)
 			//retrieve pods
-			pods, err := h.Kube().CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: "name=" + name})
+			pods, err := h.Kube().CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: "name=" + name})
 			Expect(err).ToNot(HaveOccurred(), "failed fetching pods")
 
 			var restartSum int32 = 0
@@ -108,9 +108,9 @@ func checkPod(h *helper.H, namespace string, name string, gracePeriod int, maxAc
 func checkServiceAccounts(h *helper.H, operatorNamespace string, serviceAccounts []string) {
 	// Check that deployed serviceAccounts exist
 	ginkgo.Context("serviceAccounts", func() {
-		util.GinkgoIt("should exist", func() {
+		util.GinkgoIt("should exist", func(ctx context.Context) {
 			for _, serviceAccountName := range serviceAccounts {
-				_, err := h.Kube().CoreV1().ServiceAccounts(operatorNamespace).Get(context.TODO(), serviceAccountName, metav1.GetOptions{})
+				_, err := h.Kube().CoreV1().ServiceAccounts(operatorNamespace).Get(ctx, serviceAccountName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred(), "failed to get serviceAccount %v\n", serviceAccountName)
 			}
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
@@ -120,8 +120,8 @@ func checkServiceAccounts(h *helper.H, operatorNamespace string, serviceAccounts
 func checkClusterRoles(h *helper.H, clusterRoles []string, matchPrefix bool) {
 	// Check that the clusterRoles exist
 	ginkgo.Context("clusterRoles", func() {
-		util.GinkgoIt("should exist", func() {
-			allClusterRoles, err := h.Kube().RbacV1().ClusterRoles().List(context.TODO(), metav1.ListOptions{})
+		util.GinkgoIt("should exist", func(ctx context.Context) {
+			allClusterRoles, err := h.Kube().RbacV1().ClusterRoles().List(ctx, metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred(), "failed to list clusterRoles\n")
 
 			for _, clusterRoleToFind := range clusterRoles {
@@ -142,8 +142,8 @@ func checkClusterRoles(h *helper.H, clusterRoles []string, matchPrefix bool) {
 func checkClusterRoleBindings(h *helper.H, clusterRoleBindings []string, matchPrefix bool) {
 	// Check that the clusterRoles exist
 	ginkgo.Context("clusterRoleBindings", func() {
-		util.GinkgoIt("should exist", func() {
-			allClusterRoleBindings, err := h.Kube().RbacV1().ClusterRoleBindings().List(context.TODO(), metav1.ListOptions{})
+		util.GinkgoIt("should exist", func(ctx context.Context) {
+			allClusterRoleBindings, err := h.Kube().RbacV1().ClusterRoleBindings().List(ctx, metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred(), "failed to list clusterRoles\n")
 
 			for _, clusterRoleBindingToFind := range clusterRoleBindings {
@@ -164,9 +164,9 @@ func checkClusterRoleBindings(h *helper.H, clusterRoleBindings []string, matchPr
 func checkRole(h *helper.H, namespace string, roles []string) {
 	// Check that deployed roles exist
 	ginkgo.Context("roles", func() {
-		util.GinkgoIt("should exist", func() {
+		util.GinkgoIt("should exist", func(ctx context.Context) {
 			for _, roleName := range roles {
-				_, err := h.Kube().RbacV1().Roles(namespace).Get(context.TODO(), roleName, metav1.GetOptions{})
+				_, err := h.Kube().RbacV1().Roles(namespace).Get(ctx, roleName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred(), "failed to get role %v\n", roleName)
 			}
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
@@ -176,9 +176,9 @@ func checkRole(h *helper.H, namespace string, roles []string) {
 
 func checkRolesWithNamePrefix(h *helper.H, namespace string, prefix string, count int) {
 	ginkgo.Context("roles with prefix", func() {
-		util.GinkgoIt("should exist", func() {
+		util.GinkgoIt("should exist", func(ctx context.Context) {
 			Eventually(func() int {
-				rolesList, err := h.Kube().RbacV1().Roles(namespace).List(context.TODO(), metav1.ListOptions{})
+				rolesList, err := h.Kube().RbacV1().Roles(namespace).List(ctx, metav1.ListOptions{})
 				Expect(err).NotTo(HaveOccurred(), "failed to get roles in namespace %s", namespace)
 				var roleCount int
 				for _, r := range rolesList.Items {
@@ -194,9 +194,9 @@ func checkRolesWithNamePrefix(h *helper.H, namespace string, prefix string, coun
 
 func checkRoleBindingsWithNamePrefix(h *helper.H, namespace string, prefix string, count int) {
 	ginkgo.Context("roles with prefix", func() {
-		util.GinkgoIt("should exist", func() {
+		util.GinkgoIt("should exist", func(ctx context.Context) {
 			Eventually(func() int {
-				roleBindings, err := h.Kube().RbacV1().RoleBindings(namespace).List(context.TODO(), metav1.ListOptions{})
+				roleBindings, err := h.Kube().RbacV1().RoleBindings(namespace).List(ctx, metav1.ListOptions{})
 				Expect(err).NotTo(HaveOccurred(), "failed to get roles in namespace %s", namespace)
 				var roleCount int
 				for _, r := range roleBindings.Items {
@@ -212,9 +212,9 @@ func checkRoleBindingsWithNamePrefix(h *helper.H, namespace string, prefix strin
 func checkRoleBindings(h *helper.H, namespace string, roleBindings []string) {
 	// Check that deployed rolebindings exist
 	ginkgo.Context("roleBindings", func() {
-		util.GinkgoIt("should exist", func() {
+		util.GinkgoIt("should exist", func(ctx context.Context) {
 			for _, roleBindingName := range roleBindings {
-				err := pollRoleBinding(h, namespace, roleBindingName)
+				err := pollRoleBinding(ctx, h, namespace, roleBindingName)
 				Expect(err).NotTo(HaveOccurred(), "failed to get roleBinding %v\n", roleBindingName)
 			}
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
@@ -225,9 +225,9 @@ func checkRoleBindings(h *helper.H, namespace string, roleBindings []string) {
 func checkSecrets(h *helper.H, namespace string, secrets []string) {
 	// Check that deployed secrets exist
 	ginkgo.Context("secrets", func() {
-		util.GinkgoIt("should exist", func() {
+		util.GinkgoIt("should exist", func(ctx context.Context) {
 			for _, secretName := range secrets {
-				_, err := h.Kube().CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+				_, err := h.Kube().CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred(), "failed to get secret %v\n", secretName)
 			}
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
@@ -241,18 +241,18 @@ func checkUpgrade(h *helper.H, subNamespace string, subName string, packageName 
 		installPlanPollingDuration := 5 * time.Minute
 		upgradePollingDuration := 15 * time.Minute
 
-		util.GinkgoIt("should upgrade from the replaced version", func() {
+		util.GinkgoIt("should upgrade from the replaced version", func(ctx context.Context) {
 
 			var latestCSV string
 			var sub *operatorv1.Subscription
 			var err error
 
 			// The subscription must first exist on the cluster
-			sub, err = h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Get(context.TODO(), subName, metav1.GetOptions{})
+			sub, err = h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Get(ctx, subName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("subscription %s not found", subName))
 
 			// Get the CSV we're currently installed with
-			installedCSVs, err := h.Operator().OperatorsV1alpha1().ClusterServiceVersions(subNamespace).List(context.TODO(), metav1.ListOptions{})
+			installedCSVs, err := h.Operator().OperatorsV1alpha1().ClusterServiceVersions(subNamespace).List(ctx, metav1.ListOptions{})
 			for _, csv := range installedCSVs.Items {
 				if csv.Spec.DisplayName == packageName && csv.Status.Phase == operatorv1.CSVPhaseSucceeded {
 					latestCSV = csv.Name
@@ -263,22 +263,22 @@ func checkUpgrade(h *helper.H, subNamespace string, subName string, packageName 
 			Expect(latestCSV).NotTo(BeEmpty(), fmt.Sprintf("no successfully installed CSV found for subscription %s", subName))
 
 			// Get the N-1 version of the CSV to test an upgrade from
-			previousCSV, err := getReplacesCSV(h, subNamespace, packageName, regServiceName)
+			previousCSV, err := getReplacesCSV(ctx, h, subNamespace, packageName, regServiceName)
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed trying to get previous CSV for Subscription %s in %s namespace", subName, subNamespace))
 
 			log.Printf("Reverting to package %v from %v to test upgrade of %v", previousCSV, latestCSV, subName)
 
 			// Delete current Operator installation
-			err = h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Delete(context.TODO(), subName, metav1.DeleteOptions{})
+			err = h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Delete(ctx, subName, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed trying to delete Subscription %s", subName))
 			log.Printf("Removed subscription %s", subName)
 
-			err = h.Operator().OperatorsV1alpha1().ClusterServiceVersions(subNamespace).Delete(context.TODO(), latestCSV, metav1.DeleteOptions{})
+			err = h.Operator().OperatorsV1alpha1().ClusterServiceVersions(subNamespace).Delete(ctx, latestCSV, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed trying to delete ClusterServiceVersion %s", latestCSV))
 			log.Printf("Removed csv %s", latestCSV)
 
 			err = wait.PollImmediate(10*time.Second, installPlanPollingDuration, func() (bool, error) {
-				ips, err := h.Operator().OperatorsV1alpha1().InstallPlans(subNamespace).List(context.TODO(), metav1.ListOptions{})
+				ips, err := h.Operator().OperatorsV1alpha1().InstallPlans(subNamespace).List(ctx, metav1.ListOptions{})
 				if err != nil {
 					return false, err
 				}
@@ -296,7 +296,7 @@ func checkUpgrade(h *helper.H, subNamespace string, subName string, packageName 
 			log.Printf("Verified installplan removal")
 
 			// Create subscription to the previous version
-			sub, err = h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Create(context.TODO(), &operatorv1.Subscription{
+			sub, err = h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Create(ctx, &operatorv1.Subscription{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      subName,
 					Namespace: subNamespace,
@@ -316,7 +316,7 @@ func checkUpgrade(h *helper.H, subNamespace string, subName string, packageName 
 
 			// Wait for the operator to arrive back on its latest CSV
 			err = wait.PollImmediate(5*time.Second, upgradePollingDuration, func() (bool, error) {
-				csv, err := h.Operator().OperatorsV1alpha1().ClusterServiceVersions(sub.Namespace).Get(context.TODO(), latestCSV, metav1.GetOptions{})
+				csv, err := h.Operator().OperatorsV1alpha1().ClusterServiceVersions(sub.Namespace).Get(ctx, latestCSV, metav1.GetOptions{})
 				if err != nil && !kerror.IsNotFound(err) {
 					log.Printf("Returning err %v", err)
 					return false, err
@@ -330,7 +330,7 @@ func checkUpgrade(h *helper.H, subNamespace string, subName string, packageName 
 
 			// Lastly, verify that the Subscription correctly reflects that the CSV is installed.
 			err = wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
-				sub, err = h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Get(context.TODO(), subName, metav1.GetOptions{})
+				sub, err = h.Operator().OperatorsV1alpha1().Subscriptions(subNamespace).Get(ctx, subName, metav1.GetOptions{})
 				if err != nil {
 					return false, err
 				}
@@ -352,9 +352,9 @@ func checkService(h *helper.H, namespace string, name string, port int) {
 	ginkgo.Context("service", func() {
 		util.GinkgoIt(
 			"should exist",
-			func() {
+			func(ctx context.Context) {
 				Eventually(func() bool {
-					_, err := h.Kube().CoreV1().Services(namespace).Get(context.Background(), name, metav1.GetOptions{})
+					_, err := h.Kube().CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
 					if err != nil {
 						return false
 					}
@@ -366,7 +366,7 @@ func checkService(h *helper.H, namespace string, name string, port int) {
 	})
 }
 
-func pollClusterRoleBinding(h *helper.H, clusterRoleBindingName string) error {
+func pollClusterRoleBinding(ctx context.Context, h *helper.H, clusterRoleBindingName string) error {
 	// pollRoleBinding will check for the existence of a clusterRole
 	// in the specified project, and wait for it to exist, until a timeout
 
@@ -384,7 +384,7 @@ func pollClusterRoleBinding(h *helper.H, clusterRoleBindingName string) error {
 
 Loop:
 	for {
-		_, err = h.Kube().RbacV1().ClusterRoleBindings().Get(context.TODO(), clusterRoleBindingName, metav1.GetOptions{})
+		_, err = h.Kube().RbacV1().ClusterRoleBindings().Get(ctx, clusterRoleBindingName, metav1.GetOptions{})
 		elapsed := time.Since(start)
 
 		switch {
@@ -407,7 +407,7 @@ Loop:
 	return err
 }
 
-func pollRoleBinding(h *helper.H, projectName string, roleBindingName string) error {
+func pollRoleBinding(ctx context.Context, h *helper.H, projectName string, roleBindingName string) error {
 	// pollRoleBinding will check for the existence of a roleBinding
 	// in the specified project, and wait for it to exist, until a timeout
 
@@ -425,7 +425,7 @@ func pollRoleBinding(h *helper.H, projectName string, roleBindingName string) er
 
 Loop:
 	for {
-		_, err = h.Kube().RbacV1().RoleBindings(projectName).Get(context.TODO(), roleBindingName, metav1.GetOptions{})
+		_, err = h.Kube().RbacV1().RoleBindings(projectName).Get(ctx, roleBindingName, metav1.GetOptions{})
 		elapsed := time.Since(start)
 
 		switch {
@@ -448,7 +448,7 @@ Loop:
 	return err
 }
 
-func pollLockFile(h *helper.H, namespace, operatorLockFile string) error {
+func pollLockFile(ctx context.Context, h *helper.H, namespace, operatorLockFile string) error {
 	// GetConfigMap polls for a configMap with a timeout
 	// to handle the case when a new cluster is up but the OLM has not yet
 	// finished deploying the operator
@@ -467,7 +467,7 @@ func pollLockFile(h *helper.H, namespace, operatorLockFile string) error {
 
 Loop:
 	for {
-		_, err = h.Kube().CoreV1().ConfigMaps(namespace).Get(context.TODO(), operatorLockFile, metav1.GetOptions{})
+		_, err = h.Kube().CoreV1().ConfigMaps(namespace).Get(ctx, operatorLockFile, metav1.GetOptions{})
 		elapsed := time.Since(start)
 
 		switch {
@@ -490,7 +490,7 @@ Loop:
 	return err
 }
 
-func pollDeployment(h *helper.H, namespace, deploymentName string) (*appsv1.Deployment, error) {
+func pollDeployment(ctx context.Context, h *helper.H, namespace, deploymentName string) (*appsv1.Deployment, error) {
 	// pollDeployment polls for a deployment with a timeout
 	// to handle the case when a new cluster is up but the OLM has not yet
 	// finished deploying the operator
@@ -510,7 +510,7 @@ func pollDeployment(h *helper.H, namespace, deploymentName string) (*appsv1.Depl
 
 Loop:
 	for {
-		deployment, err = h.Kube().AppsV1().Deployments(namespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+		deployment, err = h.Kube().AppsV1().Deployments(namespace).Get(ctx, deploymentName, metav1.GetOptions{})
 		elapsed := time.Since(start)
 
 		switch {
@@ -534,7 +534,7 @@ Loop:
 	return deployment, err
 }
 
-func getReplacesCSV(h *helper.H, subscriptionNS string, csvDisplayName string, catalogSvcName string) (string, error) {
+func getReplacesCSV(ctx context.Context, h *helper.H, subscriptionNS string, csvDisplayName string, catalogSvcName string) (string, error) {
 	cmdTimeoutInSeconds := 60
 	cmdTestTemplate, err := templates.LoadTemplate("registry/replaces.template")
 
@@ -554,7 +554,7 @@ func getReplacesCSV(h *helper.H, subscriptionNS string, csvDisplayName string, c
 	}
 	registrySvcPort := "50051"
 
-	h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+	h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 	r := h.RunnerWithNoCommand()
 	r.Name = fmt.Sprintf("csvq-%s", csvDisplayName)
 
@@ -619,6 +619,6 @@ func CheckPod(h *helper.H, namespace string, name string, gracePeriod int, maxAc
 	checkPod(h, namespace, name, gracePeriod, maxAcceptedRestart)
 }
 
-func PollDeployment(h *helper.H, namespace, deploymentName string) (*appsv1.Deployment, error) {
-	return pollDeployment(h, namespace, deploymentName)
+func PollDeployment(ctx context.Context, h *helper.H, namespace, deploymentName string) (*appsv1.Deployment, error) {
+	return pollDeployment(ctx, h, namespace, deploymentName)
 }

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -53,21 +53,21 @@ var _ = ginkgo.Describe(subjectPermissionsTestName, func() {
 
 func checkSubjectPermissions(h *helper.H, spName string) {
 	ginkgo.Context("SubjectPermission", func() {
-		util.GinkgoIt("should have the expected ClusterRoles, ClusterRoleBindings and RoleBindinsg", func() {
-			clusterRoles, clusterRoleBindings, roleBindings, err := getSubjectPermissionRBACInfo(h, spName)
+		util.GinkgoIt("should have the expected ClusterRoles, ClusterRoleBindings and RoleBindinsg", func(ctx context.Context) {
+			clusterRoles, clusterRoleBindings, roleBindings, err := getSubjectPermissionRBACInfo(ctx, h, spName)
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, clusterRoleName := range clusterRoles {
-				_, err := h.Kube().RbacV1().ClusterRoles().Get(context.TODO(), clusterRoleName, metav1.GetOptions{})
+				_, err := h.Kube().RbacV1().ClusterRoles().Get(ctx, clusterRoleName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred(), "failed to get clusterRole %v\n", clusterRoleName)
 			}
 
 			for _, clusterRoleBindingName := range clusterRoleBindings {
-				err := pollClusterRoleBinding(h, clusterRoleBindingName)
+				err := pollClusterRoleBinding(ctx, h, clusterRoleBindingName)
 				Expect(err).ToNot(HaveOccurred(), "failed to get clusterRoleBinding %v\n", clusterRoleBindingName)
 			}
 			for _, roleBindingName := range roleBindings {
-				err := pollRoleBinding(h, h.CurrentProject(), roleBindingName)
+				err := pollRoleBinding(ctx, h, h.CurrentProject(), roleBindingName)
 				Expect(err).NotTo(HaveOccurred(), "failed to get roleBinding %v\n", roleBindingName)
 			}
 
@@ -75,11 +75,11 @@ func checkSubjectPermissions(h *helper.H, spName string) {
 	})
 }
 
-func getSubjectPermissionRBACInfo(h *helper.H, spName string) ([]string, []string, []string, error) {
+func getSubjectPermissionRBACInfo(ctx context.Context, h *helper.H, spName string) ([]string, []string, []string, error) {
 	us, err := h.Dynamic().Resource(schema.GroupVersionResource{
 		Group:    "managed.openshift.io",
 		Version:  "v1alpha1",
-		Resource: "subjectpermissions"}).Namespace(operatorNamespace).Get(context.TODO(), spName, metav1.GetOptions{})
+		Resource: "subjectpermissions"}).Namespace(operatorNamespace).Get(ctx, spName, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("Error getting %s SubjectPermission", spName)
 	}

--- a/pkg/e2e/operators/routemonitor.go
+++ b/pkg/e2e/operators/routemonitor.go
@@ -25,7 +25,7 @@ import (
 var routeMonitorOperatorTestName string = "[Suite: informing] [OSD] Route Monitor Operator (rmo)"
 
 func init() {
-  alert.RegisterGinkgoAlert(routeMonitorOperatorTestName, "SD-SREP", "@sre-platform-team-orange", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
+	alert.RegisterGinkgoAlert(routeMonitorOperatorTestName, "SD-SREP", "@sre-platform-team-orange", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
 var _ = ginkgo.Describe(routeMonitorOperatorTestName, func() {
@@ -65,7 +65,7 @@ var _ = ginkgo.Describe(routeMonitorOperatorTestName, func() {
 
 func verifyExistingRouteMonitorsAreValid(h *helper.H) {
 	ginkgo.Context("rmo Route Monitor Operator regression for console", func() {
-		util.GinkgoIt("has all of the required resouces", func() {
+		util.GinkgoIt("has all of the required resouces", func(ctx context.Context) {
 			const (
 				consoleNamespace = "openshift-route-monitor-operator"
 				consoleName      = "console"
@@ -73,9 +73,9 @@ func verifyExistingRouteMonitorsAreValid(h *helper.H) {
 			var err error
 			// RouteMonitor is expected to be there as a selectorsyncset
 			// see https://github.com/openshift/managed-cluster-config/blob/master/deploy/osd-route-monitor-operator/100-openshift-console.console.RouteMonitor.yaml
-			_, err = h.Prometheusop().MonitoringV1().ServiceMonitors(consoleNamespace).Get(context.TODO(), consoleName, metav1.GetOptions{})
+			_, err = h.Prometheusop().MonitoringV1().ServiceMonitors(consoleNamespace).Get(ctx, consoleName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred(), "Could not get console serviceMonitor")
-			_, err = h.Prometheusop().MonitoringV1().PrometheusRules(consoleNamespace).Get(context.TODO(), consoleName, metav1.GetOptions{})
+			_, err = h.Prometheusop().MonitoringV1().PrometheusRules(consoleNamespace).Get(ctx, consoleName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred(), "Could not get console prometheusRule")
 		})
 	})
@@ -85,7 +85,7 @@ func testRouteMonitorCreationWorks(h *helper.H) {
 
 		// How long to wait for service monitors to be created
 		pollingDuration := 10 * time.Minute
-		util.GinkgoIt("Creates and deletes a RouteMonitor to see if it works accordingly", func() {
+		util.GinkgoIt("Creates and deletes a RouteMonitor to see if it works accordingly", func(ctx context.Context) {
 			var (
 				routeMonitorNamespace = h.CurrentProject()
 				err                   error
@@ -95,30 +95,30 @@ func testRouteMonitorCreationWorks(h *helper.H) {
 			ginkgo.By("Creating a pod, service and route to monitor with a ServiceMonitor and PrometheusRule")
 
 			pod := helper.SamplePod(routeMonitorName, routeMonitorNamespace, "quay.io/jitesoft/nginx:mainline")
-			err = helper.CreatePod(pod, routeMonitorNamespace, h)
+			err = helper.CreatePod(ctx, pod, routeMonitorNamespace, h)
 			Expect(err).NotTo(HaveOccurred(), "Couldn't create a testing pod")
-			phase := h.WaitForPodPhase(pod, kubev1.PodRunning, 6, time.Second*15)
+			phase := h.WaitForPodPhase(ctx, pod, kubev1.PodRunning, 6, time.Second*15)
 			Expect(phase).To(Equal(kubev1.PodRunning), fmt.Sprintf("pod %s in ns %s is not running, current pod state is %v", routeMonitorName, routeMonitorNamespace, phase))
 
 			svc := helper.SampleService(8080, 80, routeMonitorName, routeMonitorNamespace, routeMonitorName)
-			err = helper.CreateService(svc, h)
+			err = helper.CreateService(ctx, svc, h)
 			Expect(err).NotTo(HaveOccurred(), "Couldn't create a testing service")
 
 			appRoute := helper.SampleRoute(routeMonitorName, routeMonitorNamespace)
-			err = helper.CreateRoute(appRoute, routeMonitorNamespace, h)
+			err = helper.CreateRoute(ctx, appRoute, routeMonitorNamespace, h)
 			Expect(err).NotTo(HaveOccurred(), "Couldn't create application route")
 
 			ginkgo.By("Creating a sample RouteMonitor to monitor the service")
 			rmo := helper.SampleRouteMonitor(routeMonitorName, routeMonitorNamespace, h)
-			err = helper.CreateRouteMonitor(rmo, routeMonitorNamespace, h)
+			err = helper.CreateRouteMonitor(ctx, rmo, routeMonitorNamespace, h)
 			Expect(err).NotTo(HaveOccurred(), "Couldn't create application route monitor")
 
 			err = wait.PollImmediate(15*time.Second, pollingDuration, func() (bool, error) {
-				_, err = h.Prometheusop().MonitoringV1().ServiceMonitors(routeMonitorNamespace).Get(context.TODO(), routeMonitorName, metav1.GetOptions{})
+				_, err = h.Prometheusop().MonitoringV1().ServiceMonitors(routeMonitorNamespace).Get(ctx, routeMonitorName, metav1.GetOptions{})
 				if !k8serrors.IsNotFound(err) {
 					return false, err
 				}
-				_, err = h.Prometheusop().MonitoringV1().PrometheusRules(routeMonitorNamespace).Get(context.TODO(), routeMonitorName, metav1.GetOptions{})
+				_, err = h.Prometheusop().MonitoringV1().PrometheusRules(routeMonitorNamespace).Get(ctx, routeMonitorName, metav1.GetOptions{})
 				if !k8serrors.IsNotFound(err) {
 					return false, err
 				}
@@ -135,19 +135,19 @@ func testRouteMonitorCreationWorks(h *helper.H) {
 			// err = helper.UpdateRouteMonitor(modifiedRmo, routeMonitorNamespace, h)
 			// Expect(err).NotTo(HaveOccurred(), "Couldn't update application route monitor")
 
-			// modifiedPromRule, err := h.Prometheusop().MonitoringV1().PrometheusRules(routeMonitorNamespace).Get(context.TODO(), routeMonitorName, metav1.GetOptions{})
+			// modifiedPromRule, err := h.Prometheusop().MonitoringV1().PrometheusRules(routeMonitorNamespace).Get(ctx, routeMonitorName, metav1.GetOptions{})
 			// Expect(err).NotTo(HaveOccurred(), "Couldn't get sample prometheusRule, should have been generated from RouteMonitor")
 			// areEqual := reflect.DeepEqual(promRule.Spec, modifiedPromRule.Spec)
 			// Expect(areEqual).To(BeFalse(), "Modifying the RouteMonitor .spec.Slo.TargetAvailabilityPercent did not modify the PrometheusRule")
 
 			ginkgo.By("Deleting the sample RouteMonitor")
 			nsName := types.NamespacedName{Namespace: routeMonitorNamespace, Name: routeMonitorName}
-			err = helper.DeleteRouteMonitor(nsName, true, h)
+			err = helper.DeleteRouteMonitor(ctx, nsName, true, h)
 			Expect(err).NotTo(HaveOccurred(), "Couldn't delete application route monitor")
 
-			_, err = h.Prometheusop().MonitoringV1().ServiceMonitors(routeMonitorNamespace).Get(context.TODO(), routeMonitorName, metav1.GetOptions{})
+			_, err = h.Prometheusop().MonitoringV1().ServiceMonitors(routeMonitorNamespace).Get(ctx, routeMonitorName, metav1.GetOptions{})
 			Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "sample serviceMonitor still exists, deletion of RouteMonitor didn't clean it up")
-			_, err = h.Prometheusop().MonitoringV1().PrometheusRules(routeMonitorNamespace).Get(context.TODO(), routeMonitorName, metav1.GetOptions{})
+			_, err = h.Prometheusop().MonitoringV1().PrometheusRules(routeMonitorNamespace).Get(ctx, routeMonitorName, metav1.GetOptions{})
 			Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "sample prometheusRule still exists, deletion of RouteMonitor didn't clean it up")
 		}, pollingDuration.Seconds())
 	})

--- a/pkg/e2e/osd/daemonsets.go
+++ b/pkg/e2e/osd/daemonsets.go
@@ -28,35 +28,35 @@ var _ = ginkgo.Describe(daemonSetsTestName, func() {
 		h := helper.New()
 		nodeLabels := make(map[string]string)
 
-		util.GinkgoIt("empty node-label daemonset should get created", func() {
+		util.GinkgoIt("empty node-label daemonset should get created", func(ctx context.Context) {
 			// Set it to a wildcard dedicated-admin
-			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-project")
+			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
 
 			// Test creating a basic daemonset
 			ds := makeDaemonSet("empty-node-labels", h.GetNamespacedServiceAccount(), nodeLabels)
-			_, err := h.Kube().AppsV1().DaemonSets(h.CurrentProject()).Create(context.TODO(), &ds, metav1.CreateOptions{})
+			_, err := h.Kube().AppsV1().DaemonSets(h.CurrentProject()).Create(ctx, &ds, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 
-		util.GinkgoIt("worker node daemonset should get created", func() {
+		util.GinkgoIt("worker node daemonset should get created", func(ctx context.Context) {
 			// Set it to a wildcard dedicated-admin
-			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-project")
+			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
 
 			// Test creating a worker daemonset
 			nodeLabels["role"] = "worker"
 			ds := makeDaemonSet("worker-node-labels", h.GetNamespacedServiceAccount(), nodeLabels)
-			_, err := h.Kube().AppsV1().DaemonSets(h.CurrentProject()).Create(context.TODO(), &ds, metav1.CreateOptions{})
+			_, err := h.Kube().AppsV1().DaemonSets(h.CurrentProject()).Create(ctx, &ds, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 
-		util.GinkgoIt("infra node daemonset should get created", func() {
+		util.GinkgoIt("infra node daemonset should get created", func(ctx context.Context) {
 			// Set it to a wildcard dedicated-admin
-			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-project")
+			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
 
 			// Test creating an infra daemonset
 			nodeLabels["role"] = "infra"
 			ds := makeDaemonSet("infra-node-labels", h.GetNamespacedServiceAccount(), nodeLabels)
-			_, err := h.Kube().AppsV1().DaemonSets(h.CurrentProject()).Create(context.TODO(), &ds, metav1.CreateOptions{})
+			_, err := h.Kube().AppsV1().DaemonSets(h.CurrentProject()).Create(ctx, &ds, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 	})

--- a/pkg/e2e/osd/dedicatedadmin.go
+++ b/pkg/e2e/osd/dedicatedadmin.go
@@ -39,8 +39,7 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, func() {
 		// setup helper
 		h := helper.New()
 
-		util.GinkgoIt("cannot add members to cluster-admin", func() {
-
+		util.GinkgoIt("cannot add members to cluster-admin", func(ctx context.Context) {
 			h.Impersonate(rest.ImpersonationConfig{
 				UserName: "dummy-admin@redhat.com",
 				Groups: []string{
@@ -51,22 +50,20 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, func() {
 				h.Impersonate(rest.ImpersonationConfig{})
 			}()
 
-			daGroup, err := h.User().UserV1().Groups().Get(context.TODO(), "dedicated-admins", metav1.GetOptions{})
+			daGroup, err := h.User().UserV1().Groups().Get(ctx, "dedicated-admins", metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			daGroup.Users = append(daGroup.Users, "new-dummy-admin@redhat.com")
-			_, err = h.User().UserV1().Groups().Update(context.TODO(), daGroup, metav1.UpdateOptions{})
+			_, err = h.User().UserV1().Groups().Update(ctx, daGroup, metav1.UpdateOptions{})
 			Expect(err).To(HaveOccurred())
-
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 
-		util.GinkgoIt("cannot delete members from cluster-admin", func() {
-
+		util.GinkgoIt("cannot delete members from cluster-admin", func(ctx context.Context) {
 			// add dummy user
-			daGroup, err := h.User().UserV1().Groups().Get(context.TODO(), "dedicated-admins", metav1.GetOptions{})
+			daGroup, err := h.User().UserV1().Groups().Get(ctx, "dedicated-admins", metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			daGroup.Users = append(daGroup.Users, "user-to-delete@redhat.com")
-			daGroup, err = h.User().UserV1().Groups().Update(context.TODO(), daGroup, metav1.UpdateOptions{})
+			daGroup, err = h.User().UserV1().Groups().Update(ctx, daGroup, metav1.UpdateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			// remove dummy user as dedicated-admin
@@ -82,12 +79,10 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, func() {
 			}()
 			_, err = h.User().UserV1().Groups().Update(context.TODO(), daGroup, metav1.UpdateOptions{})
 			Expect(err).To(HaveOccurred())
-
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 
 		// dedicated-admin SA can create projectrequest object
-		util.GinkgoIt("ded-admin SA can create projectrequest", func() {
-
+		util.GinkgoIt("ded-admin SA can create projectrequest", func(ctx context.Context) {
 			// Impersonate ded-admin
 			h.Impersonate(rest.ImpersonationConfig{
 				UserName: "dummy-admin@redhat.com",
@@ -105,14 +100,12 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, func() {
 				},
 				DisplayName: "osde2e-sample-cust-proj",
 			}
-			_, err := h.Project().ProjectV1().ProjectRequests().Create(context.TODO(), proj, metav1.CreateOptions{})
+			_, err := h.Project().ProjectV1().ProjectRequests().Create(ctx, proj, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 
 		// regular dedicated-admin user can create 'admin' rolebinding
-		util.GinkgoIt("ded-admin user can create 'admin' rolebinding", func() {
-
+		util.GinkgoIt("ded-admin user can create 'admin' rolebinding", func(ctx context.Context) {
 			// Impersonate ded-admin
 			h.Impersonate(rest.ImpersonationConfig{
 				UserName: "dummy-admin@redhat.com",
@@ -134,14 +127,12 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, func() {
 			dummyNs := "osde2e-sample-cust-proj"
 			dummyKind := "ClusterRole"
 			dummyKindName := "admin"
-			_, err := createRolebinding(dummyNs, user, dummyKind, dummyKindName, h)
+			_, err := createRolebinding(ctx, dummyNs, user, dummyKind, dummyKindName, h)
 			Expect(err).NotTo(HaveOccurred())
-
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 
 		// regular dedicated-admin user can create 'edit' rolebinding
-		util.GinkgoIt("ded-admin user can create edit rolebinding", func() {
-
+		util.GinkgoIt("ded-admin user can create edit rolebinding", func(ctx context.Context) {
 			// Impersonate ded-admin
 			h.Impersonate(rest.ImpersonationConfig{
 				UserName: "dummy-admin@redhat.com",
@@ -163,14 +154,12 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, func() {
 			dummyNs := "osde2e-sample-cust-proj"
 			dummyKind := "ClusterRole"
 			dummyKindName := "edit"
-			_, err := createRolebinding(dummyNs, user, dummyKind, dummyKindName, h)
+			_, err := createRolebinding(ctx, dummyNs, user, dummyKind, dummyKindName, h)
 			Expect(err).NotTo(HaveOccurred())
-
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 
 		// dedicated-admin SA can create 'edit' rolebinding
-		util.GinkgoIt("ded-admin SA can create 'edit' rolebinding", func() {
-
+		util.GinkgoIt("ded-admin SA can create 'edit' rolebinding", func(ctx context.Context) {
 			// Impersonate ded-admin
 			h.Impersonate(rest.ImpersonationConfig{
 				UserName: "dummy-admin@redhat.com",
@@ -192,14 +181,12 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, func() {
 			dummyNs := "osde2e-sample-cust-proj"
 			dummyKind := "ClusterRole"
 			dummyKindName := "edit"
-			_, err := createRolebinding(dummyNs, user, dummyKind, dummyKindName, h)
+			_, err := createRolebinding(ctx, dummyNs, user, dummyKind, dummyKindName, h)
 			Expect(err).NotTo(HaveOccurred())
-
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 
 		// dedicated-admin SA can create 'admin' rolebinding
-		util.GinkgoIt("ded-admin SA can create 'admin' rolebinding", func() {
-
+		util.GinkgoIt("ded-admin SA can create 'admin' rolebinding", func(ctx context.Context) {
 			// Impersonate ded-admin
 			h.Impersonate(rest.ImpersonationConfig{
 				UserName: "dummy-admin@redhat.com",
@@ -221,14 +208,12 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, func() {
 			dummyNs := "osde2e-sample-cust-proj"
 			dummyKind := "ClusterRole"
 			dummyKindName := "admin"
-			_, err := createRolebinding(dummyNs, user, dummyKind, dummyKindName, h)
+			_, err := createRolebinding(ctx, dummyNs, user, dummyKind, dummyKindName, h)
 			Expect(err).NotTo(HaveOccurred())
-
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 
 		// dedicated-admin SA can delete project
-		util.GinkgoIt("ded-admin SA can delete project", func() {
-
+		util.GinkgoIt("ded-admin SA can delete project", func(ctx context.Context) {
 			// Impersonate ded-admin
 			h.Impersonate(rest.ImpersonationConfig{
 				UserName: "dummy-admin@redhat.com",
@@ -246,15 +231,13 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, func() {
 				},
 				DisplayName: "osde2e-sample-cust-proj",
 			}
-			err := h.Project().ProjectV1().Projects().Delete(context.TODO(), proj.Name, metav1.DeleteOptions{})
+			err := h.Project().ProjectV1().Projects().Delete(ctx, proj.Name, metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
-
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 
 		// dedicated-admin can manage secrets
 		// in selected namespaces
-		util.GinkgoIt("ded-admin can manage secrets in selected namespaces", func() {
-
+		util.GinkgoIt("ded-admin can manage secrets in selected namespaces", func(ctx context.Context) {
 			// Impersonate ded-admin
 			h.Impersonate(rest.ImpersonationConfig{
 				UserName: "dummy-admin@redhat.com",
@@ -266,15 +249,13 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, func() {
 				h.Impersonate(rest.ImpersonationConfig{})
 			}()
 
-			err := manageSecrets(namespaceList, h)
+			err := manageSecrets(ctx, namespaceList, h)
 			Expect(err).NotTo(HaveOccurred())
-
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 
 		// dedicated-admin can manage subscriptions
 		// in selected namespaces
-		util.GinkgoIt("ded-admin can manage subscriptions in selected namespaces", func() {
-
+		util.GinkgoIt("ded-admin can manage subscriptions in selected namespaces", func(ctx context.Context) {
 			// Impersonate ded-admin
 			h.Impersonate(rest.ImpersonationConfig{
 				UserName: "dummy-admin@redhat.com",
@@ -286,19 +267,23 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, func() {
 				h.Impersonate(rest.ImpersonationConfig{})
 			}()
 
-			err := manageSubscriptions(namespaceList, h)
+			err := manageSubscriptions(ctx, namespaceList, h)
 			Expect(err).NotTo(HaveOccurred())
-
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
-
 	})
 })
 
 // createRolebinding takes in the desired namespace, user, and roleRef kind and kindName
 // returns the corresponding rolebinding created on cluster
-func createRolebinding(ns string, user *userv1.User, kind string, kindName string, h *helper.H) (*rbacv1.RoleBinding, error) {
-
-	rb, err := h.Kube().RbacV1().RoleBindings(ns).Create(context.TODO(), &rbacv1.RoleBinding{
+func createRolebinding(
+	ctx context.Context,
+	ns string,
+	user *userv1.User,
+	kind string,
+	kindName string,
+	h *helper.H,
+) (*rbacv1.RoleBinding, error) {
+	rb, err := h.Kube().RbacV1().RoleBindings(ns).Create(ctx, &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "osde2e-admin-rolebind",
 		},
@@ -319,15 +304,14 @@ func createRolebinding(ns string, user *userv1.User, kind string, kindName strin
 
 // manageSecrets takes in a list of namespaces
 // and returns error if an action fails
-func manageSecrets(nsList []string, h *helper.H) error {
-
+func manageSecrets(ctx context.Context, nsList []string, h *helper.H) error {
 	for _, ns := range nsList {
 
 		newSecretName := "sample-cust-secret"
 
 		// check 'create' permission
 		secrets := h.Kube().CoreV1().Secrets(ns)
-		_, err := secrets.Create(context.TODO(), &corev1.Secret{
+		_, err := secrets.Create(ctx, &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      newSecretName,
 				Namespace: ns,
@@ -336,20 +320,20 @@ func manageSecrets(nsList []string, h *helper.H) error {
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to create secret %s in namespace %s", newSecretName, ns))
 
 		// check 'get' permission
-		dummySecret, err := secrets.Get(context.TODO(), newSecretName, metav1.GetOptions{})
+		dummySecret, err := secrets.Get(ctx, newSecretName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to get secret %s in namespace %s", newSecretName, ns))
 
 		// check 'list' permission
-		_, err = secrets.List(context.TODO(), metav1.ListOptions{})
+		_, err = secrets.List(ctx, metav1.ListOptions{})
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to list secret %s in namespace %s", newSecretName, ns))
 
 		// check 'update' permission
 		dummySecret.Type = corev1.SecretTypeOpaque
-		_, err = secrets.Update(context.TODO(), dummySecret, metav1.UpdateOptions{})
+		_, err = secrets.Update(ctx, dummySecret, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to update secret %s in namespace %s", newSecretName, ns))
 
 		// check 'delete' permission
-		err = secrets.Delete(context.TODO(), newSecretName, metav1.DeleteOptions{})
+		err = secrets.Delete(ctx, newSecretName, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to delete secret %s in namespace %s", newSecretName, ns))
 	}
 	return nil
@@ -357,15 +341,14 @@ func manageSecrets(nsList []string, h *helper.H) error {
 
 // manageSubscription takes in a list of namespaces
 // and returns error if an action fails
-func manageSubscriptions(nsList []string, h *helper.H) error {
-
+func manageSubscriptions(ctx context.Context, nsList []string, h *helper.H) error {
 	newSubscriptionName := "sample-cust-subscription"
 
 	for _, ns := range nsList {
 
 		// check 'create permission
 		subscriptions := h.Operator().OperatorsV1alpha1().Subscriptions(ns)
-		_, err := subscriptions.Create(context.TODO(), &operatorv1.Subscription{
+		_, err := subscriptions.Create(ctx, &operatorv1.Subscription{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      newSubscriptionName,
 				Namespace: ns,
@@ -374,29 +357,41 @@ func manageSubscriptions(nsList []string, h *helper.H) error {
 				Channel: "alpha",
 			},
 		}, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to create subscription %s in namespace %s", newSubscriptionName, ns))
+		Expect(
+			err,
+		).NotTo(HaveOccurred(), fmt.Sprintf("failed to create subscription %s in namespace %s", newSubscriptionName, ns))
 
 		// check 'get' permission
-		_, err = subscriptions.Get(context.TODO(), newSubscriptionName, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to get subscription %s in namespace %s", newSubscriptionName, ns))
+		_, err = subscriptions.Get(ctx, newSubscriptionName, metav1.GetOptions{})
+		Expect(
+			err,
+		).NotTo(HaveOccurred(), fmt.Sprintf("failed to get subscription %s in namespace %s", newSubscriptionName, ns))
 
 		// check 'list' permission
-		_, err = subscriptions.List(context.TODO(), metav1.ListOptions{})
-		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to list subscription %s in namespace %s", newSubscriptionName, ns))
+		_, err = subscriptions.List(ctx, metav1.ListOptions{})
+		Expect(
+			err,
+		).NotTo(HaveOccurred(), fmt.Sprintf("failed to list subscription %s in namespace %s", newSubscriptionName, ns))
 
 		err = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-			sub, err := subscriptions.Get(context.TODO(), newSubscriptionName, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to get subscription %s in namespace %s", newSubscriptionName, ns))
+			sub, err := subscriptions.Get(ctx, newSubscriptionName, metav1.GetOptions{})
+			Expect(
+				err,
+			).NotTo(HaveOccurred(), fmt.Sprintf("failed to get subscription %s in namespace %s", newSubscriptionName, ns))
 			// check 'update' permission
 			sub.Spec.Channel = "beta"
-			_, err = subscriptions.Update(context.TODO(), sub, metav1.UpdateOptions{})
+			_, err = subscriptions.Update(ctx, sub, metav1.UpdateOptions{})
 			return err
 		})
-		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to update subscription %s in namespace %s", newSubscriptionName, ns))
+		Expect(
+			err,
+		).NotTo(HaveOccurred(), fmt.Sprintf("failed to update subscription %s in namespace %s", newSubscriptionName, ns))
 
 		// check 'delete' permission
-		err = subscriptions.Delete(context.TODO(), newSubscriptionName, metav1.DeleteOptions{})
-		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to delete subscription %s in namespace %s", newSubscriptionName, ns))
+		err = subscriptions.Delete(ctx, newSubscriptionName, metav1.DeleteOptions{})
+		Expect(
+			err,
+		).NotTo(HaveOccurred(), fmt.Sprintf("failed to delete subscription %s in namespace %s", newSubscriptionName, ns))
 	}
 	return nil
 }

--- a/pkg/e2e/osd/machinehealthcheck.go
+++ b/pkg/e2e/osd/machinehealthcheck.go
@@ -2,6 +2,7 @@ package osd
 
 import (
 	"context"
+
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -20,14 +21,24 @@ const (
 var machineHealthTestName string = "[Suite: e2e] MachineHealthChecks"
 
 func init() {
-	alert.RegisterGinkgoAlert(machineHealthTestName, "SD-SRE", "Alex Chvatal", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
+	alert.RegisterGinkgoAlert(
+		machineHealthTestName,
+		"SD-SRE",
+		"Alex Chvatal",
+		"sd-cicd-alerts",
+		"sd-cicd@redhat.com",
+		4,
+	)
 }
 
 var _ = ginkgo.Describe(machineHealthTestName, func() {
 	h := helper.New()
 
-	util.GinkgoIt("infra MHC should exist", func() {
-		mhc, err := h.Machine().MachineV1beta1().MachineHealthChecks(machineAPINamespace).Get(context.TODO(), "srep-infra-healthcheck", metav1.GetOptions{})
+	util.GinkgoIt("infra MHC should exist", func(ctx context.Context) {
+		mhc, err := h.Machine().
+			MachineV1beta1().
+			MachineHealthChecks(machineAPINamespace).
+			Get(ctx, "srep-infra-healthcheck", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		// verify there's an MHC for infra nodes
@@ -58,8 +69,11 @@ var _ = ginkgo.Describe(machineHealthTestName, func() {
 		))
 	}, float64(500))
 
-	util.GinkgoIt("worker MHC should exist", func() {
-		mhc, err := h.Machine().MachineV1beta1().MachineHealthChecks(machineAPINamespace).Get(context.TODO(), "srep-worker-healthcheck", metav1.GetOptions{})
+	util.GinkgoIt("worker MHC should exist", func(ctx context.Context) {
+		mhc, err := h.Machine().
+			MachineV1beta1().
+			MachineHealthChecks(machineAPINamespace).
+			Get(ctx, "srep-worker-healthcheck", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		// verify there's an MHC for worker nodes

--- a/pkg/e2e/osd/nodelabels.go
+++ b/pkg/e2e/osd/nodelabels.go
@@ -23,11 +23,11 @@ var _ = ginkgo.Describe(nodeLabelsTestName, func() {
 	ginkgo.Context("Modifying nodeLabels is not allowed", func() {
 		// setup helper
 		h := helper.New()
-		util.GinkgoIt("node-label cannot be added", func() {
+		util.GinkgoIt("node-label cannot be added", func(ctx context.Context) {
 			// Set it to a wildcard dedicated-admin
-			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-cluster")
+			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-cluster")
 
-			nodes, err := h.Kube().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+			nodes, err := h.Kube().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(nodes.Items)).Should(BeNumerically(">", 0))
 
@@ -35,7 +35,7 @@ var _ = ginkgo.Describe(nodeLabelsTestName, func() {
 
 			node.Labels["osde2e"] = "touched by osde2e"
 
-			_, err = h.Kube().CoreV1().Nodes().Update(context.TODO(), &node, metav1.UpdateOptions{})
+			_, err = h.Kube().CoreV1().Nodes().Update(ctx, &node, metav1.UpdateOptions{})
 			Expect(err).To(HaveOccurred())
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 	})

--- a/pkg/e2e/osd/olm.go
+++ b/pkg/e2e/osd/olm.go
@@ -27,8 +27,11 @@ var _ = ginkgo.Describe(olmTestName, func() {
 		// setup helper
 		h := helper.New()
 
-		util.GinkgoIt("subscriptions are satisfied", func() {
-			subs, err := h.Operator().OperatorsV1alpha1().Subscriptions(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+		util.GinkgoIt("subscriptions are satisfied", func(ctx context.Context) {
+			subs, err := h.Operator().
+				OperatorsV1alpha1().
+				Subscriptions(metav1.NamespaceAll).
+				List(ctx, metav1.ListOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, sub := range subs.Items {

--- a/pkg/e2e/osd/privileged.go
+++ b/pkg/e2e/osd/privileged.go
@@ -46,21 +46,20 @@ var _ = ginkgo.Describe(privilegedTestname, func() {
 		// setup helper
 		h := helper.New()
 
-		util.GinkgoIt("privileged container should not get created", func() {
+		util.GinkgoIt("privileged container should not get created", func(ctx context.Context) {
 			// Set it to a wildcard dedicated-admin
-			h.SetServiceAccount("system:serviceaccount:%s:dedicated-admin-project")
+			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
 
 			// Test creating a privileged pod and expect a failure
 			pod := makePod("privileged-pod", h.GetNamespacedServiceAccount(), true)
 
-			_, err := h.Kube().CoreV1().Pods(h.CurrentProject()).Create(context.TODO(), &pod, metav1.CreateOptions{})
+			_, err := h.Kube().CoreV1().Pods(h.CurrentProject()).Create(ctx, &pod, metav1.CreateOptions{})
 			Expect(err).To(HaveOccurred())
 
 			// Test creating an unprivileged pod and expect success
 			pod = makePod("unprivileged-pod", h.GetNamespacedServiceAccount(), false)
-			_, err = h.Kube().CoreV1().Pods(h.CurrentProject()).Create(context.TODO(), &pod, metav1.CreateOptions{})
+			_, err = h.Kube().CoreV1().Pods(h.CurrentProject()).Create(ctx, &pod, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
-
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 	})
 })

--- a/pkg/e2e/proxy/postinstall.go
+++ b/pkg/e2e/proxy/postinstall.go
@@ -48,8 +48,8 @@ var _ = ginkgo.Describe(postInstallProxyTestName, func() {
 	})
 })
 
-func testAddProxy()  {
-	util.GinkgoIt("can add a proxy to the cluster successfully", func() {
+func testAddProxy() {
+	util.GinkgoIt("can add a proxy to the cluster successfully", func(ctx context.Context) {
 		// setup helper
 		h := helper.New()
 
@@ -75,7 +75,7 @@ func testAddProxy()  {
 			var cabundle *v1.ConfigMap
 
 			// Validate state of proxy on-cluster vs what values it should have
-			proxy, err = h.Cfg().ConfigV1().Proxies().Get(context.TODO(), "cluster", metav1.GetOptions{})
+			proxy, err = h.Cfg().ConfigV1().Proxies().Get(ctx, "cluster", metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			if userCABundle != "" {
@@ -83,7 +83,7 @@ func testAddProxy()  {
 					return false, nil
 				}
 				// Check if the ConfigMap exists
-				cabundle, err = h.Kube().CoreV1().ConfigMaps("openshift-config").Get(context.TODO(), "user-ca-bundle", metav1.GetOptions{})
+				cabundle, err = h.Kube().CoreV1().ConfigMaps("openshift-config").Get(ctx, "user-ca-bundle", metav1.GetOptions{})
 				// don't treat the cabundle not existing as an error
 				if err != nil && !apierrors.IsNotFound(err) {
 					return false, err
@@ -133,7 +133,7 @@ func testAddProxy()  {
 }
 
 func testRemoveProxy() {
-	util.GinkgoIt("can remove proxy from the cluster successfully", func() {
+	util.GinkgoIt("can remove proxy from the cluster successfully", func(ctx context.Context) {
 		// setup helper
 		h := helper.New()
 
@@ -150,7 +150,7 @@ func testRemoveProxy() {
 			var proxy *configv1.Proxy
 
 			// Validate state of proxy on-cluster vs what values it should have
-			proxy, err = h.Cfg().ConfigV1().Proxies().Get(context.TODO(), "cluster", metav1.GetOptions{})
+			proxy, err = h.Cfg().ConfigV1().Proxies().Get(ctx, "cluster", metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			if proxy.Spec.HTTPProxy != "" || proxy.Status.HTTPProxy != "" {
@@ -160,7 +160,7 @@ func testRemoveProxy() {
 				return false, nil
 			}
 
-			_, err = h.Kube().CoreV1().ConfigMaps("openshift-config").Get(context.TODO(), "user-ca-bundle", metav1.GetOptions{})
+			_, err = h.Kube().CoreV1().ConfigMaps("openshift-config").Get(ctx, "user-ca-bundle", metav1.GetOptions{})
 			if !apierrors.IsNotFound(err) {
 				return false, nil
 			}

--- a/pkg/e2e/routemonitors/routemonitors.go
+++ b/pkg/e2e/routemonitors/routemonitors.go
@@ -48,18 +48,18 @@ type RouteMonData struct {
 }
 
 // Detects the available routes in the cluster and initializes monitors for their availability
-func Create() (*RouteMonitors, error) {
+func Create(ctx context.Context) (*RouteMonitors, error) {
 	h := helper.NewOutsideGinkgo()
 
 	if h == nil {
-		return nil, fmt.Errorf("Unable to generate helper outside ginkgo")
+		return nil, fmt.Errorf("unable to generate helper outside ginkgo")
 	}
 
 	// record all targeters created in a map, accessible via a key which is their URL
 	targeters := make(map[string]vegeta.Targeter, 0)
 
 	// Create a monitor for the web console
-	consoleRoute, err := h.Route().RouteV1().Routes(consoleNamespace).Get(context.TODO(), consoleLabel, metav1.GetOptions{})
+	consoleRoute, err := h.Route().RouteV1().Routes(consoleNamespace).Get(ctx, consoleLabel, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve console route %s", consoleLabel)
 	}
@@ -74,7 +74,7 @@ func Create() (*RouteMonitors, error) {
 	}
 
 	// Create a monitor for the oauth URL
-	oauthRoute, err := h.Route().RouteV1().Routes(oauthNamespace).Get(context.TODO(), oauthName, metav1.GetOptions{})
+	oauthRoute, err := h.Route().RouteV1().Routes(oauthNamespace).Get(ctx, oauthName, metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve oauth route %s", oauthName)
 	}
@@ -89,7 +89,7 @@ func Create() (*RouteMonitors, error) {
 	}
 
 	// Create monitors for API Server URLs
-	apiservers, err := h.Cfg().ConfigV1().APIServers().List(context.TODO(), metav1.ListOptions{})
+	apiservers, err := h.Cfg().ConfigV1().APIServers().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve list of API servers")
 	}
@@ -110,7 +110,7 @@ func Create() (*RouteMonitors, error) {
 	}
 
 	// If we created any routes during workload testing, let's add them too
-	workloadRoutes, err := h.Route().RouteV1().Routes(h.CurrentProject()).List(context.TODO(), metav1.ListOptions{})
+	workloadRoutes, err := h.Route().RouteV1().Routes(h.CurrentProject()).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve list of workload routes")
 	}
@@ -127,7 +127,7 @@ func Create() (*RouteMonitors, error) {
 	}
 
 	// Create monitors for each route existing in openshift-monitoring
-	monitoringRoutes, err := h.Route().RouteV1().Routes(monitoringNamespace).List(context.TODO(), metav1.ListOptions{})
+	monitoringRoutes, err := h.Route().RouteV1().Routes(monitoringNamespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve list of workload routes")
 	}

--- a/pkg/e2e/scale/mastervertical.go
+++ b/pkg/e2e/scale/mastervertical.go
@@ -1,6 +1,8 @@
 package scale
 
 import (
+	"context"
+
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
@@ -28,13 +30,13 @@ var _ = ginkgo.Describe(masterVerticalTestName, func() {
 	h := helper.New()
 
 	masterVerticalTimeoutInSeconds := 7200
-	util.GinkgoIt("should be tested with MasterVertical", func() {
+	util.GinkgoIt("should be tested with MasterVertical", func(ctx context.Context) {
 		var err error
 		// Before we do anything, scale the cluster.
 		err = cluster.ScaleCluster(viper.GetString(config.Cluster.ID), numNodesToScaleTo)
 		Expect(err).NotTo(HaveOccurred())
 
-		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 		// setup runner
 		scaleCfg := scaleRunnerConfig{
 			Name:         "master-vertical",

--- a/pkg/e2e/scale/nodes_and_pods.go
+++ b/pkg/e2e/scale/nodes_and_pods.go
@@ -1,6 +1,7 @@
 package scale
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/onsi/ginkgo/v2"
@@ -27,8 +28,8 @@ var _ = ginkgo.Describe(nodesPodsTestName, func() {
 	h := helper.New()
 
 	nodeVerticalTimeoutInSeconds := 3600
-	util.GinkgoIt("should be tested with NodeVertical", func() {
-		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+	util.GinkgoIt("should be tested with NodeVertical", func(ctx context.Context) {
+		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 		// setup runner
 		scaleCfg := scaleRunnerConfig{
 			Name:         "node-vertical",
@@ -54,8 +55,8 @@ var _ = ginkgo.Describe(nodesPodsTestName, func() {
 	}, float64(nodeVerticalTimeoutInSeconds))
 
 	podVerticalTimeoutInSeconds := 3600
-	util.GinkgoIt("should be tested with PodVertical", func() {
-		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+	util.GinkgoIt("should be tested with PodVertical", func(ctx context.Context) {
+		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 		// setup runner
 		scaleCfg := scaleRunnerConfig{
 			Name:         "pod-vertical",

--- a/pkg/e2e/scale/performance.go
+++ b/pkg/e2e/scale/performance.go
@@ -1,6 +1,8 @@
 package scale
 
 import (
+	"context"
+
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	kubev1 "k8s.io/api/core/v1"
@@ -21,8 +23,8 @@ var _ = ginkgo.Describe(performanceTestName, func() {
 	h := helper.New()
 
 	httpTimeoutInSeconds := 7200
-	util.GinkgoIt("should be tested with HTTP", func() {
-		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+	util.GinkgoIt("should be tested with HTTP", func(ctx context.Context) {
+		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 		// setup runner
 		scaleCfg := scaleRunnerConfig{
 			Name:         "http",

--- a/pkg/e2e/state/alerts.go
+++ b/pkg/e2e/state/alerts.go
@@ -3,7 +3,6 @@ package state
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"log"
@@ -41,10 +40,10 @@ var _ = ginkgo.Describe(clusterStateTestName, func() {
 	h := helper.New()
 
 	alertsTimeoutInSeconds := 900
-	util.GinkgoIt("should have no alerts", func() {
+	util.GinkgoIt("should have no alerts", func(ctx context.Context) {
 
 		//Set up prometheus client
-		h.SetServiceAccount("system:serviceaccount:%s:cluster-admin")
+		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 		promClient, err := prometheus.CreateClusterClient(h)
 		Expect(err).NotTo(HaveOccurred(), "error creating a prometheus client")
 		promAPI := promv1.NewAPI(promClient)
@@ -53,8 +52,8 @@ var _ = ginkgo.Describe(clusterStateTestName, func() {
 
 		// Query for alerts with a retry count of 40 and timeout of 20 minutes
 		err = wait.PollImmediate(30*time.Second, 20*time.Minute, func() (bool, error) {
-			query := fmt.Sprintf("ALERTS{alertstate!=\"pending\",alertname!=\"Watchdog\"}")
-			context, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			query := "ALERTS{alertstate!=\"pending\",alertname!=\"Watchdog\"}"
+			context, cancel := context.WithTimeout(ctx, 1*time.Minute)
 			defer cancel()
 			value, _, err := promAPI.Query(context, query, time.Now())
 			if err != nil {

--- a/pkg/e2e/verify/check_workloads.go
+++ b/pkg/e2e/verify/check_workloads.go
@@ -27,19 +27,19 @@ var _ = ginkgo.Describe(onNodesTestName, func() {
 
 	ginkgo.Context("worker nodes", func() {
 
-		util.GinkgoIt("on worker nodes", func() {
+		util.GinkgoIt("on worker nodes", func(ctx context.Context) {
 
-			_, infra, err := listNodesByType(h.Kube().CoreV1())
+			_, infra, err := listNodesByType(ctx, h.Kube().CoreV1())
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = checkPods(h.Kube().CoreV1(), infra)
+			_, err = checkPods(ctx, h.Kube().CoreV1(), infra)
 			Expect(err).NotTo(HaveOccurred())
 
 		})
 	})
 })
 
-func checkPods(podClient v1.CoreV1Interface, infra []string) (map[string]string, error) {
+func checkPods(ctx context.Context, podClient v1.CoreV1Interface, infra []string) (map[string]string, error) {
 
 	type (
 		PodName      = string
@@ -59,7 +59,7 @@ func checkPods(podClient v1.CoreV1Interface, infra []string) (map[string]string,
 
 	listOpts := metav1.ListOptions{}
 
-	list, err := podClient.Pods(metav1.NamespaceAll).List(context.TODO(), listOpts)
+	list, err := podClient.Pods(metav1.NamespaceAll).List(ctx, listOpts)
 	if err != nil {
 		return nil, fmt.Errorf("error getting pod list: %v", err)
 	}
@@ -90,13 +90,13 @@ func checkPods(podClient v1.CoreV1Interface, infra []string) (map[string]string,
 }
 
 //This function returns a list of worker nodes and a list of infra nodes
-func listNodesByType(nodeClient v1.CoreV1Interface) (worker, infra []string, err error) {
+func listNodesByType(ctx context.Context, nodeClient v1.CoreV1Interface) (worker, infra []string, err error) {
 
 	log.Printf("Getting node list")
 
 	listOpts := metav1.ListOptions{}
 	//This call will list all the nodes in the cluster
-	list, err := nodeClient.Nodes().List(context.TODO(), listOpts)
+	list, err := nodeClient.Nodes().List(ctx, listOpts)
 
 	if err != nil {
 		return nil, nil, fmt.Errorf("error getting node list: %v", err)

--- a/pkg/e2e/verify/fips.go
+++ b/pkg/e2e/verify/fips.go
@@ -38,7 +38,7 @@ var _ = ginkgo.Describe(fipsTestName, func() {
 		}
 		h := helper.New()
 
-		util.GinkgoIt("for all nodes in a cluster", func() {
+		util.GinkgoIt("for all nodes in a cluster", func(ctx context.Context) {
 			testName := fmt.Sprintf("test-fips-%s-%d-%d", time.Now().Format("20060102-150405"), time.Now().Nanosecond()/1000000, ginkgo.GinkgoParallelProcess())
 
 			// Create Daemonset to test FIPS for each node
@@ -112,19 +112,19 @@ var _ = ginkgo.Describe(fipsTestName, func() {
 				},
 			}
 
-			ds, err := h.Kube().AppsV1().DaemonSets(h.CurrentProject()).Create(context.TODO(), ds, metav1.CreateOptions{})
+			ds, err := h.Kube().AppsV1().DaemonSets(h.CurrentProject()).Create(ctx, ds, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			defer func() {
-				err := h.Kube().AppsV1().DaemonSets(h.CurrentProject()).Delete(context.TODO(), ds.Name, metav1.DeleteOptions{})
+				err := h.Kube().AppsV1().DaemonSets(h.CurrentProject()).Delete(ctx, ds.Name, metav1.DeleteOptions{})
 				Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error deleting Daemonset: %v", err))
 			}()
 
-			nodes, err := h.Kube().CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+			nodes, err := h.Kube().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 			Expect(err).ToNot(HaveOccurred(), fmt.Sprintf("Error retrieving nodes: %v", err))
 
 			// Poll until the number of ready pods is equal to the number of nodes, indicating FIPS is enabled for the cluster
 			err = wait.PollImmediate(fipsTestPollInterval, fipsTestPollDuration, func() (bool, error) {
-				ds, err = h.Kube().AppsV1().DaemonSets(h.CurrentProject()).Get(context.TODO(), testName, metav1.GetOptions{})
+				ds, err = h.Kube().AppsV1().DaemonSets(h.CurrentProject()).Get(ctx, testName, metav1.GetOptions{})
 				if err != nil {
 					return false, err
 				}

--- a/pkg/e2e/verify/imagestreams.go
+++ b/pkg/e2e/verify/imagestreams.go
@@ -22,8 +22,8 @@ func init() {
 var _ = ginkgo.Describe(imageStreamsTestName, func() {
 	h := helper.New()
 
-	util.GinkgoIt("should exist in the cluster", func() {
-		list, err := h.Image().ImageV1().ImageStreams(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	util.GinkgoIt("should exist in the cluster", func(ctx context.Context) {
+		list, err := h.Image().ImageV1().ImageStreams(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		Expect(err).NotTo(HaveOccurred(), "couldn't list ImageStreams")
 		Expect(list).NotTo(BeNil())
 

--- a/pkg/e2e/verify/loadbalancers.go
+++ b/pkg/e2e/verify/loadbalancers.go
@@ -30,21 +30,21 @@ func init() {
 var _ = ginkgo.Describe(loadBalancersTestName, func() {
 	h := helper.New()
 
-	util.GinkgoIt("router/ingress load balancer should exist", func() {
-		exists, err := loadBalancerExists(h, routerIngressLoadBalancerNamespace, routerIngressLoadBalancer)
+	util.GinkgoIt("router/ingress load balancer should exist", func(ctx context.Context) {
+		exists, err := loadBalancerExists(ctx, h, routerIngressLoadBalancerNamespace, routerIngressLoadBalancer)
 		Expect(err).ToNot(HaveOccurred(), "an error should not have occurred when looking for the load balancer")
 		Expect(exists).To(BeTrue(), "the load balancer should exist")
 	}, 10)
 
-	util.GinkgoIt("external load balancer should exist", func() {
-		exists, err := loadBalancerExists(h, externalLoadBalancerNamespace, externalLoadBalancer)
+	util.GinkgoIt("external load balancer should exist", func(ctx context.Context) {
+		exists, err := loadBalancerExists(ctx, h, externalLoadBalancerNamespace, externalLoadBalancer)
 		Expect(err).ToNot(HaveOccurred(), "an error should not have occurred when looking for the load balancer")
 		Expect(exists).To(BeTrue(), "the load balancer should exist")
 	}, 10)
 })
 
-func loadBalancerExists(h *helper.H, namespace string, loadBalancer string) (bool, error) {
-	service, err := h.Kube().CoreV1().Services(namespace).Get(context.TODO(), loadBalancer, metav1.GetOptions{})
+func loadBalancerExists(ctx context.Context, h *helper.H, namespace string, loadBalancer string) (bool, error) {
+	service, err := h.Kube().CoreV1().Services(namespace).Get(ctx, loadBalancer, metav1.GetOptions{})
 
 	if err != nil {
 		return false, fmt.Errorf("error getting loadbalancer: %v", err)

--- a/pkg/e2e/verify/oauth_tokens.go
+++ b/pkg/e2e/verify/oauth_tokens.go
@@ -31,19 +31,19 @@ var _ = ginkgo.Describe(oauthTokensTestName, func() {
 
 		var oauthcfg *configv1.OAuth
 
-		ginkgo.BeforeEach(func() {
+		ginkgo.BeforeEach(func(ctx context.Context) {
 			var err error
-			oauthcfg, err = h.Cfg().ConfigV1().OAuths().Get(context.TODO(), "cluster", metav1.GetOptions{})
+			oauthcfg, err = h.Cfg().ConfigV1().OAuths().Get(ctx, "cluster", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		util.GinkgoIt("should include token max age", func() {
+		util.GinkgoIt("should include token max age", func(_ context.Context) {
 			tokenConfig := oauthcfg.Spec.TokenConfig
 			Expect(tokenConfig).ShouldNot(BeNil(), "tokenConfig should be set")
 			Expect(tokenConfig.AccessTokenMaxAgeSeconds).ToNot(BeZero(), "access token max age setting should not be zero")
 		})
 
-		util.OnSupportedVersionIt(util.Version460, h, "should include token inactivity timeout", func() {
+		util.OnSupportedVersionIt(util.Version460, h, "should include token inactivity timeout", func(_ context.Context) {
 			tokenConfig := oauthcfg.Spec.TokenConfig
 			Expect(tokenConfig).ShouldNot(BeNil(), "tokenConfig should be set")
 			Expect(tokenConfig.AccessTokenInactivityTimeoutSeconds).ToNot(BeZero(), "access token idle timeout setting should not be zero")
@@ -56,38 +56,38 @@ var _ = ginkgo.Describe(oauthTokensTestName, func() {
 		var user *userv1.User
 		var client *oauthv1.OAuthClient
 
-		ginkgo.BeforeEach(func() {
-			user, _ = createUser("osde2e-token-user-"+util.RandomStr(5), nil, nil, h)
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			user, _ = createUser(ctx, "osde2e-token-user-"+util.RandomStr(5), nil, nil, h)
 			Expect(user).ToNot(BeNil())
-			client = createOAuthClient(getOAuthClient(oauthTokensTestClientName, h), h)
+			client = createOAuthClient(ctx, getOAuthClient(ctx, oauthTokensTestClientName, h), h)
 			Expect(client).ToNot(BeNil())
 		})
 
-		util.OnSupportedVersionIt(util.Version460, h, "should be present on oauthaccesstokens", func() {
-			_, oauthAccessToken := simulateLogin(user, client, h)
+		util.OnSupportedVersionIt(util.Version460, h, "should be present on oauthaccesstokens", func(ctx context.Context) {
+			_, oauthAccessToken := simulateLogin(ctx, user, client, h)
 			Expect(oauthAccessToken.ExpiresIn).ToNot(BeZero(), "oauthaccesstoken expiry time should not be zero")
 			Expect(oauthAccessToken.InactivityTimeoutSeconds).ToNot(BeZero(), "oauthaccesstoken idle timeout should not be zero")
 		}, 30)
 
-		util.OnSupportedVersionIt(util.Version460, h, "should not affect active sessions", func() {
-			bearerToken, _ := simulateLogin(user, client, h)
-			tokenCheck := verifyUserToken(bearerToken, user, h)
+		util.OnSupportedVersionIt(util.Version460, h, "should not affect active sessions", func(ctx context.Context) {
+			bearerToken, _ := simulateLogin(ctx, user, client, h)
+			tokenCheck := verifyUserToken(ctx, bearerToken, user, h)
 			Expect(tokenCheck()).To(BeTrue(), "bearer token should be valid")
 			Consistently(tokenCheck, oauthTokensTestIdleTimeout+time.Minute, time.Minute).
 				Should(BeTrue(), "bearer token should still be valid")
 		}, (oauthTokensTestIdleTimeout + (2 * time.Minute)).Seconds())
 
-		util.OnSupportedVersionIt(util.Version460, h, "should end idle sessions", func() {
-			bearerToken, _ := simulateLogin(user, client, h)
-			tokenCheck := verifyUserToken(bearerToken, user, h)
+		util.OnSupportedVersionIt(util.Version460, h, "should end idle sessions", func(ctx context.Context) {
+			bearerToken, _ := simulateLogin(ctx, user, client, h)
+			tokenCheck := verifyUserToken(ctx, bearerToken, user, h)
 			Expect(tokenCheck()).To(BeTrue(), "bearer token should be valid")
 			time.Sleep(oauthTokensTestIdleTimeout + time.Minute)
 			Expect(tokenCheck()).To(BeFalse(), "bearer token should no longer be valid")
 		}, (oauthTokensTestIdleTimeout + (2 * time.Minute)).Seconds())
 
-		ginkgo.AfterEach(func() {
-			deleteUser(user.Name, h)
-			deleteOAuthClient(client.Name, h)
+		ginkgo.AfterEach(func(ctx context.Context) {
+			deleteUser(ctx, user.Name, h)
+			deleteOAuthClient(ctx, client.Name, h)
 		})
 
 	})
@@ -95,15 +95,15 @@ var _ = ginkgo.Describe(oauthTokensTestName, func() {
 })
 
 // simulates normal oauth login flow by creating and redeeming an authorization code
-func simulateLogin(user *userv1.User, client *oauthv1.OAuthClient, h *helper.H) (bearerToken string, oauthAccessToken *oauthv1.OAuthAccessToken) {
-	code := createAuthorizeToken(client, user, h)
+func simulateLogin(ctx context.Context, user *userv1.User, client *oauthv1.OAuthClient, h *helper.H) (bearerToken string, oauthAccessToken *oauthv1.OAuthAccessToken) {
+	code := createAuthorizeToken(ctx, client, user, h)
 	Expect(code).ToNot(BeNil(), "should be able to create oauthauthorizetokens")
 
-	bearerToken = exchangeToken(code, h)
+	bearerToken = exchangeToken(ctx, code, h)
 	Expect(bearerToken).ToNot(BeEmpty(), "should be able to redeem authorization code")
 
 	Eventually(func() *oauthv1.OAuthAccessToken {
-		oauthAccessToken = findOAuthAccessToken(code, h)
+		oauthAccessToken = findOAuthAccessToken(ctx, code, h)
 		return oauthAccessToken
 	}, time.Minute, time.Second).ShouldNot(BeNil(), "should have an oauthaccesstoken")
 
@@ -111,11 +111,11 @@ func simulateLogin(user *userv1.User, client *oauthv1.OAuthClient, h *helper.H) 
 }
 
 // exchanges an authorisation code for an access token
-func exchangeToken(code *oauthv1.OAuthAuthorizeToken, h *helper.H) (token string) {
+func exchangeToken(ctx context.Context, code *oauthv1.OAuthAuthorizeToken, h *helper.H) (token string) {
 	Expect(http.PostForm((&url.URL{
 		Scheme: "https",
 		User:   url.UserPassword(code.ClientName, ""),
-		Host:   oauthRoute(h).Spec.Host,
+		Host:   oauthRoute(ctx, h).Spec.Host,
 		Path:   "/oauth/token",
 	}).String(), url.Values{
 		"code":          []string{code.Name},
@@ -137,8 +137,8 @@ func exchangeToken(code *oauthv1.OAuthAuthorizeToken, h *helper.H) (token string
 }
 
 // creates an oauthauthorizetoken for the given oauthclient (must be a challenging client)
-func createAuthorizeToken(client *oauthv1.OAuthClient, user *userv1.User, h *helper.H) *oauthv1.OAuthAuthorizeToken {
-	code, err := h.OAuth().OauthV1().OAuthAuthorizeTokens().Create(context.TODO(), &oauthv1.OAuthAuthorizeToken{
+func createAuthorizeToken(ctx context.Context, client *oauthv1.OAuthClient, user *userv1.User, h *helper.H) *oauthv1.OAuthAuthorizeToken {
+	code, err := h.OAuth().OauthV1().OAuthAuthorizeTokens().Create(ctx, &oauthv1.OAuthAuthorizeToken{
 		ObjectMeta:          metav1.ObjectMeta{Name: util.RandomStr(32)},
 		ClientName:          client.Name,
 		CodeChallenge:       util.RandomStr(48),
@@ -154,8 +154,8 @@ func createAuthorizeToken(client *oauthv1.OAuthClient, user *userv1.User, h *hel
 }
 
 // find an oauthaccesstoken corresponding to an oauthauthorizetoken
-func findOAuthAccessToken(code *oauthv1.OAuthAuthorizeToken, h *helper.H) *oauthv1.OAuthAccessToken {
-	tokens, err := h.OAuth().OauthV1().OAuthAccessTokens().List(context.TODO(), metav1.ListOptions{
+func findOAuthAccessToken(ctx context.Context, code *oauthv1.OAuthAuthorizeToken, h *helper.H) *oauthv1.OAuthAccessToken {
+	tokens, err := h.OAuth().OauthV1().OAuthAccessTokens().List(ctx, metav1.ListOptions{
 		FieldSelector: "authorizeToken==" + code.Name,
 	})
 	Expect(err).ToNot(HaveOccurred())
@@ -163,16 +163,16 @@ func findOAuthAccessToken(code *oauthv1.OAuthAuthorizeToken, h *helper.H) *oauth
 	return &tokens.Items[0]
 }
 
-func getOAuthClient(name string, h *helper.H) *oauthv1.OAuthClient {
-	client, err := h.OAuth().OauthV1().OAuthClients().Get(context.TODO(), name, metav1.GetOptions{})
+func getOAuthClient(ctx context.Context, name string, h *helper.H) *oauthv1.OAuthClient {
+	client, err := h.OAuth().OauthV1().OAuthClients().Get(ctx, name, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	return client
 }
 
 // creates an oauthclient with an inactivity timeout
-func createOAuthClient(tpl *oauthv1.OAuthClient, h *helper.H) *oauthv1.OAuthClient {
+func createOAuthClient(ctx context.Context, tpl *oauthv1.OAuthClient, h *helper.H) *oauthv1.OAuthClient {
 	timeoutSeconds := int32(oauthTokensTestIdleTimeout.Seconds())
-	client, err := h.OAuth().OauthV1().OAuthClients().Create(context.TODO(), &oauthv1.OAuthClient{
+	client, err := h.OAuth().OauthV1().OAuthClients().Create(ctx, &oauthv1.OAuthClient{
 		ObjectMeta:                          metav1.ObjectMeta{Name: "osde2e-oauth-" + util.RandomStr(5)},
 		AccessTokenInactivityTimeoutSeconds: &timeoutSeconds,
 		GrantMethod:                         tpl.GrantMethod,
@@ -184,14 +184,14 @@ func createOAuthClient(tpl *oauthv1.OAuthClient, h *helper.H) *oauthv1.OAuthClie
 	return client
 }
 
-func deleteOAuthClient(name string, h *helper.H) {
-	err := h.OAuth().OauthV1().OAuthClients().Delete(context.Background(), name, metav1.DeleteOptions{})
+func deleteOAuthClient(ctx context.Context, name string, h *helper.H) {
+	err := h.OAuth().OauthV1().OAuthClients().Delete(ctx, name, metav1.DeleteOptions{})
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func verifyUserToken(token string, user *userv1.User, h *helper.H) func() bool {
+func verifyUserToken(ctx context.Context, token string, user *userv1.User, h *helper.H) func() bool {
 	return func() bool {
-		tokenuser, err := h.WithToken(token).User().UserV1().Users().Get(context.TODO(), "~", metav1.GetOptions{})
+		tokenuser, err := h.WithToken(token).User().UserV1().Users().Get(ctx, "~", metav1.GetOptions{})
 		if err != nil {
 			return false
 		}
@@ -202,7 +202,7 @@ func verifyUserToken(token string, user *userv1.User, h *helper.H) func() bool {
 // createUser creates the given user.
 // Note that it may take time for operators to reconcile the permissions of new users,
 // so it's best to poll your first attempt to use the resulting user for a couple minutes.
-func createUser(userName string, identities []string, groups []string, h *helper.H) (*userv1.User, error) {
+func createUser(ctx context.Context, userName string, identities []string, groups []string, h *helper.H) (*userv1.User, error) {
 	user := &userv1.User{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: userName,
@@ -210,9 +210,9 @@ func createUser(userName string, identities []string, groups []string, h *helper
 		Identities: identities,
 		Groups:     groups,
 	}
-	return h.User().UserV1().Users().Create(context.TODO(), user, metav1.CreateOptions{})
+	return h.User().UserV1().Users().Create(ctx, user, metav1.CreateOptions{})
 }
 
-func deleteUser(userName string, h *helper.H) error {
-	return h.User().UserV1().Users().Delete(context.TODO(), userName, metav1.DeleteOptions{})
+func deleteUser(ctx context.Context, userName string, h *helper.H) error {
+	return h.User().UserV1().Users().Delete(ctx, userName, metav1.DeleteOptions{})
 }

--- a/pkg/e2e/verify/pods.go
+++ b/pkg/e2e/verify/pods.go
@@ -27,8 +27,8 @@ func init() {
 var _ = ginkgo.Describe(podsTestName, func() {
 	h := helper.New()
 
-	util.GinkgoIt("should not be Failed", func() {
-		list, err := h.Kube().CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	util.GinkgoIt("should not be Failed", func(ctx context.Context) {
+		list, err := h.Kube().CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		filteredList := &v1.PodList{}
 
 		for _, pod := range list.Items {

--- a/pkg/e2e/verify/regularuser_webhook.go
+++ b/pkg/e2e/verify/regularuser_webhook.go
@@ -23,7 +23,7 @@ var _ = ginkgo.Describe(regularuserWebhookTestName, func() {
 	h := helper.New()
 
 	ginkgo.Context("regularuser validating webhook", func() {
-		util.GinkgoIt("Privledged users allowed to create autoscalers and delete clusterversion objects", func() {
+		util.GinkgoIt("Privledged users allowed to create autoscalers and delete clusterversion objects", func(ctx context.Context) {
 			h.Impersonate(rest.ImpersonationConfig{
 				UserName: "system:admin",
 				Groups: []string{
@@ -32,10 +32,10 @@ var _ = ginkgo.Describe(regularuserWebhookTestName, func() {
 				},
 			})
 			defer func() {
-				err := h.Cfg().ConfigV1().ClusterVersions().Delete(context.TODO(), "osde2e-version", metav1.DeleteOptions{})
+				err := h.Cfg().ConfigV1().ClusterVersions().Delete(ctx, "osde2e-version", metav1.DeleteOptions{})
 				Expect(err).NotTo(HaveOccurred())
 			}()
-			_, err := h.Cfg().ConfigV1().ClusterVersions().Create(context.TODO(), &v1.ClusterVersion{
+			_, err := h.Cfg().ConfigV1().ClusterVersions().Create(ctx, &v1.ClusterVersion{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "osde2e-version",
 				},

--- a/pkg/e2e/verify/routes.go
+++ b/pkg/e2e/verify/routes.go
@@ -33,29 +33,29 @@ func init() {
 var _ = ginkgo.Describe(routesTestName, func() {
 	h := helper.New()
 
-	util.GinkgoIt("should be created for Console", func() {
-		consoleRoutes(h)
+	util.GinkgoIt("should be created for Console", func(ctx context.Context) {
+		consoleRoutes(ctx, h)
 	}, 300)
 
-	util.GinkgoIt("should be functioning for Console", func() {
-		for _, route := range consoleRoutes(h) {
-			testRouteIngresses(route, http.StatusOK)
+	util.GinkgoIt("should be functioning for Console", func(ctx context.Context) {
+		for _, route := range consoleRoutes(ctx, h) {
+			testRouteIngresses(ctx, route, http.StatusOK)
 		}
 	}, 300)
 
-	util.GinkgoIt("should be created for oauth", func() {
-		oauthRoute(h)
+	util.GinkgoIt("should be created for oauth", func(ctx context.Context) {
+		oauthRoute(ctx, h)
 	}, 300)
 
-	util.GinkgoIt("should be functioning for oauth", func() {
-		testRouteIngresses(oauthRoute(h), http.StatusForbidden)
+	util.GinkgoIt("should be functioning for oauth", func(ctx context.Context) {
+		testRouteIngresses(ctx, oauthRoute(ctx, h), http.StatusForbidden)
 	}, 300)
 
 })
 
-func consoleRoutes(h *helper.H) []v1.Route {
+func consoleRoutes(ctx context.Context, h *helper.H) []v1.Route {
 	labelSelector := fmt.Sprintf("app=%s", consoleLabel)
-	list, err := h.Route().RouteV1().Routes(consoleNamespace).List(context.TODO(), metav1.ListOptions{
+	list, err := h.Route().RouteV1().Routes(consoleNamespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil || list == nil {
@@ -68,8 +68,8 @@ func consoleRoutes(h *helper.H) []v1.Route {
 	return list.Items
 }
 
-func oauthRoute(h *helper.H) v1.Route {
-	route, err := h.Route().RouteV1().Routes(oauthNamespace).Get(context.TODO(), oauthName, metav1.GetOptions{})
+func oauthRoute(ctx context.Context, h *helper.H) v1.Route {
+	route, err := h.Route().RouteV1().Routes(oauthNamespace).Get(ctx, oauthName, metav1.GetOptions{})
 	if err != nil || route == nil {
 		err = fmt.Errorf("failed requesting routes: %v", err)
 	}
@@ -77,7 +77,7 @@ func oauthRoute(h *helper.H) v1.Route {
 	return *route
 }
 
-func testRouteIngresses(route v1.Route, status int) {
+func testRouteIngresses(ctx context.Context, route v1.Route, status int) {
 	Expect(route.Status.Ingress).ShouldNot(HaveLen(0),
 		"no ingresses have been setup for the route '%s/%s'", route.Namespace, route.Name)
 

--- a/pkg/e2e/verify/strict_transport_security.go
+++ b/pkg/e2e/verify/strict_transport_security.go
@@ -21,21 +21,21 @@ var _ = ginkgo.Describe(hstsTestName, func() {
 	monitorNamespace := "openshift-monitoring"
 
 	ginkgo.Context("Validating HTTP strict transport security", func() {
-		util.GinkgoIt("should be set for openshift-console OSD managed routes", func() {
-			foundKey, err := hstsManagedRoutes(h, consoleNamespace)
+		util.GinkgoIt("should be set for openshift-console OSD managed routes", func(ctx context.Context) {
+			foundKey, err := hstsManagedRoutes(ctx, h, consoleNamespace)
 			Expect(err).NotTo(HaveOccurred(), "failed getting routes for %v", consoleNamespace)
 			Expect(foundKey).Should(BeTrue(), "%v namespace routes have HTTP strict transport security set", consoleNamespace)
 		}, 5)
-		util.GinkgoIt("should be set for openshift-monitoring OSD managed routes", func() {
-			foundKey, err := hstsManagedRoutes(h, monitorNamespace)
+		util.GinkgoIt("should be set for openshift-monitoring OSD managed routes", func(ctx context.Context) {
+			foundKey, err := hstsManagedRoutes(ctx, h, monitorNamespace)
 			Expect(err).NotTo(HaveOccurred(), "failed getting routes for %v", monitorNamespace)
 			Expect(foundKey).Should(BeTrue(), "%v namespace routes have HTTP strict transport security set", monitorNamespace)
 		}, 5)
 	})
 })
 
-func hstsManagedRoutes(h *helper.H, namespace string) (bool, error) {
-	route, err := h.Route().RouteV1().Routes(namespace).List(context.TODO(), metav1.ListOptions{})
+func hstsManagedRoutes(ctx context.Context, h *helper.H, namespace string) (bool, error) {
+	route, err := h.Route().RouteV1().Routes(namespace).List(ctx, metav1.ListOptions{})
 	hstsExists := false
 	annotationHsts := "hsts_header"
 	hstsSetting := "max-age=31536000;preload"

--- a/pkg/e2e/verify/techpreviewnoupgrade_webhook.go
+++ b/pkg/e2e/verify/techpreviewnoupgrade_webhook.go
@@ -25,7 +25,7 @@ var _ = ginkgo.Describe(techPreviewNoUpgradeWebhookTestName, func() {
 	h := helper.New()
 
 	ginkgo.Context("techpreviewnoupgrade webhook", func() {
-		util.GinkgoIt("Webhook will block UPDATE requests if TechPreviewNoUpgrade feature set exists in FeatureGate", func() {
+		util.GinkgoIt("Webhook will block UPDATE requests if TechPreviewNoUpgrade feature set exists in FeatureGate", func(ctx context.Context) {
 			h.Impersonate(rest.ImpersonationConfig{
 				UserName: "system:admin",
 				Groups: []string{
@@ -37,12 +37,12 @@ var _ = ginkgo.Describe(techPreviewNoUpgradeWebhookTestName, func() {
 			}()
 
 			// first fetch the ResourceVersion
-			existingFeatureGate, err := h.Cfg().ConfigV1().FeatureGates().Get(context.TODO(), "cluster", metav1.GetOptions{})
+			existingFeatureGate, err := h.Cfg().ConfigV1().FeatureGates().Get(ctx, "cluster", metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			existingFeatureGate.Spec.FeatureSet = "TechPreviewNoUpgrade"
 
-			_, err = h.Cfg().ConfigV1().FeatureGates().Update(context.TODO(), existingFeatureGate, metav1.UpdateOptions{})
+			_, err = h.Cfg().ConfigV1().FeatureGates().Update(ctx, existingFeatureGate, metav1.UpdateOptions{})
 
 			Expect(err).To((HaveOccurred()))
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))

--- a/pkg/e2e/verify/validation_webhook.go
+++ b/pkg/e2e/verify/validation_webhook.go
@@ -28,23 +28,23 @@ var _ = ginkgo.Describe(validationWebhookTestName, func() {
 
 	h := helper.New()
 
-	util.GinkgoIt("should exist and be running in the cluster", func() {
+	util.GinkgoIt("should exist and be running in the cluster", func(ctx context.Context) {
 
 		// Expect project to exist
-		_, err := h.Project().ProjectV1().Projects().Get(context.TODO(), namespace, metav1.GetOptions{})
+		_, err := h.Project().ProjectV1().Projects().Get(ctx, namespace, metav1.GetOptions{})
 		Expect(err).ShouldNot(HaveOccurred(), "project should have been created")
 
 		// Ensure presence of config map
-		_, err = h.Kube().CoreV1().ConfigMaps(namespace).Get(context.TODO(), configMapName, metav1.GetOptions{})
+		_, err = h.Kube().CoreV1().ConfigMaps(namespace).Get(ctx, configMapName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred(), "failed to get config map %v\n", configMapName)
 
 		// Ensure presence of secret
-		_, err = h.Kube().CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+		_, err = h.Kube().CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred(), "failed to get secretName %v\n", secretName)
 
 		// Ensure pods are in a running state
 		listOpts := metav1.ListOptions{}
-		list, err := h.Kube().CoreV1().Pods(namespace).List(context.TODO(), listOpts)
+		list, err := h.Kube().CoreV1().Pods(namespace).List(ctx, listOpts)
 		Expect(err).NotTo(HaveOccurred(), "failed to get running pods\n")
 		Expect(list).NotTo(BeNil())
 		Expect(list.Items).ShouldNot(HaveLen(0), "at least one pod should be present")
@@ -54,7 +54,7 @@ var _ = ginkgo.Describe(validationWebhookTestName, func() {
 		}
 
 		// Ensure service is present
-		_, err = h.Kube().CoreV1().Services(namespace).Get(context.TODO(), service, metav1.GetOptions{})
+		_, err = h.Kube().CoreV1().Services(namespace).Get(ctx, service, metav1.GetOptions{})
 		Expect(err).ShouldNot(HaveOccurred(), "service should have been created")
 
 	}, 300)


### PR DESCRIPTION
Within tests and test helpers, push the ginkgo context down to be used
over `context.TODO()` allowing ginkgo to cancel requests based on
timeout or aborting the process.

Signed-off-by: Brady Pratt <bpratt@redhat.com>
