### PR TITLE
Bump osde2e dockerfile parent images tags

### DIFF
--- a/Dockerfile.osde2e
+++ b/Dockerfile.osde2e
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.16
+FROM registry.ci.openshift.org/openshift/release:golang-1.18
 
 ENV GOFLAGS=
 ENV PKG=/go/src/github.com/openshift/osde2e/
@@ -9,7 +9,7 @@ RUN go env
 RUN make check
 RUN make build
 
-FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 RUN mkdir /osde2e-bin
 COPY --from=0 /go/src/github.com/openshift/osde2e/out/osde2e /osde2e-bin


### PR DESCRIPTION
This commit addresses the following:
 1. Bump the golang image tag to 1.18 to stay inline with go.mod go version defined
 2. Bump ubi to version 8 as 7 full support has ended and is only in extended life cycle support