### PR TITLE
support setting ginkgo loglevel

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -102,6 +102,7 @@ Some environment variables commonly used for pipelines under osde2e are indicate
 |POLLING_TIMEOUT| PollingTimeout is how long (in seconds) to wait for an object to be created before failing the test.|
 |GINKGO_SKIP| GinkgoSkip is a regex passed to Ginkgo that skips any test suites matching the regex. ex. "Operator"|
 |GINKGO_FOCUS| GinkgoFocus is a regex passed to Ginkgo that focus on any test suites matching the regex. ex. "Operator"|
+|GINKGO_LOG_LEVEL| GinkgoLogLevel allows controlling the Ginkgo reporter output|
 |TESTS_TO_RUN| TestsToRun is a list of files which should be executed as part of a test suite|
 |SUPPRESS_SKIP_NOTIFICATIONS| SuppressSkipNotifications suppresses the notifications of skipped tests|
 |CLEAN_RUNS| CleanRuns is the number of times the test-version is run before skipping.|

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -194,6 +194,10 @@ var Tests = struct {
 	// Env: GINKGO_FOCUS
 	GinkgoFocus string
 
+	// GinkgoLogLevel contrls the logging level used by ginkgo when providing test output
+	// Env: GINKGO_LOG_LEVEL
+	GinkgoLogLevel string
+
 	// TestsToRun is a list of files which should be executed as part of a test suite
 	// Env: TESTS_TO_RUN
 	TestsToRun string
@@ -232,10 +236,10 @@ var Tests = struct {
 	// Env: ENABLE_FIPS
 	EnableFips string
 }{
-
 	PollingTimeout:             "tests.pollingTimeout",
 	GinkgoSkip:                 "tests.ginkgoSkip",
 	GinkgoFocus:                "tests.focus",
+	GinkgoLogLevel:             "tests.ginkgoLogLevel",
 	TestsToRun:                 "tests.testsToRun",
 	SuppressSkipNotifications:  "tests.suppressSkipNotifications",
 	CleanRuns:                  "tests.cleanRuns",
@@ -651,6 +655,8 @@ func InitViper() {
 
 	viper.BindEnv(Tests.GinkgoFocus, "GINKGO_FOCUS")
 
+	viper.BindEnv(Tests.GinkgoLogLevel, "GINKGO_LOG_LEVEL")
+
 	viper.BindEnv(Tests.TestsToRun, "TESTS_TO_RUN")
 
 	viper.SetDefault(Tests.SuppressSkipNotifications, true)
@@ -850,7 +856,6 @@ func InitViper() {
 
 	viper.BindEnv(Proxy.UserCABundle, "USER_CA_BUNDLE")
 	RegisterSecret(Proxy.UserCABundle, "user-ca-bundle")
-
 }
 
 func init() {


### PR DESCRIPTION
allow for controlling the ginkgo reporter output which can be set to one
of `succinct` (default), `v` (verbose, printing GinkgoWriter output) and
`vv` (very-verbose, including skipped and pending tests). This will
allow tests to then use the `GinkgoWriter` and improve the output of
osde2e.

https://onsi.github.io/ginkgo/#controlling-ginkgos-output

Signed-off-by: Brady Pratt <bpratt@redhat.com>
