### PR TITLE
[OSD-13500] osd-metrics-exporter: fix grpcurl-query pod not starting

### DIFF
--- a/assets/registry/replaces.template
+++ b/assets/registry/replaces.template
@@ -1,11 +1,46 @@
 REGISTRY_QUERY_FILE="{{.OutputDir}}/registry.json"
 
-oc delete pod --ignore-not-found=true -n {{.Namespace}} grpcurl-query
+oc delete job --ignore-not-found=true -n {{.Namespace}} grpcurl-query
 
-oc run grpcurl-query -n {{.Namespace}} --quiet --rm=true --restart=Never --attach=true \
-    --image=quay.io/rogbas/grpcurl -- -plaintext -d \
-    '{"pkgName":"{{.PackageName}}","channelName":"{{.PackageChannel}}"}' \
-    {{.ServiceName}}:{{.ServicePort}} api.Registry/GetBundleForChannel > "$REGISTRY_QUERY_FILE"
+set -e
+cat <<EOF | oc apply -n {{.Namespace}} --wait -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    run: grpcurl-query
+  name: grpcurl-query
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsUser: 1000
+      containers:
+      - args:
+        - -plaintext
+        - -d
+        - '{"pkgName":"{{.PackageName}}","channelName":"{{.PackageChannel}}"}'
+        - '{{.ServiceName}}:{{.ServicePort}}'
+        - api.Registry/GetBundleForChannel
+        image: quay.io/rogbas/grpcurl
+        name: grpcurl-query
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          seccompProfile: 
+            type: RuntimeDefault
+          capabilities:
+            drop:
+              - ALL
+            add:
+              - NET_BIND_SERVICE
+      dnsPolicy: ClusterFirst
+      restartPolicy: Never
+EOF
+oc -n {{.Namespace}} wait --for=condition=complete job/grpcurl-query
+oc -n {{.Namespace}} logs job/grpcurl-query > $REGISTRY_QUERY_FILE
+set +e
+
 
 if ! [ -s "$REGISTRY_QUERY_FILE" ]
 then


### PR DESCRIPTION
The `grpcurl-query` pod was unable to start causing the osd-metrics-exporter test cases to fail. The pods error message was:
```
/osde2e-payload/payload.sh: line 13: `Error from server (Forbidden): pods "grpcurl-query" is forbidden: violates PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "grpcurl-query" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "grpcurl-query" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "grpcurl-query" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "grpcurl-query" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")'
```

This caused the test to timeout and eventually fail:
```
------------------------------
• [FAILED] [1700.001 seconds]
[Suite: operators] [OSD] OSD Metrics Exporter Basic Test Operator Upgrade [It] should upgrade from the replaced version
/home/maschulz/code/openshift/osde2e/pkg/common/util/util.go:43

  Unexpected error:
      <*errors.errorString | 0xc000453270>: {
          s: "failed waiting for Pod: the Pod has a phase of Failed",
      }
      failed waiting for Pod: the Pod has a phase of Failed
  occurred
  In [It] at: /home/maschulz/code/openshift/osde2e/pkg/e2e/operators/operators.go:594
------------------------------
SSSSSSSSSSSSS


Summarizing 1 Failure:
  [FAIL] [Suite: operators] [OSD] OSD Metrics Exporter Basic Test Operator Upgrade [It] should upgrade from the replaced version
  /home/maschulz/code/openshift/osde2e/pkg/e2e/operators/operators.go:594

Ran 7 of 237 Specs in 1701.175 seconds
```

