### PR TITLE
providers/ocmprovider: remove ccs overwrite logic

### DIFF
--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -202,18 +202,9 @@ func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 					}
 				}
 			} else {
-				var err error
-				var ccsUser string
-				ccsUser, err = aws.VerifyCCS()
+				_, err = aws.VerifyCCS()
 				if err != nil {
 					return "", fmt.Errorf("error verifying CCS credentials: %v", err)
-				}
-				log.Printf("ocm.ccs.overwrite is: %v - will attempt to generate CCS keys.", viper.GetString(CCS_OVERWRITE))
-				if viper.GetBool("ocm.ccs.overwrite") && ccsUser != "osdCcsAdmin" {
-					awsAccessKey, awsSecretKey, err = aws.CcsScale()
-				}
-				if err != nil {
-					return "", fmt.Errorf("error generating CCS keys: %v", err)
 				}
 
 				newCluster = newCluster.CCS(v1.NewCCS().Enabled(true)).AWS(

--- a/pkg/common/providers/ocmprovider/config.go
+++ b/pkg/common/providers/ocmprovider/config.go
@@ -39,9 +39,6 @@ const (
 	// CCS defines whether the cluster should expect cloud credentials or not
 	CCS = "ocm.ccs"
 
-	// CCS_OVERWRITE defines an overwrite flag that will attempt to create CCS credentials for the cluster
-	CCS_OVERWRITE = "ocm.ccs.overwrite"
-
 	// AWSAccount is used in CCS clusters
 	AWSAccount = "ocm.aws.account"
 	// AWSAccessKey is used in CCS clusters
@@ -96,9 +93,7 @@ func init() {
 	viper.BindEnv(AdditionalLabels, "OCM_ADDITIONAL_LABELS")
 
 	viper.SetDefault(CCS, false)
-	viper.SetDefault(CCS_OVERWRITE, false)
 	viper.BindEnv(CCS, "OCM_CCS", "CCS")
-	viper.BindEnv(CCS_OVERWRITE, "CCS_OVERWRITE", "CCS_ADMIN")
 
 	viper.BindEnv(AWSAccount, "OCM_AWS_ACCOUNT", "AWS_ACCOUNT")
 	viper.BindEnv(AWSAccessKey, "OCM_AWS_ACCESS_KEY", "AWS_ACCESS_KEY_ID")


### PR DESCRIPTION
remove the ccs.overwrite setting and logic as it is no longer needed/used

Signed-off-by: Brady Pratt <bpratt@redhat.com>