### PR TITLE
common/logging: add Lshortfile flag for consistency

### DIFF
--- a/pkg/common/logging/logging.go
+++ b/pkg/common/logging/logging.go
@@ -10,7 +10,7 @@ import (
 // the log package.
 func CreateNewStdLoggerOrUseExistingLogger(logger *log.Logger) *log.Logger {
 	if logger == nil {
-		return log.New(os.Stderr, "", log.LstdFlags)
+		return log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile)
 	}
 
 	return logger


### PR DESCRIPTION
std log is set up in cmd/osde2e/main.go, any new loggers created should
match those settings for consistency

Signed-off-by: Brady Pratt <bpratt@redhat.com>
