### PR TITLE
Handle error when writing metrics to s3 bucket for cluster properties

### DIFF
--- a/pkg/common/aws/s3.go
+++ b/pkg/common/aws/s3.go
@@ -65,9 +65,13 @@ func WriteToS3(outputKey string, data []byte) error {
 		Body:   reader,
 	})
 
+	if err != nil {
+		return err
+	}
+
 	log.Printf("Uploaded to %s", outputKey)
 
-	return err
+	return nil
 }
 
 // CreateS3URL creates an S3 URL from a bucket and a key string.


### PR DESCRIPTION
When the jobName setting is defined, osde2e attempts to write metrics to s3 bucket. When updating with cluster properties, it was silently continuing on when the upload to s3 was failing. Added a conditional check to return when errors occur.

Also includes checking the error returned when uploading to s3 bucket. When successful, then print the message to the console stating the upload to message. This helps to clean up the logs.