### PR TITLE
various logging cleanup

### DIFF
--- a/pkg/common/runner/runner.go
+++ b/pkg/common/runner/runner.go
@@ -35,7 +35,7 @@ var DefaultRunner = &Runner{
 	Server:    "https://kubernetes.default",
 	CA:        serviceAccountDir + "/ca.crt",
 	TokenFile: serviceAccountDir + "/token",
-	Logger:    log.New(os.Stderr, "", log.LstdFlags),
+	Logger:    log.New(os.Stderr, "", log.LstdFlags|log.Lshortfile),
 }
 
 // Runner runs the OpenShift extended test suite within a cluster.

--- a/pkg/e2e/addons/addon_test_harness.go
+++ b/pkg/e2e/addons/addon_test_harness.go
@@ -21,8 +21,8 @@ var _ = ginkgo.Describe("[Suite: addons] Addon Test Harness", func() {
 	h := helper.New()
 
 	addonTimeoutInSeconds := float64(viper.GetFloat64(config.Addons.PollingTimeout))
-	log.Printf("addon timeout is %v", addonTimeoutInSeconds)
 	util.GinkgoIt("should run until completion", func(ctx context.Context) {
+		log.Printf("addon timeout is %v", addonTimeoutInSeconds)
 		h.SetServiceAccount(ctx, viper.GetString(config.Addons.TestUser))
 		harnesses := strings.Split(viper.GetString(config.Addons.TestHarnesses), ",")
 		failed := h.RunAddonTests(ctx, "addon-tests", int(addonTimeoutInSeconds), harnesses, []string{})

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -934,7 +934,7 @@ func runTestsInPhase(phase string, description string, suiteConfig types.SuiteCo
 		}
 		clusterState = cluster.State()
 	}
-	if !suiteConfig.DryRun && clusterState == spi.ClusterStateReady {
+	if !suiteConfig.DryRun && clusterState == spi.ClusterStateReady && viper.GetString(config.JobName) != "" {
 		h := helper.NewOutsideGinkgo()
 		if h == nil {
 			log.Println("Unable to generate helper outside of ginkgo")

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -110,7 +110,7 @@ func beforeSuite() bool {
 		viper.Set(config.CloudProvider.Region, cluster.Region())
 		log.Printf("CLOUD_PROVIDER_REGION set to %s from OCM.", viper.GetString(config.CloudProvider.Region))
 
-		if !viper.GetBool(config.Addons.SkipAddonList) || viper.GetString(config.Provider) != "mock" {
+		if (!viper.GetBool(config.Addons.SkipAddonList) || viper.GetString(config.Provider) != "mock") && len(cluster.Addons()) > 0 {
 			log.Printf("Found addons: %s", strings.Join(cluster.Addons(), ","))
 		}
 


### PR DESCRIPTION
skip over printing that is not relevant (local run, no addons) and use the same settings on common/runner logger as the rest of the codebase