### PR TITLE
[OSD-13651] add test for dedicated admin can patch console

### DIFF
--- a/pkg/e2e/osd/dedicatedadmin.go
+++ b/pkg/e2e/osd/dedicatedadmin.go
@@ -17,6 +17,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/retry"
 )
@@ -267,6 +269,27 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, func() {
 			}()
 
 			err := manageSubscriptions(ctx, namespaceList, h)
+			Expect(err).NotTo(HaveOccurred())
+		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
+
+		util.GinkgoIt("dedicated-admin user can patch consoles.operator.openshift.io CR", func(ctx context.Context) {
+			// Impersonate ded-admin
+			h.Impersonate(rest.ImpersonationConfig{
+				UserName: "dummy-admin@redhat.com",
+				Groups: []string{
+					"dedicated-admin",
+				},
+			})
+			defer func() {
+				h.Impersonate(rest.ImpersonationConfig{})
+			}()
+
+			patchData := []byte(fmt.Sprintf(`{"spec":{"plugins":["test"]}}`))
+
+			_, err := h.Dynamic().Resource(schema.GroupVersionResource{
+				Group: "operator.openshift.io", Version: "v1",
+				Resource: "consoles",
+			}).Patch(ctx, "cluster", types.MergePatchType, patchData, metav1.PatchOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 	})

--- a/pkg/e2e/osd/dedicatedadmin.go
+++ b/pkg/e2e/osd/dedicatedadmin.go
@@ -277,7 +277,7 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, func() {
 			h.Impersonate(rest.ImpersonationConfig{
 				UserName: "dummy-admin@redhat.com",
 				Groups: []string{
-					"dedicated-admin",
+					"dedicated-admins",
 				},
 			})
 			defer func() {
@@ -290,6 +290,14 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, func() {
 				Group: "operator.openshift.io", Version: "v1",
 				Resource: "consoles",
 			}).Patch(ctx, "cluster", types.MergePatchType, patchData, metav1.PatchOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			// revret the changes
+			patchEmpty := []byte(fmt.Sprintf(`{"spec":{"plugins":[""]}}`))
+
+			_, err = h.Dynamic().Resource(schema.GroupVersionResource{
+				Group: "operator.openshift.io", Version: "v1",
+				Resource: "consoles",
+			}).Patch(ctx, "cluster", types.MergePatchType, patchEmpty, metav1.PatchOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 	})


### PR DESCRIPTION
Add test case for dedicated admin user:
-  can patch **consoles.operator.openshift.io**

_Fix_ :  [OSD-13651](https://issues.redhat.com/browse/OSD-13651)