### PR TITLE
e2e/operators/cloudingress: skip on STS

### DIFF
--- a/pkg/e2e/operators/cloudingress/apischeme_cr.go
+++ b/pkg/e2e/operators/cloudingress/apischeme_cr.go
@@ -10,6 +10,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,8 +23,8 @@ import (
 
 var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
-		if viper.GetBool("rosa.STS") {
-			ginkgo.Skip("STS does not support MVO")
+		if viper.GetBool(rosaprovider.STS) {
+			ginkgo.Skip("STS does not support CIO")
 		}
 	})
 	h := helper.New()

--- a/pkg/e2e/operators/cloudingress/certificate.go
+++ b/pkg/e2e/operators/cloudingress/certificate.go
@@ -6,8 +6,10 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -15,6 +17,12 @@ import (
 
 // tests
 var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+	ginkgo.BeforeEach(func() {
+		if viper.GetBool(rosaprovider.STS) {
+			ginkgo.Skip("STS does not support CIO")
+		}
+	})
+
 	h := helper.New()
 	var originalCert string
 

--- a/pkg/e2e/operators/cloudingress/deletetapps2.go
+++ b/pkg/e2e/operators/cloudingress/deletetapps2.go
@@ -11,8 +11,10 @@ import (
 
 	operatorv1 "github.com/openshift/api/operator/v1"
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/pkg/apis/cloudingress/v1alpha1"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/e2e/operators"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -23,6 +25,12 @@ import (
 )
 
 var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+	ginkgo.BeforeEach(func() {
+		if viper.GetBool(rosaprovider.STS) {
+			ginkgo.Skip("STS does not support CIO")
+		}
+	})
+
 	h := helper.New()
 	ginkgo.Context("Delete apps2 ingresscontroller", func() {
 		ginkgo.It(

--- a/pkg/e2e/operators/cloudingress/dnsname.go
+++ b/pkg/e2e/operators/cloudingress/dnsname.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -16,6 +18,12 @@ import (
 
 // tests
 var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+	ginkgo.BeforeEach(func() {
+		if viper.GetBool(rosaprovider.STS) {
+			ginkgo.Skip("STS does not support CIO")
+		}
+	})
+
 	h := helper.New()
 	var dnsnameOriginal string
 	// How long to wait for IngressController changes

--- a/pkg/e2e/operators/cloudingress/installed.go
+++ b/pkg/e2e/operators/cloudingress/installed.go
@@ -10,11 +10,11 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
-
-	"github.com/openshift/osde2e/pkg/common/config"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -23,8 +23,8 @@ import (
 
 var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
-		if viper.GetBool("rosa.STS") {
-			ginkgo.Skip("STS does not support MVO")
+		if viper.GetBool(rosaprovider.STS) {
+			ginkgo.Skip("STS does not support CIO")
 		}
 	})
 

--- a/pkg/e2e/operators/cloudingress/public_private.go
+++ b/pkg/e2e/operators/cloudingress/public_private.go
@@ -12,6 +12,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,8 +25,8 @@ import (
 // tests
 var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
-		if viper.GetBool("rosa.STS") {
-			ginkgo.Skip("STS does not support MVO")
+		if viper.GetBool(rosaprovider.STS) {
+			ginkgo.Skip("STS does not support CIO")
 		}
 	})
 

--- a/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
+++ b/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
@@ -9,6 +9,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,8 +21,8 @@ import (
 
 var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
-		if viper.GetBool("rosa.STS") {
-			ginkgo.Skip("STS does not support MVO")
+		if viper.GetBool(rosaprovider.STS) {
+			ginkgo.Skip("STS does not support CIO")
 		}
 	})
 	h := helper.New()

--- a/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -28,8 +29,8 @@ import (
 
 var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
-		if viper.GetBool("rosa.STS") {
-			ginkgo.Skip("STS does not support MVO")
+		if viper.GetBool(rosaprovider.STS) {
+			ginkgo.Skip("STS does not support CIO")
 		}
 	})
 

--- a/pkg/e2e/operators/cloudingress/routeSelector.go
+++ b/pkg/e2e/operators/cloudingress/routeSelector.go
@@ -7,8 +7,10 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -16,6 +18,12 @@ import (
 
 // tests
 var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+	ginkgo.BeforeEach(func() {
+		if viper.GetBool(rosaprovider.STS) {
+			ginkgo.Skip("STS does not support CIO")
+		}
+	})
+
 	h := helper.New()
 
 	// How long to wait for IngressController changes

--- a/pkg/e2e/operators/cloudingress/secondary_router.go
+++ b/pkg/e2e/operators/cloudingress/secondary_router.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
 	"github.com/openshift/osde2e/pkg/e2e/operators"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,8 +24,8 @@ import (
 
 var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
-		if viper.GetBool("rosa.STS") {
-			ginkgo.Skip("STS does not support MVO")
+		if viper.GetBool(rosaprovider.STS) {
+			ginkgo.Skip("STS does not support CIO")
 		}
 	})
 

--- a/pkg/e2e/operators/cloudingress/upgrade.go
+++ b/pkg/e2e/operators/cloudingress/upgrade.go
@@ -5,17 +5,18 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/e2e/operators"
 )
 
 var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
-		if viper.GetBool("rosa.STS") {
-			ginkgo.Skip("STS does not support MVO")
+		if viper.GetBool(rosaprovider.STS) {
+			ginkgo.Skip("STS does not support CIO")
 		}
 	})
 
 	h := helper.New()
-	operators.CheckUpgrade(h, "openshift-cloud-ingress-operator", "cloud-ingress-operator", "cloud-ingress-operator", "cloud-ingress-operator-registry")
-	operators.CheckPod(h, "openshift-cloud-ingress-operator", "cloud-ingress-operator", 200, 0)
+	operators.CheckUpgrade(h, OperatorNamespace, OperatorName, OperatorName, "cloud-ingress-operator-registry")
+	operators.CheckPod(h, OperatorNamespace, OperatorName, 200, 0)
 })


### PR DESCRIPTION
half of the tests are already set to skip on STS being configured and CIO is not deployed to an STS cluster so these tests fail anyway. No pipeline is currently testing ROSA STS so it hasn't been noticed/fixed.

Signed-off-by: Brady Pratt <bpratt@redhat.com>