### PR TITLE
OSD-13922 update machinehealthcheck tests for metal instance support

### DIFF
--- a/pkg/e2e/osd/machinehealthcheck.go
+++ b/pkg/e2e/osd/machinehealthcheck.go
@@ -87,6 +87,11 @@ var _ = ginkgo.Describe(machineHealthTestName, func() {
 				Key:      "machine.openshift.io/cluster-api-machineset",
 				Operator: metav1.LabelSelectorOpExists,
 			},
+			metav1.LabelSelectorRequirement{
+				Key:      "machine.openshift.io/instance-type",
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{"m5.metal", "m5d.metal", "m5n.metal", "m5dn.metal", "m5zn.metal", "m6i.metal", "r5.metal", "r5d.metal", "r5n.metal", "r5dn.metal", "r6i.metal", "x2iezn.metal", "z1d.metal", "c5.metal", "c5d.metal", "c5n.metal", "c6i.metal", "i3.metal", "i3en.metal"},
+			},
 		))
 
 		// verify the unhealthy conditions are on all nodes
@@ -100,6 +105,46 @@ var _ = ginkgo.Describe(machineHealthTestName, func() {
 				Type:    corev1.NodeReady,
 				Status:  corev1.ConditionUnknown,
 				Timeout: "480s",
+			},
+		))
+	}, float64(500))
+
+	util.GinkgoIt("metal worker MHC should exist", func(ctx context.Context) {
+		mhc, err := h.Machine().
+			MachineV1beta1().
+			MachineHealthChecks(machineAPINamespace).
+			Get(ctx, "srep-metal-worker-healthcheck", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// verify there's an MHC for metal worker nodes
+		Expect(mhc.Spec.Selector.MatchExpressions).To(ConsistOf(
+			metav1.LabelSelectorRequirement{
+				Key:      "machine.openshift.io/cluster-api-machine-role",
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{"infra", "master"},
+			},
+			metav1.LabelSelectorRequirement{
+				Key:      "machine.openshift.io/cluster-api-machineset",
+				Operator: metav1.LabelSelectorOpExists,
+			},
+			metav1.LabelSelectorRequirement{
+				Key:      "machine.openshift.io/instance-type",
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"m5.metal", "m5d.metal", "m5n.metal", "m5dn.metal", "m5zn.metal", "m6i.metal", "r5.metal", "r5d.metal", "r5n.metal", "r5dn.metal", "r6i.metal", "x2iezn.metal", "z1d.metal", "c5.metal", "c5d.metal", "c5n.metal", "c6i.metal", "i3.metal", "i3en.metal"},
+			},
+		))
+
+		// verify the unhealthy conditions are on all nodes
+		Expect(mhc.Spec.UnhealthyConditions).To(ConsistOf(
+			machineV1beta1.UnhealthyCondition{
+				Type:    corev1.NodeReady,
+				Status:  corev1.ConditionFalse,
+				Timeout: "8m",
+			},
+			machineV1beta1.UnhealthyCondition{
+				Type:    corev1.NodeReady,
+				Status:  corev1.ConditionUnknown,
+				Timeout: "15m",
 			},
 		))
 	}, float64(500))


### PR DESCRIPTION
OSD has added support for metal instance types with a separate machinehealthcheck. this updates the worker rule matchers and adds tests to confirm the presence of the metal mhc