### PR TITLE
Remove unneeded dedicated-admin tests

### DIFF
--- a/pkg/e2e/osd/dedicatedadmin.go
+++ b/pkg/e2e/osd/dedicatedadmin.go
@@ -38,48 +38,6 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, func() {
 		// setup helper
 		h := helper.New()
 
-		util.GinkgoIt("cannot add members to cluster-admin", func(ctx context.Context) {
-			h.Impersonate(rest.ImpersonationConfig{
-				UserName: "dummy-admin@redhat.com",
-				Groups: []string{
-					"dedicated-admins",
-				},
-			})
-			defer func() {
-				h.Impersonate(rest.ImpersonationConfig{})
-			}()
-
-			daGroup, err := h.User().UserV1().Groups().Get(ctx, "dedicated-admins", metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			daGroup.Users = append(daGroup.Users, "new-dummy-admin@redhat.com")
-			_, err = h.User().UserV1().Groups().Update(ctx, daGroup, metav1.UpdateOptions{})
-			Expect(err).To(HaveOccurred())
-		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
-
-		util.GinkgoIt("cannot delete members from cluster-admin", func(ctx context.Context) {
-			// add dummy user
-			daGroup, err := h.User().UserV1().Groups().Get(ctx, "dedicated-admins", metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			daGroup.Users = append(daGroup.Users, "user-to-delete@redhat.com")
-			daGroup, err = h.User().UserV1().Groups().Update(ctx, daGroup, metav1.UpdateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			// remove dummy user as dedicated-admin
-			daGroup.Users = []string{}
-			h.Impersonate(rest.ImpersonationConfig{
-				UserName: "dummy-admin@redhat.com",
-				Groups: []string{
-					"dedicated-admins",
-				},
-			})
-			defer func() {
-				h.Impersonate(rest.ImpersonationConfig{})
-			}()
-			_, err = h.User().UserV1().Groups().Update(context.TODO(), daGroup, metav1.UpdateOptions{})
-			Expect(err).To(HaveOccurred())
-		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
-
 		// dedicated-admin SA can create projectrequest object
 		util.GinkgoIt("ded-admin SA can create projectrequest", func(ctx context.Context) {
 			// Impersonate ded-admin


### PR DESCRIPTION
# What it does

Removes two broken tests from the dedicated-admin informing test suite.

# Why

Whilst reviewing #1404, I noticed these had been failing for what seems like forever in the testgrid results.

As best I can tell, they are not really valid:

1. They purport to test `dedicated-admin`'s ability to update the `cluster-admins` group, but they are not actually testing any changes to the `cluster-admins` group.
2. This is something that our RBAC explicitly allows anyway [0], so these tests are expecting a failure condition that will never occur.

[0] https://github.com/openshift/managed-cluster-config/blob/74e57e82ff5cabd78a1d0410396d857e88fda704/deploy/rbac-permissions-operator-config/05-dedicated-admins-aggregate-cluster.ClusterRole.yaml#L213