### PR TITLE
common: load kubeconfig on helper setup

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -896,15 +896,21 @@ func GetAllSecrets() []Secret {
 	return keyToSecretMapping
 }
 
+var loadOnce sync.Once
+
 // LoadKubeconfig will, given a path to a kubeconfig, attempt to load it into the Viper config.
 func LoadKubeconfig() error {
-	kubeconfigPath := viper.GetString(Kubeconfig.Path)
-	if kubeconfigPath != "" {
-		kubeconfigBytes, err := os.ReadFile(kubeconfigPath)
-		if err != nil {
-			return fmt.Errorf("failed reading '%s' which has been set as the TEST_KUBECONFIG: %v", kubeconfigPath, err)
+	var kubeconfigBytes []byte
+	var err error
+	loadOnce.Do(func() {
+		kubeconfigPath := viper.GetString(Kubeconfig.Path)
+		if kubeconfigPath != "" && viper.GetString(Kubeconfig.Contents) == "" {
+			kubeconfigBytes, err = os.ReadFile(kubeconfigPath)
+			if err != nil {
+				err = fmt.Errorf("failed reading '%s' which has been set as the TEST_KUBECONFIG: %v", kubeconfigPath, err)
+			}
+			viper.Set(Kubeconfig.Contents, string(kubeconfigBytes))
 		}
-		viper.Set(Kubeconfig.Contents, string(kubeconfigBytes))
-	}
-	return nil
+	})
+	return err
 }

--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -92,6 +92,9 @@ func (h *H) Setup() error {
 	defer ginkgo.GinkgoRecover()
 
 	ctx := context.TODO()
+	if err = config.LoadKubeconfig(); err != nil {
+		return fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
 
 	h.restConfig, err = clientcmd.RESTConfigFromKubeConfig([]byte(viper.GetString(config.Kubeconfig.Contents)))
 	if h.OutsideGinkgo && err != nil {


### PR DESCRIPTION
loading kubeconfig on helper setup allows for running the tests directly with ginkgo and an existing cluster (outside of the framework) which is easier for development

also add additional check to no-op `LoadKubeconfig` after the first call (we call helper.Setup() a lot)

Signed-off-by: Brady Pratt <bpratt@redhat.com>