### PR TITLE
Replace deprecated ioutil package with io and os

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -3,9 +3,9 @@ package cluster
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
+	"os"
 	"strings"
 	"time"
 
@@ -489,7 +489,7 @@ func getRestConfig(provider spi.Provider, clusterID string) (*rest.Config, error
 		}
 	} else if len(kubeconfigPath) != 0 {
 		kubeconfigPath := viper.GetString(config.Kubeconfig.Path)
-		kubeconfigBytes, err = ioutil.ReadFile(kubeconfigPath)
+		kubeconfigBytes, err = os.ReadFile(kubeconfigPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed reading '%s' which has been set as the TEST_KUBECONFIG: %v", kubeconfigPath, err)
 		}

--- a/pkg/common/cluster/healthchecks/healthcheckjob.go
+++ b/pkg/common/cluster/healthchecks/healthcheckjob.go
@@ -3,7 +3,6 @@ package healthchecks
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -50,7 +49,7 @@ func CheckHealthcheckJob(k8sClient *kubernetes.Clientset, ctx context.Context, l
 					if err != nil {
 						log.Printf("failed getting logs for pod %s: %s", pod.Name, err.Error())
 					}
-					if err = ioutil.WriteFile(filepath.Join(viper.GetString(config.ReportDir), fmt.Sprintf("%s.log", pod.Name)), data, os.FileMode(0o644)); err != nil {
+					if err = os.WriteFile(filepath.Join(viper.GetString(config.ReportDir), fmt.Sprintf("%s.log", pod.Name)), data, os.FileMode(0o644)); err != nil {
 						log.Printf("unable to output container logfile %s.log: %s", pod.Name, err.Error())
 					}
 				}

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -3,8 +3,8 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -900,7 +900,7 @@ func GetAllSecrets() []Secret {
 func LoadKubeconfig() error {
 	kubeconfigPath := viper.GetString(Kubeconfig.Path)
 	if kubeconfigPath != "" {
-		kubeconfigBytes, err := ioutil.ReadFile(kubeconfigPath)
+		kubeconfigBytes, err := os.ReadFile(kubeconfigPath)
 		if err != nil {
 			return fmt.Errorf("failed reading '%s' which has been set as the TEST_KUBECONFIG: %v", kubeconfigPath, err)
 		}

--- a/pkg/common/helper/runner.go
+++ b/pkg/common/helper/runner.go
@@ -1,7 +1,6 @@
 package helper
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -40,7 +39,7 @@ func (h *H) WriteResults(results map[string][]byte) {
 		dst := filepath.Join(viper.GetString(config.ReportDir), viper.GetString(config.Phase), filename)
 		err := os.MkdirAll(filepath.Dir(dst), os.FileMode(0o755))
 		Expect(err).NotTo(HaveOccurred())
-		err = ioutil.WriteFile(dst, data, os.ModePerm)
+		err = os.WriteFile(dst, data, os.ModePerm)
 		Expect(err).NotTo(HaveOccurred())
 	}
 }

--- a/pkg/common/helper/workloads.go
+++ b/pkg/common/helper/workloads.go
@@ -3,8 +3,8 @@ package helper
 import (
 	"context"
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"strings"
 	"time"
 
@@ -65,7 +65,7 @@ func ReadK8sYaml(file string) (runtime.Object, error) {
 		return nil, err
 	}
 
-	f, err := ioutil.ReadAll(fileReader)
+	f, err := io.ReadAll(fileReader)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/common/load/load.go
+++ b/pkg/common/load/load.go
@@ -3,7 +3,6 @@ package load
 import (
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -90,7 +89,7 @@ func Configs(configs []string, customConfig string, secretLocations []string) er
 				if err != nil {
 					return fmt.Errorf("Error walking folder %s: %s", folder, err.Error())
 				}
-				data, err := ioutil.ReadFile(path)
+				data, err := os.ReadFile(path)
 				if err != nil {
 					return fmt.Errorf("error loading passthru-secret file %s", path)
 				}
@@ -175,7 +174,7 @@ func loadSecretFileIntoKey(key string, filename string, secretLocations []string
 
 		stat, err := os.Stat(fullFilename)
 		if err == nil && !stat.IsDir() {
-			data, err := ioutil.ReadFile(fullFilename)
+			data, err := os.ReadFile(fullFilename)
 			if err != nil {
 				return fmt.Errorf("error loading secret file %s from location %s", filename, secretLocation)
 			}

--- a/pkg/common/metadata/metadata.go
+++ b/pkg/common/metadata/metadata.go
@@ -3,7 +3,6 @@ package metadata
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -264,7 +263,7 @@ func (m *Metadata) WriteToJSON(reportDir string) (err error) {
 		return err
 	}
 
-	files, err := ioutil.ReadDir(reportDir)
+	files, err := os.ReadDir(reportDir)
 	if err != nil {
 		return err
 	}
@@ -275,7 +274,7 @@ func (m *Metadata) WriteToJSON(reportDir string) (err error) {
 			if file.IsDir() {
 				phase := file.Name()
 				phaseDir := filepath.Join(reportDir, phase)
-				phaseFiles, err := ioutil.ReadDir(phaseDir)
+				phaseFiles, err := os.ReadDir(phaseDir)
 				if err != nil {
 					return err
 				}
@@ -290,7 +289,7 @@ func (m *Metadata) WriteToJSON(reportDir string) (err error) {
 						}
 
 						// Unmarshal addon metadata to map
-						addonData, err := ioutil.ReadFile(filepath.Join(phaseDir, phaseFile.Name()))
+						addonData, err := os.ReadFile(filepath.Join(phaseDir, phaseFile.Name()))
 						if err != nil {
 							return err
 						}
@@ -311,11 +310,11 @@ func (m *Metadata) WriteToJSON(reportDir string) (err error) {
 		}
 	}
 
-	if err = ioutil.WriteFile(filepath.Join(reportDir, CustomMetadataFile), data, os.FileMode(0o644)); err != nil {
+	if err = os.WriteFile(filepath.Join(reportDir, CustomMetadataFile), data, os.FileMode(0o644)); err != nil {
 		return err
 	}
 
-	if err = ioutil.WriteFile(filepath.Join(reportDir, MetadataFile), data, os.FileMode(0o644)); err != nil {
+	if err = os.WriteFile(filepath.Join(reportDir, MetadataFile), data, os.FileMode(0o644)); err != nil {
 		return err
 	}
 

--- a/pkg/common/metadata/metadata_test.go
+++ b/pkg/common/metadata/metadata_test.go
@@ -3,7 +3,6 @@ package metadata
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -86,7 +85,7 @@ func TestMetadata(t *testing.T) {
 
 func writeAndTestMetadata(m *Metadata) (err error) {
 	var tempDir string
-	if tempDir, err = ioutil.TempDir("", ""); err != nil {
+	if tempDir, err = os.MkdirTemp("", ""); err != nil {
 		return err
 	}
 
@@ -97,7 +96,7 @@ func writeAndTestMetadata(m *Metadata) (err error) {
 	}
 
 	var data []byte
-	if data, err = ioutil.ReadFile(filepath.Join(tempDir, MetadataFile)); err != nil {
+	if data, err = os.ReadFile(filepath.Join(tempDir, MetadataFile)); err != nil {
 		return err
 	}
 

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -2,8 +2,8 @@ package mock
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -163,7 +163,7 @@ func (m *MockProvider) ClusterKubeconfig(clusterID string) ([]byte, error) {
 			return nil, err
 		}
 	}
-	f, err := ioutil.ReadAll(fileReader)
+	f, err := io.ReadAll(fileReader)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -3,7 +3,7 @@ package ocmprovider
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math"
 	"math/rand"
@@ -877,7 +877,7 @@ func getLocalKubeConfig(path string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	f, err := ioutil.ReadAll(fileReader)
+	f, err := io.ReadAll(fileReader)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/common/providers/ocmprovider/proxy.go
+++ b/pkg/common/providers/ocmprovider/proxy.go
@@ -2,8 +2,8 @@ package ocmprovider
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 
 	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
@@ -83,7 +83,7 @@ func (o *OCMProvider) updateCluster(clusterId string, clusterSpec *cmv1.Cluster)
 }
 
 func (o *OCMProvider) LoadUserCaBundleData(file string) (string, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return "", fmt.Errorf(
 			"can't read userCABundle file '%s': %w",

--- a/pkg/common/runner/results_test.go
+++ b/pkg/common/runner/results_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -215,5 +214,5 @@ func (r response) Stream(context.Context) (io.ReadCloser, error) {
 	if len(r) == 0 {
 		return nil, errors.New("file does not exist")
 	}
-	return ioutil.NopCloser(bytes.NewReader(r)), nil
+	return io.NopCloser(bytes.NewReader(r)), nil
 }

--- a/pkg/common/runner/service.go
+++ b/pkg/common/runner/service.go
@@ -3,7 +3,7 @@ package runner
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -111,7 +111,7 @@ func (r *Runner) getAllLogsFromPod(podName string) error {
 
 			defer logStream.Close()
 
-			logBytes, err := ioutil.ReadAll(logStream)
+			logBytes, err := io.ReadAll(logStream)
 			if err != nil {
 				allErrors = multierror.Append(allErrors, err)
 				return
@@ -126,7 +126,7 @@ func (r *Runner) getAllLogsFromPod(podName string) error {
 
 			logOutput := filepath.Join(configMapDirectory, fmt.Sprintf("%s-%s.log", podName, containerStatus.Name))
 
-			allErrors = multierror.Append(allErrors, ioutil.WriteFile(logOutput, logBytes, os.FileMode(0o644)))
+			allErrors = multierror.Append(allErrors, os.WriteFile(logOutput, logBytes, os.FileMode(0o644)))
 		}()
 	}
 

--- a/pkg/common/templates/templates.go
+++ b/pkg/common/templates/templates.go
@@ -3,8 +3,8 @@ package templates
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"path/filepath"
 	"text/template"
 
@@ -23,7 +23,7 @@ func LoadTemplate(path string) (*template.Template, error) {
 		return nil, fmt.Errorf("unable to open template: %v", err)
 	}
 
-	if data, err = ioutil.ReadAll(fileReader); err != nil {
+	if data, err = io.ReadAll(fileReader); err != nil {
 		return nil, fmt.Errorf("unable to read template: %v", err)
 	}
 

--- a/pkg/debug/diff.go
+++ b/pkg/debug/diff.go
@@ -3,7 +3,7 @@ package debug
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"sort"
@@ -38,7 +38,7 @@ func GenerateDiff(phase, dependencies string) error {
 		return err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"math"
 	"os"
@@ -221,7 +220,7 @@ func writeLogs(m map[string][]byte) {
 	for k, v := range m {
 		name := k + "-log.txt"
 		filePath := filepath.Join(viper.GetString(config.ReportDir), name)
-		err := ioutil.WriteFile(filePath, v, os.ModePerm)
+		err := os.WriteFile(filePath, v, os.ModePerm)
 		if err != nil {
 			log.Printf("Error writing log %s: %s", filePath, err.Error())
 		}
@@ -311,7 +310,7 @@ func runGinkgoTests() (int, error) {
 	// setup reporter
 	reportDir := viper.GetString(config.ReportDir)
 	if reportDir == "" {
-		reportDir, err = ioutil.TempDir("", "")
+		reportDir, err = os.MkdirTemp("", "")
 
 		if err != nil {
 			return Failure, fmt.Errorf("error creating temporary directory: %v", err)
@@ -756,7 +755,7 @@ func runTestsInPhase(
 		ginkgoPassed = ginkgo.RunSpecs(ginkgo.GinkgoT(), description, suiteConfig, reporterConfig)
 	}()
 
-	files, err := ioutil.ReadDir(phaseDirectory)
+	files, err := os.ReadDir(phaseDirectory)
 	if err != nil {
 		log.Printf("error reading phase directory: %s", err.Error())
 		return false, testCaseData
@@ -842,7 +841,7 @@ func runTestsInPhase(
 		metadata.Instance.SetPassRate(phase, passRate)
 	}
 
-	files, err = ioutil.ReadDir(reportDir)
+	files, err = os.ReadDir(reportDir)
 	if err != nil {
 		log.Printf("error reading phase directory: %s", err.Error())
 		return false, testCaseData
@@ -856,7 +855,7 @@ func runTestsInPhase(
 
 	for _, file := range files {
 		if logFileRegex.MatchString(file.Name()) {
-			data, err := ioutil.ReadFile(filepath.Join(reportDir, file.Name()))
+			data, err := os.ReadFile(filepath.Join(reportDir, file.Name()))
 			if err != nil {
 				log.Printf("error opening log file %s: %s", file.Name(), err.Error())
 				return false, testCaseData
@@ -958,7 +957,7 @@ func runTestsInPhase(
 		if err != nil {
 			log.Printf("Error generating dependencies: %s", err.Error())
 		} else {
-			if err = ioutil.WriteFile(filepath.Join(phaseDirectory, "dependencies.txt"), []byte(dependencies), 0o644); err != nil {
+			if err = os.WriteFile(filepath.Join(phaseDirectory, "dependencies.txt"), []byte(dependencies), 0o644); err != nil {
 				log.Printf("Error writing dependencies.txt: %s", err.Error())
 			}
 
@@ -984,7 +983,7 @@ func checkBeforeMetricsGeneration() error {
 
 // uploadFileToMetricsBucket uploads the given file (with absolute path) to the metrics S3 bucket "incoming" directory.
 func uploadFileToMetricsBucket(filename string) error {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}

--- a/pkg/e2e/e2e_test.go
+++ b/pkg/e2e/e2e_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestNoHiveLogs(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Errorf("failed to create temporary directory: %v", err)
 	}

--- a/pkg/e2e/metrics.go
+++ b/pkg/e2e/metrics.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
 	"os"
@@ -117,7 +116,7 @@ func init() {
 // WritePrometheusFile collects data and writes it out in the prometheus export file format (https://github.com/prometheus/docs/blob/master/content/docs/instrumenting/exposition_formats.md)
 // Returns the prometheus file name.
 func (m *Metrics) WritePrometheusFile(reportDir string) (string, error) {
-	files, err := ioutil.ReadDir(reportDir)
+	files, err := os.ReadDir(reportDir)
 	if err != nil {
 		return "", err
 	}
@@ -128,7 +127,7 @@ func (m *Metrics) WritePrometheusFile(reportDir string) (string, error) {
 			if file.IsDir() {
 				phase := file.Name()
 				phaseDir := filepath.Join(reportDir, phase)
-				phaseFiles, err := ioutil.ReadDir(phaseDir)
+				phaseFiles, err := os.ReadDir(phaseDir)
 				if err != nil {
 					return "", err
 				}
@@ -157,7 +156,7 @@ func (m *Metrics) WritePrometheusFile(reportDir string) (string, error) {
 		return "", err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(reportDir, prometheusFileName), output, os.FileMode(0o644))
+	err = os.WriteFile(filepath.Join(reportDir, prometheusFileName), output, os.FileMode(0o644))
 	if err != nil {
 		return "", err
 	}
@@ -173,7 +172,7 @@ func (m *Metrics) WritePrometheusFile(reportDir string) (string, error) {
 // result="passed|failed|skipped", phase="currentphase",
 // suite="suitename", testname="testname", upgrade_version="upgrade-version"}
 func (m *Metrics) processJUnitXMLFile(phase string, junitFile string) (err error) {
-	data, err := ioutil.ReadFile(junitFile)
+	data, err := os.ReadFile(junitFile)
 	if err != nil {
 		return err
 	}
@@ -224,7 +223,7 @@ func (m *Metrics) processJUnitXMLFile(phase string, junitFile string) (err error
 // values and capturing strings through the use of labels is of questionable
 // value.
 func (m *Metrics) processJSONFile(gatherer *prometheus.GaugeVec, jsonFile string, phase string) (err error) {
-	data, err := ioutil.ReadFile(jsonFile)
+	data, err := os.ReadFile(jsonFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/e2e/metrics_test.go
+++ b/pkg/e2e/metrics_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -75,7 +74,7 @@ cicd_jUnitResult{cloud_provider="aws",cluster_id="1a2b3c",environment="prod",ins
 		},
 	}
 
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Errorf("error creating temporary directory: %v", err)
 	}
@@ -88,7 +87,7 @@ cicd_jUnitResult{cloud_provider="aws",cluster_id="1a2b3c",environment="prod",ins
 		if m == nil {
 			t.Error("error creating new metrics provider")
 		}
-		tmpFile, err := ioutil.TempFile(tmpDir, "*")
+		tmpFile, err := os.CreateTemp(tmpDir, "*")
 		if err != nil {
 			t.Errorf("error writing temporary file: %v", err)
 		}
@@ -177,7 +176,7 @@ cicd_addon_metadata{cloud_provider="aws",cluster_id="1a2b3c",environment="prod",
 		},
 	}
 
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Errorf("error creating temporary directory: %v", err)
 	}
@@ -189,7 +188,7 @@ cicd_addon_metadata{cloud_provider="aws",cluster_id="1a2b3c",environment="prod",
 		if m == nil {
 			t.Error("error creating new metrics provider")
 		}
-		tmpFile, err := ioutil.TempFile(tmpDir, "*")
+		tmpFile, err := os.CreateTemp(tmpDir, "*")
 		if err != nil {
 			t.Errorf("error writing temporary file: %v", err)
 		}
@@ -340,7 +339,7 @@ cicd_addon_metadata{cloud_provider="aws",cluster_id="1a2b3c",environment="prod",
 		if m == nil {
 			t.Error("error creating new metrics provider")
 		}
-		tmpDir, err := ioutil.TempDir("", "")
+		tmpDir, err := os.MkdirTemp("", "")
 		if err != nil {
 			t.Errorf("error creating temporary directory: %v", err)
 		}
@@ -355,7 +354,7 @@ cicd_addon_metadata{cloud_provider="aws",cluster_id="1a2b3c",environment="prod",
 					t.Errorf("error creating jUnit file directory: %v", err)
 				}
 			}
-			tmpFile, err := ioutil.TempFile(jUnitDir, "junit*.xml")
+			tmpFile, err := os.CreateTemp(jUnitDir, "junit*.xml")
 			if err != nil {
 				t.Errorf("error writing junit file: %v", err)
 			}
@@ -366,14 +365,14 @@ cicd_addon_metadata{cloud_provider="aws",cluster_id="1a2b3c",environment="prod",
 		}
 
 		if test.metadataFileContents != "" {
-			err = ioutil.WriteFile(filepath.Join(tmpDir, metadata.CustomMetadataFile), []byte(test.metadataFileContents), os.FileMode(0o644))
+			err = os.WriteFile(filepath.Join(tmpDir, metadata.CustomMetadataFile), []byte(test.metadataFileContents), os.FileMode(0o644))
 			if err != nil {
 				t.Errorf("error writing metadata file: %v", err)
 			}
 		}
 
 		if test.addonMetadataFileContents != "" {
-			err = ioutil.WriteFile(filepath.Join(tmpDir, "install", metadata.AddonMetadataFile), []byte(test.addonMetadataFileContents), os.FileMode(0o644))
+			err = os.WriteFile(filepath.Join(tmpDir, "install", metadata.AddonMetadataFile), []byte(test.addonMetadataFileContents), os.FileMode(0o644))
 			if err != nil {
 				t.Errorf("error writing metadata file: %v", err)
 			}
@@ -388,7 +387,7 @@ cicd_addon_metadata{cloud_provider="aws",cluster_id="1a2b3c",environment="prod",
 			t.Errorf("unexpected prometheus filename: %s", prometheusFile)
 		}
 
-		data, err := ioutil.ReadFile(filepath.Join(tmpDir, prometheusFile))
+		data, err := os.ReadFile(filepath.Join(tmpDir, prometheusFile))
 		if err != nil {
 			t.Errorf("error while reading prometheus file: %v", err)
 		}

--- a/pkg/e2e/scale/scale.go
+++ b/pkg/e2e/scale/scale.go
@@ -3,8 +3,8 @@ package scale
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/fs"
-	"io/ioutil"
 	"sync"
 	"text/template"
 
@@ -51,7 +51,7 @@ func init() {
 		panic(fmt.Sprintf("unable to open scale runner template: %v", err))
 	}
 
-	if data, err = ioutil.ReadAll(fileReader); err != nil {
+	if data, err = io.ReadAll(fileReader); err != nil {
 		panic(fmt.Sprintf("unable to read scale runner template: %v", err))
 	}
 


### PR DESCRIPTION
# Change

Replaces the deprecated use of `ioutil` package with `io` and `os` packages. `ioutil` has been deprecated as of go version 1.16. OSDE2E minium go version is now 1.18 making it okay to official drop `ioutil`. Most of the functions called anyways were calling functions from the other packages.