### PR TITLE
e2e/operators/dvo: delete ns afterall

### DIFF
--- a/pkg/e2e/operators/dvo.go
+++ b/pkg/e2e/operators/dvo.go
@@ -8,14 +8,12 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
-
+	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/util"
-
-	. "github.com/onsi/gomega"
-	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,7 +26,7 @@ func init() {
 	alert.RegisterGinkgoAlert(deploymentValidationOperatorTestName, "SD-SREP", "Ron Green", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(deploymentValidationOperatorTestName, func() {
+var _ = ginkgo.Describe(deploymentValidationOperatorTestName, ginkgo.Ordered, func() {
 	const (
 		operatorNamespace      = "openshift-deployment-validation-operator"
 		operatorName           = "deployment-validation-operator"
@@ -75,7 +73,9 @@ var _ = ginkgo.Describe(deploymentValidationOperatorTestName, func() {
 	checkPodLogs(h, operatorNamespace, testNamespace, operatorDeploymentName, operatorName, dvoString, 300)
 
 	// Delete DVO Test Deployment
-	defer deleteNamespace(context.TODO(), testNamespace, true, h)
+	ginkgo.AfterAll(func(ctx context.Context) {
+		deleteNamespace(ctx, testNamespace, true, h)
+	})
 })
 
 // Function to create a standard deployment
@@ -114,8 +114,6 @@ func makeDeployment(name, sa string, nodeLabels map[string]string) appsv1.Deploy
 
 // Check Pod Logs to see if DVO pod is reporting correct metrics
 func checkPodLogs(h *helper.H, namespace string, testNamespace string, name string, containerName string, dvoString string, gracePeriod int) {
-	fmt.Println("Enterned Check Pod Logs")
-
 	podLogOptions := v1.PodLogOptions{
 		Container: containerName,
 	}


### PR DESCRIPTION
this gets ran immediately since it is outside of a test and setup/teardown

also remove log outside of tests (printed on start)

Signed-off-by: Brady Pratt <bpratt@redhat.com>

before

```
$ TEST_KUBECONFIG=rosa-kubeconfig ROSA_STS=true ginkgo run -v --focus "dvo"
Enterned Check Pod Logs
2022/11/22 06:32:59 Deleting namespace for namespace validation webhook (osde2e-dvo-test)
Assertion or Panic detected during tree construction
var _ = ginkgo.Describe(deploymentValidationOperatorTestName, func() {
/var/home/bpratt/git/openshift/osde2e/pkg/e2e/operators/dvo.go:31
  Ginkgo detected a panic while constructing the spec tree.
  You may be trying to make an assertion in the body of a container node
  (i.e. Describe, Context, or When).

  Please ensure all assertions are inside leaf nodes such as BeforeEach,
  It, etc.

  Here's the content of the panic that was caught:
  runtime error: invalid memory address or nil pointer dereference

  Learn more at: http://onsi.github.io/ginkgo/#no-assertions-in-container-nodes


Ginkgo ran 1 suite in 6.204979153s

Test Suite Failed
```

after:

```
...
[Suite: informing] [OSD] Deployment Validation Operator (dvo) deployment should exist
/var/home/bpratt/git/openshift/osde2e/pkg/e2e/operators/operators.go:65
• [0.053 seconds]
------------------------------
[Suite: informing] [OSD] Deployment Validation Operator (dvo) deployment should have all desired replicas ready
/var/home/bpratt/git/openshift/osde2e/pkg/e2e/operators/operators.go:70
• [0.043 seconds]
------------------------------
[Suite: informing] [OSD] Deployment Validation Operator (dvo) service should exist
/var/home/bpratt/git/openshift/osde2e/pkg/e2e/operators/operators.go:349
• [0.043 seconds]
------------------------------
[Suite: informing] [OSD] Deployment Validation Operator (dvo) pods should have 3 or less restart(s)
/var/home/bpratt/git/openshift/osde2e/pkg/e2e/operators/operators.go:90
• [2.050 seconds]
------------------------------
[Suite: informing] [OSD] Deployment Validation Operator (dvo) clusterRoles should exist
/var/home/bpratt/git/openshift/osde2e/pkg/e2e/operators/operators.go:123
• [0.149 seconds]
------------------------------
[Suite: informing] [OSD] Deployment Validation Operator (dvo) Create and test deployment for DVO functionality
/var/home/bpratt/git/openshift/osde2e/pkg/e2e/operators/dvo.go:57
2022/11/22 06:36:48 Created SA: dedicated-admin-project
2022/11/22 06:36:48 Created SA: dedicated-admin-cluster
2022/11/22 06:36:48 Created SA: cluster-admin
2022/11/22 06:36:48 ServiceAccount is now set to `system:serviceaccount:osde2e-dvo-test:cluster-admin`
• [0.447 seconds]
------------------------------
[Suite: informing] [OSD] Deployment Validation Operator (dvo) pods Check logs in test namespace osde2e-dvo-test
/var/home/bpratt/git/openshift/osde2e/pkg/e2e/operators/dvo.go:124
Waiting for grace period
Grabbing Logs for pod
  [FAILED] in [It] - /var/home/bpratt/git/openshift/osde2e/pkg/e2e/operators/dvo.go:148 @ 11/22/22 06:50:08.436
2022/11/22 06:50:08 Deleting namespace for namespace validation webhook (osde2e-dvo-test)
• [FAILED] [812.285 seconds]
[Suite: informing] [OSD] Deployment Validation Operator (dvo) pods [It] Check logs in test namespace osde2e-dvo-test
/var/home/bpratt/git/openshift/osde2e/pkg/e2e/operators/dvo.go:124

  [FAILED] Expected an error-type.  Got:
      <bool>: false
  In [It] at: /var/home/bpratt/git/openshift/osde2e/pkg/e2e/operators/dvo.go:148 @ 11/22/22 06:50:08.436
...
```

the failure is not related to the changes