### PR TITLE
Add support for using ginkgo labels

### DIFF
--- a/cmd/osde2e/test/cmd.go
+++ b/cmd/osde2e/test/cmd.go
@@ -49,6 +49,7 @@ var args struct {
 	mustGather       bool
 	focusTests       string
 	skipTests        string
+	labelFilter      string
 }
 
 func init() {
@@ -124,6 +125,12 @@ func init() {
 		false,
 		"Control the Must Gather process at the end of a failed testing run.",
 	)
+	pfs.StringVar(
+		&args.labelFilter,
+		"label-filter",
+		"",
+		"Only run any Ginkgo tests matching the ginkgo label filter",
+	)
 
 	viper.BindPFlag(config.Cluster.ID, Cmd.PersistentFlags().Lookup("cluster-id"))
 	viper.BindPFlag(ocmprovider.Env, Cmd.PersistentFlags().Lookup("environment"))
@@ -133,6 +140,7 @@ func init() {
 	viper.BindPFlag(config.Tests.GinkgoFocus, Cmd.PersistentFlags().Lookup("focus-tests"))
 	viper.BindPFlag(config.Tests.GinkgoSkip, Cmd.PersistentFlags().Lookup("skip-tests"))
 	viper.BindPFlag(config.MustGather, Cmd.PersistentFlags().Lookup("must-gather"))
+	viper.BindPFlag(config.Tests.GinkgoLabelFilter, Cmd.PersistentFlags().Lookup("label-filter"))
 }
 
 func run(cmd *cobra.Command, argv []string) {

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -199,9 +199,13 @@ var Tests = struct {
 	// Env: GINKGO_FOCUS
 	GinkgoFocus string
 
-	// GinkgoLogLevel contrls the logging level used by ginkgo when providing test output
+	// GinkgoLogLevel controls the logging level used by ginkgo when providing test output
 	// Env: GINKGO_LOG_LEVEL
 	GinkgoLogLevel string
+
+	// GinkgoLabelFilter controls which test suites or tests to run
+	// Env: GINKGO_LABEL_FILTER
+	GinkgoLabelFilter string
 
 	// TestsToRun is a list of files which should be executed as part of a test suite
 	// Env: TESTS_TO_RUN
@@ -245,6 +249,7 @@ var Tests = struct {
 	GinkgoSkip:                 "tests.ginkgoSkip",
 	GinkgoFocus:                "tests.focus",
 	GinkgoLogLevel:             "tests.ginkgoLogLevel",
+	GinkgoLabelFilter:          "tests.ginkgoLabelFilter",
 	TestsToRun:                 "tests.testsToRun",
 	SuppressSkipNotifications:  "tests.suppressSkipNotifications",
 	CleanRuns:                  "tests.cleanRuns",
@@ -661,6 +666,8 @@ func InitOSDe2eViper() {
 	viper.BindEnv(Tests.GinkgoFocus, "GINKGO_FOCUS")
 
 	viper.BindEnv(Tests.GinkgoLogLevel, "GINKGO_LOG_LEVEL")
+
+	viper.BindEnv(Tests.GinkgoLabelFilter, "GINKGO_LABEL_FILTER")
 
 	viper.BindEnv(Tests.TestsToRun, "TESTS_TO_RUN")
 

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -278,6 +278,10 @@ func runGinkgoTests() (int, error) {
 		suiteConfig.SkipStrings = append(suiteConfig.SkipStrings, skip)
 	}
 
+	if labels := viper.GetString(config.Tests.GinkgoLabelFilter); labels != "" {
+		suiteConfig.LabelFilter = labels
+	}
+
 	if testsToRun := viper.GetStringSlice(config.Tests.TestsToRun); len(testsToRun) > 0 {
 		// Flag to delete sice these Print statements are duplicated, all we really are doing is setting an array to be passed to the Ginkgo suite.
 		log.Printf("%v", testsToRun)


### PR DESCRIPTION
# Change

This PR adds the initial ground work for enabling the ability to use ginkgo labels. It provides the ability for osde2e to accept a label filter query to pass to ginkgo. Where ginkgo can use that to decide which test cases it should execute.

# Why

Labels are going to play a large role as we work towards defining standardization and consistency across all OSD operator tests. Labels are a way to easily tag test cases.

With the use of labels, we can fine tune new tests and existing tests cases based on a standard set of supported labels (list will be provided next week for review/discussion).

Labels can be applied to both ginkgo describe nodes (test suites) and ginkgo it nodes (test cases).

*Example*: Test suites can define a label such as `operators` or `<specific-operator>`, then within the suite, test cases can be tagged according to their represented category (e.g. `smoke`, `e2e`, `upgrade`). Allowing to build label filter queries such as:
   * `--label-filter "smoke"` << run everything tagged as smoke tests
   * `--label-filter "operators && smoke"` << run all operators smoke tests
   * `--label-filter "<specific-operator> && smoke"` << run the specific operator smoke tests
   * `--label-filter "e2e"` << run everything tagged as e2e tests
   * `--label-filter "e2e && smoke"` << run all smoke tests that are part of the e2e suite

These are just some basic examples above to demonstrate the ability of using labels.

# Additional Info

* With the introduction to support labels, focus strings still works. They can work together with labels.
* Separate PR's will be created to tag test cases as we work towards a few selected OSD operators to start with.

