### PR TITLE
e2e/operators/cloudingress: specify correct groupversion

### DIFF
--- a/pkg/e2e/operators/cloudingress/apischeme_cr.go
+++ b/pkg/e2e/operators/cloudingress/apischeme_cr.go
@@ -7,7 +7,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	cloudingress "github.com/openshift/cloud-ingress-operator/api/v1alpha1"
-	"github.com/openshift/cloud-ingress-operator/pkg/ingresscontroller"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
@@ -76,7 +75,7 @@ func createApischeme(name string) cloudingress.APIScheme {
 	apischeme := cloudingress.APIScheme{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "APIScheme",
-			APIVersion: ingresscontroller.SchemeGroupVersion.String(),
+			APIVersion: cloudingress.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,


### PR DESCRIPTION
accidentally set this to be the ingresscontroller groupversion instead of the cio

Signed-off-by: Brady Pratt <bpratt@redhat.com>

https://github.com/openshift/cloud-ingress-operator/blob/ed3525c8ae22ab9f01630ae1fbfa319b72766577/api/v1alpha1/groupversion_info.go#L29