### PR TITLE
OSDe2e update hypershift un/install times

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -93,7 +93,7 @@ func WaitForClusterReadyPostInstall(clusterID string, logger *log.Logger) error 
 
 	installTimeout := viper.GetInt64(config.Cluster.InstallTimeout)
 	if viper.GetBool(config.Hypershift) {
-		//Install timeout 30 minutes for hypershift
+		// Install timeout 30 minutes for hypershift
 		installTimeout = 30
 	}
 	logger.Printf("Waiting %v minutes for cluster '%s' to be ready...\n", installTimeout, clusterID)

--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -92,6 +92,10 @@ func WaitForClusterReadyPostInstall(clusterID string, logger *log.Logger) error 
 	}
 
 	installTimeout := viper.GetInt64(config.Cluster.InstallTimeout)
+	if viper.GetBool(config.Hypershift) {
+		//Install timeout 30 minutes for hypershift
+		installTimeout = 30
+	}
 	logger.Printf("Waiting %v minutes for cluster '%s' to be ready...\n", installTimeout, clusterID)
 
 	_, err = waitForOCMProvisioning(provider, clusterID, installTimeout, logger, false)

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -263,7 +263,7 @@ func (m *ROSAProvider) DeleteCluster(clusterID string) error {
 
 func (m *ROSAProvider) stsClusterCleanup(clusterID string) error {
 	// wait for the cluster to no longer be available
-	wait.PollImmediate(3*time.Minute, 15*time.Minute, func() (bool, error) {
+	wait.PollImmediate(2*time.Minute, 30*time.Minute, func() (bool, error) {
 		clusters, err := m.ocmProvider.ListClusters(fmt.Sprintf("id = '%s'", clusterID))
 		if err != nil {
 			return false, err


### PR DESCRIPTION
1. Set the install time for HCP clusters to 30 minutes. 
2. Increased the uninstall wait time to 30 after seeing an increase in pipeline failures:
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/osde2e-hypershift-stage/1597651843805089792

Locally running the hypershift pipeline there was an average uninstall time of 22 minutes. 
