### PR TITLE
common/label: initial commit of ginkgo labels

### DIFF
--- a/pkg/common/label/label.go
+++ b/pkg/common/label/label.go
@@ -1,0 +1,67 @@
+// Package label implements a standard set of Ginkgo labels for classifying
+// OpenShift Dedicated end to end platform/component tests.
+//
+// A label is for classifying or grouping a test based on what it is doing,
+// what is supports, and it's level of importance in decision making. These
+// labels can be used to target specific subsets of the overall suite during
+// execution by providing the Ginkgo/osde2e `--label-filter` flag.
+//
+// Within the `Describe` or `It` of a test, one to many labels can be included
+// to categorize the specific test(s) like so:
+//
+// var _ = Describe(testName, label.Blocking, func() { ... })
+//
+// Complex conditions can be provided to combine or negate different labels
+// such as `ROSA && Upgrade` or `e2e && !privatelink`. See the [Ginkgo
+// docs](https://onsi.github.io/ginkgo/#spec-labels) for more details. New
+// labels introduced should be generic and applicable to multiple test suites.
+//
+// Labels can also be used in conjunction with the `--focus` flag to provide
+// the ability to run a specific suite's category of tests, for example:
+// `--label-filter Install --focus "Managed Cluster Validating Webhooks"`
+// `--label-filter Upgrade --focus "Splunk Operator"`
+package label
+
+import "github.com/onsi/ginkgo/v2"
+
+var (
+	// Informing tests are new and needs to be proven stable before being
+	// promoted to Blocking
+	Informing = ginkgo.Label("Informing")
+
+	// Blocking tests are stable and important enough to block a new release
+	Blocking = ginkgo.Label("Blocking")
+
+	// Install tests cover validating the component is available and ready
+	Install = ginkgo.Label("Install")
+
+	// Upgrade tests validate the component moving to a newer version
+	Upgrade = ginkgo.Label("Upgrade")
+
+	// ROSA tests support running on ROSA clusters
+	ROSA = ginkgo.Label("ROSA")
+
+	// HyperShift tests support running on a HyperShift cluster
+	HyperShift = ginkgo.Label("HyperShift")
+
+	// STS tests support running on a cluster deployed using STS
+	STS = ginkgo.Label("STS")
+
+	// PrivateLink tests support running on a cluster deployed using PrivateLink
+	PrivateLink = ginkgo.Label("PrivateLink")
+
+	// CCS tests support running on a Customer Cloud Subscription cluster
+	CCS = ginkgo.Label("CCS")
+
+	// E2E tests are included in a full end to end run of the suite
+	E2E = ginkgo.Label("E2E")
+
+	// AWS tests support running on a cluster in AWS
+	AWS = ginkgo.Label("AWS")
+
+	// GCP tests support running on a cluster in GCP
+	GCP = ginkgo.Label("GCP")
+
+	// Azure tests support running on a cluster in Azure
+	Azure = ginkgo.Label("Azure")
+)


### PR DESCRIPTION
Add a common label package defining a set of Ginkgo labels that can be used for classifying tests based on what they are doing, what they support, and how important they are. These labels will be introduced to tests in following patches to provide a path forward for converting from mainly using the focus filter to utilizing labels.

Labels provide a great way of grouping tests while not losing the focus ability currently used today. This should enhance the ability to pick tests based on the specific criteria when used in combination with the focus-filter flag.

This list is not all encompassing, new labels can be added as required and old labels that are no longer relevant should be removed. This list roughly covers the initial requirements for refactoring a handful of tests. Any label added should be generic enough to apply to a set of tests. Focus should be used in conjunction when more granularity past the category is required.

Signed-off-by: Brady Pratt <bpratt@redhat.com>