### PR TITLE
Introduce e2e label

### DIFF
--- a/pkg/e2e/osd/machinehealthcheck.go
+++ b/pkg/e2e/osd/machinehealthcheck.go
@@ -10,6 +10,7 @@ import (
 	machineV1beta1 "github.com/openshift/api/machine/v1beta1"
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +33,7 @@ func init() {
 	)
 }
 
-var _ = ginkgo.Describe(machineHealthTestName, func() {
+var _ = ginkgo.Describe(machineHealthTestName, label.E2E, func() {
 	h := helper.New()
 
 	util.GinkgoIt("infra MHC should exist", func(ctx context.Context) {

--- a/pkg/e2e/osd/ocm.go
+++ b/pkg/e2e/osd/ocm.go
@@ -16,6 +16,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/providers"
 	"github.com/openshift/osde2e/pkg/common/util"
 	v1 "k8s.io/api/core/v1"
@@ -69,7 +70,7 @@ func cmdFromIPs(ips []string, templ *template.Template) string {
 	return buf.String()
 }
 
-var _ = ginkgo.Describe(ocmTestName, func() {
+var _ = ginkgo.Describe(ocmTestName, label.E2E, func() {
 	ginkgo.Context("Metrics", func() {
 		clusterID := viper.GetString(config.Cluster.ID)
 		util.GinkgoIt("do exist and are not empty", func(ctx context.Context) {

--- a/pkg/e2e/state/alerts.go
+++ b/pkg/e2e/state/alerts.go
@@ -9,6 +9,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -34,7 +35,7 @@ func init() {
 	alert.RegisterGinkgoAlert(clusterStateTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(clusterStateTestName, func() {
+var _ = ginkgo.Describe(clusterStateTestName, label.E2E, func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/pkg/e2e/state/prometheus.go
+++ b/pkg/e2e/state/prometheus.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/runner"
 	"github.com/openshift/osde2e/pkg/common/util"
 	"github.com/openshift/osde2e/pkg/e2e/verify"
@@ -21,7 +22,7 @@ const (
 	clusterStateInformingName = "[Suite: e2e] Cluster state"
 )
 
-var _ = ginkgo.Describe(clusterStateInformingName, func() {
+var _ = ginkgo.Describe(clusterStateInformingName, label.E2E, func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/pkg/e2e/verify/encrypted_storage.go
+++ b/pkg/e2e/verify/encrypted_storage.go
@@ -16,6 +16,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
 
@@ -49,7 +50,7 @@ func init() {
 	alert.RegisterGinkgoAlert(encryptedStorageTestName, "SD-SREP", "Trevor Nierman", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(encryptedStorageTestName, func() {
+var _ = ginkgo.Describe(encryptedStorageTestName, label.E2E, func() {
 	ginkgo.Context("in GCP clusters", func() {
 		if viper.GetString(config.CloudProvider.CloudProviderID) != "gcp" {
 			return

--- a/pkg/e2e/verify/fips.go
+++ b/pkg/e2e/verify/fips.go
@@ -12,6 +12,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -31,7 +32,7 @@ func init() {
 	alert.RegisterGinkgoAlert(fipsTestName, "SD-SREP", "Trevor Nierman", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(fipsTestName, func() {
+var _ = ginkgo.Describe(fipsTestName, label.E2E, func() {
 	ginkgo.Context("is enabled", func() {
 		if !viper.GetBool(config.Tests.EnableFips) {
 			return

--- a/pkg/e2e/verify/imagestreams.go
+++ b/pkg/e2e/verify/imagestreams.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 )
 
@@ -19,7 +20,7 @@ func init() {
 	alert.RegisterGinkgoAlert(imageStreamsTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(imageStreamsTestName, func() {
+var _ = ginkgo.Describe(imageStreamsTestName, label.E2E, func() {
 	h := helper.New()
 
 	util.GinkgoIt("should exist in the cluster", func(ctx context.Context) {

--- a/pkg/e2e/verify/namespace_webhook.go
+++ b/pkg/e2e/verify/namespace_webhook.go
@@ -11,6 +11,7 @@ import (
 	userv1 "github.com/openshift/api/user/v1"
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	monv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	v1 "k8s.io/api/core/v1"
@@ -31,7 +32,7 @@ func init() {
 	alert.RegisterGinkgoAlert(namespaceWebhookTestName, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(namespaceWebhookTestName, func() {
+var _ = ginkgo.Describe(namespaceWebhookTestName, label.E2E, func() {
 	const (
 		// Group to use for impersonation
 		DUMMY_GROUP = "random-group-name"

--- a/pkg/e2e/verify/pods.go
+++ b/pkg/e2e/verify/pods.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 )
 
@@ -24,7 +25,7 @@ func init() {
 	alert.RegisterGinkgoAlert(podsTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(podsTestName, func() {
+var _ = ginkgo.Describe(podsTestName, label.E2E, func() {
 	h := helper.New()
 
 	util.GinkgoIt("should not be Failed", func(ctx context.Context) {

--- a/pkg/e2e/verify/prom_exporters.go
+++ b/pkg/e2e/verify/prom_exporters.go
@@ -10,6 +10,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	clusterProviders "github.com/openshift/osde2e/pkg/common/providers"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -22,7 +23,7 @@ func init() {
 	alert.RegisterGinkgoAlert(promExportersTestname, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(promExportersTestname, func() {
+var _ = ginkgo.Describe(promExportersTestname, label.E2E, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("Prometheus Exporters (ebs-iops-reporter and stuck-ebs-vols) are not deployed to STS clusters")

--- a/pkg/e2e/verify/routes.go
+++ b/pkg/e2e/verify/routes.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 )
 
@@ -30,7 +31,7 @@ func init() {
 	alert.RegisterGinkgoAlert(routesTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(routesTestName, func() {
+var _ = ginkgo.Describe(routesTestName, label.E2E, func() {
 	h := helper.New()
 
 	util.GinkgoIt("should be created for Console", func(ctx context.Context) {

--- a/pkg/e2e/verify/samesite_cookie.go
+++ b/pkg/e2e/verify/samesite_cookie.go
@@ -9,6 +9,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -25,7 +26,7 @@ const (
 
 var samesiteTestName string = "[Suite: e2e] [OSD] Samesite Cookie Strict"
 
-var _ = ginkgo.Describe(samesiteTestName, func() {
+var _ = ginkgo.Describe(samesiteTestName, label.E2E, func() {
 	h := helper.New()
 
 	ginkgo.Context("Validating samesite cookie", func() {

--- a/pkg/e2e/verify/sccs.go
+++ b/pkg/e2e/verify/sccs.go
@@ -11,6 +11,7 @@ import (
 	v1 "github.com/openshift/api/security/v1"
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,7 +25,7 @@ func init() {
 	alert.RegisterGinkgoAlert(dedicatedAdminSccTestName, "SD-CICD", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(dedicatedAdminSccTestName, func() {
+var _ = ginkgo.Describe(dedicatedAdminSccTestName, label.E2E, func() {
 	h := helper.New()
 
 	workloadDir := "workloads/e2e/scc"

--- a/pkg/e2e/verify/storage.go
+++ b/pkg/e2e/verify/storage.go
@@ -14,6 +14,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/storage/v1"
@@ -38,7 +39,7 @@ const (
 	poll = 1 * time.Second
 )
 
-var _ = ginkgo.Describe(storageTestName, func() {
+var _ = ginkgo.Describe(storageTestName, label.E2E, func() {
 	h := helper.New()
 
 	ginkgo.Context("storage", func() {

--- a/pkg/e2e/verify/strict_transport_security.go
+++ b/pkg/e2e/verify/strict_transport_security.go
@@ -8,13 +8,14 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var hstsTestName string = "[Suite: e2e] [OSD] HTTP Strict Transport Security"
 
-var _ = ginkgo.Describe(hstsTestName, func() {
+var _ = ginkgo.Describe(hstsTestName, label.E2E, func() {
 	h := helper.New()
 
 	consoleNamespace := "openshift-console"

--- a/pkg/e2e/verify/validation_webhook.go
+++ b/pkg/e2e/verify/validation_webhook.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 )
 
@@ -20,7 +21,7 @@ func init() {
 	alert.RegisterGinkgoAlert(validationWebhookTestName, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(validationWebhookTestName, func() {
+var _ = ginkgo.Describe(validationWebhookTestName, label.E2E, func() {
 	namespace := "openshift-validation-webhook"
 	service := "validation-webhook"
 	configMapName := "webhook-cert"

--- a/pkg/e2e/workloads/guestbook/guestbook.go
+++ b/pkg/e2e/workloads/guestbook/guestbook.go
@@ -17,6 +17,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -40,7 +41,7 @@ func init() {
 	alert.RegisterGinkgoAlert(testName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(testName, func() {
+var _ = ginkgo.Describe(testName, label.E2E, func() {
 	defer ginkgo.GinkgoRecover()
 	// setup helper
 	h := helper.New()

--- a/pkg/e2e/workloads/redmine/redmine.go
+++ b/pkg/e2e/workloads/redmine/redmine.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/cluster/healthchecks"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 
 	"github.com/onsi/ginkgo/v2"
@@ -42,7 +43,7 @@ func init() {
 	alert.RegisterGinkgoAlert(testName, "SD-SREP", "Matt Bargenquast", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(testName, func() {
+var _ = ginkgo.Describe(testName, label.E2E, func() {
 	defer ginkgo.GinkgoRecover()
 	// setup helper
 	h := helper.New()


### PR DESCRIPTION
Amend the `label.E2E` to each `Describe` within the `Suite: e2e` to
allow executing these tests based on label rather than focus-filter.

Focus filter will continue working as is. Eventually (once the initial
label introduction is complete), the configs will be updated to use
labels and/or focus where applicable.

depends on #1432

/hold