### PR TITLE
common/helper: remove dedicated-admin service account deletion

### DIFF
--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -171,10 +171,6 @@ func (h *H) Cleanup(ctx context.Context) {
 			if err != nil {
 				log.Printf("Error deleting project `%s` in Cleanup(): %s", project.Name, err.Error())
 			}
-			err = h.Kube().CoreV1().ServiceAccounts("dedicated-admin").Delete(ctx, project.Name, metav1.DeleteOptions{})
-			if err != nil {
-				log.Printf("Error deleting dedicated-admin serviceaccount for '%s': %v", project.Name, err)
-			}
 		}
 	}
 


### PR DESCRIPTION
deletion is happening after the namespace deletion which takes this service account with it, an error is always printed for this failed:

"Error deleting dedicated-admin serviceaccount for 'osde2e-omwhi': serviceaccounts "osde2e-omwhi" not found"

Signed-off-by: Brady Pratt <bpratt@redhat.com>