### PR TITLE
Drop the constants package in efforts for test case tagging

### DIFF
--- a/pkg/common/constants/constants.go
+++ b/pkg/common/constants/constants.go
@@ -1,9 +1,0 @@
-// Package provides constants that are consumable when designing test suites
-package constants
-
-const (
-	SuiteInforming = "[Suite: informing] "
-	SuiteOperators = "[Suite: operators] "
-	// SuiteDummy is used for testing a specific test
-	SuiteDummy = "[Suite: dummy] "
-)

--- a/pkg/e2e/operators/cloudingress/apischeme_cr.go
+++ b/pkg/e2e/operators/cloudingress/apischeme_cr.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/gomega"
 	cloudingress "github.com/openshift/cloud-ingress-operator/api/v1alpha1"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -21,7 +20,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")

--- a/pkg/e2e/operators/cloudingress/certificate.go
+++ b/pkg/e2e/operators/cloudingress/certificate.go
@@ -7,7 +7,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +15,7 @@ import (
 )
 
 // tests
-var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: informing] "+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")

--- a/pkg/e2e/operators/cloudingress/cloudingress.go
+++ b/pkg/e2e/operators/cloudingress/cloudingress.go
@@ -2,7 +2,6 @@ package cloudingress
 
 import (
 	"github.com/openshift/osde2e/pkg/common/alert"
-	"github.com/openshift/osde2e/pkg/common/constants"
 )
 
 const (
@@ -14,6 +13,6 @@ const (
 
 // utils
 func init() {
-	alert.RegisterGinkgoAlert(constants.SuiteInforming+TestPrefix, "SD-SRE", "@sd-sre-aurora-team", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
-	alert.RegisterGinkgoAlert(constants.SuiteOperators+TestPrefix, "SD-SRE", "@sd-sre-aurora-team", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
+	alert.RegisterGinkgoAlert("[Suite: informing] "+TestPrefix, "SD-SRE", "@sd-sre-aurora-team", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
+	alert.RegisterGinkgoAlert("[Suite: operators] "+TestPrefix, "SD-SRE", "@sd-sre-aurora-team", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }

--- a/pkg/e2e/operators/cloudingress/deletetapps2.go
+++ b/pkg/e2e/operators/cloudingress/deletetapps2.go
@@ -12,7 +12,6 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/api/v1alpha1"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/e2e/operators"
@@ -24,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: informing] "+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")

--- a/pkg/e2e/operators/cloudingress/dnsname.go
+++ b/pkg/e2e/operators/cloudingress/dnsname.go
@@ -8,7 +8,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +16,7 @@ import (
 )
 
 // tests
-var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: informing] "+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")

--- a/pkg/e2e/operators/cloudingress/installed.go
+++ b/pkg/e2e/operators/cloudingress/installed.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
-	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -21,7 +20,7 @@ import (
 
 // tests
 
-var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")

--- a/pkg/e2e/operators/cloudingress/public_private.go
+++ b/pkg/e2e/operators/cloudingress/public_private.go
@@ -10,7 +10,6 @@ import (
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/api/v1alpha1"
 
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -23,7 +22,7 @@ import (
 )
 
 // tests
-var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: informing] "+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")

--- a/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
+++ b/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
@@ -8,7 +8,6 @@ import (
 	cloudingress "github.com/openshift/cloud-ingress-operator/api/v1alpha1"
 	"github.com/openshift/cloud-ingress-operator/pkg/ingresscontroller"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -20,7 +19,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")

--- a/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
@@ -14,7 +14,6 @@ import (
 
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
-	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -27,7 +26,7 @@ import (
 
 // tests
 
-var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")

--- a/pkg/e2e/operators/cloudingress/rhapi_lb.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_lb.go
@@ -11,7 +11,6 @@ import (
 
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
-	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +28,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-var _ = ginkgo.Describe(constants.SuiteOperators+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool("rosa.STS") {
 			ginkgo.Skip("Cluster is STS. For now we skip rh-api LB reconcile test for STS")

--- a/pkg/e2e/operators/cloudingress/routeSelector.go
+++ b/pkg/e2e/operators/cloudingress/routeSelector.go
@@ -8,7 +8,6 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +16,7 @@ import (
 )
 
 // tests
-var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: informing] "+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")

--- a/pkg/e2e/operators/cloudingress/secondary_router.go
+++ b/pkg/e2e/operators/cloudingress/secondary_router.go
@@ -11,7 +11,6 @@ import (
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/api/v1alpha1"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
-	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -22,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: informing] "+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")

--- a/pkg/e2e/operators/cloudingress/upgrade.go
+++ b/pkg/e2e/operators/cloudingress/upgrade.go
@@ -3,13 +3,12 @@ package cloudingress
 import (
 	"github.com/onsi/ginkgo/v2"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/constants"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/e2e/operators"
 )
 
-var _ = ginkgo.Describe(constants.SuiteInforming+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: informing] "+TestPrefix, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")


### PR DESCRIPTION
As we work towards improving the quality of the tests and test standards. Test case tagging will be applied eventually to all tests. What this means is, test suites will no longer need to define the type of test (e.g. informing, operator, e2e) within the string and will be applied using a label.

These constants being removed have only been used by a handful of tests and others were hard coded into the string in their test suite names. These tests have been updated to hard code the string for now as these will eventually be removed in a future PR (when labels are applied).