### PR TITLE
SDCICD-856 generic test harness runner, suite and template

### DIFF
--- a/assets/harness/harness-runner.template
+++ b/assets/harness/harness-runner.template
@@ -1,0 +1,69 @@
+cat <<WORKLOAD > workload.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{.JobName}}
+spec:
+  parallelism: 1
+  completions: 1
+  activeDeadlineSeconds: {{.Timeout}}
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccount: {{.ServiceAccount}}
+      containers:
+      - name: test-harness
+        image: {{.Image}}
+        imagePullPolicy: Always
+        {{ if .Arguments }}
+        args: {{.Arguments}}
+        {{ end }}
+        volumeMounts:
+        - mountPath: {{.OutputDir}}
+          name: test-output
+      - name: push-results
+        image: {{.PushResultsContainer}}
+        imagePullPolicy: Always
+        command: [/bin/sh, /push-results/push-results.sh]
+        volumeMounts:
+        - mountPath: {{.OutputDir}}
+          name: test-output
+        - mountPath: /push-results
+          name: push-results
+      volumes:
+      - name: test-output
+        emptyDir: {}
+      - name: push-results
+        configMap:
+          name: push-results-{{.Suffix}}
+      restartPolicy: Never
+WORKLOAD
+
+set -e
+
+cat <<PUSH_RESULTS > push-results.sh
+#!/usr/bin/env bash
+
+JOB_POD=\$(oc get pods -l job-name={{.JobName}} -o=jsonpath='{.items[0].metadata.name}')
+echo "Found Job Pod: \$JOB_POD"
+while ! oc get pod \$JOB_POD -o jsonpath='{.status.containerStatuses[?(@.name=="test-harness")].state}' | grep -q terminated; do sleep 1; done
+for i in {1..5}; do oc rsync {{.OutputDir}}/. $(hostname):{{.OutputDir}} && break; sleep 10; done
+PUSH_RESULTS
+
+cat workload.yaml
+cat push-results.sh
+
+oc create configmap push-results-{{.Suffix}} --from-file=push-results.sh
+
+oc apply -f workload.yaml
+
+sleep 5
+
+set +e
+
+while oc get job/{{.JobName}} -o=jsonpath='{.status}' | grep -q active; do sleep 1; done
+
+mkdir -p "{{.OutputDir}}/containerLogs"
+JOB_POD=$(oc get pods -l job-name={{.JobName}} -o=jsonpath='{.items[0].metadata.name}')
+oc logs $JOB_POD -c test-harness > "{{.OutputDir}}/containerLogs/${JOB_POD}-test-harness.log"
+oc logs $JOB_POD -c push-results > "{{.OutputDir}}/containerLogs/${JOB_POD}-push-results.log"

--- a/configs/harness-suite.yaml
+++ b/configs/harness-suite.yaml
@@ -1,0 +1,3 @@
+tests:
+  testsToRun:
+  - '\[Suite\: harnesses\]'

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -493,6 +493,19 @@ var Addons = struct {
 	PollingTimeout:   "addons.pollingTimeout",
 }
 
+// test harness config keys.
+var Harness = struct {
+	Images         string
+	TestUser       string
+	SlackChannel   string
+	PollingTimeout string
+}{
+	Images:         "harness.images",
+	TestUser:       "harness.testUser",
+	SlackChannel:   "harness.slackChannel",
+	PollingTimeout: "harness.pollingTimeout",
+}
+
 // Scale config keys.
 var Scale = struct {
 	// WorkloadsRepository is the git repository where the openshift-scale workloads are located.
@@ -816,6 +829,18 @@ func InitOSDe2eViper() {
 
 	viper.SetDefault(Addons.PollingTimeout, 3600)
 	viper.BindEnv(Addons.PollingTimeout, "ADDON_POLLING_TIMEOUT")
+
+	// ----- Harnesses -----
+	viper.BindEnv(Harness.Images, "HARNESS_IMAGES")
+
+	viper.SetDefault(Harness.TestUser, "system:serviceaccount:%s:cluster-admin")
+	viper.BindEnv(Harness.TestUser, "HARNESS_TEST_USER")
+
+	viper.SetDefault(Harness.SlackChannel, "sd-cicd-alerts")
+	viper.BindEnv(Harness.SlackChannel, "HARNESS_SLACK_CHANNEL")
+
+	viper.SetDefault(Harness.PollingTimeout, 3600)
+	viper.BindEnv(Harness.PollingTimeout, "HARNESS_POLLING_TIMEOUT")
 
 	// ----- Scale -----
 	viper.SetDefault(Scale.WorkloadsRepository, "https://github.com/openshift-scale/workloads")

--- a/pkg/common/helper/harnesses.go
+++ b/pkg/common/helper/harnesses.go
@@ -1,0 +1,93 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/osde2e/pkg/common/runner"
+	"github.com/openshift/osde2e/pkg/common/templates"
+	"github.com/openshift/osde2e/pkg/common/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+//GEneralizd harness runner: Essentially replicates addon harness runner, with generalized harness template
+func (h *H) RunTestHarness(ctx context.Context, name string, timeout int, harnesses, args []string) (failed []string) {
+	testHarnessTemplate, err := templates.LoadTemplate("harness/harness-runner.template")
+	if err != nil {
+		panic(fmt.Sprintf("error while loading test harness runner: %v", err))
+	}
+
+	h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
+	for _, harness := range harnesses {
+		// configure tests
+		// setup runner
+		r := h.RunnerWithNoCommand()
+
+		suffix := util.RandomStr(5)
+
+		latestImageStream, err := r.GetLatestImageStreamTag()
+		jobName := fmt.Sprintf("%s-%s", name, suffix)
+		Expect(err).NotTo(HaveOccurred())
+		serviceAccountDir := "/var/run/secrets/kubernetes.io/serviceaccount"
+		values := struct {
+			Name                 string
+			JobName              string
+			Arguments            string
+			Timeout              int
+			Image                string
+			OutputDir            string
+			ServiceAccount       string
+			PushResultsContainer string
+			Suffix               string
+			Server               string
+			CA                   string
+			TokenFile            string
+		}{
+			Name:                 jobName,
+			JobName:              jobName,
+			Timeout:              timeout,
+			Image:                harness,
+			OutputDir:            runner.DefaultRunner.OutputDir,
+			ServiceAccount:       h.GetNamespacedServiceAccount(),
+			PushResultsContainer: latestImageStream,
+			Suffix:               suffix,
+			Server:               "https://kubernetes.default",
+			CA:                   serviceAccountDir + "/ca.crt",
+			TokenFile:            serviceAccountDir + "/token",
+		}
+
+		if len(args) > 0 {
+			values.Arguments = fmt.Sprintf("[\"%s\"]", strings.Join(args, "\", \""))
+		}
+		testHarnessCommand, err := h.ConvertTemplateToString(testHarnessTemplate, values)
+		Expect(err).NotTo(HaveOccurred())
+
+		r.Name = "test-harness"
+		r.Cmd = testHarnessCommand
+
+		// run tests
+		stopCh := make(chan struct{})
+		err = r.Run(timeout, stopCh)
+		Expect(err).NotTo(HaveOccurred())
+
+		// get results
+		results, err := r.RetrieveTestResults()
+
+		// write results
+		h.WriteResults(results)
+
+		// evaluate results
+		Expect(err).NotTo(HaveOccurred())
+
+		// ensure job has not failed
+		job, err := h.Kube().BatchV1().Jobs(r.Namespace).Get(ctx, jobName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		if !Expect(job.Status.Failed).Should(BeNumerically("==", 0)) {
+			failed = append(failed, harness)
+		}
+	}
+	return failed
+}

--- a/pkg/common/helper/harnesses.go
+++ b/pkg/common/helper/harnesses.go
@@ -13,7 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//GEneralizd harness runner: Essentially replicates addon harness runner, with generalized harness template
+// GEneralizd harness runner: Essentially replicates addon harness runner, with generalized harness template
 func (h *H) RunTestHarness(ctx context.Context, name string, timeout int, harnesses, args []string) (failed []string) {
 	testHarnessTemplate, err := templates.LoadTemplate("harness/harness-runner.template")
 	if err != nil {

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -91,7 +91,8 @@ func beforeSuite() bool {
 
 		viper.Set(config.Cluster.ID, cluster.ID())
 		log.Printf("CLUSTER_ID set to %s from OCM.", viper.GetString(config.Cluster.ID))
-		if viper.Get(config.Addons.IDs) != nil {
+		// set up passthrough secrets for addons as well as generic harness images
+		if viper.Get(config.Addons.IDs) != nil || viper.GetString(config.Harness.Images) != "" {
 			passthruSecrets := viper.GetStringMapString(config.NonOSDe2eSecrets)
 			passthruSecrets["CLUSTER_ID"] = viper.GetString(config.Cluster.ID)
 			viper.Set(config.NonOSDe2eSecrets, passthruSecrets)
@@ -181,7 +182,7 @@ func beforeSuite() bool {
 
 	// If there are test harnesses present, we need to populate the
 	// secrets into the test cluster
-	if viper.GetString(config.Addons.TestHarnesses) != "" {
+	if viper.GetString(config.Addons.TestHarnesses) != "" || viper.GetString(config.Harness.Images) != "" {
 		secretsNamespace := "ci-secrets"
 		h := helper.NewOutsideGinkgo()
 		h.CreateProject(context.TODO(), secretsNamespace)

--- a/pkg/e2e/test_harness.go
+++ b/pkg/e2e/test_harness.go
@@ -1,0 +1,40 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/util"
+
+	"github.com/openshift/osde2e/pkg/common/alert"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/prow"
+)
+
+//Generic harness suite: Essentially replicates addon harness suite, with generalized harness suite
+var _ = ginkgo.Describe("[Suite: harnesses] Test Harness", func() {
+	defer ginkgo.GinkgoRecover()
+	h := helper.New()
+
+	testTimeoutInSeconds := float64(viper.GetFloat64(config.Harness.PollingTimeout))
+	util.GinkgoIt("should run until completion", func(ctx context.Context) {
+		log.Printf(" timeout is %v", testTimeoutInSeconds)
+		h.SetServiceAccount(ctx, viper.GetString(config.Harness.TestUser))
+		harnesses := strings.Split(viper.GetString(config.Harness.Images), ",")
+		failed := h.RunTestHarness(ctx, "test-harness", int(testTimeoutInSeconds), harnesses, []string{})
+		if len(failed) > 0 {
+			message := fmt.Sprintf("Tests failed: %v", failed)
+			if url, ok := prow.JobURL(); ok {
+				message += "\n" + url
+			}
+			if err := alert.SendSlackMessage(viper.GetString(config.Harness.SlackChannel), message); err != nil {
+				log.Printf("Failed sending slack alert for test failure: %v", err)
+			}
+		}
+	}, testTimeoutInSeconds+30)
+})

--- a/pkg/e2e/test_harness.go
+++ b/pkg/e2e/test_harness.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/prow"
 )
 
-//Generic harness suite: Essentially replicates addon harness suite, with generalized harness suite
+// Generic harness suite: Essentially replicates addon harness suite, with generalized harness suite
 var _ = ginkgo.Describe("[Suite: harnesses] Test Harness", func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()


### PR DESCRIPTION
jira: [SDCICD-856 ](https://issues.redhat.com/browse/SDCICD-856)

Generic  test harness  to run given test harness image

**Description**: 

- `osde2e` accepts "HARNESS_IMAGES" env var and utilizes a template which spins up a job in an osde2e namespace. This namespace should contain a job runner pod and a test pod. Test pod contains test-harness and push-result containers. Passthrough keys are passed through.
- This mechanism of running the test image (job template, runner routine, test suite) is similar to addons, but this change does not alter or utilize existing addon harness. It also doesn't have the "install" part of addon harnesses and it assumes required components (eg operators) are installed on test cluster. 
- Existing code touched: In Config.go, Harness struct maps to the harness env vars HARNESS_IMAGES etc . In e2e.go, passthrough keys are loaded if harness is provided. 
 


**To test locally**, build the binary, then:
```
ROSA_ENV=stage HARNESS_IMAGES=quay.io/rmundhe_oc/avo-test-harness  HARNESS_POLLING_TIMEOUT=200 CLUSTER_ID={your-test-cluster}. ./out/osde2e -- test --configs rosa,stage,harness-suite l --must-gather false --destroy-cluster false --skip-health-check true
```

**Expected Result**: Output files should be dumped in your local test-output directory.  Currently there's a single assertion within the test image, which should fail as it checks for a non-existent CRD. 
The harness image  quay.io/rmundhe_oc/avo-test-harness, is currently in my dev quay repo, and there's a separate [jira](https://issues.redhat.com/browse/SDCICD-855) to fix the assertion and move it to app-sre quay


