### PR TITLE
Introduce the operators label to the existing operator tests

### DIFF
--- a/pkg/common/label/label.go
+++ b/pkg/common/label/label.go
@@ -64,4 +64,7 @@ var (
 
 	// Azure tests support running on a cluster in Azure
 	Azure = ginkgo.Label("Azure")
+
+	// Operator tests supported on all cluster types
+	Operators = ginkgo.Label("Operators")
 )

--- a/pkg/e2e/operators/certman.go
+++ b/pkg/e2e/operators/certman.go
@@ -9,6 +9,7 @@ import (
 	osv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,7 +22,7 @@ func init() {
 	alert.RegisterGinkgoAlert(certmanOperatorTestName, "SD-SREP", "@certman-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(certmanOperatorTestName, func() {
+var _ = ginkgo.Describe(certmanOperatorTestName, label.Operators, func() {
 	h := helper.New()
 
 	ginkgo.Context("certificate secret should be applied when cluster installed", func() {

--- a/pkg/e2e/operators/cloudingress/apischeme_cr.go
+++ b/pkg/e2e/operators/cloudingress/apischeme_cr.go
@@ -9,6 +9,7 @@ import (
 	cloudingress "github.com/openshift/cloud-ingress-operator/api/v1alpha1"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -20,7 +21,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, label.Operators, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")

--- a/pkg/e2e/operators/cloudingress/installed.go
+++ b/pkg/e2e/operators/cloudingress/installed.go
@@ -12,6 +12,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
 	appsv1 "k8s.io/api/apps/v1"
@@ -20,7 +21,7 @@ import (
 
 // tests
 
-var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, label.Operators, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")

--- a/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
+++ b/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/cloud-ingress-operator/pkg/ingresscontroller"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -19,7 +20,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, label.Operators, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")

--- a/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
@@ -15,6 +15,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,7 +27,7 @@ import (
 
 // tests
 
-var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, label.Operators, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")

--- a/pkg/e2e/operators/cloudingress/rhapi_lb.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_lb.go
@@ -12,6 +12,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -28,7 +29,7 @@ import (
 	"google.golang.org/api/option"
 )
 
-var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, func() {
+var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, label.Operators, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool("rosa.STS") {
 			ginkgo.Skip("Cluster is STS. For now we skip rh-api LB reconcile test for STS")

--- a/pkg/e2e/operators/configurealertmanager.go
+++ b/pkg/e2e/operators/configurealertmanager.go
@@ -4,6 +4,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 )
 
 var configureAlertManagerOperators string = "[Suite: operators] [OSD] Configure AlertManager Operator"
@@ -12,7 +13,7 @@ func init() {
 	alert.RegisterGinkgoAlert(configureAlertManagerOperators, "SD-SREP", "@sd-srep-team-thor", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(configureAlertManagerOperators, func() {
+var _ = ginkgo.Describe(configureAlertManagerOperators, label.Operators, func() {
 	operatorName := "configure-alertmanager-operator"
 	var operatorNamespace string = "openshift-monitoring"
 	var operatorLockFile string = "configure-alertmanager-operator-lock"

--- a/pkg/e2e/operators/customdomains.go
+++ b/pkg/e2e/operators/customdomains.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -53,7 +54,7 @@ func init() {
 	alert.RegisterGinkgoAlert(customDomainsOperatorTestName, "SD-SREP", "@custom-domains-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(customDomainsOperatorTestName, func() {
+var _ = ginkgo.Describe(customDomainsOperatorTestName, label.Operators, func() {
 	// custom dialer for use w/ resolver and http.client
 	dialer := &net.Dialer{
 		Resolver: &net.Resolver{

--- a/pkg/e2e/operators/managedvelero.go
+++ b/pkg/e2e/operators/managedvelero.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/alert"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,7 +27,7 @@ func init() {
 	alert.RegisterGinkgoAlert(veleroOperatorTestName, "SD-SREP", "@managed-velero-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(veleroOperatorTestName, func() {
+var _ = ginkgo.Describe(veleroOperatorTestName, label.Operators, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool("rosa.STS") {
 			ginkgo.Skip("STS does not support MVO")

--- a/pkg/e2e/operators/mustgather.go
+++ b/pkg/e2e/operators/mustgather.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	mustgatherv1alpha1 "github.com/redhat-cop/must-gather-operator/api/v1alpha1"
 	kv1 "k8s.io/api/core/v1"
@@ -25,7 +26,7 @@ func init() {
 	alert.RegisterGinkgoAlert(mustGatherOperatorTest, "SD-SREP", "@sd-sre-aurora-team", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(mustGatherOperatorTest, func() {
+var _ = ginkgo.Describe(mustGatherOperatorTest, label.Operators, func() {
 	operatorName := "must-gather-operator"
 	operatorNamespace := "openshift-must-gather-operator"
 	operatorLockFile := "must-gather-operator-lock"

--- a/pkg/e2e/operators/osdmetricsexporter.go
+++ b/pkg/e2e/operators/osdmetricsexporter.go
@@ -4,6 +4,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 )
 
 var (
@@ -15,7 +16,7 @@ func init() {
 	alert.RegisterGinkgoAlert(osdMetricsExporterBasicTest, "SD_SREP", "@sre-platform-team-v1alpha1", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(osdMetricsExporterBasicTest, func() {
+var _ = ginkgo.Describe(osdMetricsExporterBasicTest, label.Operators, func() {
 	var (
 		operatorNamespace = "openshift-osd-metrics"
 		operatorName      = "osd-metrics-exporter"

--- a/pkg/e2e/operators/prunejob.go
+++ b/pkg/e2e/operators/prunejob.go
@@ -12,6 +12,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -26,7 +27,7 @@ func init() {
 	alert.RegisterGinkgoAlert(pruneJobsTestName, "SD-SREP", "Haoran Wang", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(pruneJobsTestName, func() {
+var _ = ginkgo.Describe(pruneJobsTestName, label.Operators, func() {
 	h := helper.New()
 	ginkgo.Context("pruner jobs should works", func() {
 		namespace := "openshift-sre-pruning"

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -10,6 +10,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unstruct "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -28,7 +29,7 @@ func init() {
 	alert.RegisterGinkgoAlert(subjectPermissionsTestName, "SD-SREP", "@rbac-permissions-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(rbacOperatorBlocking, func() {
+var _ = ginkgo.Describe(rbacOperatorBlocking, label.Operators, func() {
 	operatorLockFile := "rbac-permissions-operator-lock"
 	var defaultDesiredReplicas int32 = 1
 
@@ -48,7 +49,7 @@ var _ = ginkgo.Describe(rbacOperatorBlocking, func() {
 		"rbac-permissions-operator", "rbac-permissions-operator-registry")
 })
 
-var _ = ginkgo.Describe(subjectPermissionsTestName, func() {
+var _ = ginkgo.Describe(subjectPermissionsTestName, label.Operators, func() {
 	h := helper.New()
 	checkSubjectPermissions(h, "dedicated-admins")
 })

--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	sfv1alpha1 "github.com/openshift/splunk-forwarder-operator/api/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -29,7 +30,7 @@ func init() {
 }
 
 // Blocking SplunkForwarder Signal
-var _ = ginkgo.Describe(splunkForwarderBlocking, func() {
+var _ = ginkgo.Describe(splunkForwarderBlocking, label.Operators, func() {
 	operatorName := "splunk-forwarder-operator"
 	var operatorNamespace string = "openshift-splunk-forwarder-operator"
 	var operatorLockFile string = "splunk-forwarder-operator-lock"
@@ -80,7 +81,7 @@ var _ = ginkgo.Describe(splunkForwarderBlocking, func() {
 })
 
 // Informing SplunkForwarder Signal
-var _ = ginkgo.Describe(splunkForwarderInforming, func() {
+var _ = ginkgo.Describe(splunkForwarderInforming, label.Operators, func() {
 	operatorName := "splunk-forwarder-operator"
 	var operatorNamespace string = "openshift-splunk-forwarder-operator"
 	var operatorLockFile string = "splunk-forwarder-operator-lock"

--- a/pkg/e2e/osd/inhibitions.go
+++ b/pkg/e2e/osd/inhibitions.go
@@ -11,6 +11,7 @@ import (
 	configV1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	osde2ePrometheus "github.com/openshift/osde2e/pkg/common/prometheus"
 	"github.com/openshift/osde2e/pkg/common/util"
 	alertmanagerConfig "github.com/prometheus/alertmanager/config"
@@ -36,7 +37,7 @@ func init() {
 var inhibitionsTestName string = "[Suite: operators] AlertmanagerInhibitions"
 
 // tests start here
-var _ = ginkgo.Describe(inhibitionsTestName, func() {
+var _ = ginkgo.Describe(inhibitionsTestName, label.Operators, func() {
 	h := helper.New()
 
 	util.GinkgoIt("should exist", func(ctx context.Context) {


### PR DESCRIPTION
This change is amending to the existing operator tests describe nodes.
Which allows the suite of tests to be executed using ginkgos label
filter feature over using the focus filter.

Focus filter will continue to work as the string `Suite: operators`
still exists within the test case names. It will eventually be removed
in replacement of the label identifiers.

Closes [SDCICD-860](https://issues.redhat.com//browse/SDCICD-860)