### PR TITLE
e2e/operators/splunkforwarder: skip on hypershift

### DIFF
--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -7,6 +7,8 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -31,6 +33,12 @@ func init() {
 
 // Blocking SplunkForwarder Signal
 var _ = ginkgo.Describe(splunkForwarderBlocking, label.Operators, func() {
+	ginkgo.BeforeEach(func() {
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Splunk Forwarder Operator is not deployed to a ROSA hosted-cp cluster (OSD-11605)")
+		}
+	})
+
 	operatorName := "splunk-forwarder-operator"
 	var operatorNamespace string = "openshift-splunk-forwarder-operator"
 	var operatorLockFile string = "splunk-forwarder-operator-lock"


### PR DESCRIPTION
SFO is not deployed the same as on non-hypershift clusters, these tests will need to be skipped until a solution comes out of [OSD-11605](https://issues.redhat.com//browse/OSD-11605)

[SDCICD-868](https://issues.redhat.com//browse/SDCICD-868)

Signed-off-by: Brady Pratt <bpratt@redhat.com>