### PR TITLE
Introduce the service definition label to the existing tests

### DIFF
--- a/pkg/common/label/label.go
+++ b/pkg/common/label/label.go
@@ -67,4 +67,8 @@ var (
 
 	// Operator tests supported on all cluster types
 	Operators = ginkgo.Label("Operators")
+
+	// Service definition tests verifying openshift dedicated policies
+	// https://docs.openshift.com/dedicated/osd_architecture/osd_policy/osd-service-definition.html
+	ServiceDefinition = ginkgo.Label("ServiceDefinition")
 )

--- a/pkg/e2e/osd/daemonsets.go
+++ b/pkg/e2e/osd/daemonsets.go
@@ -10,6 +10,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -22,7 +23,7 @@ func init() {
 	alert.RegisterGinkgoAlert(daemonSetsTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(daemonSetsTestName, func() {
+var _ = ginkgo.Describe(daemonSetsTestName, label.ServiceDefinition, func() {
 	ginkgo.Context("DaemonSets are not allowed", func() {
 		// setup helper
 		h := helper.New()

--- a/pkg/e2e/osd/nodelabels.go
+++ b/pkg/e2e/osd/nodelabels.go
@@ -9,6 +9,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,7 +20,7 @@ func init() {
 	alert.RegisterGinkgoAlert(nodeLabelsTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(nodeLabelsTestName, func() {
+var _ = ginkgo.Describe(nodeLabelsTestName, label.ServiceDefinition, func() {
 	ginkgo.Context("Modifying nodeLabels is not allowed", func() {
 		// setup helper
 		h := helper.New()

--- a/pkg/e2e/osd/privileged.go
+++ b/pkg/e2e/osd/privileged.go
@@ -10,6 +10,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,7 +42,7 @@ func init() {
 	alert.RegisterGinkgoAlert(privilegedTestname, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(privilegedTestname, func() {
+var _ = ginkgo.Describe(privilegedTestname, label.ServiceDefinition, func() {
 	ginkgo.Context("Privileged containers are not allowed", func() {
 		// setup helper
 		h := helper.New()

--- a/pkg/e2e/verify/regularuser_webhook.go
+++ b/pkg/e2e/verify/regularuser_webhook.go
@@ -8,6 +8,7 @@ import (
 	v1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
@@ -19,7 +20,7 @@ func init() {
 	alert.RegisterGinkgoAlert(regularuserWebhookTestName, "SD-SREP", "Max Whittingham", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(regularuserWebhookTestName, func() {
+var _ = ginkgo.Describe(regularuserWebhookTestName, label.ServiceDefinition, func() {
 	h := helper.New()
 
 	ginkgo.Context("regularuser validating webhook", func() {


### PR DESCRIPTION
This change is amending to the existing tests describe nodes. Which allows the suite of tests to be executed using ginkgos label filter feature over using the focus filter.

Focus filter will continue to work as the string Suite: service-definition still exists within the test case names. It will eventually be removed in replacement of the label identifiers.

Closes [SDCICD-861](https://issues.redhat.com//browse/SDCICD-861)