### PR TITLE
common/expect: add initial expect helpers

### DIFF
--- a/pkg/common/expect/expect.go
+++ b/pkg/common/expect/expect.go
@@ -1,0 +1,22 @@
+package expect
+
+import (
+	"github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+// Error expects an error happens, otherwise an exception raises
+func Error(err error, explain ...any) {
+	gomega.ExpectWithOffset(1, err).To(gomega.HaveOccurred(), explain...)
+}
+
+// NoError checks if "err" is set and raises an exception if so
+func NoError(err error, explain ...any) {
+	gomega.ExpectWithOffset(1, err, explain...).ShouldNot(gomega.HaveOccurred())
+}
+
+// Forbidden checks if "err" is set a `metav1.StatusReasonForbidden` or `404`
+// response using `apierrors` package, raising an exception otherwise
+func Forbidden(err error) {
+	gomega.ExpectWithOffset(1, apierrors.IsForbidden(err)).To(gomega.BeTrue(), "expected to be forbidden: %s", err)
+}


### PR DESCRIPTION
Add a set of common gomega assertion helpers to be used within tests to provide a consistent experience. New helpers can be added as needed.

A helper can be used to assert an error is in the expected state like so:

```
err := client.Get(ctx, ...)
expect.NoError(err, "unable to find the thing")

err = client.Create(ctx, ...)
expect.Forbidden(err)
```

inspired by/ripped from k8s test utils expect package https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/expect.go (these aren't meant to be depended on in test/e2e/framework and I don't want to pull in the whole framework)

Signed-off-by: Brady Pratt <bpratt@redhat.com>