### PR TITLE
Introduce the app builds label to the existing tests

### DIFF
--- a/pkg/common/label/label.go
+++ b/pkg/common/label/label.go
@@ -71,4 +71,7 @@ var (
 	// Service definition tests verifying openshift dedicated policies
 	// https://docs.openshift.com/dedicated/osd_architecture/osd_policy/osd-service-definition.html
 	ServiceDefinition = ginkgo.Label("ServiceDefinition")
+
+	// Application build tests verify the ability to deploy applications
+	AppBuilds = ginkgo.Label("AppBuilds")
 )

--- a/pkg/e2e/openshift/app_builds.go
+++ b/pkg/e2e/openshift/app_builds.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/runner"
 	"github.com/openshift/osde2e/pkg/common/util"
 	kubev1 "k8s.io/api/core/v1"
@@ -47,7 +48,7 @@ func init() {
 	alert.RegisterGinkgoAlert(appBuildsTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(appBuildsTestName, func() {
+var _ = ginkgo.Describe(appBuildsTestName, label.AppBuilds, func() {
 	defer ginkgo.GinkgoRecover()
 
 	h := helper.New()


### PR DESCRIPTION
This change is amending to the existing tests describe nodes. Which allows the suite of tests to be executed using ginkgos label filter feature over using the focus filter.

Focus filter will continue to work as the string Suite: app-builds still exists within the test case names. It will eventually be removed in replacement of the label identifiers.

For [SDCICD-862](https://issues.redhat.com//browse/SDCICD-862)