### PR TITLE
sdcicd-869 remove hardcoded timeouts, default timeout to POLLING_TIMEOUT

### DIFF
--- a/pkg/common/util/util.go
+++ b/pkg/common/util/util.go
@@ -9,6 +9,8 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 )
 
 const (
@@ -40,6 +42,9 @@ func SemverToOpenshiftVersion(version *semver.Version) string {
 
 // GinkgoIt wraps the 2.0 Ginkgo It function to allow for additional functionality.
 func GinkgoIt(text string, body func(ctx context.Context), timeout ...float64) bool {
+	if len(timeout) == 0 {
+		timeout = append(timeout, viper.GetFloat64(config.Tests.PollingTimeout))
+	}
 	defer ginkgo.GinkgoRecover()
 	return ginkgo.It(text, ginkgo.Offset(1), func(ctx context.Context) {
 		done := make(chan interface{})

--- a/pkg/common/util/util.go
+++ b/pkg/common/util/util.go
@@ -42,9 +42,6 @@ func SemverToOpenshiftVersion(version *semver.Version) string {
 
 // GinkgoIt wraps the 2.0 Ginkgo It function to allow for additional functionality.
 func GinkgoIt(text string, body func(ctx context.Context), timeout ...float64) bool {
-	if len(timeout) == 0 {
-		timeout = append(timeout, viper.GetFloat64(config.Tests.PollingTimeout))
-	}
 	defer ginkgo.GinkgoRecover()
 	return ginkgo.It(text, ginkgo.Offset(1), func(ctx context.Context) {
 		done := make(chan interface{})
@@ -54,9 +51,11 @@ func GinkgoIt(text string, body func(ctx context.Context), timeout ...float64) b
 			close(done)
 		}()
 		duration := time.Duration(5) * time.Second
-		if len(timeout) > 0 {
-			duration = time.Duration(timeout[0]) * time.Second
+		if len(timeout) == 0 {
+			timeout = append(timeout, viper.GetFloat64(config.Tests.PollingTimeout))
 		}
+		duration = time.Duration(timeout[0]) * time.Second
+
 		Eventually(done, duration).Should(BeClosed())
 	})
 }

--- a/pkg/common/util/util.go
+++ b/pkg/common/util/util.go
@@ -9,8 +9,6 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/config"
 )
 
 const (
@@ -40,7 +38,8 @@ func SemverToOpenshiftVersion(version *semver.Version) string {
 	return VersionPrefix + version.String()
 }
 
-// GinkgoIt wraps the 2.0 Ginkgo It function to allow for additional functionality.
+// GinkgoIt wraps the 2.0 Ginkgo It functions to allow for additional functionality.
+// timeout defaults to 5 seconds if not provided
 func GinkgoIt(text string, body func(ctx context.Context), timeout ...float64) bool {
 	defer ginkgo.GinkgoRecover()
 	return ginkgo.It(text, ginkgo.Offset(1), func(ctx context.Context) {
@@ -51,11 +50,9 @@ func GinkgoIt(text string, body func(ctx context.Context), timeout ...float64) b
 			close(done)
 		}()
 		duration := time.Duration(5) * time.Second
-		if len(timeout) == 0 {
-			timeout = append(timeout, viper.GetFloat64(config.Tests.PollingTimeout))
+		if len(timeout) > 0 {
+			duration = time.Duration(timeout[0]) * time.Second
 		}
-		duration = time.Duration(timeout[0]) * time.Second
-
 		Eventually(done, duration).Should(BeClosed())
 	})
 }

--- a/pkg/e2e/openshift/app_builds.go
+++ b/pkg/e2e/openshift/app_builds.go
@@ -11,6 +11,8 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/runner"
@@ -53,7 +55,7 @@ var _ = ginkgo.Describe(appBuildsTestName, label.AppBuilds, func() {
 
 	h := helper.New()
 
-	e2eTimeoutInSeconds := 3600
+	e2eTimeoutInSeconds := viper.GetInt(config.Tests.PollingTimeout)
 	util.GinkgoIt("should get created in the cluster", func(ctx context.Context) {
 		namespacesExist := false
 		for _, application := range testApplications {

--- a/pkg/e2e/openshift/disruptive.go
+++ b/pkg/e2e/openshift/disruptive.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
@@ -23,7 +25,7 @@ var _ = ginkgo.Describe(disruptiveTestName, func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 
-	e2eTimeoutInSeconds := 3600
+	e2eTimeoutInSeconds := viper.GetInt(config.Tests.PollingTimeout)
 	util.GinkgoIt("should run until completion", func(ctx context.Context) {
 		// configure tests
 		cfg := DefaultE2EConfig

--- a/pkg/e2e/openshift/images.go
+++ b/pkg/e2e/openshift/images.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
@@ -26,7 +28,7 @@ var _ = ginkgo.Describe(imageRegistryTestName, func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 
-	e2eTimeoutInSeconds := 3600
+	e2eTimeoutInSeconds := viper.GetInt(config.Tests.PollingTimeout)
 	util.GinkgoIt("should run until completion", func(ctx context.Context) {
 		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 		// configure tests
@@ -59,7 +61,7 @@ var _ = ginkgo.Describe(imageEcosystemTestName, func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 
-	e2eTimeoutInSeconds := 3600
+	e2eTimeoutInSeconds := viper.GetInt(config.Tests.PollingTimeout)
 	util.GinkgoIt("should run until completion", func(ctx context.Context) {
 		// configure tests
 		cfg := DefaultE2EConfig

--- a/pkg/e2e/verify/pods.go
+++ b/pkg/e2e/verify/pods.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +18,10 @@ import (
 	"github.com/openshift/osde2e/pkg/common/util"
 )
 
-var podsTestName string = "[Suite: e2e] Pods"
+var (
+	podsTestName        = "[Suite: e2e] Pods"
+	e2eTimeoutInSeconds = viper.GetInt(config.Tests.PollingTimeout)
+)
 
 func init() {
 	alert.RegisterGinkgoAlert(podsTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
@@ -48,5 +53,5 @@ var _ = ginkgo.Describe(podsTestName, label.E2E, func() {
 		Expect(err).NotTo(HaveOccurred(), "couldn't list Pods")
 		Expect(filteredList).NotTo(BeNil())
 		Expect(filteredList.Items).Should(HaveLen(0), "'%d' Pods are 'Failed'", len(filteredList.Items))
-	})
+	}, float64(e2eTimeoutInSeconds))
 })

--- a/pkg/e2e/verify/pods.go
+++ b/pkg/e2e/verify/pods.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +20,7 @@ import (
 
 var (
 	podsTestName        string = "[Suite: e2e] Pods"
-	e2eTimeoutInSeconds int    = 3600
+	e2eTimeoutInSeconds int    = viper.GetInt(config.Tests.PollingTimeout)
 )
 
 func init() {
@@ -51,5 +53,5 @@ var _ = ginkgo.Describe(podsTestName, label.E2E, func() {
 		Expect(err).NotTo(HaveOccurred(), "couldn't list Pods")
 		Expect(filteredList).NotTo(BeNil())
 		Expect(filteredList.Items).Should(HaveLen(0), "'%d' Pods are 'Failed'", len(filteredList.Items))
-	}, float64(e2eTimeoutInSeconds))
+	})
 })

--- a/pkg/e2e/verify/pods.go
+++ b/pkg/e2e/verify/pods.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/config"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,10 +16,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/util"
 )
 
-var (
-	podsTestName        string = "[Suite: e2e] Pods"
-	e2eTimeoutInSeconds int    = viper.GetInt(config.Tests.PollingTimeout)
-)
+var podsTestName string = "[Suite: e2e] Pods"
 
 func init() {
 	alert.RegisterGinkgoAlert(podsTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)

--- a/pkg/e2e/verify/storage.go
+++ b/pkg/e2e/verify/storage.go
@@ -220,7 +220,6 @@ type Config struct {
 // makeTestPod returns a pod definition based on the namespace. The pod references the PVC's
 // name.
 func makeTestPod(ns string, pvclaims []*corev1.PersistentVolumeClaim, isPrivileged bool) *corev1.Pod {
-
 	timeout := viper.GetInt(config.Tests.PollingTimeout)
 	containerCmd := "echo 'hello' > /mnt/volume1/hello.txt && sleep 1 && sync && grep hello /mnt/volume1/hello.txt; sleep " + strconv.Itoa(timeout)
 	podSpec := &corev1.Pod{
@@ -238,7 +237,7 @@ func makeTestPod(ns string, pvclaims []*corev1.PersistentVolumeClaim, isPrivileg
 					Name:    "dummy",
 					Image:   "registry.access.redhat.com/ubi8/ubi-minimal",
 					Command: []string{"/bin/sh"},
-					Args:    []string{"-c",containerCmd },
+					Args:    []string{"-c", containerCmd},
 					Stdin:   true,
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: &isPrivileged,

--- a/pkg/e2e/verify/storage.go
+++ b/pkg/e2e/verify/storage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -219,6 +220,9 @@ type Config struct {
 // makeTestPod returns a pod definition based on the namespace. The pod references the PVC's
 // name.
 func makeTestPod(ns string, pvclaims []*corev1.PersistentVolumeClaim, isPrivileged bool) *corev1.Pod {
+
+	timeout := viper.GetInt(config.Tests.PollingTimeout)
+	containerCmd := "echo 'hello' > /mnt/volume1/hello.txt && sleep 1 && sync && grep hello /mnt/volume1/hello.txt; sleep " + strconv.Itoa(timeout)
 	podSpec := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
@@ -234,7 +238,7 @@ func makeTestPod(ns string, pvclaims []*corev1.PersistentVolumeClaim, isPrivileg
 					Name:    "dummy",
 					Image:   "registry.access.redhat.com/ubi8/ubi-minimal",
 					Command: []string{"/bin/sh"},
-					Args:    []string{"-c", "echo 'hello' > /mnt/volume1/hello.txt && sleep 1 && sync && grep hello /mnt/volume1/hello.txt; sleep 3600"},
+					Args:    []string{"-c",containerCmd },
 					Stdin:   true,
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: &isPrivileged,

--- a/pkg/e2e/verify/strict_transport_security.go
+++ b/pkg/e2e/verify/strict_transport_security.go
@@ -40,7 +40,7 @@ func hstsManagedRoutes(ctx context.Context, h *helper.H, namespace string) (bool
 	oneYearInSeconds := "31536000"
 	hstsExists := false
 	annotationHsts := "hsts_header"
-	hstsSetting := "max-age="+oneYearInSeconds+";preload"
+	hstsSetting := "max-age=" + oneYearInSeconds + ";preload"
 
 	if err != nil || route == nil {
 		return false, fmt.Errorf("failed requesting routes: %v", err)

--- a/pkg/e2e/verify/strict_transport_security.go
+++ b/pkg/e2e/verify/strict_transport_security.go
@@ -37,9 +37,10 @@ var _ = ginkgo.Describe(hstsTestName, label.E2E, func() {
 
 func hstsManagedRoutes(ctx context.Context, h *helper.H, namespace string) (bool, error) {
 	route, err := h.Route().RouteV1().Routes(namespace).List(ctx, metav1.ListOptions{})
+	oneYearInSeconds := "31536000"
 	hstsExists := false
 	annotationHsts := "hsts_header"
-	hstsSetting := "max-age=31536000;preload"
+	hstsSetting := "max-age="+oneYearInSeconds+";preload"
 
 	if err != nil || route == nil {
 		return false, fmt.Errorf("failed requesting routes: %v", err)


### PR DESCRIPTION
 Jira: https://issues.redhat.com/browse/SDCICD-869 

1. Replaced occurrences of hardcoded timeouts with viper config
2. Updated GinkgoIt wrapper to default timeout to viper config when not provided.  - reverted