### PR TITLE
Apply test case standards to ocm agent operator tests

### DIFF
--- a/cmd/osde2e/test/cmd.go
+++ b/cmd/osde2e/test/cmd.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/openshift/osde2e/pkg/e2e/openshift/hypershift"
 	_ "github.com/openshift/osde2e/pkg/e2e/operators"
 	_ "github.com/openshift/osde2e/pkg/e2e/operators/cloudingress"
+	_ "github.com/openshift/osde2e/pkg/e2e/operators/ocmagent"
 	_ "github.com/openshift/osde2e/pkg/e2e/osd"
 	_ "github.com/openshift/osde2e/pkg/e2e/proxy"
 	_ "github.com/openshift/osde2e/pkg/e2e/scale"

--- a/configs/informing-suite.yaml
+++ b/configs/informing-suite.yaml
@@ -1,3 +1,4 @@
 tests:
     testsToRun:
     - '\[Suite\: informing\]'
+    - 'OCM Agent Operator'

--- a/pkg/common/helper/impersonate.go
+++ b/pkg/common/helper/impersonate.go
@@ -3,11 +3,13 @@ package helper
 import (
 	"github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
+
 	quotav1 "github.com/openshift/api/quota/v1"
 	route "github.com/openshift/api/route/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 	customdomainv1alpha1 "github.com/openshift/custom-domains-operator/api/v1alpha1"
 	mustgatherv1alpha1 "github.com/openshift/must-gather-operator/api/v1alpha1"
+	operatorhubv1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
@@ -35,6 +37,7 @@ func (h *H) AsUser(username string, groups ...string) *resources.Resources {
 	mustgatherv1alpha1.AddToScheme(client.GetScheme())
 	customdomainv1alpha1.AddToScheme(client.GetScheme())
 	route.AddToScheme(client.GetScheme())
+	operatorhubv1.AddToScheme(client.GetScheme())
 
 	return client
 }

--- a/pkg/e2e/operators/ocmagent/ocmagent.go
+++ b/pkg/e2e/operators/ocmagent/ocmagent.go
@@ -133,11 +133,7 @@ var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.Operators, label.Inform
 		err := client.Delete(ctx, deployment)
 		expect.NoError(err)
 
-		err = wait.For(conditions.New(client).ResourceMatch(
-			deployment, func(object k8s.Object) bool {
-				obj := object.(*appsv1.Deployment)
-				return obj.Status.AvailableReplicas >= 1
-			}))
+		err = wait.For(conditions.New(client).DeploymentConditionMatch(deployment, appsv1.DeploymentAvailable, v1.ConditionTrue))
 		expect.NoError(err)
 	})
 

--- a/pkg/e2e/operators/ocmagent/ocmagent.go
+++ b/pkg/e2e/operators/ocmagent/ocmagent.go
@@ -229,6 +229,7 @@ var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.Operators, label.Inform
 	})
 
 	ginkgo.It("can be upgraded from previous version", label.Upgrade, func(ctx context.Context) {
-		operators.PerformUpgrade(ctx, h, namespace, operatorName, operatorName, operatorRegistry, 5, 30)
+		errorMsg, err := operators.PerformUpgrade(ctx, h, namespace, operatorName, operatorName, operatorRegistry, 5, 30)
+		expect.NoError(err, errorMsg)
 	})
 })

--- a/pkg/e2e/operators/operators.go
+++ b/pkg/e2e/operators/operators.go
@@ -241,7 +241,7 @@ func checkSecrets(h *helper.H, namespace string, secrets []string) {
 	})
 }
 
-func performUpgrade(ctx context.Context, h *helper.H, subNamespace string, subName string, packageName string, regServiceName string,
+func PerformUpgrade(ctx context.Context, h *helper.H, subNamespace string, subName string, packageName string, regServiceName string,
 	installPlanPollCount time.Duration, upgradePollCount time.Duration,
 ) {
 	installPlanPollingDuration := installPlanPollCount * time.Minute
@@ -353,7 +353,7 @@ func checkUpgrade(h *helper.H, subNamespace string, subName string, packageName 
 		upgradePollingDuration := 15 * time.Minute
 
 		util.GinkgoIt("should upgrade from the replaced version", func(ctx context.Context) {
-			performUpgrade(ctx, h, subNamespace, subName, packageName, regServiceName, 5, 15)
+			PerformUpgrade(ctx, h, subNamespace, subName, packageName, regServiceName, 5, 15)
 		}, upgradePollingDuration.Seconds()+installPlanPollingDuration.Seconds()+
 			float64(viper.GetFloat64(config.Tests.PollingTimeout)))
 	})


### PR DESCRIPTION
# Change

This commit modifies the existing ocm agent operator tests to follow the
new consistent set of standards for writing test cases. Changes consist
of the following:

 1. Reformatted the test case names
 2. Uses the kubernetes-sigs/e2e-framework client (kclient) allowing the
    tests to dynamically interact with the objects.
 3. Use the available wait for conditions provided by
    kubernetes-sigs/e2e-framework to verify objects reach desired state.
 4. Fix operator upgrade test to increase upgrade poll count. Seeing
    inconsistent times when performing upgrades. Average time takes
    around 18 minutes.
 5. Removed test case where it was checking for pods in the operators
    namespace (redundant).
 6. Labels working as expected:
    * --label-filter "Operators && Informing" --focus-tests "OCM Agent
      Operator"
    * --label-filter "Operators && Informing && !Upgrade" --focus-tests
      "OCM Agent Operator"

To fix the operator upgrade test, the core functionality performing the
upgrade was moved into a new function `performUpgrade`. Which can be
imported/used across other files. Where test suites can create their own
ginkgo.It statements and apply labels, etc. The original function
`checkUpgrade` is left unaffected and is called by the `performUpgrade`
function.

Included new string to `informing-suite` config to include ocm agent
operator tests. This config will be updated in separate PR to use label
filters.

For [SDCICD-872](https://issues.redhat.com//browse/SDCICD-872)

# Verification

**Before**

```
<testcase name="[Suite: informing] [OSD] OCM Agent Operator Basic Test clusterServiceVersion openshift-ocm-agent-operator/ocm-agent-operator should be present and in succeeded state" classname="OSD e2e suite" status="passed" time="0.112089802">
<testcase name="[Suite: informing] [OSD] OCM Agent Operator Basic Test deployment should exist" classname="OSD e2e suite" status="passed" time="0.010639884">
<testcase name="[Suite: informing] [OSD] OCM Agent Operator Basic Test deployment should have all desired replicas ready" classname="OSD e2e suite" status="passed" time="0.010570013">
<testcase name="[Suite: informing] [OSD] OCM Agent Operator Basic Test clusterRoles should exist" classname="OSD e2e suite" status="passed" time="0.040857103">
<testcase name="[Suite: informing] [OSD] OCM Agent Operator Basic Test clusterRoleBindings should exist" classname="OSD e2e suite" status="passed" time="0.021054343">
<testcase name="[Suite: informing] [OSD] OCM Agent Operator Basic Test deployment should exist" classname="OSD e2e suite" status="passed" time="0.011003013">
<testcase name="[Suite: informing] [OSD] OCM Agent Operator Basic Test deployment should have all desired replicas ready" classname="OSD e2e suite" status="passed" time="0.010367247">
<testcase name="[Suite: informing] [OSD] OCM Agent Operator Basic Test Operator Upgrade should upgrade from the replaced version" classname="OSD e2e suite" status="failed" time="1700.001338583">
<testcase name="[Suite: informing] [OSD] OCM Agent Operator Basic Test pods should have 3 or less restart(s)" classname="OSD e2e suite" status="passed" time="300.025504833">
<testcase name="[Suite: informing] [OSD] OCM Agent Operator Basic Test Reconcile resources ocm-agent deployment should be restored when it gets deleted" classname="OSD e2e suite" status="passed" time="30.011694873">
<testcase name="[Suite: informing] [OSD] OCM Agent Operator Basic Test Reconcile resources ocm-agent-config configmap should be restored when it gets deleted" classname="OSD e2e suite" status="passed" time="30.020568758">
<testcase name="[Suite: informing] [OSD] OCM Agent Operator Basic Test Reconcile resources ocm-agent-token secret should be restored when it gets deleted" classname="OSD e2e suite" status="passed" time="30.018005425">
<testcase name="[Suite: informing] [OSD] OCM Agent Operator Basic Test Reconcile resources ocm-agent-metrics servicemonitor should be restored when it gets deleted" classname="OSD e2e suite" status="passed" time="30.022546947">
<testcase name="[Suite: informing] [OSD] OCM Agent Operator Basic Test Reconcile resources ocm-agent service should be restored when it gets deleted" classname="OSD e2e suite" status="passed" time="30.041312268">
<testcase name="[Suite: informing] [OSD] OCM Agent Operator Basic Test Reconcile resources ocm-agent-allow-only-alertmanager  networkpolicy should restored when it gets deleted" classname="OSD e2e suite" status="passed" time="30.018533269">
```

**After**

```
<testcase name="OCM Agent Operator cluster service version exists" classname="OSD e2e suite" status="passed" time="5.106705678">
<testcase name="OCM Agent Operator deployments exist" classname="OSD e2e suite" status="passed" time="0.056713263">
<testcase name="OCM Agent Operator cluster roles exist" classname="OSD e2e suite" status="passed" time="0.136676734">
<testcase name="OCM Agent Operator cluster role bindings exist" classname="OSD e2e suite" status="passed" time="0.052746637">
<testcase name="OCM Agent Operator can be upgraded from previous version" classname="OSD e2e suite" status="passed" time="1280.945213619">
<testcase name="OCM Agent Operator deployment is restored when removed" classname="OSD e2e suite" status="passed" time="25.063418658">
<testcase name="OCM Agent Operator config map is restored when removed" classname="OSD e2e suite" status="passed" time="5.173847659">
<testcase name="OCM Agent Operator secret is restored when removed" classname="OSD e2e suite" status="passed" time="5.063593169">
<testcase name="OCM Agent Operator service monitor is restored when removed" classname="OSD e2e suite" status="passed" time="5.066386902">
<testcase name="OCM Agent Operator service is restored when removed" classname="OSD e2e suite" status="passed" time="5.073827921">
<testcase name="OCM Agent Operator network policy is restored when removed" classname="OSD e2e suite" status="passed" time="5.060768379">
```

Once running consistently for a week in the [informing job](https://testgrid.k8s.io/redhat-osd#osde2e-main-aws-prod-informing-default), will promote them to e2e suite for the operators label.
