### PR TITLE
HyperShift tests maintenance

### DIFF
--- a/configs/hypershift.yaml
+++ b/configs/hypershift.yaml
@@ -4,5 +4,4 @@ rosa:
   Env: stage
   STS: True
 tests:
-  testsToRun:
-  - '\[Suite\: hypershift\]'
+  ginkgoLabelFilter: HyperShift

--- a/pkg/e2e/openshift/hypershift/verifyInstall.go
+++ b/pkg/e2e/openshift/hypershift/verifyInstall.go
@@ -7,54 +7,47 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/aws"
-	"github.com/openshift/osde2e/pkg/common/cluster"
-	"github.com/openshift/osde2e/pkg/common/config"
-	"github.com/openshift/osde2e/pkg/common/util"
+	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
+
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 )
 
-var hypershiftInstallVerify = "[Suite: hypershift]"
+var (
+	suiteName = "HyperShift"
+	client    *resources.Resources
+)
 
 func init() {
-	alert.RegisterGinkgoAlert(hypershiftInstallVerify, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
+	alert.RegisterGinkgoAlert(suiteName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
 // Checks the installation of the hypershift worker nodes in CCS AWS account
-var _ = ginkgo.Describe(hypershiftInstallVerify, func() {
-	ginkgo.Context("Verify Hypershift worker node in CCS Account", func() {
-		util.GinkgoIt("Worker nodes are available in AWS", func(ctx context.Context) {
-			ginkgo.By("Getting the list of worker nodes from the cluster")
-			workerNodes, err := getWorkerNodesInCluster(ctx)
-			Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error getting worker nodes in cluster: %v", err))
-			Expect(len(*workerNodes)).To(BeNumerically(">", 0), "no worker nodes found in cluster")
+var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.HyperShift, func() {
+	h := helper.New()
+	client = h.AsUser("")
 
-			ginkgo.By("Checking if the worker nodes are present in AWS")
-			err = checkWorkerNodesInAWS(workerNodes)
-			Expect(err).NotTo(HaveOccurred(), "Error checking if worker nodes are present in AWS")
-		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
+	ginkgo.It("worker nodes are available in aws ccs account", func(ctx context.Context) {
+		ginkgo.By("getting the list of worker nodes from the cluster")
+		workerNodes, err := getWorkerNodesInCluster(ctx)
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("error getting worker nodes in cluster: %v", err))
+		Expect(len(*workerNodes)).To(BeNumerically(">", 0), "no worker nodes found in cluster")
+
+		ginkgo.By("checking if the worker nodes are present in aws")
+		err = checkWorkerNodesInAWS(workerNodes)
+		Expect(err).NotTo(HaveOccurred(), "Error checking if worker nodes are present in AWS")
 	})
 })
 
 // checkWorkerNodesInCluster returns a list of nodes in the cluster
 func getWorkerNodesInCluster(ctx context.Context) (*[]string, error) {
-	restConfig, _, err := cluster.ClusterConfig(viper.GetString(config.Cluster.ID))
-	if err != nil {
-		return nil, fmt.Errorf("error getting cluster config: %v", err)
-	}
-
-	// Create a clientset to interact with the cluster
-	clientset, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return nil, fmt.Errorf("error creating clientset: %v", err)
-	}
-
 	// Get the list of nodes in the cluster
-	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	var nodes v1.NodeList
+	err := client.List(ctx, &nodes)
 	if err != nil {
 		return nil, fmt.Errorf("error getting nodes: %v", err)
 	}


### PR DESCRIPTION
# Change

This change covers the following:
 1. Add the HyperShift label to the verifyinstall test suite
 2. Use label filter for selecting HyperShift tests to run over using focus strings
 3. Uses the kubernetes-sigs/e2e-framework client to interface with the cluster. Used to get the list of worker nodes in the cluster.
 4. Reformatted test case name to remove duplicate words

# Verification

**Before**

```
<testcase name="[Suite: hypershift] Verify Hypershift worker node in CCS Account Worker nodes are available in AWS" classname="OSD e2e suite" status="passed" time="0.703881072">
```

**After**

```
<testcase name="HyperShift worker nodes are available in aws ccs account" classname="OSD e2e suite" status="passed" time="0.702320559">
```

For [SDCICD-878](https://issues.redhat.com/browse/SDCICD-878)

