### PR TITLE
Enable route verification tests for hypershift clusters

### DIFF
--- a/pkg/common/helper/impersonate.go
+++ b/pkg/common/helper/impersonate.go
@@ -4,6 +4,7 @@ import (
 	"github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
 	quotav1 "github.com/openshift/api/quota/v1"
+	route "github.com/openshift/api/route/v1"
 	securityv1 "github.com/openshift/api/security/v1"
 	customdomainv1alpha1 "github.com/openshift/custom-domains-operator/api/v1alpha1"
 	mustgatherv1alpha1 "github.com/openshift/must-gather-operator/api/v1alpha1"
@@ -33,6 +34,7 @@ func (h *H) AsUser(username string, groups ...string) *resources.Resources {
 	monitoringv1.AddToScheme(client.GetScheme())
 	mustgatherv1alpha1.AddToScheme(client.GetScheme())
 	customdomainv1alpha1.AddToScheme(client.GetScheme())
+	route.AddToScheme(client.GetScheme())
 
 	return client
 }


### PR DESCRIPTION
# Change

As a customer, they will be accessing the hypershift clusters console in addition to using the client/API. This change enables the tests verifying the console url is available/accessible for hypershift clusters. It does not check for the oauth url as it is not available on hypershift clusters. Users logged into the cluster are still able to access oauth endpoint to generate a token for authentication.

Also includes:
* Moved the code to get the routes into the ginkgo it statements directly (only being used in one location)
* Use the kubernetes-sigs/e2e-framework client
* Handle assertions within test cases to ensure proper offset when errors occur

For [SDCICD-879](https://issues.redhat.com/browse/SDCICD-879)

# Verification

## HyperShift

```
<testcase name="HyperShift worker nodes are available in aws ccs account" classname="OSD e2e suite" status="passed" time="0.590621719">
    <system-err>> Enter [It] worker nodes are available in aws ccs account - /home/rywillia/osd/osde2e/pkg/e2e/openshift/hypershift/verifyInstall.go:34 @ 01/09/23 13:25:56.8 STEP: getting the list of worker nodes from the cluster - /home/rywillia/osd/osde2e/pkg/e2e/openshift/hypershift/verifyInstall.go:35 @ 01/09/23 13:25:56.8 STEP: checking if the worker nodes are present in aws - /home/rywillia/osd/osde2e/pkg/e2e/openshift/hypershift/verifyInstall.go:40 @ 01/09/23 13:25:56.833 < Exit [It] worker nodes are available in aws ccs account - /home/rywillia/osd/osde2e/pkg/e2e/openshift/hypershift/verifyInstall.go:34 @ 01/09/23 13:25:57.391 (591ms) </system-err>
</testcase>
<testcase name="[Suite: e2e] Routes exist for console and is operational" classname="OSD e2e suite" status="passed" time="0.586990713">
    <system-err>> Enter [BeforeAll] [Suite: e2e] Routes - /home/rywillia/osd/osde2e/pkg/e2e/verify/routes.go:40 @ 01/09/23 13:25:56.207 < Exit [BeforeAll] [Suite: e2e] Routes - /home/rywillia/osd/osde2e/pkg/e2e/verify/routes.go:40 @ 01/09/23 13:25:56.369 (162ms) > Enter [It] exist for console and is operational - /home/rywillia/osd/osde2e/pkg/e2e/verify/routes.go:45 @ 01/09/23 13:25:56.369 < Exit [It] exist for console and is operational - /home/rywillia/osd/osde2e/pkg/e2e/verify/routes.go:45 @ 01/09/23 13:25:56.794 (425ms) </system-err>
</testcase>
<testcase name="[Suite: e2e] Routes exist for oauth and is operational" classname="OSD e2e suite" status="skipped" time="0">
    <skipped message="skipped"/>
</testcase>
```

## OSD

```
<testcase name="[Suite: e2e] Routes exist for console and is operational" classname="OSD e2e suite" status="passed" time="0.700443182">
    <system-err>> Enter [BeforeAll] [Suite: e2e] Routes - /home/rywillia/osd/osde2e/pkg/e2e/verify/routes.go:40 @ 01/09/23 13:29:23.976 < Exit [BeforeAll] [Suite: e2e] Routes - /home/rywillia/osd/osde2e/pkg/e2e/verify/routes.go:40 @ 01/09/23 13:29:24.12 (144ms) > Enter [It] exist for console and is operational - /home/rywillia/osd/osde2e/pkg/e2e/verify/routes.go:45 @ 01/09/23 13:29:24.12 < Exit [It] exist for console and is operational - /home/rywillia/osd/osde2e/pkg/e2e/verify/routes.go:45 @ 01/09/23 13:29:24.676 (557ms) </system-err>
</testcase>
<testcase name="[Suite: e2e] Routes exist for oauth and is operational" classname="OSD e2e suite" status="passed" time="0.561174114">
    <system-err>> Enter [It] exist for oauth and is operational - /home/rywillia/osd/osde2e/pkg/e2e/verify/routes.go:57 @ 01/09/23 13:29:24.677 < Exit [It] exist for oauth and is operational - /home/rywillia/osd/osde2e/pkg/e2e/verify/routes.go:57 @ 01/09/23 13:29:25.238 (561ms) </system-err>
</testcase>
```