### PR TITLE
Initialize variables using beforeall for hypershift install tests

### DIFF
--- a/pkg/e2e/openshift/hypershift/verifyInstall.go
+++ b/pkg/e2e/openshift/hypershift/verifyInstall.go
@@ -28,8 +28,12 @@ func init() {
 
 // Checks the installation of the hypershift worker nodes in CCS AWS account
 var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.HyperShift, func() {
-	h := helper.New()
-	client = h.AsUser("")
+	var h *helper.H
+
+	ginkgo.BeforeAll(func() {
+		h = helper.New()
+		client = h.AsUser("")
+	})
 
 	ginkgo.It("worker nodes are available in aws ccs account", func(ctx context.Context) {
 		ginkgo.By("getting the list of worker nodes from the cluster")


### PR DESCRIPTION
Since the test suite is ordered, we can use beforeall to initialize the helper/client once before running any of the test cases. Changed requested for commit https://github.com/openshift/osde2e/commit/e281f614b76eb55040ad051fc1ac22e664d26a74#r95514958