### PR TITLE
Enable node labels tests as part of hypershift suite

### DIFF
--- a/pkg/e2e/osd/nodelabels.go
+++ b/pkg/e2e/osd/nodelabels.go
@@ -2,42 +2,43 @@ package osd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
-	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/expect"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
-	"github.com/openshift/osde2e/pkg/common/util"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "k8s.io/api/core/v1"
 )
 
-var nodeLabelsTestName string = "[Suite: service-definition] [OSD] NodeLabels"
+var nodeLabelsTestName string = "[Suite: service-definition] [OSD] Node labels"
 
 func init() {
 	alert.RegisterGinkgoAlert(nodeLabelsTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(nodeLabelsTestName, label.ServiceDefinition, func() {
-	ginkgo.Context("Modifying nodeLabels is not allowed", func() {
-		// setup helper
-		h := helper.New()
-		util.GinkgoIt("node-label cannot be added", func(ctx context.Context) {
-			// Set it to a wildcard dedicated-admin
-			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-cluster")
+var _ = ginkgo.Describe(nodeLabelsTestName, ginkgo.Ordered, label.ServiceDefinition, label.HyperShift, func() {
+	var h *helper.H
 
-			nodes, err := h.Kube().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(len(nodes.Items)).Should(BeNumerically(">", 0))
+	ginkgo.BeforeAll(func() {
+		h = helper.New()
+	})
 
-			node := nodes.Items[0]
+	ginkgo.It("cannot be modified after node creation", func(ctx context.Context) {
+		client := h.AsServiceAccount(fmt.Sprintf("system:serviceaccount:%s:dedicated-admin-cluster", h.CurrentProject()))
 
-			node.Labels["osde2e"] = "touched by osde2e"
+		var nodes v1.NodeList
+		err := client.List(ctx, &nodes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(nodes.Items)).To(BeNumerically(">", 0), "no nodes found in cluster")
 
-			_, err = h.Kube().CoreV1().Nodes().Update(ctx, &node, metav1.UpdateOptions{})
-			Expect(err).To(HaveOccurred())
-		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
+		for _, node := range nodes.Items {
+			node.Labels["osde2e"] = "modified by osde2e"
+			err = client.Update(ctx, &node)
+			expect.Forbidden(err)
+		}
 	})
 })

--- a/pkg/e2e/osd/nodelabels.go
+++ b/pkg/e2e/osd/nodelabels.go
@@ -32,7 +32,7 @@ var _ = ginkgo.Describe(nodeLabelsTestName, ginkgo.Ordered, label.ServiceDefinit
 
 		var nodes v1.NodeList
 		err := client.List(ctx, &nodes)
-		Expect(err).NotTo(HaveOccurred())
+		expect.NoError(err)
 		Expect(len(nodes.Items)).To(BeNumerically(">", 0), "no nodes found in cluster")
 
 		for _, node := range nodes.Items {


### PR DESCRIPTION
# Change

As part of the [openshift dedicated service definition](https://docs.openshift.com/dedicated/osd_architecture/osd_policy/osd-service-definition.html#node-labels_osd-service-definition), users are unable to add custom node labels after the nodes are created. This same service definition applies to hypershift clusters.

Uses the kubernetes-sigs/e2e-framework client to interface with OpenShift objects and cleans up the test case name.

For [SDCICD-884](https://issues.redhat.com/browse/SDCICD-884)

# Verification

```
<testcase name="[Suite: service-definition] [OSD] Node labels cannot be modified after node creation" classname="OSD e2e suite" status="passed" time="0.281066853">
<system-err>> Enter [BeforeAll] [Suite: service-definition] [OSD] Node labels - /home/rywillia/osd/osde2e/pkg/e2e/osd/nodelabels.go:26 @ 01/10/23 14:45:02.095 < Exit [BeforeAll] [Suite: service-definition] [OSD] Node labels - /home/rywillia/osd/osde2e/pkg/e2e/osd/nodelabels.go:26 @ 01/10/23 14:45:02.129 (34ms) > Enter [It] cannot be modified after node creation - /home/rywillia/osd/osde2e/pkg/e2e/osd/nodelabels.go:30 @ 01/10/23 14:45:02.129 < Exit [It] cannot be modified after node creation - /home/rywillia/osd/osde2e/pkg/e2e/osd/nodelabels.go:30 @ 01/10/23 14:45:02.376 (247ms) </system-err>
</testcase>
```