### PR TITLE
Enable privileged containers tests as part of hypershift suite

### DIFF
--- a/pkg/e2e/osd/privileged.go
+++ b/pkg/e2e/osd/privileged.go
@@ -5,36 +5,16 @@ import (
 	"fmt"
 
 	"github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
-	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/config"
+
+	"github.com/openshift/osde2e/pkg/common/expect"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
-	"github.com/openshift/osde2e/pkg/common/util"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 )
-
-func makePod(name, sa string, privileged bool) v1.Pod {
-	return v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s-%s", name, util.RandomStr(5)),
-		},
-		Spec: v1.PodSpec{
-			ServiceAccountName: sa,
-			Containers: []v1.Container{
-				{
-					Name:  "test",
-					Image: "registry.access.redhat.com/ubi8/ubi-minimal",
-					SecurityContext: &v1.SecurityContext{
-						Privileged: &privileged,
-					},
-				},
-			},
-		},
-	}
-}
 
 var privilegedTestname string = "[Suite: service-definition] [OSD] Privileged Containers"
 
@@ -42,25 +22,53 @@ func init() {
 	alert.RegisterGinkgoAlert(privilegedTestname, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(privilegedTestname, label.ServiceDefinition, func() {
-	ginkgo.Context("Privileged containers are not allowed", func() {
-		// setup helper
-		h := helper.New()
+var _ = ginkgo.Describe(privilegedTestname, ginkgo.Ordered, label.ServiceDefinition, label.HyperShift, func() {
+	var h *helper.H
 
-		util.GinkgoIt("privileged container should not get created", func(ctx context.Context) {
-			// Set it to a wildcard dedicated-admin
-			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
+	ginkgo.BeforeAll(func() {
+		h = helper.New()
+	})
 
-			// Test creating a privileged pod and expect a failure
-			pod := makePod("privileged-pod", h.GetNamespacedServiceAccount(), true)
+	makePod := func() v1.Pod {
+		privileged := true
 
-			_, err := h.Kube().CoreV1().Pods(h.CurrentProject()).Create(ctx, &pod, metav1.CreateOptions{})
-			Expect(err).To(HaveOccurred())
+		return v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "osde2e-",
+				Namespace:    h.CurrentProject(),
+			},
+			Spec: v1.PodSpec{
+				ServiceAccountName: h.GetNamespacedServiceAccount(),
+				Containers: []v1.Container{
+					{
+						Name:  "test",
+						Image: "registry.access.redhat.com/ubi8/ubi-minimal",
+						SecurityContext: &v1.SecurityContext{
+							Privileged: &privileged,
+						},
+						Command: []string{"/bin/true"},
+					},
+				},
+				RestartPolicy: v1.RestartPolicyNever,
+			},
+		}
+	}
 
-			// Test creating an unprivileged pod and expect success
-			pod = makePod("unprivileged-pod", h.GetNamespacedServiceAccount(), false)
-			_, err = h.Kube().CoreV1().Pods(h.CurrentProject()).Create(ctx, &pod, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-		}, float64(viper.GetFloat64(config.Tests.PollingTimeout)))
+	ginkgo.It("are not available by default", func(ctx context.Context) {
+		client := h.AsServiceAccount(fmt.Sprintf("system:serviceaccount:%s:dedicated-admin-project", h.CurrentProject()))
+		pod := makePod()
+		err := client.Create(ctx, &pod)
+		expect.Forbidden(err)
+	})
+
+	ginkgo.It("are only available for cluster-admin users", func(ctx context.Context) {
+		client := h.AsServiceAccount(fmt.Sprintf("system:serviceaccount:%s:cluster-admin", h.CurrentProject()))
+		pod := makePod()
+		err := client.Create(ctx, &pod)
+		expect.NoError(err)
+		err = wait.For(conditions.New(client).PodPhaseMatch(&pod, v1.PodSucceeded))
+		expect.NoError(err)
+		err = client.Delete(ctx, &pod)
+		expect.NoError(err)
 	})
 })


### PR DESCRIPTION
# Change

This commit adds the privileged containers tests to be included as part of the hypershift suite. These tests validate the service definition for privileged containers for osd.

Includes:
 * Remove unneeded test verifying unprivileged container
 * Use kubernetes-sigs/e2e-framework client
 * Restrict pod to ignore container restarts
 * Add new test to verify cluster-admin users can created privileged containers

For [SDCICD-891](https://issues.redhat.com/browse/SDCICD-891)

# Verification

JUnit results

```xml
<testcase name="[Suite: service-definition] [OSD] Privileged Containers are not available by default" classname="OSD e2e suite" status="passed" time="0.215065118">
  <system-err>> Enter [BeforeAll] [Suite: service-definition] [OSD] Privileged Containers - /home/rywillia/osd/osde2e/pkg/e2e/osd/privileged.go:28 @ 01/11/23 13:53:31.285 < Exit [BeforeAll] [Suite: service-definition] [OSD] Privileged Containers - /home/rywillia/osd/osde2e/pkg/e2e/osd/privileged.go:28 @ 01/11/23 13:53:31.323 (37ms) > Enter [It] are not available by default - /home/rywillia/osd/osde2e/pkg/e2e/osd/privileged.go:57 @ 01/11/23 13:53:31.323 < Exit [It] are not available by default - /home/rywillia/osd/osde2e/pkg/e2e/osd/privileged.go:57 @ 01/11/23 13:53:31.5 (178ms) </system-err>
</testcase>
<testcase name="[Suite: service-definition] [OSD] Privileged Containers are only available for cluster-admin users" classname="OSD e2e suite" status="passed" time="5.2607471199999996">
  <system-err>> Enter [It] are only available for cluster-admin users - /home/rywillia/osd/osde2e/pkg/e2e/osd/privileged.go:64 @ 01/11/23 13:53:31.501 < Exit [It] are only available for cluster-admin users - /home/rywillia/osd/osde2e/pkg/e2e/osd/privileged.go:64 @ 01/11/23 13:53:36.761 (5.261s) </system-err>
</testcase>
```