### PR TITLE
common/expect: fix NoError description

### DIFF
--- a/pkg/common/expect/expect.go
+++ b/pkg/common/expect/expect.go
@@ -12,7 +12,7 @@ func Error(err error, explain ...any) {
 
 // NoError checks if "err" is set and raises an exception if so
 func NoError(err error, explain ...any) {
-	gomega.ExpectWithOffset(1, err, explain...).ShouldNot(gomega.HaveOccurred())
+	gomega.ExpectWithOffset(1, err).ShouldNot(gomega.HaveOccurred(), explain...)
 }
 
 // Forbidden checks if "err" is set a `metav1.StatusReasonForbidden` or `404`


### PR DESCRIPTION
this was misplaced causing an error instead of decorating the expect

Signed-off-by: Brady Pratt <bpratt@redhat.com>