### PR TITLE
Remove openshift-v prefix from version option for rosa create cluster

### DIFF
--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -76,6 +76,7 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 	var awsCreator *aws.Creator
 
 	rosaClusterVersion := viper.GetString(config.Cluster.Version)
+	rosaClusterVersion = strings.ReplaceAll(rosaClusterVersion, "openshift-v", "")
 
 	log.Printf("ROSA cluster version: %s", rosaClusterVersion)
 


### PR DESCRIPTION
# Fix

A recent commit has started to append openshift-v prefix to the version string passed to rosa create cluster. This results in rosa create cluster to fail as it is looking for a string with the format of <major.minor.patch>. Prefix openshift-v is acceptable for standard osd clusters provisioned by ocm.

**Failure example**

https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-rosa-stage-e2e-default

```
2023/01/16 18:01:11 cluster.go:213: [--cluster-name osde2e-492j4 --region XXXXXXXXX --channel-group stable --version openshift-v4.11.21 --expiration-time 2023-01-17T00:01:11Z  --replicas 2    --host-prefix 0 --mode auto --yes --properties JobID:-1 --properties OwnedBy:1006210000 --properties InstalledVersion:openshift-v4.11.21 --properties install_config:
imageContentSources:
- mirrors:
  - quay.io/openshift-release-dev/ocp-release
  - pull.q1w2.quay.rhcloud.com/openshift-release-dev/ocp-release
  source: quay.io/openshift-release-dev/ocp-release
- mirrors:
  - quay.io/openshift-release-dev/ocp-v4.0-art-dev
  - pull.q1w2.quay.rhcloud.com/openshift-release-dev/ocp-art-dev
  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
- mirrors:
  - quay.io/app-sre/managed-upgrade-operator
  - pull.q1w2.quay.rhcloud.com/app-sre/managed-upgrade-operator
  source: quay.io/app-sre/managed-upgrade-operator
- mirrors:
  - quay.io/app-sre/managed-upgrade-operator-registry
  - pull.q1w2.quay.rhcloud.com/app-sre/managed-upgrade-operator-registry
  source: quay.io/app-sre/managed-upgrade-operator-registry --properties MadeByOSDe2e:true --properties UpgradeVersion:-- --properties Status:provisioning --properties JobName:periodic-ci-openshift-osde2e-main-rosa-stage-e2e-default]
ERR: Expected a valid OpenShift version: A valid version number must be specified
Valid versions: 4.11.21 4.11.20 4.11.18 4.11.17 4.11.16 4.11.13 4.11.12 4.11.9 4.11.8 4.11.7 4.11.6 4.11.5 4.11.4 4.11.3 4.11.2 4.11.1 4.11.0 4.10.46 4.10.45 4.10.43 4.10.42 4.10.41 4.10.40 4.10.39 4.10.38 4.10.37 4.10.36 4.10.35 4.10.34 4.10.33 4.10.32 4.10.31 4.10.30 4.10.28 4.10.26 4.10.25 4.10.24 4.10.23 4.10.22 4.10.21 4.10.20 4.10.18 4.10.17 4.10.16 4.10.15 4.10.14 4.10.13 4.10.12 4.10.11 4.10.10 4.10.9 4.10.8 4.10.6 4.10.5 4.10.4 4.10.3 4.9.54 4.9.53 4.9.52 4.9.51 4.9.50 4.9.49 4.9.48 4.9.47 4.9.46 4.9.45 4.9.43 4.9.42 4.9.41 4.9.40 4.9.38 4.9.37 4.9.36 4.9.35 4.9.33 4.9.32 4.9.31 4.9.29 4.9.28 4.9.27 4.9.26 4.9.25 4.9.24 4.9.23 4.9.22 4.9.21 4.9.19 4.9.18 4.9.17 4.9.15 4.9.13 4.9.12 4.9.11 4.9.10 4.9.9 4.9.8 4.9.7 4.9.6 4.9.5 4.9.4 4.9.0 4.8.55 4.8.54 4.8.53 4.8.52 4.8.51 4.8.50 4.8.49 4.8.48 4.8.47 4.8.46 4.8.45 4.8.44 4.8.43 4.8.42 4.8.41 4.8.39 4.8.37 4.8.36 4.8.35 4.8.34 4.8.33 4.8.32 4.8.31 4.8.29 4.8.28 4.8.27 4.8.26 4.8.25 4.8.24 4.8.23 4.8.22 4.8.21 4.8.20 4.8.19 4.8.18 4.8.17 4.8.15 4.8.14 4.8.13 4.8.12 4.8.11 4.8.10 4.8.9 4.8.5 4.8.4 4.8.3 4.8.2 4.7.60 4.7.59 4.7.56 4.7.55 4.7.54 4.7.53 4.7.52 4.7.51 4.7.50 4.7.49 4.7.48 4.7.47 4.7.46 4.7.45 4.7.44 4.7.43 4.7.42 4.7.41 4.7.40 4.7.39 4.7.38 4.7.37 4.7.36 4.7.34 4.7.33 4.7.32 4.7.31 4.7.30 4.7.29 4.7.28 4.7.24 4.7.23 4.7.22 4.7.21 4.7.20 4.7.19 4.7.18 4.7.17 4.7.16 4.7.15 4.7.14 4.7.13 4.7.12 4.7.11 4.7.10 4.7.9 4.7.8 4.7.7 4.7.6 4.7.5 4.7.4 4.7.3 4.7.2 4.7.1 4.7.0
{"component":"entrypoint","error":"wrapped process failed: exit status 1","file":"k8s.io/test-infra/prow/entrypoint/run.go:79","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","severity":"error","time":"2023-01-16T18:01:11Z"} 
[36mINFO[0m[2023-01-16T18:01:19Z] Ran for 32s                                  
[31mERRO[0m[2023-01-16T18:01:19Z] Some steps failed:     
```

For [SDCICD-898](https://issues.redhat.com/browse/SDCICD-898)

# Verification

Local run:

```
INFO: Logged in as 'interop-qe-ms' on 'https://api.stage.openshift.com'
2023/01/16 13:24:39 cluster.go:400: created OCM client
2023/01/16 13:24:40 version.go:103: Using the current default '4.11.21'
2023/01/16 13:24:40 version.go:130: No upgrade selector found. Not selecting an upgrade version.
2023/01/16 13:24:40 e2e.go:386: Running e2e tests...
2023/01/16 13:24:40 cluster.go:81: ROSA cluster version: 4.11.21
2023/01/16 13:24:40 cluster.go:208: Pruning `--compute-machine-type` and ``
2023/01/16 13:24:40 cluster.go:208: Pruning `--machine-cidr` and ``
2023/01/16 13:24:40 cluster.go:208: Pruning `--service-cidr` and ``
2023/01/16 13:24:40 cluster.go:208: Pruning `--pod-cidr` and ``
2023/01/16 13:24:40 cluster.go:214: [--cluster-name rw-rosa --region us-east-1 --channel-group stable --version 4.11.21 --expiration-time 2023-01-17T00:24:40Z  --replicas 2    --host-prefix 0 --mode auto --yes --sts --properties Status:provisioning --properties JobName: --properties JobID:-1 --properties OwnedBy:rywillia --properties InstalledVersion:openshift-v4.11.21 --properties MadeByOSDe2e:true --properties UpgradeVersion:--]
```