### PR TITLE
e2e/operators: skip on hypershift

### DIFF
--- a/pkg/e2e/operators/certman.go
+++ b/pkg/e2e/operators/certman.go
@@ -8,6 +8,8 @@ import (
 	. "github.com/onsi/gomega"
 	osv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/osde2e/pkg/common/alert"
+	"github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -23,6 +25,12 @@ func init() {
 }
 
 var _ = ginkgo.Describe(certmanOperatorTestName, label.Operators, func() {
+	ginkgo.BeforeEach(func() {
+		if concurrentviper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Certman Operator is not supported on HyperShift")
+		}
+	})
+
 	h := helper.New()
 
 	ginkgo.Context("certificate secret should be applied when cluster installed", func() {

--- a/pkg/e2e/operators/cloudingress/apischeme_cr.go
+++ b/pkg/e2e/operators/cloudingress/apischeme_cr.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	cloudingress "github.com/openshift/cloud-ingress-operator/api/v1alpha1"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
@@ -25,6 +26,9 @@ var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, label.Operators, func(
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")
+		}
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Cloud Ingress Operator is not supported on HyperShift")
 		}
 	})
 	h := helper.New()

--- a/pkg/e2e/operators/cloudingress/certificate.go
+++ b/pkg/e2e/operators/cloudingress/certificate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
@@ -20,6 +21,9 @@ var _ = ginkgo.Describe("[Suite: informing] "+TestPrefix, label.Informing, func(
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")
+		}
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Cloud Ingress Operator is not supported on HyperShift")
 		}
 	})
 

--- a/pkg/e2e/operators/cloudingress/deletetapps2.go
+++ b/pkg/e2e/operators/cloudingress/deletetapps2.go
@@ -12,6 +12,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/api/v1alpha1"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
@@ -28,6 +29,9 @@ var _ = ginkgo.Describe("[Suite: informing] "+TestPrefix, label.Informing, func(
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")
+		}
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Cloud Ingress Operator is not supported on HyperShift")
 		}
 	})
 

--- a/pkg/e2e/operators/cloudingress/dnsname.go
+++ b/pkg/e2e/operators/cloudingress/dnsname.go
@@ -8,6 +8,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
@@ -21,6 +22,9 @@ var _ = ginkgo.Describe("[Suite: informing] "+TestPrefix, label.Informing, func(
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")
+		}
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Cloud Ingress Operator is not supported on HyperShift")
 		}
 	})
 

--- a/pkg/e2e/operators/cloudingress/installed.go
+++ b/pkg/e2e/operators/cloudingress/installed.go
@@ -26,6 +26,9 @@ var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, label.Operators, func(
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")
 		}
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Cloud Ingress Operator is not supported on HyperShift")
+		}
 	})
 
 	var defaultDesiredReplicas int32 = 1

--- a/pkg/e2e/operators/cloudingress/public_private.go
+++ b/pkg/e2e/operators/cloudingress/public_private.go
@@ -10,6 +10,7 @@ import (
 	cloudingressv1alpha1 "github.com/openshift/cloud-ingress-operator/api/v1alpha1"
 
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
@@ -27,6 +28,9 @@ var _ = ginkgo.Describe("[Suite: informing] "+TestPrefix, label.Informing, func(
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")
+		}
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Cloud Ingress Operator is not supported on HyperShift")
 		}
 	})
 

--- a/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
+++ b/pkg/e2e/operators/cloudingress/publishingstrategies_cr.go
@@ -8,6 +8,7 @@ import (
 	cloudingress "github.com/openshift/cloud-ingress-operator/api/v1alpha1"
 	"github.com/openshift/cloud-ingress-operator/pkg/ingresscontroller"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
@@ -24,6 +25,9 @@ var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, label.Operators, func(
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")
+		}
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Cloud Ingress Operator is not supported on HyperShift")
 		}
 	})
 	h := helper.New()

--- a/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_endpoint.go
@@ -32,6 +32,9 @@ var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, label.Operators, func(
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")
 		}
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Cloud Ingress Operator is not supported on HyperShift")
+		}
 	})
 
 	h := helper.New()

--- a/pkg/e2e/operators/cloudingress/rhapi_lb.go
+++ b/pkg/e2e/operators/cloudingress/rhapi_lb.go
@@ -37,6 +37,9 @@ var _ = ginkgo.Describe("[Suite: operators] "+TestPrefix, label.Operators, func(
 		if viper.GetBool("ocm.ccs") != true {
 			ginkgo.Skip("Cluster is non-CCS. For now we skip rh-api LB reconcile test for non-CCS.")
 		}
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Cloud Ingress Operator is not supported on HyperShift")
+		}
 	})
 
 	h := helper.New()

--- a/pkg/e2e/operators/cloudingress/routeSelector.go
+++ b/pkg/e2e/operators/cloudingress/routeSelector.go
@@ -8,6 +8,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
@@ -21,6 +22,9 @@ var _ = ginkgo.Describe("[Suite: informing] "+TestPrefix, label.Informing, func(
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")
+		}
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Cloud Ingress Operator is not supported on HyperShift")
 		}
 	})
 

--- a/pkg/e2e/operators/cloudingress/secondary_router.go
+++ b/pkg/e2e/operators/cloudingress/secondary_router.go
@@ -27,6 +27,9 @@ var _ = ginkgo.Describe("[Suite: informing] "+TestPrefix, label.Informing, func(
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")
 		}
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Cloud Ingress Operator is not supported on HyperShift")
+		}
 	})
 
 	h := helper.New()

--- a/pkg/e2e/operators/cloudingress/upgrade.go
+++ b/pkg/e2e/operators/cloudingress/upgrade.go
@@ -3,6 +3,7 @@ package cloudingress
 import (
 	"github.com/onsi/ginkgo/v2"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
@@ -13,6 +14,9 @@ var _ = ginkgo.Describe("[Suite: informing] "+TestPrefix, label.Informing, func(
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(rosaprovider.STS) {
 			ginkgo.Skip("STS does not support CIO")
+		}
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Cloud Ingress Operator is not supported on HyperShift")
 		}
 	})
 

--- a/pkg/e2e/operators/configurealertmanager.go
+++ b/pkg/e2e/operators/configurealertmanager.go
@@ -3,6 +3,8 @@ package operators
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/openshift/osde2e/pkg/common/alert"
+	"github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 )
@@ -14,6 +16,12 @@ func init() {
 }
 
 var _ = ginkgo.Describe(configureAlertManagerOperators, label.Operators, func() {
+	ginkgo.BeforeEach(func() {
+		if concurrentviper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Configure AlertManager Operator is not supported on HyperShift")
+		}
+	})
+
 	operatorName := "configure-alertmanager-operator"
 	var operatorNamespace string = "openshift-monitoring"
 	var operatorLockFile string = "configure-alertmanager-operator-lock"

--- a/pkg/e2e/operators/customdomains.go
+++ b/pkg/e2e/operators/customdomains.go
@@ -21,6 +21,8 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/util"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -67,6 +69,12 @@ var _ = ginkgo.Describe(customDomainsOperatorTestName, label.Operators, func() {
 			},
 		},
 	}
+
+	ginkgo.BeforeEach(func() {
+		if concurrentviper.GetBool(config.Hypershift) {
+			ginkgo.Skip("CustomDomains Operator is not supported on HyperShift")
+		}
+	})
 
 	ginkgo.Context("Should allow dedicated-admins to", func() {
 		var (

--- a/pkg/e2e/operators/dvo.go
+++ b/pkg/e2e/operators/dvo.go
@@ -3,13 +3,13 @@ package operators
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
+	"github.com/openshift/osde2e/pkg/common/concurrentviper"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
@@ -28,6 +28,12 @@ func init() {
 }
 
 var _ = ginkgo.Describe(deploymentValidationOperatorTestName, label.Informing, ginkgo.Ordered, func() {
+	ginkgo.BeforeEach(func() {
+		if concurrentviper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Deployment Validation Operator is not supported on HyperShift")
+		}
+	})
+
 	const (
 		operatorNamespace      = "openshift-deployment-validation-operator"
 		operatorName           = "deployment-validation-operator"
@@ -155,7 +161,6 @@ func checkPodLogs(h *helper.H, namespace string, testNamespace string, name stri
 
 // Delete Namespace
 func deleteNamespace(ctx context.Context, namespace string, waitForDelete bool, h *helper.H) error {
-	log.Printf("Deleting namespace for namespace validation webhook (%s)", namespace)
 	err := h.Kube().CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to delete namespace '%s': %v", namespace, err)

--- a/pkg/e2e/operators/managedupgrade.go
+++ b/pkg/e2e/operators/managedupgrade.go
@@ -10,6 +10,8 @@ import (
 	v1 "github.com/openshift/api/config/v1"
 	upgradev1alpha1 "github.com/openshift/managed-upgrade-operator/api/v1alpha1"
 	"github.com/openshift/osde2e/pkg/common/alert"
+	"github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/prometheus"
@@ -32,6 +34,12 @@ func init() {
 }
 
 var _ = ginkgo.Describe(managedUpgradeOperatorTestName, label.Informing, func() {
+	ginkgo.BeforeEach(func() {
+		if concurrentviper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Managed Upgrade Operator is not supported on HyperShift")
+		}
+	})
+
 	operatorName := "managed-upgrade-operator"
 	var operatorNamespace string = "openshift-managed-upgrade-operator"
 	var operatorLockFile string = "managed-upgrade-operator-lock"

--- a/pkg/e2e/operators/managedvelero.go
+++ b/pkg/e2e/operators/managedvelero.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -31,6 +32,9 @@ var _ = ginkgo.Describe(veleroOperatorTestName, label.Operators, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool("rosa.STS") {
 			ginkgo.Skip("STS does not support MVO")
+		}
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Managed Velero Operator is not supported on HyperShift")
 		}
 	})
 	operatorName := "managed-velero-operator"

--- a/pkg/e2e/operators/mustgather.go
+++ b/pkg/e2e/operators/mustgather.go
@@ -7,6 +7,8 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
+	"github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -27,6 +29,12 @@ func init() {
 }
 
 var _ = ginkgo.Describe(mustGatherOperatorTest, label.Operators, func() {
+	ginkgo.BeforeEach(func() {
+		if concurrentviper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Must Gather Operator is not supported on HyperShift")
+		}
+	})
+
 	operatorName := "must-gather-operator"
 	operatorNamespace := "openshift-must-gather-operator"
 	operatorLockFile := "must-gather-operator-lock"

--- a/pkg/e2e/operators/ocmagent/ocmagent.go
+++ b/pkg/e2e/operators/ocmagent/ocmagent.go
@@ -7,6 +7,8 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
+	"github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/expect"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
@@ -35,6 +37,12 @@ func init() {
 
 // TODO: Separate PR to remove 'Informing' label from test suite
 var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.Operators, label.Informing, func() {
+	ginkgo.BeforeEach(func() {
+		if concurrentviper.GetBool(config.Hypershift) {
+			ginkgo.Skip("OCM Agent Operator is not supported on HyperShift")
+		}
+	})
+
 	var h *helper.H
 	var client *resources.Resources
 

--- a/pkg/e2e/operators/osdmetricsexporter.go
+++ b/pkg/e2e/operators/osdmetricsexporter.go
@@ -3,6 +3,8 @@ package operators
 import (
 	"github.com/onsi/ginkgo/v2"
 	"github.com/openshift/osde2e/pkg/common/alert"
+	"github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 )
@@ -17,6 +19,12 @@ func init() {
 }
 
 var _ = ginkgo.Describe(osdMetricsExporterBasicTest, label.Operators, func() {
+	ginkgo.BeforeEach(func() {
+		if concurrentviper.GetBool(config.Hypershift) {
+			ginkgo.Skip("OSD Metrics Exporter is not supported on HyperShift")
+		}
+	})
+
 	var (
 		operatorNamespace = "openshift-osd-metrics"
 		operatorName      = "osd-metrics-exporter"

--- a/pkg/e2e/operators/prunejob.go
+++ b/pkg/e2e/operators/prunejob.go
@@ -9,6 +9,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
+	"github.com/openshift/osde2e/pkg/common/concurrentviper"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
@@ -28,6 +29,12 @@ func init() {
 }
 
 var _ = ginkgo.Describe(pruneJobsTestName, label.Operators, func() {
+	ginkgo.BeforeEach(func() {
+		if concurrentviper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Jobs pruner is not deployed on HyperShift")
+		}
+	})
+
 	h := helper.New()
 	ginkgo.Context("pruner jobs should works", func() {
 		namespace := "openshift-sre-pruning"

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -7,6 +7,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
+	"github.com/openshift/osde2e/pkg/common/concurrentviper"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
@@ -30,6 +31,12 @@ func init() {
 }
 
 var _ = ginkgo.Describe(rbacOperatorBlocking, label.Operators, func() {
+	ginkgo.BeforeEach(func() {
+		if concurrentviper.GetBool(config.Hypershift) {
+			ginkgo.Skip("RBAC Permissions Operator is not supported on HyperShift")
+		}
+	})
+
 	operatorLockFile := "rbac-permissions-operator-lock"
 	var defaultDesiredReplicas int32 = 1
 
@@ -50,6 +57,11 @@ var _ = ginkgo.Describe(rbacOperatorBlocking, label.Operators, func() {
 })
 
 var _ = ginkgo.Describe(subjectPermissionsTestName, label.Operators, func() {
+	ginkgo.BeforeEach(func() {
+		if concurrentviper.GetBool(config.Hypershift) {
+			ginkgo.Skip("RBAC Permissions Operator is not supported on HyperShift")
+		}
+	})
 	h := helper.New()
 	checkSubjectPermissions(h, "dedicated-admins")
 })

--- a/pkg/e2e/operators/routemonitor.go
+++ b/pkg/e2e/operators/routemonitor.go
@@ -11,6 +11,8 @@ import (
 	. "github.com/onsi/gomega" // go-staticcheck ST1001  should not use dot imports
 
 	"github.com/openshift/osde2e/pkg/common/alert"
+	"github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -30,6 +32,12 @@ func init() {
 }
 
 var _ = ginkgo.Describe(routeMonitorOperatorTestName, label.Informing, func() {
+	ginkgo.BeforeEach(func() {
+		if concurrentviper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Route Monitor Operator is not supported on HyperShift")
+		}
+	})
+
 	const (
 		operatorNamespace      = "openshift-route-monitor-operator"
 		operatorName           = "route-monitor-operator"

--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -90,6 +90,12 @@ var _ = ginkgo.Describe(splunkForwarderBlocking, label.Operators, func() {
 
 // Informing SplunkForwarder Signal
 var _ = ginkgo.Describe(splunkForwarderInforming, label.Operators, label.Informing, func() {
+	ginkgo.BeforeEach(func() {
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Splunk Forwarder Operator is not deployed to a ROSA hosted-cp cluster (OSD-11605)")
+		}
+	})
+
 	operatorName := "splunk-forwarder-operator"
 	var operatorNamespace string = "openshift-splunk-forwarder-operator"
 	var operatorLockFile string = "splunk-forwarder-operator-lock"
@@ -198,7 +204,6 @@ func deleteSplunkforwarder(ctx context.Context, name string, namespace string, h
 	_, err := h.Dynamic().Resource(schema.GroupVersionResource{
 		Group: "splunkforwarder.managed.openshift.io", Version: "v1alpha1", Resource: "splunkforwarders",
 	}).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
-	log.Printf("Get splunkforwarder %s in namespace %s; Error:(%v)", name, operatorNamespace, err)
 	if err == nil {
 		e := h.Dynamic().Resource(schema.GroupVersionResource{
 			Group: "splunkforwarder.managed.openshift.io", Version: "v1alpha1", Resource: "splunkforwarders",


### PR DESCRIPTION
skip operator tests on hypershift since these are not deployed to the hosted cluster

- certman
- customdomains
- managedupgrade
- cloudingress
- configurealertmanager
- ocmagent
- prunejobs
- rbac
- managedvelero

[SDCICD-897](https://issues.redhat.com//browse/SDCICD-897)

Signed-off-by: Brady Pratt <bpratt@redhat.com>

```
❯ HYPERSHIFT=true TEST_KUBECONFIG=autumn2-kubeconfig ginkgo run
2023/01/17 05:12:19 Setup called for osde2e-4i9k6
2023/01/17 05:12:19 Created SA: dedicated-admin-project
2023/01/17 05:12:19 Created SA: dedicated-admin-cluster
2023/01/17 05:12:19 Created SA: cluster-admin
Running Suite: osde2e - /var/home/bpratt/git/openshift/osde2e
=============================================================
Random Seed: 1673953935

Will run 110 of 110 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 0 of 110 Specs in 1.096 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 110 Skipped
PASS

Ginkgo ran 1 suite in 6.104977427s
Test Suite Passed
```