### PR TITLE
e2e/scale: disable on hypershift

### DIFF
--- a/pkg/e2e/scale/mastervertical.go
+++ b/pkg/e2e/scale/mastervertical.go
@@ -5,14 +5,12 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/util"
-	kubev1 "k8s.io/api/core/v1"
-
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/cluster"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	kubev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -26,11 +24,16 @@ func init() {
 }
 
 var _ = ginkgo.Describe(masterVerticalTestName, func() {
-	defer ginkgo.GinkgoRecover()
-	h := helper.New()
+	var h *helper.H
+	ginkgo.BeforeEach(func() {
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("HyperShift does not have exposed masters to scale")
+		}
+		h = helper.New()
+	})
 
 	masterVerticalTimeoutInSeconds := 7200
-	util.GinkgoIt("should be tested with MasterVertical", func(ctx context.Context) {
+	ginkgo.It("should be tested with MasterVertical", func(ctx context.Context) {
 		var err error
 		// Before we do anything, scale the cluster.
 		err = cluster.ScaleCluster(viper.GetString(config.Cluster.ID), numNodesToScaleTo)

--- a/pkg/e2e/scale/nodes_and_pods.go
+++ b/pkg/e2e/scale/nodes_and_pods.go
@@ -6,11 +6,11 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	kubev1 "k8s.io/api/core/v1"
-
 	"github.com/openshift/osde2e/pkg/common/alert"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
-	"github.com/openshift/osde2e/pkg/common/util"
+	kubev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -24,11 +24,16 @@ func init() {
 }
 
 var _ = ginkgo.Describe(nodesPodsTestName, func() {
-	defer ginkgo.GinkgoRecover()
-	h := helper.New()
+	var h *helper.H
+	ginkgo.BeforeEach(func() {
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("HyperShift does not support machinesets")
+		}
+		h = helper.New()
+	})
 
 	nodeVerticalTimeoutInSeconds := 3600
-	util.GinkgoIt("should be tested with NodeVertical", func(ctx context.Context) {
+	ginkgo.It("should be tested with NodeVertical", func(ctx context.Context) {
 		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 		// setup runner
 		scaleCfg := scaleRunnerConfig{
@@ -55,7 +60,7 @@ var _ = ginkgo.Describe(nodesPodsTestName, func() {
 	}, float64(nodeVerticalTimeoutInSeconds))
 
 	podVerticalTimeoutInSeconds := 3600
-	util.GinkgoIt("should be tested with PodVertical", func(ctx context.Context) {
+	ginkgo.It("should be tested with PodVertical", func(ctx context.Context) {
 		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 		// setup runner
 		scaleCfg := scaleRunnerConfig{

--- a/pkg/e2e/scale/performance.go
+++ b/pkg/e2e/scale/performance.go
@@ -8,8 +8,9 @@ import (
 	kubev1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/osde2e/pkg/common/alert"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
-	"github.com/openshift/osde2e/pkg/common/util"
 )
 
 var performanceTestName string = "[Suite: scale-performance] Scaling"
@@ -19,11 +20,16 @@ func init() {
 }
 
 var _ = ginkgo.Describe(performanceTestName, func() {
-	defer ginkgo.GinkgoRecover()
-	h := helper.New()
+	var h *helper.H
+	ginkgo.BeforeEach(func() {
+		if viper.GetBool(config.Hypershift) {
+			ginkgo.Skip("Not supported on HyperShift")
+		}
+		h = helper.New()
+	})
 
 	httpTimeoutInSeconds := 7200
-	util.GinkgoIt("should be tested with HTTP", func(ctx context.Context) {
+	ginkgo.It("should be tested with HTTP", func(ctx context.Context) {
 		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 		// setup runner
 		scaleCfg := scaleRunnerConfig{


### PR DESCRIPTION
these tests are either currently not supported on hosted clusters or they are failing (http)

```
$ oc logs scale-ci-http-bxtf4 -n scale-ci-tooling
exec /root/workload/run.sh: permission denied
```

```
...
TASK [Get cluster name] ********************************************************
task path: /src/github.com/openshift-scale/workloads/workloads/podvertical.yml:46
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "oc get machineset -n openshift-machine-api -o=go-template='{{index (index .items 0).metadata.labels \"machine.openshift.io/cluster-api-cluster\"}}'\n", "delta": "0:00:00.857721", "end": "2023-01-17 13:34:31.373731", "msg": "non-zero return code", "rc": 1, "start": "2023-01-17 13:34:30.516010", "stderr": "error: the server doesn't have a resource type \"machineset\"", "stderr_lines": ["error: the server doesn't have a resource type \"machineset\""], "stdout": "", "stdout_lines": []}
...
```

Signed-off-by: Brady Pratt <bpratt@redhat.com>