### PR TITLE
SDCICD-898: Use label filters for osde2e configs over focus strings

### DIFF
--- a/configs/e2e-suite.yaml
+++ b/configs/e2e-suite.yaml
@@ -1,7 +1,3 @@
 tests:
-  testsToRun:
-  - '\[Suite\: e2e\]'
-  - '\[Suite\: operators\]'
-  - '\[Suite\: service-definition\]'
-  - '\[Suite\: app-builds\]'
-  - 'Managed Cluster Validating Webhooks'
+  ginkgoLabelFilter: >
+    (E2E || Operators || ServiceDefinition || AppBuilds) && !Informing

--- a/configs/informing-suite.yaml
+++ b/configs/informing-suite.yaml
@@ -1,4 +1,2 @@
 tests:
-    testsToRun:
-    - '\[Suite\: informing\]'
-    - 'OCM Agent Operator'
+  ginkgoLabelFilter: Informing


### PR DESCRIPTION
# Change

Now that all test cases have been tagged with an initial label based on their previous test type (e.g. e2e, operator). This commit updates the configs selecting these tests to use label filters over focus strings.

This will now allow for cleaner test case names, removing the need to have (e.g. Suite: e2e, Suite: operator) within the name. These classifications are controlled by the tags "labels".

Updates both the e2e-suite and informing-suite configs as they are the primary configs used by the periodic jobs.

Includes an updated README describing how users of osde2e can select tests to run.

For [SDCICD-899](https://issues.redhat.com/browse/SDCICD-899)

# Verification

Tested locally against rosa stage sts cluster. Below is for the `e2e-suite`.

* Focus strings

```xml
<?xml version="1.0" encoding="UTF-8"?>
  <testsuites tests="232" disabled="131" errors="0" failures="0" time="2481.389474978">
      <testsuite name="OSD e2e suite" package="/home/rywillia/osd/osde2e" tests="232" disabled="0" skipped="131" errors="0" failures="0" time="2481.389474978" timestamp="2023-01-16T15:37:26">
          <properties>
              <property name="SuiteSucceeded" value="true"></property>
              <property name="SuiteHasProgrammaticFocus" value="false"></property>
              <property name="SpecialSuiteFailureReason" value=""></property>
              <property name="SuiteLabels" value="[]"></property>
              <property name="RandomSeed" value="1673901439"></property>
              <property name="RandomizeAllSpecs" value="false"></property>
              <property name="LabelFilter" value=""></property>
              <property name="FocusStrings" value="\[Suite\: e2e\],\[Suite\: operators\],\[Suite\: service-definition\],\[Suite\: app-builds\],Managed Cluster Validating Webhooks"></property>
              <property name="SkipStrings" value=""></property>
              <property name="FocusFiles" value=""></property>
              <property name="SkipFiles" value=""></property>
              <property name="FailOnPending" value="false"></property>
              <property name="FailFast" value="false"></property>
              <property name="FlakeAttempts" value="0"></property>
              <property name="DryRun" value="false"></property>
              <property name="ParallelTotal" value="1"></property>
              <property name="OutputInterceptorMode" value=""></property>
          </properties>
```

* Label filters

```xml
<?xml version="1.0" encoding="UTF-8"?>
  <testsuites tests="232" disabled="131" errors="0" failures="0" time="2580.236307608">
    <testsuite name="OSD e2e suite" package="/home/rywillia/osd/osde2e" tests="232" disabled="0" skipped="131" errors="0" failures="0" time="2580.236307608" timestamp="2023-01-17T07:57:15">
      <properties>
        <property name="SuiteSucceeded" value="true"/>
        <property name="SuiteHasProgrammaticFocus" value="false"/>
        <property name="SpecialSuiteFailureReason" value=""/>
        <property name="SuiteLabels" value="[]"/>
        <property name="RandomSeed" value="1673956230"/>
        <property name="RandomizeAllSpecs" value="false"/>
        <property name="LabelFilter" value="(E2E || Operators || ServiceDefinition || AppBuilds) && !Informing "/>
        <property name="FocusStrings" value=""/>
        <property name="SkipStrings" value=""/>
        <property name="FocusFiles" value=""/>
        <property name="SkipFiles" value=""/>
        <property name="FailOnPending" value="false"/>
        <property name="FailFast" value="false"/>
        <property name="FlakeAttempts" value="0"/>
        <property name="DryRun" value="false"/>
        <property name="ParallelTotal" value="1"/>
        <property name="OutputInterceptorMode" value=""/>
      </properties>
```

