### PR TITLE
SDCICD-915: support fips through rosaprovider

### DIFF
--- a/configs/fedramp.yaml
+++ b/configs/fedramp.yaml
@@ -1,5 +1,6 @@
-tests:
+cluster:
   enableFips: true
+tests:
   testsToRun:
   - '\[Suite\: service-definition\]'
   - '\[Suite\: app-builds\]'

--- a/configs/fips.yaml
+++ b/configs/fips.yaml
@@ -1,2 +1,2 @@
-tests:
+cluster:
   enableFips: true

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -240,10 +240,6 @@ var Tests = struct {
 	// ServiceAccount defines what user the tests should run as. By default, osde2e uses system:admin
 	// Env: SERVICE_ACCOUNT
 	ServiceAccount string
-
-	// EnableFips enables the FIPS test suite
-	// Env: ENABLE_FIPS
-	EnableFips string
 }{
 	PollingTimeout:             "tests.pollingTimeout",
 	GinkgoSkip:                 "tests.ginkgoSkip",
@@ -258,7 +254,6 @@ var Tests = struct {
 	MetricsBucket:              "tests.metricsBucket",
 	ServiceAccount:             "tests.serviceAccount",
 	ClusterHealthChecksTimeout: "tests.clusterHealthChecksTimeout",
-	EnableFips:                 "tests.enableFips",
 }
 
 // Cluster config keys.
@@ -379,6 +374,10 @@ var Cluster = struct {
 
 	// UseProxyForInstall will attempt to use a cluster-wide proxy for cluster installation, provided that a cluster-wide proxy config is supplied
 	UseProxyForInstall string
+
+	// EnableFips enables the FIPS test suite
+	// Env: ENABLE_FIPS
+	EnableFips string
 }{
 	MultiAZ:                             "cluster.multiAZ",
 	Channel:                             "cluster.channel",
@@ -412,6 +411,7 @@ var Cluster = struct {
 	Passing:                             "cluster.passing",
 	Reused:                              "cluster.rused",
 	InspectNamespaces:                   "cluster.inspectNamespaces",
+	EnableFips:                          "cluster.enableFips",
 }
 
 // CloudProvider config keys.
@@ -690,9 +690,6 @@ func InitOSDe2eViper() {
 
 	viper.BindEnv(Tests.ServiceAccount, "SERVICE_ACCOUNT")
 
-	viper.SetDefault(Tests.EnableFips, false)
-	viper.BindEnv(Tests.EnableFips, "ENABLE_FIPS")
-
 	// ----- Cluster -----
 	viper.SetDefault(Cluster.MultiAZ, false)
 	viper.BindEnv(Cluster.MultiAZ, "MULTI_AZ")
@@ -782,6 +779,9 @@ func InitOSDe2eViper() {
 
 	viper.SetDefault(Cluster.InspectNamespaces, strings.Join(defaultInspectNamespaces, ","))
 	viper.BindEnv(Cluster.InspectNamespaces, "INSPECT_NAMESPACES")
+
+	viper.SetDefault(Cluster.EnableFips, false)
+	viper.BindEnv(Cluster.EnableFips, "ENABLE_FIPS")
 
 	// ----- Cloud Provider -----
 	viper.SetDefault(CloudProvider.CloudProviderID, "aws")

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -144,6 +144,10 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 		}
 	}
 
+	if viper.GetBool(config.Tests.EnableFips) {
+		createClusterArgs = append(createClusterArgs, "--fips")
+	}
+
 	err = callAndSetAWSSession(func() error {
 		// Retrieve AWS Account info
 		logger := logging.NewLogger()

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -144,7 +144,7 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 		}
 	}
 
-	if viper.GetBool(config.Tests.EnableFips) {
+	if viper.GetBool(config.Cluster.EnableFips) {
 		createClusterArgs = append(createClusterArgs, "--fips")
 	}
 

--- a/pkg/e2e/verify/fips.go
+++ b/pkg/e2e/verify/fips.go
@@ -34,7 +34,7 @@ func init() {
 
 var _ = ginkgo.Describe(fipsTestName, label.E2E, func() {
 	ginkgo.Context("is enabled", func() {
-		if !viper.GetBool(config.Tests.EnableFips) {
+		if !viper.GetBool(config.Cluster.EnableFips) {
 			return
 		}
 		h := helper.New()


### PR DESCRIPTION
fips is supported on ROSA and should be tested. This adds support for deploying fips enabled clusters through osde2e

Signed-off-by: Brady Pratt <bpratt@redhat.com>