### PR TITLE
SDCICD-848 - Fix OSD CCS flow

### DIFF
--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -198,6 +198,7 @@ func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 					newCluster = newCluster.Proxy(proxy)
 				}
 			}
+			newCluster = newCluster.CCS(v1.NewCCS().Enabled(true)).AWS(awsBuilder)
 		} else if viper.GetString(config.CloudProvider.CloudProviderID) == "gcp" && viper.GetString(GCPProjectID) != "" {
 			// If GCP credentials are set, this must be a GCP CCS cluster
 			newCluster = newCluster.CCS(v1.NewCCS().Enabled(true)).GCP(v1.NewGCP().


### PR DESCRIPTION
[SDCICD-848](https://issues.redhat.com/browse/SDCICD-848)

It seems the logic to append the newcluster with CCS enabled must have been deleted. 

Edit: It was removed when I reworked the subnetID gating the CCS logic over here:
https://github.com/openshift/osde2e/commit/c78f92ec7dd4540aaeb149b64d2c18da2b1ddafc