### PR TITLE
Destroy cluster after tests with failures when flag is enabled

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -260,7 +260,7 @@ func RunTests() int {
 
 	exitCode, err = runGinkgoTests()
 	if err != nil {
-		log.Printf("Tests failed: %v", err)
+		log.Printf("OSDE2E failed: %v", err)
 	}
 
 	return exitCode
@@ -537,11 +537,6 @@ func runGinkgoTests() (int, error) {
 
 	}
 
-	if !testsPassed || !upgradeTestsPassed {
-		viper.Set(config.Cluster.Passing, false)
-		return Failure, fmt.Errorf("please inspect logs for more details")
-	}
-
 	if viper.GetBool(config.Cluster.DestroyAfterTest) {
 		log.Printf("Destroying cluster '%s'...", viper.GetString(config.Cluster.ID))
 
@@ -553,6 +548,11 @@ func runGinkgoTests() (int, error) {
 		if provider != nil {
 			log.Printf("For debugging, please look for cluster ID %s in environment %s", viper.GetString(config.Cluster.ID), provider.Environment())
 		}
+	}
+
+	if !testsPassed || !upgradeTestsPassed {
+		viper.Set(config.Cluster.Passing, false)
+		return Failure, fmt.Errorf("tests failed, please inspect logs for more details")
 	}
 
 	return Success, nil


### PR DESCRIPTION
# Change

Currently after test execution finishes, some clean up tasks are performed and then it checks if test failures occurred, it will return back a failure. Causing osde2e to end with no cluster clean up performed.

When the user supplies the option `destroyAfterTest` as true, no matter what the results are of the tests, the cluster should be destroyed. The default value for `destroyAfterTest` is true. So clusters should be deleted for every run.

This commit fixes this issue by moving the destroy cluster block above the checking if any test failures occurred. Allowing osde2e to properly destroy the cluster and then analyze the test failures/return.

For [SDCICD-919](https://issues.redhat.com/browse/SDCICD-919)

# Verification

_Current behavior (with test failures)_

```
Ran 7 of 232 Specs in 33.034 seconds
FAIL! -- 6 Passed | 1 Failed | 0 Pending | 225 Skipped
2023/01/27 11:00:34 e2e.go:517: Skipping metrics upload for local osde2e run.
2023/01/27 11:00:35 e2e.go:600: Gathering Cluster State...
2023/01/27 11:00:36 state.go:85: Encountered error listing getting resource 'machineconfiguration.openshift.io/v1, Resource=machineconfigpools': the server could not find the requested resource
2023/01/27 11:00:37 state.go:85: Encountered error listing getting resource 'machineconfiguration.openshift.io/v1, Resource=machineconfigs': the server could not find the requested resource
2023/01/27 11:00:38 state.go:94: Encountered error listing getting resource 'machine.openshift.io/v1beta1, Resource=machines': the server could not find the requested resource
2023/01/27 11:00:41 e2e.go:628: Writing cluster state results
2023/01/27 11:00:41 e2e.go:639: Gathering cluster state from rosa
2023/01/27 11:00:41 e2e.go:660: Cluster addons: []
2023/01/27 11:00:41 e2e.go:661: Cluster cloud provider: aws
2023/01/27 11:00:41 e2e.go:662: Cluster expiration: 2023-01-27 22:36:42 +0000 UTC
2023/01/27 11:00:41 e2e.go:663: Cluster flavor: osd-4
2023/01/27 11:00:41 e2e.go:664: Cluster state: ready
2023/01/27 11:00:41 e2e.go:672: Addon cleanup: false
2023/01/27 11:00:41 helper.go:171: Deleting project `osde2e-alglo`
2023/01/27 11:00:42 cluster.go:1286: Successfully added property[Status] - completed-failing 
2023/01/27 11:00:42 cluster.go:1286: Successfully added property[JobID] -  
2023/01/27 11:00:42 cluster.go:1286: Successfully added property[JobName] -  
2023/01/27 11:00:54 e2e.go:263: Tests failed: please inspect logs for more details
```

_Updated behavior (with test failures)_

Cluster is destroyed based on the config setting `destroyAfterTest = true` and then analyzes the test results.

```
Ran 7 of 232 Specs in 37.849 seconds
FAIL! -- 6 Passed | 1 Failed | 0 Pending | 225 Skipped
2023/01/27 12:41:09 e2e.go:517: Skipping metrics upload for local osde2e run.
2023/01/27 12:41:09 e2e.go:600: Gathering Cluster State...
2023/01/27 12:41:11 state.go:85: Encountered error listing getting resource 'machineconfiguration.openshift.io/v1, Resource=machineconfigpools': the server could not find the requested resource
2023/01/27 12:41:11 state.go:85: Encountered error listing getting resource 'machineconfiguration.openshift.io/v1, Resource=machineconfigs': the server could not find the requested resource
2023/01/27 12:41:13 state.go:94: Encountered error listing getting resource 'machine.openshift.io/v1beta1, Resource=machines': the server could not find the requested resource
2023/01/27 12:41:15 e2e.go:628: Writing cluster state results
2023/01/27 12:41:15 e2e.go:639: Gathering cluster state from rosa
2023/01/27 12:41:15 e2e.go:660: Cluster addons: []
2023/01/27 12:41:15 e2e.go:661: Cluster cloud provider: aws
2023/01/27 12:41:15 e2e.go:662: Cluster expiration: 2023-01-27 22:36:42 +0000 UTC
2023/01/27 12:41:15 e2e.go:663: Cluster flavor: osd-4
2023/01/27 12:41:15 e2e.go:664: Cluster state: ready
2023/01/27 12:41:15 e2e.go:672: Addon cleanup: false
2023/01/27 12:41:16 helper.go:171: Deleting project `osde2e-vjw4l`
2023/01/27 12:41:16 cluster.go:1286: Successfully added property[Status] - completed-failing 
2023/01/27 12:41:17 cluster.go:1286: Successfully added property[JobID] -  
2023/01/27 12:41:17 cluster.go:1286: Successfully added property[JobName] -  
2023/01/27 12:41:21 e2e.go:541: Destroying cluster '21gndd834kbog03ea2dclepuq3majma8'...
<suppressed>
2023/01/27 12:41:26 e2e.go:263: OSDE2E failed: tests failed, please inspect logs for more details
```

_Updated behavior (unchanged with no test failures all passing)_

```
[1674842058] OSD e2e suite - 10/232 specs SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•SSSSSS••SSSSSS SUCCESS! 58.510689856s 2023/01/27 12:56:24 e2e.go:517: Skipping metrics upload for local osde2e run.
2023/01/27 12:56:24 e2e.go:600: Gathering Cluster State...
2023/01/27 12:56:26 state.go:85: Encountered error listing getting resource 'machineconfiguration.openshift.io/v1, Resource=machineconfigpools': the server could not find the requested resource
2023/01/27 12:56:26 state.go:85: Encountered error listing getting resource 'machineconfiguration.openshift.io/v1, Resource=machineconfigs': the server could not find the requested resource
2023/01/27 12:56:28 state.go:94: Encountered error listing getting resource 'machine.openshift.io/v1beta1, Resource=machines': the server could not find the requested resource
2023/01/27 12:56:30 e2e.go:628: Writing cluster state results
2023/01/27 12:56:30 e2e.go:639: Gathering cluster state from rosa
2023/01/27 12:56:30 e2e.go:660: Cluster addons: []
2023/01/27 12:56:30 e2e.go:661: Cluster cloud provider: aws
2023/01/27 12:56:30 e2e.go:662: Cluster expiration: 2023-01-27 22:36:42 +0000 UTC
2023/01/27 12:56:30 e2e.go:663: Cluster flavor: osd-4
2023/01/27 12:56:30 e2e.go:664: Cluster state: ready
2023/01/27 12:56:30 e2e.go:672: Addon cleanup: false
2023/01/27 12:56:30 helper.go:171: Deleting project `osde2e-snjvg`
2023/01/27 12:56:31 cluster.go:1286: Successfully added property[Status] - completed-passing 
2023/01/27 12:56:31 cluster.go:1286: Successfully added property[JobID] -  
2023/01/27 12:56:31 cluster.go:1286: Successfully added property[JobName] -  
2023/01/27 12:56:35 e2e.go:541: Destroying cluster '21gndd834kbog03ea2dclepuq3majma8'...
<suppressed> 
```