### PR TITLE
Extend grpc query for operator previous csv retries

### DIFF
--- a/pkg/e2e/operators/operators.go
+++ b/pkg/e2e/operators/operators.go
@@ -623,7 +623,7 @@ func getReplacesCSV(ctx context.Context, h *helper.H, subscriptionNS string, csv
 
 	csv := &operatorv1.ClusterServiceVersion{}
 
-	r := retry.New(retry.Sleep(2), retry.Tries(3), retry.Recover())
+	r := retry.New(retry.Sleep(5), retry.Tries(6), retry.Recover())
 	err = r.Do(func() error {
 		bundle, err := rc.GetBundleInPackageChannel(ctx, csvDisplayName, packageChannel)
 		if err != nil {


### PR DESCRIPTION
# Change
[SDCICD-903](https://issues.redhat.com//browse/SDCICD-903) introduced retry logic when querying grpc service to handle intermittent 503 HTTP errors returned. The latest runs still seem to be getting these HTTP errors. This commit bumps the retry/delay up to 6 retries with 5 second delay between.

If errors still occur after this PR, then we will need to dig deeper into the logic to see if there is any other way we can look to resolve this. I have been testing locally and unable to reproduce this issue.

https://testgrid.k8s.io/redhat-osd#osde2e-main-aws-prod-e2e-default&width=90

