### PR TITLE
providers/rosa: use region set in config file

### DIFF
--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -154,7 +154,7 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 
 		awsClient, err := aws.NewClient().
 			Logger(logger).
-			Region(aws.DefaultRegion).
+			Region(viper.GetString(config.AWSRegion)).
 			Build()
 		if err != nil {
 			return err


### PR DESCRIPTION
This causes an error if trying to use govcloud because it is forcing us-east-1 instead of what is specified by the user

Signed-off-by: Brady Pratt <bpratt@redhat.com>
