### PR TITLE
SDCICD-932: Add support to use aws profile for rosa and aws authentication

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -182,13 +182,14 @@ The following are the values that can be plugged in for the --configs flag when 
 
 
 ### AWS specific values:
-| Environment variable  | Usage                                                           |
-| --------------------- | --------------------------------------------------------------- |
-| AWS_ACCOUNT           | AWS account to use for testing.                                 |
-| AWS_ACCESS_KEY        | AWSAccessKeyID for provisioning clusters.                       |
-| AWS_SECRET_ACCESS_KEY | AWSSecretAccessKey for provisioning clusters.                   |
-| AWS_REGION            | AWSRegion for provisioning clusters.                            |
-| AWS_VPC_SUBNET_IDS    | AWSVPCSubnetIDs for provisioning clusters for BYO-VPC clusters. |
+| Environment variable  | Usage                                                                                |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| AWS_ACCOUNT           | AWS account to use for testing.                                                      |
+| AWS_ACCESS_KEY        | AWSAccessKeyID for provisioning clusters.                                            |
+| AWS_SECRET_ACCESS_KEY | AWSSecretAccessKey for provisioning clusters.                                        |
+| AWS_REGION            | AWSRegion for provisioning clusters.                                                 |
+| AWS_VPC_SUBNET_IDS    | AWSVPCSubnetIDs for provisioning clusters for BYO-VPC clusters.                      |
+| AWS_PROFILE           | AWSProfile defines which profile in the aws credentials to use (ROSA provider only). |
 
 ### Cluster Provider values:
 

--- a/pkg/common/config/aws_config.go
+++ b/pkg/common/config/aws_config.go
@@ -8,11 +8,17 @@ import (
 var (
 	// AWSAccount is the AWS account
 	AWSAccount = "config.aws.account"
+
 	// AWSAccessKey is the AWS access key
 	AWSAccessKey = "config.aws.accessKey"
+
 	// AWSSecretKey is the AWS secret access key
 	AWSSecretAccessKey = "config.aws.secretAccessKey"
-	// AWSRegion sets the AWS region to use
+
+	// AWSProfile is the AWS profile to use
+	AWSProfile = "config.aws.profile"
+
+	// AWSRegion is the AWS region to use
 	AWSRegion = "config.aws.region"
 
 	// AWSVPCSubnetIDs is comma-separated list of strings to specify the subnets for cluster provision
@@ -28,6 +34,9 @@ func InitAWSViper() {
 
 	viper.BindEnv(AWSSecretAccessKey, "AWS_SECRET_ACCESS_KEY", "OCM_AWS_SECRET_KEY", "ROSA_AWS_SECRET_ACCESS_KEY")
 	RegisterSecret(AWSSecretAccessKey, "aws-secret-access-key")
+
+	viper.BindEnv(AWSProfile, "AWS_PROFILE")
+	RegisterSecret(AWSProfile, "aws-profile")
 
 	viper.BindEnv(AWSRegion, "AWS_REGION", "ROSA_AWS_REGION")
 	RegisterSecret(AWSRegion, "aws-region")


### PR DESCRIPTION
# Change

This commit adds support to osde2e users allowing them to use aws profiles to authenticate with aws. This gives an additional option over just using access keys for authentication.

When the profile is set, access keys can be ignored, when profile is not set access keys will need to be set to authenticate.

For [SDCICD-932](https://issues.redhat.com/browse/SDCICD-932)