### PR TITLE
common/cluster: fix hosted-cp healthcheck timeout check

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -22,7 +22,6 @@ import (
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/util"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
@@ -131,7 +130,7 @@ func WaitForClusterReadyPostInstall(clusterID string, logger *log.Logger) error 
 			nodes, err := kubeClient.CoreV1().Nodes().List(context.Background(), v1.ListOptions{})
 			if err != nil {
 				// if the api server is not ready yet
-				if apierrors.IsTimeout(err) {
+				if os.IsTimeout(err) {
 					logger.Println(err)
 					return false, nil
 				}


### PR DESCRIPTION
this is actually an `os.IsTimeout` instead of from apierrors

Signed-off-by: Brady Pratt <bpratt@redhat.com>

```
2023/02/21 04:45:51 e2e.go:134: *******************
2023/02/21 04:45:51 e2e.go:135: Cluster failed health check: HyperShift healthcheck: Get "https://api.autumn.xyza.s3.devshift.org:443/api/v1/nodes": dial tcp 54.222.222.116:443: i/o timeout
2023/02/21 04:45:51 e2e.go:136: *******************
```
