### PR TITLE
SDCICD-933: Auto create ROSA hosted control plane VPC when undefined

### DIFF
--- a/assets/terraform/setup-vpc.tf
+++ b/assets/terraform/setup-vpc.tf
@@ -1,30 +1,23 @@
 variable "aws_region" {
   type        = string
   description = "The region to create the ROSA cluster in"
-  default     = "us-east-1"
-
-  validation {
-    condition     = contains(["us-east-1", "eu-west-1"], var.aws_region)
-    error_message = "HyperShift is currently only availble in these regions: us-east-1, eu-west-1."
-  }
 }
 
 variable "az_ids" {
   type = object({
-    us-east-1 = list(string)
-    eu-west-1 = list(string)
+    us-east-2 = list(string)
+    us-west-2 = list(string)
   })
   description = "A list of region-mapped AZ IDs that a subnet should get deployed into"
   default = {
-    us-east-1 = ["use1-az1", "use1-az2"]
-    eu-west-1 = ["euw1-az1", "euw1-az2"]
+    us-east-2 = ["use2-az1", "use2-az2"]
+    us-west-2 = ["usw2-az1", "usw2-az2"]
   }
 }
 
 variable "cluster_name" {
   type        = string
   description = "The name of the ROSA cluster to create"
-  default     = "rosa-cluster"
 
   validation {
     condition     = can(regex("^[a-z][-a-z0-9]{0,13}[a-z0-9]$", var.cluster_name))

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -277,6 +277,11 @@ func (m *MockProvider) AddProperty(cluster *spi.Cluster, tag string, value strin
 	return fmt.Errorf("AddProperty is unsupported by mock clusters")
 }
 
+// GetProperty mocks getting a property from the properties field of an existing cluster.
+func (m *MockProvider) GetProperty(clusterID string, property string) (string, error) {
+	return "GetProperty is unsupported by mock clusters", nil
+}
+
 // Upgrade mocks initiates a cluster upgrade to the given version
 func (m *MockProvider) Upgrade(clusterID string, version string, t time.Time) error {
 	return fmt.Errorf("Upgrade is unsupported by mock clusters")

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -1297,6 +1297,25 @@ func (o *OCMProvider) AddProperty(cluster *spi.Cluster, tag string, value string
 	return nil
 }
 
+// Get a specific cluster property
+func (o *OCMProvider) GetProperty(clusterID string, property string) (string, error) {
+	clusterClient := o.conn.ClustersMgmt().V1().Clusters().Cluster(clusterID)
+	response, err := clusterClient.Get().Send()
+	if err != nil {
+		return "", err
+	}
+
+	cluster := response.Body()
+	properties, _ := cluster.GetProperties()
+	propertyValue, exist := properties[property]
+
+	if !exist {
+		return "", fmt.Errorf("cluster property: %s is undefined", property)
+	}
+
+	return propertyValue, nil
+}
+
 // Upgrade initiates a cluster upgrade to the given version
 func (o *OCMProvider) Upgrade(clusterID string, version string, t time.Time) error {
 	policy, err := v1.NewUpgradePolicy().Version(version).NextRun(t).ScheduleType("manual").Build()

--- a/pkg/common/providers/rosaprovider/vpc.go
+++ b/pkg/common/providers/rosaprovider/vpc.go
@@ -1,0 +1,134 @@
+package rosaprovider
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/terraform-exec/tfexec"
+	"github.com/openshift/osde2e/assets"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/terraform"
+)
+
+type HyperShiftVPC struct {
+	PrivateSubnet     string
+	PublicSubnet      string
+	NodePrivateSubnet string
+}
+
+// copyFile copies the srcFile provided to the destFile
+func copyFile(srcFile string, destFile string) error {
+	srcReader, err := assets.FS.Open(srcFile)
+	if err != nil {
+		return fmt.Errorf("error opening %s file: %w", srcFile, err)
+	}
+	defer srcReader.Close()
+
+	destReader, err := os.Create(destFile)
+	if err != nil {
+		return fmt.Errorf("error creating runtime %s file: %w", destFile, err)
+	}
+	defer destReader.Close()
+
+	_, err = io.Copy(destReader, srcReader)
+	if err != nil {
+		return fmt.Errorf("error copying source file to destination file: %w", err)
+	}
+
+	return nil
+}
+
+// createHyperShiftVPC creates the vpc to provision HyperShift clusters
+func createHyperShiftVPC() (*HyperShiftVPC, error) {
+	ctx := context.Background()
+
+	var vpc HyperShiftVPC
+	workingDir := viper.GetString(config.ReportDir)
+
+	tf, err := terraform.New(workingDir)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		_ = tf.Uninstall(ctx)
+	}()
+
+	log.Println("Creating ROSA HyperShift aws vpc")
+
+	err = copyFile("terraform/setup-vpc.tf", fmt.Sprintf("%s/setup-vpc.tf", workingDir))
+	if err != nil {
+		return nil, err
+	}
+
+	err = tf.Init(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	err = tf.Plan(
+		ctx,
+		tfexec.Var(fmt.Sprintf("aws_region=%s", viper.GetString(config.AWSRegion))),
+		tfexec.Var(fmt.Sprintf("cluster_name=%s", viper.GetString(config.Cluster.Name))),
+	)
+	if err != nil {
+		return &vpc, err
+	}
+
+	err = tf.Apply(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	output, err := tf.Output(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	vpc.PrivateSubnet = strings.ReplaceAll(string(output["cluster-private-subnet"].Value), "\"", "")
+	vpc.PublicSubnet = strings.ReplaceAll(string(output["cluster-public-subnet"].Value), "\"", "")
+	vpc.NodePrivateSubnet = strings.ReplaceAll(string(output["node-private-subnet"].Value), "\"", "")
+
+	log.Println("ROSA HyperShift aws vpc created!")
+
+	return &vpc, nil
+}
+
+// deleteHyperShiftVPC deletes the vpc created to provision HyperShift clusters
+func deleteHyperShiftVPC(workingDir string) error {
+	ctx := context.Background()
+
+	tf, err := terraform.New(workingDir)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		_ = tf.Uninstall(ctx)
+	}()
+
+	err = tf.Init(ctx)
+	if err != nil {
+		return err
+	}
+
+	log.Println("Deleting ROSA HyperShift aws vpc")
+
+	err = tf.Destroy(
+		ctx,
+		tfexec.Var(fmt.Sprintf("aws_region=%s", viper.GetString(config.AWSRegion))),
+		tfexec.Var(fmt.Sprintf("cluster_name=%s", viper.GetString(config.Cluster.Name))),
+	)
+	if err != nil {
+		return err
+	}
+
+	log.Println("ROSA HyperShift aws vpc deleted!")
+
+	return nil
+}

--- a/pkg/common/providers/rosaprovider/wrapped_calls.go
+++ b/pkg/common/providers/rosaprovider/wrapped_calls.go
@@ -78,6 +78,11 @@ func (m *ROSAProvider) AddProperty(cluster *spi.Cluster, tag string, value strin
 	return m.ocmProvider.AddProperty(cluster, tag, value)
 }
 
+// GetProperty will call GetProperty from the OCM provider.
+func (m *ROSAProvider) GetProperty(clusterID string, property string) (string, error) {
+	return m.ocmProvider.GetProperty(clusterID, property)
+}
+
 // Upgrade initiates a cluster upgrade from the OCM provider.
 func (m *ROSAProvider) Upgrade(clusterID string, version string, t time.Time) error {
 	return m.ocmProvider.Upgrade(clusterID, version, t)

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -119,6 +119,9 @@ type Provider interface {
 	// AddProperty adds a new property to the properties field of an existing cluster.
 	AddProperty(cluster *Cluster, tag string, value string) error
 
+	// GetProperty gets a property from the properties field of an existing cluster.
+	GetProperty(clusterID string, property string) (string, error)
+
 	// Upgrade requests the provider initiate a cluster upgrade to the given version
 	Upgrade(clusterID string, version string, t time.Time) error
 

--- a/pkg/common/terraform/terraform.go
+++ b/pkg/common/terraform/terraform.go
@@ -90,8 +90,11 @@ func (r *runner) Apply(ctx context.Context) error {
 }
 
 // Destroy performs a terraform destroy using the provided TerraformRunner receiver.
-func (r *runner) Destroy(ctx context.Context) error {
-	err := r.runner.Destroy(ctx)
+func (r *runner) Destroy(ctx context.Context, args ...tfexec.DestroyOption) error {
+	err := r.runner.Destroy(
+		ctx,
+		args...,
+	)
 	if err != nil {
 		return fmt.Errorf("error running terraform destroy: %w", err)
 	}


### PR DESCRIPTION
# Change

This PR adds support to OSDE2E to auto create the VPC for ROSA hosted control plane clusters over requiring the user to BYOVPC.

When a user calls OSDE2E with the options for a HyperShift cluster and provides the VPC subnet ids, it will not create any VPC and use the one provided.

```
provider: rosa
Hypershift: True
config:
  aws:
    vpcSubnetIDs: "subnet-1,subnet-2"
    region: us-east-1
rosa:
  env: stage
  STS: true
cluster:
  name: hcp
  version: 4.12.4
```

When a user calls OSDE2E with the options for a HyperShift cluster and does not provided any VPC subnet ids, it will automatically create the VPC and destroy the VPC when finished.

```
provider: rosa
Hypershift: True
config:
  aws:
    region: us-east-1
rosa:
  env: stage
  STS: true
cluster:
  name: hcp
  version: 4.12.4
```

# Implementation Details

When OSDE2E goes to create the VPC it will:
1. Call terraform to create VPC and fetch subnet ids
2. Pass subnet ids into rosa create cluster command
3. Pass a new cluster property to rosa create cluster command to save the location where the terraform state file exists (used for later on to delete created VPC by terraform)

When OSDE2E goes to delete the VPC it will:
1. Get the cluster property to know where on the file system it should look for the terraform state file (this is really needed when you run osde2e multiple times with destroyAfterTest set to false. Then on your final run you set it to true and need to know where the state file is.
2. Delete the cluster
3. Delete STS roles
4. Call terraform to delete auto created VPC

# Status
* In order for this to work, Jira issue **HOSTEDCP-789** has to be done and available in newer OCP version. Without this, VPC deletion will fail due to ELB security group still existing.

For [SDCICD-933](https://issues.redhat.com/browse/SDCICD-933)

Triggered by #1558. That PR was the first implementation which was later own broken down into multiple PR's to introduce the functionality.