### PR TITLE
common/cluster: catch x509 errors in healthcheck

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"context"
+	"crypto/x509"
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -130,7 +132,7 @@ func WaitForClusterReadyPostInstall(clusterID string, logger *log.Logger) error 
 			nodes, err := kubeClient.CoreV1().Nodes().List(context.Background(), v1.ListOptions{})
 			if err != nil {
 				// if the api server is not ready yet
-				if os.IsTimeout(err) {
+				if os.IsTimeout(err) || errors.As(err, &x509.UnknownAuthorityError{}) {
 					logger.Println(err)
 					return false, nil
 				}


### PR DESCRIPTION
it seems that the certificate is not signed by the time the cluster comes up so the healthcheck is failing

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-hypershift-stage-e2e-default/1630176089026334720