### PR TITLE
SDCICD-944: Rename destroy-cluster flag to skip-destroy-cluster

### DIFF
--- a/cmd/osde2e/test/cmd.go
+++ b/cmd/osde2e/test/cmd.go
@@ -39,18 +39,18 @@ var Cmd = &cobra.Command{
 }
 
 var args struct {
-	configString     string
-	customConfig     string
-	secretLocations  string
-	clusterID        string
-	environment      string
-	kubeConfig       string
-	destroyAfterTest bool
-	skipHealthChecks bool
-	mustGather       bool
-	focusTests       string
-	skipTests        string
-	labelFilter      string
+	configString       string
+	customConfig       string
+	secretLocations    string
+	clusterID          string
+	environment        string
+	kubeConfig         string
+	skipDestroyCluster bool
+	skipHealthChecks   bool
+	mustGather         bool
+	focusTests         string
+	skipTests          string
+	labelFilter        string
 }
 
 func init() {
@@ -97,10 +97,10 @@ func init() {
 		"Path to local Kube config for running tests against.",
 	)
 	pfs.BoolVar(
-		&args.destroyAfterTest,
-		"destroy-cluster",
+		&args.skipDestroyCluster,
+		"skip-destroy-cluster",
 		false,
-		"Destroy cluster after test completion.",
+		"Skip destroy cluster after test completion.",
 	)
 	pfs.BoolVar(
 		&args.skipHealthChecks,
@@ -136,7 +136,7 @@ func init() {
 	viper.BindPFlag(config.Cluster.ID, Cmd.PersistentFlags().Lookup("cluster-id"))
 	viper.BindPFlag(ocmprovider.Env, Cmd.PersistentFlags().Lookup("environment"))
 	viper.BindPFlag(config.Kubeconfig.Path, Cmd.PersistentFlags().Lookup("kube-config"))
-	viper.BindPFlag(config.Cluster.DestroyAfterTest, Cmd.PersistentFlags().Lookup("destroy-cluster"))
+	viper.BindPFlag(config.Cluster.SkipDestroyCluster, Cmd.PersistentFlags().Lookup("skip-destroy-cluster"))
 	viper.BindPFlag(config.Tests.SkipClusterHealthChecks, Cmd.PersistentFlags().Lookup("skip-health-check"))
 	viper.BindPFlag(config.Tests.GinkgoFocus, Cmd.PersistentFlags().Lookup("focus-tests"))
 	viper.BindPFlag(config.Tests.GinkgoSkip, Cmd.PersistentFlags().Lookup("skip-tests"))

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -146,10 +146,10 @@ CLI flags that are commonly used include:
 --cluster-id: Existing OCM cluster ID to run tests against.
 --configs:  A comma separated list of built in configs to use. (stage, prod, e2e-suite, etc.)
 --custom-config: Custom config file for osde2e.
---destroy-cluster: A flag to trigger cluster deletion after test completion.
 --environment: Cluster provider environment to use. (ocm, rosa, etc.).
 --kube-config: Path to local Kube config for running tests against.
---skip-health-check:  a flag to skip cluster health checks.
+--skip-destroy-cluster: Skip cluster deletion after test completion.
+--skip-health-check: Skip cluster health checks.
 --skip-tests: Skip any Ginkgo tests whose names match the regular expression.
 ``` 
 

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -268,9 +268,9 @@ var Cluster = struct {
 	// Env: CHANNEL
 	Channel string
 
-	// DestroyClusterAfterTest set to true if you want to the cluster to be explicitly deleted after the test.
-	// Env: DESTROY_CLUSTER
-	DestroyAfterTest string
+	// SkipDestroyCluster indicates whether cluster should be destroyed after test completion.
+	// Env: SKIP_DESTROY_CLUSTER
+	SkipDestroyCluster string
 
 	// ExpiryInMinutes is how long before a cluster expires and is deleted by OSD.
 	// Env: CLUSTER_EXPIRY_IN_MINUTES
@@ -383,7 +383,7 @@ var Cluster = struct {
 }{
 	MultiAZ:                             "cluster.multiAZ",
 	Channel:                             "cluster.channel",
-	DestroyAfterTest:                    "cluster.destroyAfterTest",
+	SkipDestroyCluster:                  "cluster.skipDestroyCluster",
 	ExpiryInMinutes:                     "cluster.expiryInMinutes",
 	AfterTestWait:                       "cluster.afterTestWait",
 	InstallTimeout:                      "cluster.installTimeout",
@@ -699,8 +699,7 @@ func InitOSDe2eViper() {
 	viper.SetDefault(Cluster.Channel, "stable")
 	viper.BindEnv(Cluster.Channel, "CHANNEL")
 
-	viper.SetDefault(Cluster.DestroyAfterTest, true)
-	viper.BindEnv(Cluster.DestroyAfterTest, "DESTROY_CLUSTER")
+	viper.BindEnv(Cluster.SkipDestroyCluster, "SKIP_DESTROY_CLUSTER")
 
 	viper.SetDefault(Cluster.ExpiryInMinutes, 360)
 	viper.BindEnv(Cluster.ExpiryInMinutes, "CLUSTER_EXPIRY_IN_MINUTES")

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -537,7 +537,7 @@ func runGinkgoTests() (int, error) {
 
 	}
 
-	if viper.GetBool(config.Cluster.DestroyAfterTest) {
+	if !viper.GetBool(config.Cluster.SkipDestroyCluster) {
 		log.Printf("Destroying cluster '%s'...", viper.GetString(config.Cluster.ID))
 
 		if err = provider.DeleteCluster(viper.GetString(config.Cluster.ID)); err != nil {
@@ -699,7 +699,7 @@ func cleanupAfterE2E(ctx context.Context, h *helper.H) (errors []error) {
 	// We need a provider to hibernate
 	// We need a cluster to hibernate
 	// We need to check that the test run wants to hibernate after this run
-	if provider != nil && viper.GetString(config.Cluster.ID) != "" && viper.GetBool(config.Cluster.HibernateAfterUse) && !viper.GetBool(config.Cluster.DestroyAfterTest) {
+	if provider != nil && viper.GetString(config.Cluster.ID) != "" && viper.GetBool(config.Cluster.HibernateAfterUse) && viper.GetBool(config.Cluster.SkipDestroyCluster) {
 		msg := "Unable to hibernate %s"
 		if provider.Hibernate(viper.GetString(config.Cluster.ID)) {
 			msg = "Hibernating %s"


### PR DESCRIPTION
# Change
When test execution is complete, a cluster will be destroyed by default. If a user wants to leave a cluster up, they can use the updated flag `--skip-destroy-cluster`. When passed, the cluster will be left up. Users can also set this within a custom config or by setting the environment variable `SKIP_DESTROY_CLUSTER`.

This commit addresses the inconsistency between the default value set within config.go and the value set by the CLI flag.

For [SDCICD-944](https://issues.redhat.com//browse/SDCICD-944)

# Examples

_Using the CLI option to the leave cluster up_

```
osde2e test --custom-config my-custom-config.yml --skip-destroy-cluster
```

_Using the custom config to the leave cluster up_

```
cat my-custom-config.yml
cluster:
  skipDestroyCluster: true
```

```
osde2e test --custom-config my-custom-config.yml
```

_Using the environment variable to leave the cluster up_

```
export SKIP_DESTROY_CLUSTER=true
osde2e test --custom-config my-custom-config.yml
```