### PR TITLE
SDCICD-940: Allow osde2e to workaround hypershift admin kubeconfig self cert bug

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -88,6 +88,8 @@ const (
 
 	// Hypershift enables the use of hypershift for cluster creation.
 	Hypershift = "Hypershift"
+
+	HypershiftIgnoreInvalidCert = "HypershiftIgnoreInvalidCert"
 )
 
 // This is a config key to secret file mapping. We will attempt to read in from secret files before loading anything else.
@@ -716,6 +718,9 @@ func InitOSDe2eViper() {
 
 	viper.SetDefault(Hypershift, false)
 	viper.BindEnv(Hypershift, "HYPERSHIFT")
+
+	viper.SetDefault(HypershiftIgnoreInvalidCert, false)
+	viper.BindEnv(HypershiftIgnoreInvalidCert, "HYPERSHIFT_IGNORE_INVALID_CERT")
 
 	viper.SetDefault(Cluster.UseLatestVersionForInstall, false)
 	viper.BindEnv(Cluster.UseLatestVersionForInstall, "USE_LATEST_VERSION_FOR_INSTALL")

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -867,7 +867,16 @@ func (o *OCMProvider) ClusterKubeconfig(clusterID string) ([]byte, error) {
 	o.credentialCache[clusterID] = resp.Body().Kubeconfig()
 	viper.Set(config.Kubeconfig.Contents, resp.Body().Kubeconfig())
 
-	return []byte(resp.Body().Kubeconfig()), nil
+	kubeConfigBytes := []byte(resp.Body().Kubeconfig())
+
+	// TODO: Remove once https://issues.redhat.com/browse/OCPBUGS-8101 is fixed
+	if viper.GetBool(config.Hypershift) && viper.GetBool(config.HypershiftIgnoreInvalidCert) {
+		kubeConfigBytes, err = HyperShiftInvalidCertWorkaround(resp.Body().Kubeconfig())
+		viper.Set(config.Kubeconfig.Contents, string(kubeConfigBytes))
+		return kubeConfigBytes, err
+	}
+
+	return kubeConfigBytes, nil
 }
 
 // Loads and returns the supplied filepath

--- a/pkg/common/providers/ocmprovider/kubeconfig.go
+++ b/pkg/common/providers/ocmprovider/kubeconfig.go
@@ -1,0 +1,101 @@
+package ocmprovider
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ModClusterData struct {
+	Server string
+}
+
+type ModCluster struct {
+	Name    string
+	Cluster ModClusterData
+}
+
+type ClusterData struct {
+	CertificateAuthorityData string `yaml:"certificate-authority-data"`
+	Server                   string
+}
+
+type Cluster struct {
+	Name    string
+	Cluster ClusterData
+}
+
+type ContextData struct {
+	Cluster   string
+	Namespace string
+	User      string
+}
+
+type Context struct {
+	Name    string
+	Context ContextData
+}
+
+type UserData struct {
+	ClientCertificateData string `yaml:"client-certificate-data"`
+	ClientKeyData         string `yaml:"client-key-data"`
+}
+
+type User struct {
+	Name string
+	User UserData
+}
+
+type KubeConfig struct {
+	ApiVersion     string `yaml:"apiVersion"`
+	Clusters       []Cluster
+	Contexts       []Context
+	CurrentContext string `yaml:"current-context"`
+	Kind           string
+	Preferences    map[string]string
+	Users          []User
+}
+
+type ModKubeConfig struct {
+	ApiVersion     string `yaml:"apiVersion"`
+	Clusters       []ModCluster
+	Contexts       []Context
+	CurrentContext string `yaml:"current-context"`
+	Kind           string
+	Preferences    map[string]string
+	Users          []User
+}
+
+// Remove admin-kubeconfig certificate from HyperShift clusters as it is
+// invalid. Refer to OCPBUGS-8101. This is only a workaround until the bug
+// is resolved.
+func HyperShiftInvalidCertWorkaround(kubeConfigContent string) ([]byte, error) {
+	kubeConfig := KubeConfig{}
+
+	err := yaml.Unmarshal([]byte(kubeConfigContent), &kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding kubeconfig into struct: %w", err)
+	}
+
+	modCluster := ModCluster{
+		Name: kubeConfig.Clusters[0].Name,
+		Cluster: ModClusterData{
+			Server: kubeConfig.Clusters[0].Cluster.Server,
+		},
+	}
+
+	modKubeConfigBytes, err := yaml.Marshal(ModKubeConfig{
+		ApiVersion:     kubeConfig.ApiVersion,
+		Clusters:       []ModCluster{modCluster},
+		Contexts:       kubeConfig.Contexts,
+		CurrentContext: kubeConfig.CurrentContext,
+		Kind:           kubeConfig.Kind,
+		Preferences:    kubeConfig.Preferences,
+		Users:          kubeConfig.Users,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("error serializing updated kubeconfig: %w", err)
+	}
+
+	return modKubeConfigBytes, nil
+}


### PR DESCRIPTION
# Change
This commit provides a workaround to osde2e to allow testing to carry on with the open bug where the cluster certificate does not match the one the API provides. By default this is not enabled, meaning osde2e will fail when trying to authenticate with the server. Users will need to enable this workaround manually by either:
 * Set environment variable `HYPERSHIFT_IGNORE_INVALID_CERT`
```shell
export HYPERSHIFT_IGNORE_INVALID_CERT="true"
```

 * Set `HypershiftIgnoreInvalidCert` in a custom config to authenticate successfully against the server.
```yaml
HypershiftIgnoreInvalidCert: True
```

For [SDCICD-940](https://issues.redhat.com/browse/SDCICD-940)
Requires https://github.com/openshift/release/pull/36991