### PR TITLE
SDCICD-939: Fix for rosa to use latest ocp version when not using stable channel

### DIFF
--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -77,6 +77,7 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 
 	rosaClusterVersion := viper.GetString(config.Cluster.Version)
 	rosaClusterVersion = strings.ReplaceAll(rosaClusterVersion, "openshift-v", "")
+	rosaClusterVersion = strings.ReplaceAll(rosaClusterVersion, fmt.Sprintf("-%s", viper.GetString(config.Cluster.Channel)), "")
 
 	log.Printf("ROSA cluster version: %s", rosaClusterVersion)
 
@@ -412,17 +413,9 @@ func (m *ROSAProvider) Versions() (*spi.VersionList, error) {
 		return nil, err
 	}
 
-	versionResponse, err := ocmClient.GetVersions("")
+	versionResponse, err := ocmClient.GetVersions(viper.GetString(config.Cluster.Channel))
 	if err != nil {
 		return nil, err
-	}
-
-	if viper.GetString(config.Cluster.Channel) != "stable" {
-		versionResponseChannel, err := ocmClient.GetVersions(viper.GetString(config.Cluster.Channel))
-		if err != nil {
-			return nil, err
-		}
-		versionResponse = append(versionResponse, versionResponseChannel...)
 	}
 
 	spiVersions := []*spi.Version{}


### PR DESCRIPTION
# Change

The current implementation will fail trying to create a rosa cluster when getting the latest version available over the default one set. Whether using candidate channel or nightly channel, it will append the channel group to the end of the version string. This behavior works for traditional OSD cluster installs.

This commit will address the issue with a simple solution to start (which can later follow with a more concrete implementation based on the provider for filtering the versions). This change does the following:
 1. Queries only for the versions based on the channel group defined
 2. Attempts to remove channel group that may exist within the version string

* For [SDCICD-939](https://issues.redhat.com//browse/SDCICD-939)
* Required for https://github.com/openshift/release/pull/36987

# Current Behavior

* Current implementation when attempting to get latest from candidate channel, returns this version string:

```
2023/03/07 13:46:18 cluster.go:81: ROSA cluster version: 4.12.6-fast-candidate
```

Which it should be `4.12.6`.

* Current implementation when attempting to get latest from nightly channel, returns this version string:

```
2023/02/20 19:57:04 version.go:103: Using the specific nightly '4.12.0-0.nightly-2023-02-20-172247-nightly'
```

Which it should be `4.12.0-0.nightly-2023-02-20-172247`.

# New Behavior

* Attempt to get latest from candidate channel

```
cat config.yml
cluster:
  destroyAfterTest: false
  hibernateAfterUse: false
  cleanCheckRuns: "3"
  name: rw-0308-2
  channel: candidate
  useLatestVersionForInstall: true

2023/03/08 15:12:17 cluster.go:82: ROSA cluster version: 4.12.6
2023/03/08 15:12:17 util.go:31: AWS_ACCESS_KEY_ID is not set
2023/03/08 15:12:17 util.go:31: AWS_SECRET_ACCESS_KEY is not set
2023/03/08 15:12:17 cluster.go:213: Pruning `--compute-machine-type` and ``
2023/03/08 15:12:17 cluster.go:213: Pruning `--machine-cidr` and ``
2023/03/08 15:12:17 cluster.go:213: Pruning `--service-cidr` and ``
2023/03/08 15:12:17 cluster.go:213: Pruning `--pod-cidr` and ``
2023/03/08 15:12:19 cluster.go:219: [--cluster-name rw-0308-2 --region us-west-2 --channel-group candidate --version 4.12.6 --expiration-time 2023-03-09T02:12:17Z  --replicas 2    --host-prefix 0 --mode auto --yes --subnet-ids subnet-0510299e911f1ed28,subnet-047332f25b11621d8 --hosted-cp --sts --properties JobName: --properties JobID:-1 --properties OwnedBy:rywillia --properties InstalledVersion:openshift-v4.12.6-candidate --properties MadeByOSDe2e:true --properties UpgradeVersion:-- --properties Status:provisioning]
```

```
cat config.yml
cluster:
  destroyAfterTest: false
  hibernateAfterUse: false
  cleanCheckRuns: "3"
  name: rw-0308-2
  channel: nightly
  useLatestVersionForInstall: true

2023/03/08 15:14:21 cluster.go:82: ROSA cluster version: 4.12.0-0.nightly-2023-03-07-093406
2023/03/08 15:14:21 util.go:31: AWS_ACCESS_KEY_ID is not set
2023/03/08 15:14:21 util.go:31: AWS_SECRET_ACCESS_KEY is not set
2023/03/08 15:14:21 cluster.go:213: Pruning `--compute-machine-type` and ``
2023/03/08 15:14:21 cluster.go:213: Pruning `--machine-cidr` and ``
2023/03/08 15:14:21 cluster.go:213: Pruning `--service-cidr` and ``
2023/03/08 15:14:21 cluster.go:213: Pruning `--pod-cidr` and ``
2023/03/08 15:14:22 cluster.go:219: [--cluster-name rw-0308-2 --region us-west-2 --channel-group nightly --version 4.12.0-0.nightly-2023-03-07-093406 --expiration-time 2023-03-09T02:14:21Z  --replicas 2    --host-prefix 0 --mode auto --yes --subnet-ids subnet-0510299e911f1ed28,subnet-047332f25b11621d8 --hosted-cp --sts --properties UpgradeVersion:-- --properties Status:provisioning --properties JobName: --properties JobID:-1 --properties OwnedBy:rywillia --properties InstalledVersion:openshift-v4.12.0-0.nightly-2023-03-07-093406-nightly --properties MadeByOSDe2e:true]
```