### PR TITLE
Skip test execution in the event any pre test execution setup failures occur

### DIFF
--- a/pkg/common/customerrors/customerrors.go
+++ b/pkg/common/customerrors/customerrors.go
@@ -1,0 +1,42 @@
+package customerrors
+
+// ProvisionClusterError defines a collection of fields for the error type
+type ProvisionClusterError struct {
+	Created bool
+	Message string
+}
+
+// Custom error for cluster provision errors
+func (e *ProvisionClusterError) Error() string {
+	return e.Message
+}
+
+// ClusterHealthCheckError defines a collection of fields for the error type
+type ClusterHealthCheckError struct {
+	Message string
+}
+
+// Error implementation for custom cluster health check error type
+func (e *ClusterHealthCheckError) Error() string {
+	return e.Message
+}
+
+// KubeConfigLookupError defines a collection of fields for the error type
+type KubeConfigLookupError struct {
+	Message string
+}
+
+// Error implementation for custom kubeconfig look up error type
+func (e *KubeConfigLookupError) Error() string {
+	return e.Message
+}
+
+// AddOnInstallError defines a collection of fields for the error type
+type AddOnInstallError struct {
+	Message string
+}
+
+// Error implementation for custom addon installation error type
+func (e *AddOnInstallError) Error() string {
+	return e.Message
+}


### PR DESCRIPTION
# Change
Current behavior will attempt to run tests even if the cluster health check fails. We should ensure the cluster health check is successful prior to running tests when cluster health checks are enabled.

# Verification

_Simulated forcing an error right when health check begins_

```diff
diff --git a/pkg/common/cluster/clusterutil.go b/pkg/common/cluster/clusterutil.go
index 0567046523..2122f67342 100644
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -84,6 +84,7 @@ func ScaleCluster(clusterID string, numComputeNodes int) error {
 // WaitForClusterReadyPostInstall blocks until the cluster is ready for testing using mechanisms appropriate
 // for a newly-installed cluster.
 func WaitForClusterReadyPostInstall(clusterID string, logger *log.Logger) error {
+       return fmt.Errorf("forced error")
        logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
        podErrorTracker.NewPodErrorTracker(pendingPodThreshold)
        provider, err := providers.ClusterProvider()
```

```
2023/03/14 11:57:19 configs.go:24: Will load config hypershift
2023/03/14 11:57:19 load.go:56: Custom YAML config provided, loading from rosa-hypershift-config.yml
2023/03/14 11:57:19 e2e.go:325: Writing files to temporary directory /tmp/1972387340
2023/03/14 11:57:19 e2e.go:341: Outputting log to build log at /tmp/1972387340/test_output.log
INFO: Logged in as 'interop-qe-ms' on 'https://api.stage.openshift.com'
2023/03/14 11:57:20 cluster.go:405: created OCM client
2023/03/14 11:57:20 version.go:103: Using the user supplied version '4.12.7'
2023/03/14 11:57:20 version.go:130: No upgrade selector found. Not selecting an upgrade version.
2023/03/14 11:57:20 e2e.go:387: Running e2e tests...
2023/03/14 11:57:20 clusterutil.go:576: CLUSTER_ID of '22f3pk1theeqj5ou8l2h4ompeu57es63' was provided, skipping cluster creation and using it instead
2023/03/14 11:57:21 events.go:30: Success event: InstallSuccessful
2023/03/14 11:57:21 e2e.go:94: CLUSTER_ID set to 22f3pk1theeqj5ou8l2h4ompeu57es63 from OCM.
2023/03/14 11:57:21 e2e.go:102: CLUSTER_NAME set to rw-0314-1 from OCM.
2023/03/14 11:57:21 e2e.go:105: CLUSTER_VERSION set to openshift-v4.12.7-candidate from OCM, for channel group candidate
2023/03/14 11:57:21 e2e.go:108: CLOUD_PROVIDER_ID set to aws from OCM.
2023/03/14 11:57:21 e2e.go:111: CLOUD_PROVIDER_REGION set to us-west-2 from OCM.
2023/03/14 11:57:21 cluster.go:1295: Successfully added property[UpgradeVersion] -
2023/03/14 11:57:21 e2e.go:134: *******************
2023/03/14 11:57:21 e2e.go:135: Cluster failed health check: forced error
2023/03/14 11:57:21 e2e.go:136: *******************
2023/03/14 11:57:22 e2e.go:750: Error getting kubeconfig from beforeSuite function
2023/03/14 11:57:35 e2e.go:518: Skipping metrics upload for local osde2e run.
2023/03/14 11:57:36 e2e.go:264: OSDE2E failed: Unable to generate helper object for cleanup
```