### PR TITLE
Ignore custom configs used while working on development tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ out/
 
 # pkger artifact
 pkged.go
+
+# Custom configs
+configs/custom-*
+custom-*


### PR DESCRIPTION
As a contributor to osde2e and using custom configs. They are easily subject to being tracked/checked into git. To avoid this, this commit updates the gitignore file to ignore custom configs that have a prefix of `custom-*`.