### PR TITLE
Exit with failure if version cannot be chosen

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -357,8 +357,8 @@ func runGinkgoTests() (int, error) {
 
 		// configure cluster and upgrade versions
 		if err = ChooseVersions(); err != nil {
-			// if we fail to choose versions, we should gracefully exit
-			return Success, err
+			// If we can't find a version to use, exit with an error code.
+			return Failure, err
 		}
 
 		switch {


### PR DESCRIPTION
not sure why the expectation would be a graceful exit, but it causes
false negatives like this in job runs:

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-ocp-osd-aws-nightly-4.12/1636143394818363392

in which the job effectively failed (did not run), but reports success.


There is some weird history on this change. It was originally introduced deliberately(tor eturn success) here:
https://github.com/openshift/osde2e/commit/44503b8cc4b890eb9f756c83380aee0796d45a56

But the "reason" points to this jira ticket:
https://issues.redhat.com/browse/SDCICD-639

which contains no further context beyond pointing to this slack thread:
https://coreos.slack.com/archives/CCX9DB894/p1618515431158100

which appears to be deleted.

Hopefully another maintainer on this repo can provide context on why the change was made and if this revert isn't appropriate maybe we can discuss a better solution to the problem at hand.