### PR TITLE
set ginkgo suite timeout

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -189,6 +189,10 @@ var Kubeconfig = struct {
 
 // Tests config keys.
 var Tests = struct {
+	// SuiteTimeout is how long (in hours) to wait for the entire suite to finish before timing out (default: 3)
+	// Env: SUITE_TIMEOUT
+	SuiteTimeout string
+
 	// PollingTimeout is how long (in seconds) to wait for an object to be created before failing the test.
 	// Env: POLLING_TIMEOUT
 	PollingTimeout string
@@ -243,6 +247,7 @@ var Tests = struct {
 	// Env: SERVICE_ACCOUNT
 	ServiceAccount string
 }{
+	SuiteTimeout:               "tests.suiteTimeout",
 	PollingTimeout:             "tests.pollingTimeout",
 	GinkgoSkip:                 "tests.ginkgoSkip",
 	GinkgoFocus:                "tests.focus",
@@ -660,6 +665,9 @@ func InitOSDe2eViper() {
 	viper.BindEnv(Kubeconfig.Path, "TEST_KUBECONFIG")
 
 	// ----- Tests -----
+	viper.SetDefault(Tests.SuiteTimeout, 3)
+	viper.BindEnv(Tests.SuiteTimeout, "SUITE_TIMEOUT")
+
 	viper.SetDefault(Tests.PollingTimeout, 300)
 	viper.BindEnv(Tests.PollingTimeout, "POLLING_TIMEOUT")
 

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -274,6 +274,7 @@ func runGinkgoTests() (int, error) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 	viper.Set(config.Cluster.Passing, false)
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
+	suiteConfig.Timeout = time.Hour * time.Duration(viper.GetInt(config.Tests.SuiteTimeout))
 
 	if skip := viper.GetString(config.Tests.GinkgoSkip); skip != "" {
 		suiteConfig.SkipStrings = append(suiteConfig.SkipStrings, skip)


### PR DESCRIPTION
the jobs in prow currently time out after 1 hour (the ginkgo default)
but they are not showing as skipped correctly in testgrid. Bumping the
suite timeout to 3hrs should allow the tests to finish or at least time
out at a test level.

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-ocp-osd-aws-nightly-4.13/1637686778385141760

```
Ran 28 of 232 Specs in 3630.017 seconds
FAIL! - Suite Timeout Elapsed -- 20 Passed | 8 Failed | 0 Pending | 204 Skipped 
```

Signed-off-by: Brady Pratt <bpratt@redhat.com>
