### PR TITLE
Avoid panic error when specific image selector fails to parse version

### DIFF
--- a/pkg/common/versions/installselectors/specific_image.go
+++ b/pkg/common/versions/installselectors/specific_image.go
@@ -44,9 +44,8 @@ func (m specificImage) SelectVersion(versionList *spi.VersionList) (*semver.Vers
 		versionFromImage += "-nightly"
 	}
 
-	versionToMatch := semver.MustParse(versionFromImage)
-
-	if versionToMatch == nil {
+	versionToMatch, err := semver.NewVersion(versionFromImage)
+	if err != nil {
 		return nil, versionType, fmt.Errorf("error parsing semver version for %s", specificImage)
 	}
 

--- a/pkg/common/versions/version_selector.go
+++ b/pkg/common/versions/version_selector.go
@@ -37,10 +37,7 @@ func GetVersionForInstall(versionList *spi.VersionList) (*semver.Version, string
 
 	v, selector, err := selectedVersionSelector.SelectVersion(versionList)
 	if err != nil {
-		log.Printf("No valid install version found for selector `%s`", selector)
-		for _, vers := range versionList.AvailableVersions() {
-			log.Printf("%s - Default? %v", vers.Version().Original(), vers.Default())
-		}
+		log.Printf("Unable to find image using selector `%s`. Error: %v", selector, err)
 		return nil, selector, nil
 
 	}


### PR DESCRIPTION
# Change
Current implementation throws a panic error causing osde2e to exit when trying to parse version into a semantic version object.

This commit will:
 * Switch from using `MustParse` to `NewVersion` to allow osde2e to handle the error
 * Delete printing out all available versions when unable to select a version from the versions list provided. Aims to keep the output clean when it tries for 30 minutes.

# Verification

Sample custom config used to test PR:

```yaml
cluster:
  channel: nightly
  releaseImageLatest: "registry.build01.ci.openshift.org/ci-op-9irmvgyv/release@sha256:e1574eee260c2fa2f72e00a82aad0200a99d524dd9fb73afd732d34fa7489227"
  skipDestroyCluster: true
  hibernateAfterUse: false
```

_Current Implementation_

```
2023/03/20 14:06:18 versions.go:34: Querying cluster versions endpoint.
2023/03/20 14:06:18 versions.go:72: could not parse version 'aaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbb-imageset': Invalid Semantic Version
2023/03/20 14:06:18 versions.go:72: could not parse version 'aaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbb-imageset': Invalid Semantic Version
2023/03/20 14:06:18 versions.go:72: could not parse version 'dgoodwin1-imageset': Invalid Semantic Version
2023/03/20 14:06:18 versions.go:72: could not parse version 'dgoodwin-stg-imageset': Invalid Semantic Version
2023/03/20 14:06:30 versions.go:34: Querying cluster versions endpoint.
E0320 14:13:11.381299   66632 runtime.go:79] Observed a panic: &errors.errorString{s:"Invalid Semantic Version"} (Invalid Semantic Version)
goroutine 1 [running]:
<truncated-output>
```

_Updated Implementation_

```
2023/03/20 14:15:03 versions.go:34: Querying cluster versions endpoint.
2023/03/20 14:15:04 versions.go:72: could not parse version 'aaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbb-imageset': Invalid Semantic Version
2023/03/20 14:15:04 versions.go:72: could not parse version 'aaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbbaaaaaaaaaabbbbbbbbbb-imageset': Invalid Semantic Version
2023/03/20 14:15:04 versions.go:72: could not parse version 'dgoodwin1-imageset': Invalid Semantic Version
2023/03/20 14:15:04 versions.go:72: could not parse version 'dgoodwin-stg-imageset': Invalid Semantic Version
2023/03/20 14:15:15 versions.go:34: Querying cluster versions endpoint.
2023/03/20 14:15:38 version_selector.go:40: Unable to find image using selector `specific image`. Error: error parsing semver version for registry.build01.ci.openshift.org/ci-op-9irmvgyv/release@sha256:e1574eee260c2fa2f72e00a82aad0200a99d524dd9fb73afd732d34fa7489227
2023/03/20 14:15:38 version.go:44: Waiting for registry.build01.ci.openshift.org/ci-op-9irmvgyv/release@sha256:e1574eee260c2fa2f72e00a82aad0200a99d524dd9fb73afd732d34fa7489227 CIS to sync with the Release Controller
```
