### PR TITLE
healthcheck cmd: address panic errors when checking replica/daemon sets

### DIFF
--- a/pkg/common/cluster/healthchecks/replicas.go
+++ b/pkg/common/cluster/healthchecks/replicas.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/logging"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	appsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
@@ -16,7 +15,6 @@ import (
 // CheckReplicaCountForDaemonSets checks if all the daemonsets running on the cluster have expected replicas
 func CheckReplicaCountForDaemonSets(dsClient appsv1.AppsV1Interface, logger *log.Logger) (bool, error) {
 	allErrors := &multierror.Error{}
-	helper := helper.NewOutsideGinkgo()
 	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 	logger.Print("Checking that all Daemonsets are running with expected replicas...")
 
@@ -29,7 +27,7 @@ func CheckReplicaCountForDaemonSets(dsClient appsv1.AppsV1Interface, logger *log
 	if dsTotalCount != 0 {
 		for _, ds := range dsList.Items {
 			// Ignore daemonsets in the OSDE2E project
-			if helper != nil && ds.Namespace == helper.CurrentProject() {
+			if strings.HasPrefix(ds.Namespace, "osde2e-") {
 				continue
 			}
 			// Ignore daemonsets not managed by OSD
@@ -51,7 +49,6 @@ func CheckReplicaCountForDaemonSets(dsClient appsv1.AppsV1Interface, logger *log
 
 // CheckReplicaCountForReplicaSets checks if all the replicasets running on the cluster have expected replicas
 func CheckReplicaCountForReplicaSets(dsClient appsv1.AppsV1Interface, logger *log.Logger) (bool, error) {
-	helper := helper.NewOutsideGinkgo()
 	allErrors := &multierror.Error{}
 	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 	logger.Print("Checking that all Replicasets are running with expected replicas...")
@@ -65,7 +62,7 @@ func CheckReplicaCountForReplicaSets(dsClient appsv1.AppsV1Interface, logger *lo
 	if rsTotalCount != 0 {
 		for _, rs := range rsList.Items {
 			// Ignore replicasets in the OSDE2E project
-			if helper != nil && rs.Namespace == helper.CurrentProject() {
+			if strings.HasPrefix(rs.Namespace, "osde2e-") {
 				continue
 			}
 			// Ignore replicasets not managed by OSD


### PR DESCRIPTION
# Change

The health check command was failing on a conditional check trying to make sure the namespace being verified was not created by osde2e tests. Error was related trying to use gomega assertions outside of ginkgo.

Since the helper collection (proj field) is never fully initialized (e.g. nil) due to the ginkgo recover statement. This change removes using the helper to get the current project and just make sure it does not contain the osde2e string.

# Verification

_Before_

```
$ ./out/osde2e healthcheck --cluster-id 22is8qa5agmlr4j8aenpqb319uhgd6ed --configs aws,stage
2023/03/20 17:23:49 configs.go:24: Will load config aws
2023/03/20 17:23:49 configs.go:24: Will load config stage
2023/03/20 17:23:49 Polling Cluster Health...
2023/03/20 17:23:49 Checking that CVO says the cluster is healthy...
2023/03/20 17:23:49 Checking that all Nodes are running or completed...
2023/03/20 17:23:49 Checking that machines are healthy...
2023/03/20 17:23:50 Checking that all Operators are running or completed...
2023/03/20 17:23:50 Certificate(s) has been found.
2023/03/20 17:23:50 Checking that all Daemonsets are running with expected replicas...
panic: You are trying to make an assertion, but haven't registered Gomega's fail handler.
If you're using Ginkgo then you probably forgot to put your assertion in an It().
Alternatively, you may have forgotten to register a fail handler with RegisterFailHandler() or RegisterTestingT().
Depending on your vendoring solution you may be inadvertently importing gomega and subpackages (e.g. ghhtp, gexec,...) from different locations.


goroutine 1 [running]:
github.com/onsi/gomega.ensureDefaultGomegaIsConfigured()
        /home/rywillia/go/pkg/mod/github.com/onsi/gomega@v1.27.4/gomega_dsl.go:169 +0x9c
github.com/onsi/gomega.Expect({0x352b160, 0x0}, {0x0, 0x0, 0x0})
        /home/rywillia/go/pkg/mod/github.com/onsi/gomega@v1.27.4/gomega_dsl.go:221 +0x32
github.com/openshift/osde2e/pkg/common/helper.(*H).CurrentProject(0xc0010f7110)
        /home/rywillia/sdqe/osde2e/pkg/common/helper/helper.go:304 +0x34
github.com/openshift/osde2e/pkg/common/cluster/healthchecks.CheckReplicaCountForDaemonSets({0x3ca8918, 0xc0005fb420}, 0xc0000cbef0)
        /home/rywillia/sdqe/osde2e/pkg/common/cluster/healthchecks/replicas.go:32 +0x313
github.com/openshift/osde2e/pkg/common/cluster.PollClusterHealth({0x7fff8c0cdcdc, 0x20}, 0x0?)
        /home/rywillia/sdqe/osde2e/pkg/common/cluster/clusterutil.go:487 +0x968
github.com/openshift/osde2e/cmd/osde2e/healthcheck.run(0x59cdca0?, {0xc000fe2640?, 0x4?, 0x4?})
        /home/rywillia/sdqe/osde2e/cmd/osde2e/healthcheck/cmd.go:89 +0x138
github.com/spf13/cobra.(*Command).execute(0x59cdca0, {0xc000fe2600, 0x4, 0x4})
        /home/rywillia/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:916 +0x862
github.com/spf13/cobra.(*Command).ExecuteC(0x59d04e0)
        /home/rywillia/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
        /home/rywillia/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
main.main()
        /home/rywillia/sdqe/osde2e/cmd/osde2e/main.go:56 +0x47
```

_After_

```
$ ./out/osde2e healthcheck --cluster-id 22is8qa5agmlr4j8aenpqb319uhgd6ed --configs aws,stage
2023/03/20 17:23:13 configs.go:24: Will load config aws
2023/03/20 17:23:13 configs.go:24: Will load config stage
2023/03/20 17:23:13 Polling Cluster Health...
2023/03/20 17:23:14 Checking that CVO says the cluster is healthy...
2023/03/20 17:23:14 Checking that all Nodes are running or completed...
2023/03/20 17:23:14 Checking that machines are healthy...
2023/03/20 17:23:14 Checking that all Operators are running or completed...
2023/03/20 17:23:14 Certificate(s) has been found.
2023/03/20 17:23:14 Checking that all Daemonsets are running with expected replicas...
2023/03/20 17:23:14 Checking that all Replicasets are running with expected replicas...
2023/03/20 17:23:15 cmd.go:91: Cluster 22is8qa5agmlr4j8aenpqb319uhgd6ed is healthy!
```

Needed by [SDCICD-951](https://issues.redhat.com//browse/SDCICD-951)