### PR TITLE
ordered operator installs

### DIFF
--- a/pkg/e2e/operators/certman.go
+++ b/pkg/e2e/operators/certman.go
@@ -36,16 +36,16 @@ var _ = ginkgo.Describe(certmanOperatorTestName, label.Operators, func() {
 	ginkgo.Context("certificate secret should be applied when cluster installed", func() {
 		var secretName string
 		var secrets *v1.SecretList
-		var err error
 		var apiserver *osv1.APIServer
 
 		// Waiting period to wait for certman resources to appear
 		pollingDuration := 15 * time.Minute
 		util.GinkgoIt("certificate secret exist under openshift-config namespace", func(ctx context.Context) {
-			wait.PollImmediate(30*time.Second, pollingDuration, func() (bool, error) {
+			err := wait.PollImmediate(30*time.Second, pollingDuration, func() (bool, error) {
 				listOpts := metav1.ListOptions{
 					LabelSelector: "certificate_request",
 				}
+				var err error
 				secrets, err = h.Kube().CoreV1().Secrets("openshift-config").List(ctx, listOpts)
 				if err != nil {
 					return false, err
@@ -61,8 +61,9 @@ var _ = ginkgo.Describe(certmanOperatorTestName, label.Operators, func() {
 		}, pollingDuration.Seconds())
 
 		util.GinkgoIt("certificate secret should be applied to apiserver object", func(ctx context.Context) {
-			wait.PollImmediate(30*time.Second, pollingDuration, func() (bool, error) {
+			err := wait.PollImmediate(30*time.Second, pollingDuration, func() (bool, error) {
 				getOpts := metav1.GetOptions{}
+				var err error
 				apiserver, err = h.Cfg().ConfigV1().APIServers().Get(ctx, "cluster", getOpts)
 				if err != nil {
 					return false, err

--- a/pkg/e2e/operators/managedupgrade.go
+++ b/pkg/e2e/operators/managedupgrade.go
@@ -33,7 +33,7 @@ func init() {
 	alert.RegisterGinkgoAlert(managedUpgradeOperatorTestName, "SD-SREP", "@managed-upgrade-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(managedUpgradeOperatorTestName, label.Informing, func() {
+var _ = ginkgo.Describe(managedUpgradeOperatorTestName, ginkgo.Ordered, label.Informing, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(config.Hypershift) {
 			ginkgo.Skip("Managed Upgrade Operator is not supported on HyperShift")

--- a/pkg/e2e/operators/managedvelero.go
+++ b/pkg/e2e/operators/managedvelero.go
@@ -28,7 +28,7 @@ func init() {
 	alert.RegisterGinkgoAlert(veleroOperatorTestName, "SD-SREP", "@managed-velero-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(veleroOperatorTestName, label.Operators, func() {
+var _ = ginkgo.Describe(veleroOperatorTestName, ginkgo.Ordered, label.Operators, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool("rosa.STS") {
 			ginkgo.Skip("STS does not support MVO")

--- a/pkg/e2e/operators/mustgather.go
+++ b/pkg/e2e/operators/mustgather.go
@@ -28,7 +28,7 @@ func init() {
 	alert.RegisterGinkgoAlert(mustGatherOperatorTest, "SD-SREP", "@sd-sre-aurora-team", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(mustGatherOperatorTest, label.Operators, func() {
+var _ = ginkgo.Describe(mustGatherOperatorTest, ginkgo.Ordered, label.Operators, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(config.Hypershift) {
 			ginkgo.Skip("Must Gather Operator is not supported on HyperShift")

--- a/pkg/e2e/operators/osdmetricsexporter.go
+++ b/pkg/e2e/operators/osdmetricsexporter.go
@@ -18,7 +18,7 @@ func init() {
 	alert.RegisterGinkgoAlert(osdMetricsExporterBasicTest, "SD_SREP", "@sre-platform-team-v1alpha1", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(osdMetricsExporterBasicTest, label.Operators, func() {
+var _ = ginkgo.Describe(osdMetricsExporterBasicTest, ginkgo.Ordered, label.Operators, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(config.Hypershift) {
 			ginkgo.Skip("OSD Metrics Exporter is not supported on HyperShift")

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -29,7 +29,7 @@ func init() {
 	alert.RegisterGinkgoAlert(subjectPermissionsTestName, "SD-SREP", "@rbac-permissions-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(rbacOperatorBlocking, label.Operators, func() {
+var _ = ginkgo.Describe(rbacOperatorBlocking, ginkgo.Ordered, label.Operators, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(config.Hypershift) {
 			ginkgo.Skip("RBAC Permissions Operator is not supported on HyperShift")

--- a/pkg/e2e/operators/routemonitor.go
+++ b/pkg/e2e/operators/routemonitor.go
@@ -31,7 +31,7 @@ func init() {
 	alert.RegisterGinkgoAlert(routeMonitorOperatorTestName, "SD-SREP", "@sre-platform-team-orange", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(routeMonitorOperatorTestName, label.Informing, func() {
+var _ = ginkgo.Describe(routeMonitorOperatorTestName, ginkgo.Ordered, label.Informing, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(config.Hypershift) {
 			ginkgo.Skip("Route Monitor Operator is not supported on HyperShift")

--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 // Blocking SplunkForwarder Signal
-var _ = ginkgo.Describe(splunkForwarderBlocking, label.Operators, func() {
+var _ = ginkgo.Describe(splunkForwarderBlocking, ginkgo.Ordered, label.Operators, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(config.Hypershift) {
 			ginkgo.Skip("Splunk Forwarder Operator is not deployed to a ROSA hosted-cp cluster (OSD-11605)")
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe(splunkForwarderBlocking, label.Operators, func() {
 })
 
 // Informing SplunkForwarder Signal
-var _ = ginkgo.Describe(splunkForwarderInforming, label.Operators, label.Informing, func() {
+var _ = ginkgo.Describe(splunkForwarderInforming, ginkgo.Ordered, label.Operators, label.Informing, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(config.Hypershift) {
 			ginkgo.Skip("Splunk Forwarder Operator is not deployed to a ROSA hosted-cp cluster (OSD-11605)")


### PR DESCRIPTION
- operators/rbac: ordered install tests
- operators/mustgather: ordered install tests
- operators/certman: check poll err
- operators/routemonitor: ordered install tests
- operators/managedvelero: ordered install tests
- operators/managedupgrade: ordered install tests
- operators/splunkforwarder: ordered install tests
