### PR TITLE
bump suite timeout to 6 hours

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -189,7 +189,7 @@ var Kubeconfig = struct {
 
 // Tests config keys.
 var Tests = struct {
-	// SuiteTimeout is how long (in hours) to wait for the entire suite to finish before timing out (default: 3)
+	// SuiteTimeout is how long (in hours) to wait for the entire suite to finish before timing out
 	// Env: SUITE_TIMEOUT
 	SuiteTimeout string
 
@@ -665,7 +665,7 @@ func InitOSDe2eViper() {
 	viper.BindEnv(Kubeconfig.Path, "TEST_KUBECONFIG")
 
 	// ----- Tests -----
-	viper.SetDefault(Tests.SuiteTimeout, 3)
+	viper.SetDefault(Tests.SuiteTimeout, 6)
 	viper.BindEnv(Tests.SuiteTimeout, "SUITE_TIMEOUT")
 
 	viper.SetDefault(Tests.PollingTimeout, 300)


### PR DESCRIPTION
the tests take longer than 3 hours to timeout completely

```
Ran 121 of 222 Specs in 13624.890 seconds
FAIL! -- 76 Passed | 45 Failed | 0 Pending | 101 Skipped
```