### PR TITLE
Add the ability to write files to a shared directory for later use

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -89,7 +89,12 @@ const (
 	// Hypershift enables the use of hypershift for cluster creation.
 	Hypershift = "Hypershift"
 
+	// Ignores invalid certificates within HyperShift kubeconfig
 	HypershiftIgnoreInvalidCert = "HypershiftIgnoreInvalidCert"
+
+	// SharedDir is the location where files to be used by other processes/programs are stored.
+	// This is primarily used when running within Prow and using additional steps after osde2e finishes.
+	SharedDir = "sharedDir"
 )
 
 // This is a config key to secret file mapping. We will attempt to read in from secret files before loading anything else.
@@ -619,6 +624,8 @@ func InitOSDe2eViper() {
 	viper.BindEnv(Artifacts, "ARTIFACTS")
 
 	viper.BindEnv(ReportDir, "REPORT_DIR")
+
+	viper.BindEnv(SharedDir, "SHARED_DIR")
 
 	viper.BindEnv(Suffix, "SUFFIX")
 


### PR DESCRIPTION
# Change

This change adds a new config to set a path on the file system for a shared directory to store files to be used at a later point. The trigger for this enhancement is when using osde2e in a prow workflow with following steps that need access to information about the cluster (e.g. cluster id or kubeconfig). These 2 files are the initial ones that will be stored in the shared directory.

The shared directory will automatically be picked up by prow jobs as osde2e will get the value from environment variable `SHARED_DIR` which is what prow sets for each run.

https://docs.ci.openshift.org/docs/architecture/step-registry/#available-environment-variables

In addition, the temporary directory name has changed to include osde2e when none is supplied. Making it easier for the osde2e user to understand what this directory is on their file system.

For SDCICD-951

_Before_

```
tree /tmp/125860190/
/tmp/125860190/
├── custom-prow-metadata.json
├── install
├── install-log.txt
├── metadata.json
├── test_output.log
└── uninstall-log.txt
```

_After_

```
tree -L 2 /tmp/osde2e-3besdyqm8f
/tmp/osde2e-3besdyqm8f
├── custom-prow-metadata.json
├── install
├── install-log.txt
├── metadata.json
├── shared-files
│   ├── cluster-id
│   └── kubeconfig
├── test_output.log
└── uninstall-log.txt
```