### PR TITLE
operators/managedupgrade: move out of informing suite

### DIFF
--- a/pkg/e2e/operators/managedupgrade.go
+++ b/pkg/e2e/operators/managedupgrade.go
@@ -27,13 +27,13 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-var managedUpgradeOperatorTestName string = "[Suite: informing] [OSD] Managed Upgrade Operator"
+var managedUpgradeOperatorTestName string = "Managed Upgrade Operator"
 
 func init() {
 	alert.RegisterGinkgoAlert(managedUpgradeOperatorTestName, "SD-SREP", "@managed-upgrade-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(managedUpgradeOperatorTestName, ginkgo.Ordered, label.Informing, func() {
+var _ = ginkgo.Describe(managedUpgradeOperatorTestName, ginkgo.Ordered, label.Operators, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(config.Hypershift) {
 			ginkgo.Skip("Managed Upgrade Operator is not supported on HyperShift")


### PR DESCRIPTION
these tests are stable and can be moved to the e2e suite with the other operator tests

Signed-off-by: Brady Pratt <bpratt@redhat.com>
