### PR TITLE
New version selector to get latest X.Y version available

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -326,6 +326,9 @@ var Cluster = struct {
 	// InstallSpecificNightly will select a nightly using a specific nightly given an "X.Y" formatted string
 	InstallSpecificNightly string
 
+	// InstallLatestXY will select the latest version available given an "X.Y" formatted string
+	InstallLatestXY string
+
 	// CleanCheckRuns lets us set the number of osd-verify checks we want to run before deeming a cluster "healthy"
 	// Env: CLEAN_CHECK_RUNS
 	CleanCheckRuns string
@@ -407,6 +410,7 @@ var Cluster = struct {
 	LatestYReleaseAfterProdDefault:      "cluster.latestYReleaseAfterProdDefault",
 	LatestZReleaseAfterProdDefault:      "cluster.latestZReleaseAfterProdDefault",
 	InstallSpecificNightly:              "cluster.installLatestNightly",
+	InstallLatestXY:                     "cluster.installLatestXY",
 	CleanCheckRuns:                      "cluster.cleanCheckRuns",
 	ID:                                  "cluster.id",
 	Name:                                "cluster.name",
@@ -752,6 +756,8 @@ func InitOSDe2eViper() {
 	viper.BindEnv(Cluster.LatestZReleaseAfterProdDefault, "LATEST_Z_RELEASE_AFTER_PROD_DEFAULT")
 
 	viper.BindEnv(Cluster.InstallSpecificNightly, "INSTALL_LATEST_NIGHTLY")
+
+	viper.BindEnv(Cluster.InstallLatestXY, "INSTALL_LATEST_XY")
 
 	viper.SetDefault(Cluster.DeltaReleaseFromDefault, 0)
 	viper.BindEnv(Cluster.DeltaReleaseFromDefault, "DELTA_RELEASE_FROM_DEFAULT")

--- a/pkg/common/versions/installselectors/latest_xy.go
+++ b/pkg/common/versions/installselectors/latest_xy.go
@@ -1,0 +1,43 @@
+package installselectors
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/spi"
+)
+
+func init() {
+	registerSelector(latestXYVersion{})
+}
+
+type latestXYVersion struct{}
+
+func (m latestXYVersion) ShouldUse() bool {
+	return viper.GetString(config.Cluster.InstallLatestXY) != ""
+}
+
+func (m latestXYVersion) Priority() int {
+	return 60
+}
+
+func (m latestXYVersion) SelectVersion(versionList *spi.VersionList) (*semver.Version, string, error) {
+	latestXY := viper.GetString(config.Cluster.InstallLatestXY)
+	versionType := "latest X.Y version available"
+	versions := versionList.AvailableVersions()
+
+	semVersion, err := semver.NewVersion(latestXY)
+	if err != nil {
+		return nil, versionType, fmt.Errorf("error parsing semantic version for %s", latestXY)
+	}
+
+	for _, version := range versions {
+		if version.Version().Major() == semVersion.Major() && version.Version().Minor() == semVersion.Minor() {
+			return version.Version(), versionType, nil
+		}
+	}
+
+	return nil, versionType, fmt.Errorf("unable to locate latest version for %s", latestXY)
+}


### PR DESCRIPTION
# Change

This change adds a new install selector to select a version to install for rosa/osd based on a major.minor version supplied. It will get the latest available one based on the channel group provided as well.

Needed for https://github.com/openshift/release/pull/36987 now that 4.11 is the default version again. This change will allow the HyperShift jobs to install the latest 4.12 version available since it only supports >= 4.12.

# Examples

1. Get latest 4.12 version available for candidate channel

```yaml
cluster:
  installLatestXY: "4.12"
  channel: candidate
```

```
2023/03/23 15:58:58 cluster.go:486: created OCM client
2023/03/23 15:58:59 version.go:103: Using the latest X.Y version available '4.12.9-candidate'
2023/03/23 15:58:59 version.go:130: No upgrade selector found. Not selecting an upgrade version.
```

2. Get latest 4.12 version available for stable channel

```yaml
cluster:
  installLatestXY: "4.12"
  channel: stable
```

```
2023/03/23 16:13:49 cluster.go:486: created OCM client
2023/03/23 16:13:49 version.go:103: Using the latest X.Y version available '4.12.7'
2023/03/23 16:13:49 version.go:130: No upgrade selector found. Not selecting an upgrade version.
```

3. Get latest 4.11 version available for candidate channel

```yaml
cluster:
  installLatestXY: "4.11"
  channel: candidate
```

```
2023/03/23 16:14:56 cluster.go:486: created OCM client
2023/03/23 16:14:57 version.go:103: Using the latest X.Y version available '4.11.31'
2023/03/23 16:14:57 version.go:130: No upgrade selector found. Not selecting an upgrade version.
```