### PR TITLE
Only get OCP versions compatible for ROSA HCP when HCP is enabled

### DIFF
--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -503,7 +503,9 @@ func (m *ROSAProvider) Versions() (*spi.VersionList, error) {
 	var defaultVersionOverride *semver.Version = nil
 
 	for _, v := range versionResponse {
-		if version, err := util.OpenshiftVersionToSemver(v.ID()); err != nil {
+		if viper.GetBool(config.Hypershift) && !v.HostedControlPlaneEnabled() {
+			continue
+		} else if version, err := util.OpenshiftVersionToSemver(v.ID()); err != nil {
 			log.Printf("could not parse version '%s': %v", v.ID(), err)
 		} else if v.Enabled() {
 			if v.Default() {


### PR DESCRIPTION
# Change

This PR will filter the list of OCP versions for versions that support hosted control plane clusters (when this input is provided to osde2e) prior to calling the selected version install selector.

With this change, osde2e can safely fetch the latest available OCP version (when toggled on to do so) that supports HCP and can install the cluster. Over getting the latest version that may not support HCP. Refer to https://github.com/openshift/release/pull/37882
