### PR TITLE
Fix spelling error with test harness and include a new label

### DIFF
--- a/configs/test-harness.yaml
+++ b/configs/test-harness.yaml
@@ -1,3 +1,2 @@
 tests:
-  testsToRun:
-  - '\[Suite\: harnessess\]'
+  ginkgoLabelFilter: TestHarness

--- a/pkg/common/label/label.go
+++ b/pkg/common/label/label.go
@@ -74,6 +74,9 @@ var (
 
 	// Application build tests verify the ability to deploy applications
 	AppBuilds = ginkgo.Label("AppBuilds")
+
+	// Runs tests that are using the test harness functionality
+	TestHarness = ginkgo.Label("TestHarness")
 )
 
 func AllCloudProviders() []ginkgo.Labels {

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -11,10 +11,11 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/prow"
 )
 
-var _ = ginkgo.Describe("[Suite: harnessess] Test Harness", ginkgo.Ordered, func() {
+var _ = ginkgo.Describe("Test Harness", ginkgo.Ordered, label.TestHarness, func() {
 	var h *helper.H
 	ginkgo.BeforeAll(func() {
 		h = helper.New()


### PR DESCRIPTION
# Change
Addresses the error around harnessess and adds a new label for TestHarness. Which can be used to tell osde2e to run the test harness suite.