### PR TITLE
SDCICD-959: Extend the use of AWS profiles where access key/secret access key are used

### DIFF
--- a/pkg/common/aws/session.go
+++ b/pkg/common/aws/session.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 	"sync"
 
@@ -34,7 +35,7 @@ func (CcsAwsSession *ccsAwsSession) GetAWSSessions() error {
 
 		options := session.Options{
 			Config: aws.Config{
-				Region: aws.String(viper.GetString(config.CloudProvider.Region)),
+				Region: aws.String(viper.GetString(config.AWSRegion)),
 			},
 		}
 
@@ -53,4 +54,22 @@ func (CcsAwsSession *ccsAwsSession) GetAWSSessions() error {
 	}
 
 	return nil
+}
+
+// GetCredentials returns the credentials for the current aws session
+func (CcsAwsSession *ccsAwsSession) GetCredentials() (*credentials.Value, error) {
+	if err := CcsAwsSession.GetAWSSessions(); err != nil {
+		return nil, fmt.Errorf("failed to create aws session to retrieve credentials: %v", err)
+	}
+
+	creds, err := CcsAwsSession.session.Config.Credentials.Get()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get aws credentials: %v", err)
+	}
+	return &creds, nil
+}
+
+// GetRegion returns the region set when the session was created
+func (CcsAwsSession *ccsAwsSession) GetRegion() *string {
+	return CcsAwsSession.session.Config.Region
 }

--- a/pkg/common/providers/rosaprovider/rosa.go
+++ b/pkg/common/providers/rosaprovider/rosa.go
@@ -4,6 +4,8 @@ package rosaprovider
 import (
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/openshift/osde2e/pkg/common/aws"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
 	"github.com/openshift/osde2e/pkg/common/spi"
@@ -15,7 +17,9 @@ func init() {
 
 // ROSAProvider will provision clusters via ROSA.
 type ROSAProvider struct {
-	ocmProvider *ocmprovider.OCMProvider
+	ocmProvider    *ocmprovider.OCMProvider
+	awsCredentials *credentials.Value
+	awsRegion      string
 }
 
 // New will create a new ROSAProvider.
@@ -25,8 +29,20 @@ func New() (*ROSAProvider, error) {
 		return nil, fmt.Errorf("error creating OCM provider for ROSA provider: %v", err)
 	}
 
+	awsCredentials, err := aws.CcsAwsSession.GetCredentials()
+	if err != nil {
+		return nil, fmt.Errorf("error creating aws session: %v", err)
+	}
+
+	region := *aws.CcsAwsSession.GetRegion()
+	if region == "" {
+		return nil, fmt.Errorf("aws region is undefined")
+	}
+
 	return &ROSAProvider{
-		ocmProvider: ocmProvider,
+		ocmProvider:    ocmProvider,
+		awsCredentials: awsCredentials,
+		awsRegion:      region,
 	}, nil
 }
 


### PR DESCRIPTION
# Change
This PR adds onto the previous commit for supporting aws profiles to support using profiles across additional functions communicating with aws. Functions that were previously getting the keys from config will now get the credentials from the aws session (which loads from config object). This keeps accessing aws credentials in one location over multiple.

For [SDCICD-959](https://issues.redhat.com/browse/SDCICD-959)