### PR TITLE
SDCICD-956: Skip configure alertmanager operator secret exists tests for nightly build clusters

### DIFF
--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -1029,6 +1029,7 @@ func (o *OCMProvider) ocmToSPICluster(ocmCluster *v1.Cluster) (*spi.Cluster, err
 
 	if version, ok := ocmCluster.GetVersion(); ok {
 		cluster.Version(version.ID())
+		cluster.ChannelGroup(version.ChannelGroup())
 	}
 
 	if cloudProvider, ok := ocmCluster.GetCloudProvider(); ok {

--- a/pkg/common/spi/cluster.go
+++ b/pkg/common/spi/cluster.go
@@ -37,6 +37,7 @@ type Cluster struct {
 	id                  string
 	name                string
 	version             string
+	channelGroup        string
 	cloudProvider       string
 	product             string
 	region              string
@@ -67,6 +68,11 @@ func (c *Cluster) Name() string {
 // Version returns the cluster version.
 func (c *Cluster) Version() string {
 	return c.version
+}
+
+// ChannelGroup returns the cluster channel group
+func (c *Cluster) ChannelGroup() string {
+	return c.channelGroup
 }
 
 // CloudProvider returns the cloud provider.
@@ -124,6 +130,7 @@ type ClusterBuilder struct {
 	id                  string
 	name                string
 	version             string
+	channelGroup        string
 	cloudProvider       string
 	product             string
 	region              string
@@ -159,6 +166,12 @@ func (cb *ClusterBuilder) Name(name string) *ClusterBuilder {
 // Version sets the version for a cluster builder.
 func (cb *ClusterBuilder) Version(version string) *ClusterBuilder {
 	cb.version = version
+	return cb
+}
+
+// ChannelGroup returns the cluster channel group
+func (cb *ClusterBuilder) ChannelGroup(channelGroup string) *ClusterBuilder {
+	cb.channelGroup = channelGroup
 	return cb
 }
 
@@ -235,6 +248,7 @@ func (cb *ClusterBuilder) Build() *Cluster {
 		id:                  cb.id,
 		name:                cb.name,
 		version:             cb.version,
+		channelGroup:        cb.channelGroup,
 		cloudProvider:       cb.cloudProvider,
 		product:             cb.product,
 		region:              cb.region,

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -91,6 +91,8 @@ func beforeSuite() bool {
 		}
 
 		viper.Set(config.Cluster.ID, cluster.ID())
+		viper.Set(config.Cluster.Channel, cluster.ChannelGroup())
+
 		log.Printf("CLUSTER_ID set to %s from OCM.", viper.GetString(config.Cluster.ID))
 		if viper.Get(config.Addons.IDs) != nil {
 			passthruSecrets := viper.GetStringMapString(config.NonOSDe2eSecrets)

--- a/pkg/e2e/operators/configurealertmanager/configurealertmanager.go
+++ b/pkg/e2e/operators/configurealertmanager/configurealertmanager.go
@@ -156,6 +156,11 @@ var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.Operators, func() {
 	})
 
 	ginkgo.It("secrets exist", label.Install, func(ctx context.Context) {
+		if viper.GetString(config.Cluster.Channel) == "nightly" {
+			// https://github.com/openshift/pagerduty-operator/blob/master/hack/olm-registry/olm-artifacts-template.yaml
+			ginkgo.Skip("Secrets are not applied to nightly build clusters")
+		}
+
 		for _, secret := range secrets {
 			err := client.Get(ctx, secret, namespaceName, &v1.Secret{})
 			expect.NoError(err, "secret %s not found", secret)


### PR DESCRIPTION
# Change

Configure alertmanager operator secrets (_dms-secret_ and _pd-secret_) are not applied to clusters that are deployed using nightly openshift builds. This is design to avoid paging SRE. Example can be seen [here](https://github.com/openshift/pagerduty-operator/blob/4e6ba964ab8dbd49b2fc1185f6c2af2673bec77a/hack/olm-registry/olm-artifacts-template.yaml#L95-L98)

Channel group is fetched from OCM cluster resource as it contains the channel group used when provisioned. Allowing the test case to be skipped properly if a cluster ID is provided and no channel group is defined.

For [SDCICD-956](https://issues.redhat.com/browse/SDCICD-956)