### PR TITLE
Provision for addon-metadata files created in addon harnesses

### DIFF
--- a/pkg/common/metadata/metadata.go
+++ b/pkg/common/metadata/metadata.go
@@ -22,7 +22,6 @@ const (
 
 	// AddonMetadataFile is created by some addons during execution
 	AddonMetadataFile string = "addon-metadata.json"
-	
 )
 
 // Metadata houses the metadata that will be written to the report directory after
@@ -285,7 +284,7 @@ func (m *Metadata) WriteToJSON(reportDir string) (err error) {
 
 				for _, phaseFile := range phaseFiles {
 					// Process the jUnit XML result files
-					if phaseFile.Name() == TestHarnessMetadataFile || phaseFile.Name() == AddonMetadataFile{
+					if phaseFile.Name() == TestHarnessMetadataFile || phaseFile.Name() == AddonMetadataFile {
 						// Unmarshal raw metadata to map
 						rawMetadataJSON := map[string]interface{}{}
 						if err := json.Unmarshal(data, &rawMetadataJSON); err != nil {

--- a/pkg/common/metadata/metadata.go
+++ b/pkg/common/metadata/metadata.go
@@ -19,6 +19,10 @@ const (
 
 	// TestHarnessMetadataFile is name of the test harness metadata file
 	TestHarnessMetadataFile string = "test-harness-metadata.json"
+
+	// AddonMetadataFile is created by some addons during execution
+	AddonMetadataFile string = "addon-metadata.json"
+	
 )
 
 // Metadata houses the metadata that will be written to the report directory after
@@ -281,7 +285,7 @@ func (m *Metadata) WriteToJSON(reportDir string) (err error) {
 
 				for _, phaseFile := range phaseFiles {
 					// Process the jUnit XML result files
-					if phaseFile.Name() == TestHarnessMetadataFile {
+					if phaseFile.Name() == TestHarnessMetadataFile || phaseFile.Name() == AddonMetadataFile{
 						// Unmarshal raw metadata to map
 						rawMetadataJSON := map[string]interface{}{}
 						if err := json.Unmarshal(data, &rawMetadataJSON); err != nil {


### PR DESCRIPTION
[SDCICD-717](https://issues.redhat.com//browse/SDCICD-717)

Converting addon harness to generic test harness also changed the default addon metadata filename to test-harness metadata. Addon-metadata.json file is already being used by addons to generate metadata, and main metadata file is generated based on their test phases.

To fix this, I have reintroduced the filename and included it in the condition to update the main metadata file. This creates the metadata file with the data that addons are expecting. 

Internal thread https://redhat-internal.slack.com/archives/CMK13BP4J/p1680590567087939?thread_ts=1680534911.725599&cid=CMK13BP4J 