### PR TITLE
verify/pods: ignore pods that are in osde2e prefixed namespaces

### DIFF
--- a/pkg/e2e/verify/pods.go
+++ b/pkg/e2e/verify/pods.go
@@ -34,6 +34,9 @@ var _ = ginkgo.Describe(podsTestName, ginkgo.Ordered, label.HyperShift, label.E2
 		filteredList := &v1.PodList{}
 		expect.NoError(client.WithNamespace(metav1.NamespaceAll).List(ctx, list))
 		for _, pod := range list.Items {
+			if strings.HasPrefix(pod.Namespace, "osde2e-") {
+				continue
+			}
 			if pod.Status.Phase == v1.PodFailed {
 				if len(pod.GetOwnerReferences()) > 0 {
 					if pod.GetOwnerReferences()[0].Kind == "Job" {


### PR DESCRIPTION
# Change
The verify pods test is focused on verifying no pods are in a failed state that are required to mark the cluster is operational "healthy".

If a prior test case ran but had a pod end up in a failed state/the pod was never properly cleaned up. It causes the verify/pod test to fail. The prior test should handle its clean up to not pollute following tests.

This commit ignores any pods that are within an osde2e prefixed namespace.

Job that presented this issue can be seen [here](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-ocp-osd-aws-nightly-4.13/1644192397413847040)

![img](https://user-images.githubusercontent.com/3375653/231480761-3f0e96f2-fb3c-4540-908d-ca5f5dc8feb3.png)


