### PR TITLE
SDCICD-971: add an option to toggle on/off running post upgrade tests

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -163,6 +163,9 @@ var Upgrade = struct {
 
 	// Reschedule the upgrade via provider before commence
 	ManagedUpgradeRescheduled string
+
+	// Toggle on/off running post upgrade tests
+	RunPostUpgradeTests string
 }{
 	UpgradeToLatest:                        "upgrade.toLatest",
 	UpgradeToLatestZ:                       "upgrade.ToLatestZ",
@@ -175,6 +178,7 @@ var Upgrade = struct {
 	ManagedUpgradeTestPodDisruptionBudgets: "upgrade.managedUpgradeTestPodDisruptionBudgets",
 	ManagedUpgradeTestNodeDrain:            "upgrade.managedUpgradeTestNodeDrain",
 	ManagedUpgradeRescheduled:              "upgrade.managedUpgradeRescheduled",
+	RunPostUpgradeTests:                    "upgrade.runPostUpgradeTests",
 }
 
 // Kubeconfig configBUILD_NUMBER keys.
@@ -665,6 +669,9 @@ func InitOSDe2eViper() {
 
 	viper.BindEnv(Upgrade.ManagedUpgradeRescheduled, "UPGRADE_MANAGED_TEST_RESCHEDULE")
 	viper.SetDefault(Upgrade.ManagedUpgradeRescheduled, false)
+
+	viper.BindEnv(Upgrade.RunPostUpgradeTests, "UPGRADE_RUN_POST_TESTS")
+	viper.SetDefault(Upgrade.RunPostUpgradeTests, false)
 
 	// ----- Kubeconfig -----
 	viper.BindEnv(Kubeconfig.Path, "TEST_KUBECONFIG")

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -434,8 +434,7 @@ func runGinkgoTests() (int, error) {
 			}
 			events.RecordEvent(events.UpgradeSuccessful)
 
-			// test upgrade rescheduling if desired
-			if !viper.GetBool(config.Upgrade.ManagedUpgradeRescheduled) {
+			if viper.GetBool(config.Upgrade.RunPostUpgradeTests) {
 				log.Println("Running e2e tests POST-UPGRADE...")
 				viper.Set(config.Cluster.Passing, false)
 				upgradeTestsPassed, upgradeTestCaseData = runTestsInPhase(
@@ -446,7 +445,6 @@ func runGinkgoTests() (int, error) {
 				)
 				viper.Set(config.Cluster.Passing, upgradeTestsPassed)
 			}
-			log.Println("Upgrade rescheduled, skip the POST-UPGRADE testing")
 
 			// close route monitors
 			if viper.GetBool(config.Upgrade.MonitorRoutesDuringUpgrade) && !suiteConfig.DryRun {


### PR DESCRIPTION
# Change
Ginkgo does not support calling RunSpec twice which is what osde2e is attempting to do for upgrade use cases. Ginkgo does allow to run the same spec multiple times in a row when invoked from the cli. To remove the failures in CI jobs/local osde2e runs. This commit adds a new option to toggle on/off running post upgrade tests. It sets the default to never run them until a permanent solution is in place.

```
[1681759212] OSD e2e suite - 9/222 specs SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS•••••••••SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS SUCCESS! 11.563394383s 2023/04/17 15:21:10 e2e.go:427: Route Monitors created.
2023/04/17 15:21:10 e2e.go:439: Running e2e tests POST-UPGRADE...
2023/04/17 15:21:10 e2e.go:179: Skipping health checks as requested
Ginkgo detected an issue with your spec structure
_ = ginkgo.ReportAfterSuite("OSDE2E", func(report ginkgo.Report) {
/home/rywillia/sdqe/osde2e/pkg/e2e/e2e.go:776
  It looks like you are trying to add a [ReportAfterSuite] node within a leaf
  node after the spec started running.

  ReportAfterSuite can only be called at the top level.

  Learn more at:
  http://onsi.github.io/ginkgo/#reporting-nodes---reportbeforesuite-and-reportaftersuite

Process 729381 has exited with status 1



2023/04/17 15:30:56 e2e.go:441: Running e2e tests POST-UPGRADE...
2023/04/17 15:30:56 e2e.go:179: Skipping health checks as requested
Rerunning Suite
  It looks like you are calling RunSpecs more than once. Ginkgo does not support
  rerunning suites.  If you want to rerun a suite try ginkgo --repeat=N or
  ginkgo --until-it-fails

  Learn more at:
  http://onsi.github.io/ginkgo/#repeating-spec-runs-and-managing-flaky-specs

Process 733067 has exited with status 1
```


For [SDCICD-971](https://issues.redhat.com/browse/SDCICD-971)