### PR TITLE
Bump ocm-sdk-go to version 0.1.333

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.6
-	github.com/openshift-online/ocm-sdk-go v0.1.330
+	github.com/openshift-online/ocm-sdk-go v0.1.333
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/openshift/client-go v0.0.0-20220603133046-984ee5ebedcf
 	github.com/openshift/cloud-credential-operator v0.0.0-20230210162952-a4819474e58d

--- a/go.sum
+++ b/go.sum
@@ -1189,8 +1189,8 @@ github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqi
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
 github.com/opencontainers/selinux v1.10.0/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
-github.com/openshift-online/ocm-sdk-go v0.1.330 h1:FBH/iIzCvI9vrRzHfnzW6D6VH+u3tRcpm8d2YDB537I=
-github.com/openshift-online/ocm-sdk-go v0.1.330/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
+github.com/openshift-online/ocm-sdk-go v0.1.333 h1:I8ehBm2NsiUbybbthe3gYsWKkryqtn66nOwFtX501xg=
+github.com/openshift-online/ocm-sdk-go v0.1.333/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
 github.com/openshift/api v0.0.0-20221013123534-96eec44e1979 h1:NkfbwN34Q/UtfKUFEO9pxmdY06A/jBk80YBua+mxwUc=
 github.com/openshift/api v0.0.0-20221013123534-96eec44e1979/go.mod h1:LEnw1IVscIxyDnltE3Wi7bQb/QzIM8BfPNKoGA1Qlxw=
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -978,7 +978,13 @@ func (o *OCMProvider) InstallAddons(clusterID string, addonIDs []spi.AddOnID, ad
 					return err
 				}
 
-				o.updateClusterCache(clusterID, aoar.Body().Cluster())
+				ocmCluster, err := o.getOCMCluster(clusterID)
+				if err != nil {
+					return err
+				}
+				if err = o.updateClusterCache(clusterID, ocmCluster); err != nil {
+					return fmt.Errorf("error updating cluster cache: %v", err)
+				}
 
 				return nil
 			})


### PR DESCRIPTION
# Change
As of 0.1.332 and onward, it pulls in an updated [api model](https://github.com/openshift-online/ocm-sdk-go/pull/755/files#diff-ed8217452b8a809c249edac917b68daea27f1fb5be59319b1a989dbab72caf66) which removed the cluster field for the AddOnInstallation collection. This is returned back when posting to ocm to install an add on. It was used to get the cluster body to update osde2e cluster cache collection.

Since this field no longer exists, this commit performs an api request to ocm after the add on is installed to get the updated cluster body.

Fixes https://github.com/openshift/osde2e/pull/1761

# Verification

Tested osde2e locally using the test harness example

```yml
addons:
  ids: "reference-addon"
config:
  aws:
    region: us-east-2
ocm:
  env: stage
  ccs: true
cluster:
  id: 2363ni12cukpprpedi3s1sgmcqumgq32
  skipDestroyCluster: true
  hibernateAfterUse: false
mustGather: false
tests:
  ginkgoLabelFilter: TestHarness
  pollingTimeout: "7200"
  testHarnesses: "quay.io/rmundhe_oc/osde2e-example-test-harness"
```

```xml
<?xml version="1.0" encoding="UTF-8"?>
  <testsuites tests="2" disabled="0" errors="0" failures="0" time="0.018501107">
      <testsuite name="Example Addon Test Harness" package="/" tests="2" disabled="0" skipped="0" errors="0" failures="0" time="0.018501107" timestamp="2023-04-18T13:55:32">
          <properties>
              <property name="SuiteSucceeded" value="true"></property>
              <property name="SuiteHasProgrammaticFocus" value="false"></property>
              <property name="SpecialSuiteFailureReason" value=""></property>
              <property name="SuiteLabels" value="[]"></property>
              <property name="RandomSeed" value="1681826132"></property>
              <property name="RandomizeAllSpecs" value="false"></property>
              <property name="LabelFilter" value=""></property>
              <property name="FocusStrings" value=""></property>
              <property name="SkipStrings" value=""></property>
              <property name="FocusFiles" value=""></property>
              <property name="SkipFiles" value=""></property>
              <property name="FailOnPending" value="false"></property>
              <property name="FailFast" value="false"></property>
              <property name="FlakeAttempts" value="0"></property>
              <property name="EmitSpecProgress" value="false"></property>
              <property name="DryRun" value="false"></property>
              <property name="ParallelTotal" value="1"></property>
              <property name="OutputInterceptorMode" value=""></property>
          </properties>
          <testcase name="[It] Example Addon Tests Example CRD - referenceaddons.reference.addons.managed.openshift.io - exists" classname="Example Addon Test Harness" status="passed" time="0.014584272"></testcase>
          <testcase name="[It] Example Addon Tests Example passthrough secret exists" classname="Example Addon Test Harness" status="passed" time="0.003764637"></testcase>
      </testsuite>
  </testsuites>
```

```
2023/04/18 09:30:38 e2e.go:147: Cluster is healthy and ready for testing
2023/04/18 09:33:55 cluster.go:996: Installed Addon: reference-addon
2023/04/18 09:33:56 addon.go:42: writing test harness metadata to  /tmp/osde2e-9sx8chr12f/test-harness-metadata.json
2023/04/18 09:34:12 cluster.go:1306: Successfully added property[Status] - health-check 
2023/04/18 09:34:13 cluster.go:1306: Successfully added property[Status] - healthy 
2023/04/18 09:34:13 events.go:30: Success event: InstallAddonsSuccessful
```