### PR TITLE
SDCICD-977 access AWS account ID through CCS session struct

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -178,7 +178,7 @@ The following are the values that can be plugged in for the --configs flag when 
 ### AWS specific values:
 | Environment variable  | Usage                                                                                |
 | --------------------- | ------------------------------------------------------------------------------------ |
-| AWS_ACCOUNT           | AWS account to use for testing.                                                      |
+| AWS_ACCOUNT_ID        | AWS account id to use for testing.                                                   |
 | AWS_ACCESS_KEY        | AWSAccessKeyID for provisioning clusters.                                            |
 | AWS_SECRET_ACCESS_KEY | AWSSecretAccessKey for provisioning clusters.                                        |
 | AWS_REGION            | AWSRegion for provisioning clusters.                                                 |

--- a/pkg/common/aws/session.go
+++ b/pkg/common/aws/session.go
@@ -76,7 +76,7 @@ func (CcsAwsSession *ccsAwsSession) GetRegion() *string {
 	return CcsAwsSession.session.Config.Region
 }
 
-// GetAccountID returns the aws account id in session
-func (CcsAwsSession *ccsAwsSession) GetAccountID() string {
+// GetAccountId returns the aws account id in session
+func (CcsAwsSession *ccsAwsSession) GetAccountId() string {
 	return CcsAwsSession.accountId
 }

--- a/pkg/common/aws/session.go
+++ b/pkg/common/aws/session.go
@@ -76,7 +76,7 @@ func (CcsAwsSession *ccsAwsSession) GetRegion() *string {
 	return CcsAwsSession.session.Config.Region
 }
 
-// GetAccount returns the aws account in session
-func (CcsAwsSession *ccsAwsSession) GetAccount() string {
+// GetAccountID returns the aws account id in session
+func (CcsAwsSession *ccsAwsSession) GetAccountID() string {
 	return CcsAwsSession.accountId
 }

--- a/pkg/common/aws/session.go
+++ b/pkg/common/aws/session.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"fmt"
 	"log"
-	"os"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -50,13 +49,7 @@ func (CcsAwsSession *ccsAwsSession) GetAWSSessions() error {
 		CcsAwsSession.session, err = session.NewSessionWithOptions(options)
 		CcsAwsSession.iam = iam.New(CcsAwsSession.session)
 		CcsAwsSession.ec2 = ec2.New(CcsAwsSession.session)
-		if viper.GetString(config.AWSAccount) != "" {
-			CcsAwsSession.accountId = viper.GetString(config.AWSAccount)
-		} else if os.Getenv("AWS_ACCOUNT_ID") != "" {
-			CcsAwsSession.accountId = os.Getenv("AWS_ACCOUNT_ID")
-		} else {
-			CcsAwsSession.accountId = ""
-		}
+		CcsAwsSession.accountId = viper.GetString(config.AWSAccountId)
 	})
 	if err != nil {
 		log.Printf("error initializing AWS session: %v", err)

--- a/pkg/common/config/aws_config.go
+++ b/pkg/common/config/aws_config.go
@@ -6,8 +6,8 @@ import (
 )
 
 var (
-	// AWSAccount is the AWS account
-	AWSAccount = "config.aws.account"
+	// AWSAccountId is the AWS account (Env var: AWS_ACCOUNT_ID)
+	AWSAccountId = "config.aws.account.id"
 
 	// AWSAccessKey is the AWS access key
 	AWSAccessKey = "config.aws.accessKey"
@@ -26,8 +26,8 @@ var (
 )
 
 func InitAWSViper() {
-	viper.BindEnv(AWSAccount, "AWS_ACCOUNT")
-	RegisterSecret(AWSAccount, "aws-account")
+	viper.BindEnv(AWSAccountId, "AWS_ACCOUNT_ID")
+	RegisterSecret(AWSAccountId, "aws-account-id")
 
 	viper.BindEnv(AWSAccessKey, "AWS_ACCESS_KEY", "OCM_AWS_ACCESS_KEY", "AWS_ACCESS_KEY_ID", "ROSA_AWS_ACCESS_KEY_ID")
 	RegisterSecret(AWSAccessKey, "aws-access-key")

--- a/pkg/common/config/aws_config.go
+++ b/pkg/common/config/aws_config.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	// AWSAccountId is the AWS account (Env var: AWS_ACCOUNT_ID)
-	AWSAccountId = "config.aws.account.id"
+	AWSAccountId = "config.aws.account"
 
 	// AWSAccessKey is the AWS access key
 	AWSAccessKey = "config.aws.accessKey"
@@ -27,7 +27,7 @@ var (
 
 func InitAWSViper() {
 	viper.BindEnv(AWSAccountId, "AWS_ACCOUNT_ID")
-	RegisterSecret(AWSAccountId, "aws-account-id")
+	RegisterSecret(AWSAccountId, "aws-account")
 
 	viper.BindEnv(AWSAccessKey, "AWS_ACCESS_KEY", "OCM_AWS_ACCESS_KEY", "AWS_ACCESS_KEY_ID", "ROSA_AWS_ACCESS_KEY_ID")
 	RegisterSecret(AWSAccessKey, "aws-access-key")

--- a/pkg/common/config/aws_config.go
+++ b/pkg/common/config/aws_config.go
@@ -27,7 +27,7 @@ var (
 
 func InitAWSViper() {
 	viper.BindEnv(AWSAccountId, "AWS_ACCOUNT_ID")
-	RegisterSecret(AWSAccountId, "aws-account-id")
+	RegisterSecret(AWSAccountId, "aws-account")
 
 	viper.BindEnv(AWSAccessKey, "AWS_ACCESS_KEY", "OCM_AWS_ACCESS_KEY", "AWS_ACCESS_KEY_ID", "ROSA_AWS_ACCESS_KEY_ID")
 	RegisterSecret(AWSAccessKey, "aws-access-key")

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -158,12 +158,12 @@ func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 			awsCreds, err := aws.CcsAwsSession.GetCredentials()
 			if err != nil {
 				return "", err
-			} else if aws.CcsAwsSession.GetAccount() == "" {
+			} else if aws.CcsAwsSession.GetAccountID() == "" {
 				return "", fmt.Errorf("aws account id is not set")
 			}
 
 			awsBuilder := v1.NewAWS().
-				AccountID(aws.CcsAwsSession.GetAccount()).
+				AccountID(aws.CcsAwsSession.GetAccountID()).
 				AccessKeyID(awsCreds.AccessKeyID).
 				SecretAccessKey(awsCreds.SecretAccessKey)
 			if viper.GetString(config.AWSVPCSubnetIDs) != "" {

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -158,12 +158,12 @@ func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 			awsCreds, err := aws.CcsAwsSession.GetCredentials()
 			if err != nil {
 				return "", err
-			} else if aws.CcsAwsSession.GetAccountID() == "" {
+			} else if aws.CcsAwsSession.GetAccountId() == "" {
 				return "", fmt.Errorf("aws account id is not set")
 			}
 
 			awsBuilder := v1.NewAWS().
-				AccountID(aws.CcsAwsSession.GetAccountID()).
+				AccountID(aws.CcsAwsSession.GetAccountId()).
 				AccessKeyID(awsCreds.AccessKeyID).
 				SecretAccessKey(awsCreds.SecretAccessKey)
 			if viper.GetString(config.AWSVPCSubnetIDs) != "" {

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -158,12 +158,12 @@ func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 			awsCreds, err := aws.CcsAwsSession.GetCredentials()
 			if err != nil {
 				return "", err
-			} else if viper.GetString(config.AWSAccount) == "" {
+			} else if aws.CcsAwsSession.GetAccount() == "" {
 				return "", fmt.Errorf("aws account id is not set")
 			}
 
 			awsBuilder := v1.NewAWS().
-				AccountID(viper.GetString(config.AWSAccount)).
+				AccountID(aws.CcsAwsSession.GetAccount()).
 				AccessKeyID(awsCreds.AccessKeyID).
 				SecretAccessKey(awsCreds.SecretAccessKey)
 			if viper.GetString(config.AWSVPCSubnetIDs) != "" {

--- a/pkg/common/providers/rosaprovider/oidcconfig.go
+++ b/pkg/common/providers/rosaprovider/oidcconfig.go
@@ -17,7 +17,7 @@ func (m *ROSAProvider) createOIDCConfig(prefix string) (string, error) {
 	cmd.SetArgs([]string{
 		"--mode", "auto",
 		"--prefix", prefix,
-		"--installer-role-arn", fmt.Sprintf("arn:aws:iam::%s:role/ManagedOpenShift-Installer-Role", aws.CcsAwsSession.GetAccount()),
+		"--installer-role-arn", fmt.Sprintf("arn:aws:iam::%s:role/ManagedOpenShift-Installer-Role", aws.CcsAwsSession.GetAccountID()),
 		"--yes",
 	})
 	err := callAndSetAWSSession(func() error {

--- a/pkg/common/providers/rosaprovider/oidcconfig.go
+++ b/pkg/common/providers/rosaprovider/oidcconfig.go
@@ -4,8 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/aws"
 	createOIDCConfig "github.com/openshift/rosa/cmd/create/oidcconfig"
 	deleteOIDCConfig "github.com/openshift/rosa/cmd/dlt/oidcconfig"
 )
@@ -18,7 +17,7 @@ func (m *ROSAProvider) createOIDCConfig(prefix string) (string, error) {
 	cmd.SetArgs([]string{
 		"--mode", "auto",
 		"--prefix", prefix,
-		"--installer-role-arn", fmt.Sprintf("arn:aws:iam::%s:role/ManagedOpenShift-Installer-Role", viper.GetString(config.AWSAccount)),
+		"--installer-role-arn", fmt.Sprintf("arn:aws:iam::%s:role/ManagedOpenShift-Installer-Role", aws.CcsAwsSession.GetAccount()),
 		"--yes",
 	})
 	err := callAndSetAWSSession(func() error {

--- a/pkg/common/providers/rosaprovider/oidcconfig.go
+++ b/pkg/common/providers/rosaprovider/oidcconfig.go
@@ -17,7 +17,7 @@ func (m *ROSAProvider) createOIDCConfig(prefix string) (string, error) {
 	cmd.SetArgs([]string{
 		"--mode", "auto",
 		"--prefix", prefix,
-		"--installer-role-arn", fmt.Sprintf("arn:aws:iam::%s:role/ManagedOpenShift-Installer-Role", aws.CcsAwsSession.GetAccountID()),
+		"--installer-role-arn", fmt.Sprintf("arn:aws:iam::%s:role/ManagedOpenShift-Installer-Role", aws.CcsAwsSession.GetAccountId()),
 		"--yes",
 	})
 	err := callAndSetAWSSession(func() error {


### PR DESCRIPTION
https://issues.redhat.com/browse/SDCICD-977

Adds AWS account ID as a member of CcsAwsSession. checks for   AWS_ACCOUNT_ID env var . Renames previously "AWS_ACCOUNT" to "AWS_ACCOUNT_ID". Replaces direct calls to viper config from elsewhere in code. 

Secret key name and config name are still aws-account and. config.aws.account respectively. No change there.