### PR TITLE
Use policy v1 api over v1beta1 for pod disruption budget

### DIFF
--- a/assets/workloads/e2e/pdb/pdb-1.yaml
+++ b/assets/workloads/e2e/pdb/pdb-1.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: pdb-case-1

--- a/assets/workloads/e2e/pdb/pdb-2.yaml
+++ b/assets/workloads/e2e/pdb/pdb-2.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: pdb-case-2

--- a/pkg/common/helper/workloads.go
+++ b/pkg/common/helper/workloads.go
@@ -10,7 +10,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -179,10 +179,10 @@ func CreateRuntimeObject(obj runtime.Object, ns string, kube kubernetes.Interfac
 		}
 		return newObj, nil
 	case "PodDisruptionBudget":
-		if _, ok = obj.(*policyv1beta1.PodDisruptionBudget); !ok {
+		if _, ok = obj.(*policyv1.PodDisruptionBudget); !ok {
 			return nil, fmt.Errorf("Error casting object to PodDisruptionBudget")
 		}
-		if newObj, err = kube.PolicyV1beta1().PodDisruptionBudgets(ns).Create(context.TODO(), obj.(*policyv1beta1.PodDisruptionBudget), metav1.CreateOptions{}); err != nil {
+		if newObj, err = kube.PolicyV1().PodDisruptionBudgets(ns).Create(context.TODO(), obj.(*policyv1.PodDisruptionBudget), metav1.CreateOptions{}); err != nil {
 			return nil, err
 		}
 		return newObj, nil


### PR DESCRIPTION
# Change
Part of the testing of OSD upgrades, osde2e can apply load onto the cluster before starting. The API currently used is deprecated in v1.21+ and will be removed in v1.25+.

```
W0412 13:47:39.097499      13 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget403W0412 13:47:39.144702      13 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget 
```

This change updates the api version to use policy/v1.

```
[rywillia@t14s ~]$ oc get pods -n osde2e-kzhnu
NAME                               READY   STATUS    RESTARTS   AGE
node-drain-test-6ccfcc788f-87sw9   1/1     Running   0          23s
pdb-case-1-74cbb9b4d8-wff25        1/1     Running   0          39s
pdb-case-2-7c44758d95-48dbh        1/1     Running   0          39s
[rywillia@t14s ~]$ oc get pdb -n osde2e-kzhnu
NAME         MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
pdb-case-1   N/A             0                 0                     33s
pdb-case-2   1               N/A               0                     28s
```

For [SDCICD-976](https://issues.redhat.com/browse/SDCICD-976)