### PR TITLE
common/helper/testrunner: expose OCM_CLUSTER_ID env

### DIFF
--- a/assets/tests/tests-runner.template
+++ b/assets/tests/tests-runner.template
@@ -18,6 +18,11 @@ spec:
         {{ if .Arguments }}
         args: {{.Arguments}}
         {{ end }}
+        env:
+        {{- range $env := .EnvironmentVariables }}
+        - name: {{ $env.Name }}
+          value: {{ $env.Value }}
+        {{- end }}
         volumeMounts:
         - mountPath: {{.OutputDir}}
           name: test-output

--- a/pkg/common/helper/testRunner.go
+++ b/pkg/common/helper/testRunner.go
@@ -7,6 +7,8 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/runner"
 	"github.com/openshift/osde2e/pkg/common/templates"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -48,6 +50,10 @@ func (h *H) RunTests(ctx context.Context, name string, timeout int, harnesses, a
 			Server               string
 			CA                   string
 			TokenFile            string
+			EnvironmentVariables []struct {
+				Name  string
+				Value string
+			}
 		}{
 			Name:                 jobName,
 			JobName:              jobName,
@@ -60,6 +66,15 @@ func (h *H) RunTests(ctx context.Context, name string, timeout int, harnesses, a
 			Server:               "https://kubernetes.default",
 			CA:                   serviceAccountDir + "/ca.crt",
 			TokenFile:            serviceAccountDir + "/token",
+			EnvironmentVariables: []struct {
+				Name  string
+				Value string
+			}{
+				{
+					Name:  "OCM_CLUSTER_ID",
+					Value: viper.GetString(config.Cluster.ID),
+				},
+			},
 		}
 
 		if len(args) > 0 {


### PR DESCRIPTION
expose the OCM_CLUSTER_ID to the job running the tests which would allow
a test to talk with OCM regarding the specific cluster

Signed-off-by: Brady Pratt <bpratt@redhat.com>

https://go.dev/play/p/biZUnU0lni8
