### PR TITLE
added job script for parameterized job  

### DIFF
--- a/scripts/parameterized-job.sh
+++ b/scripts/parameterized-job.sh
@@ -7,10 +7,10 @@ podman rm -i osde2e-run
 # bind mounts run into permissions issues, this creates
 # the container and copies the secrets over to ensure it has perms
 podman create --name osde2e-run -e OCM_TOKEN \
--e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
--e CLOUD_PROVIDER_REGION -e INSTANCE_TYPE \
--e REPORT_DIR=/tmp/osde2e-report quay.io/app-sre/osde2e test --configs rosa,stage,e2e-suite --skip-health-check
- 
+	-e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
+	-e CLOUD_PROVIDER_REGION -e INSTANCE_TYPE \
+	-e REPORT_DIR=/tmp/osde2e-report quay.io/app-sre/osde2e test --configs rosa,stage,e2e-suite --skip-health-check
+
 podman start -a osde2e-run
 
 # copy the junit results xml for publishing

--- a/scripts/parameterized-job.sh
+++ b/scripts/parameterized-job.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set +e
+# ensure we have a clean environment
+podman rm -i osde2e-run
+
+# bind mounts run into permissions issues, this creates
+# the container and copies the secrets over to ensure it has perms
+podman create --name osde2e-run -e OCM_TOKEN \
+-e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
+-e CLOUD_PROVIDER_REGION -e INSTANCE_TYPE \
+-e REPORT_DIR=/tmp/osde2e-report quay.io/app-sre/osde2e test --configs rosa,stage,e2e-suite --skip-health-check
+ 
+podman start -a osde2e-run
+
+# copy the junit results xml for publishing
+podman cp osde2e-run:/tmp/osde2e-report .


### PR DESCRIPTION
added job script for parameterized job to be run in app-interface ci-int job

https://issues.redhat.com/browse/SDCICD-972

The execution of this script will be configured in a app-interface MR which creates the jenkins job which will run this.

The following env vars are to be passed in from jenkins job secrets
OCM_TOKEN
AWS_SECRET_ACCESS_KEY
AWS_ACCESS_KEY_ID

Following will be provided by job parameters
CLOUD_PROVIDER_REGION
INSTANCE_TYPE


Dependent app-interface PR https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/65444#note_6391654 