### PR TITLE
Add cluster gate agreement when performing cluster upgrades

### DIFF
--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -333,3 +333,18 @@ func (m *MockProvider) RemoveUserCABundle(clusterId string) error {
 func (m *MockProvider) LoadUserCaBundleData(file string) (string, error) {
 	return "", fmt.Errorf("proxies not supported in Mock Provider")
 }
+
+// VersionGateLabel returns the provider version gate label
+func (m *MockProvider) VersionGateLabel() string {
+	return "mock"
+}
+
+// GetVersionGateID checks to see if a version gate exists for the cluster version provided
+func (m *MockProvider) GetVersionGateID(version string, label string) (string, error) {
+	return "", fmt.Errorf("version gates not supported in Mock Provider")
+}
+
+// AddGateAgreement adds the gate agreement to the cluster for cluster upgrades
+func (m *MockProvider) AddGateAgreement(clusterID string, versionGateID string) error {
+	return fmt.Errorf("add gate agreement not supported in Mock Provider")
+}

--- a/pkg/common/providers/ocmprovider/ocm.go
+++ b/pkg/common/providers/ocmprovider/ocm.go
@@ -32,12 +32,12 @@ var connectionCache = map[ocmConnectionKey]*ocm.Connection{}
 
 // OCMProvider will provision clusters using the OCM API.
 type OCMProvider struct {
-	env          string
-	conn         *ocm.Connection
-	prodProvider *OCMProvider
-
-	clusterCache    map[string]*spi.Cluster
-	credentialCache map[string]string
+	env              string
+	conn             *ocm.Connection
+	prodProvider     *OCMProvider
+	clusterCache     map[string]*spi.Cluster
+	credentialCache  map[string]string
+	versionGateLabel string
 }
 
 func init() {
@@ -116,11 +116,12 @@ func NewWithEnv(env string) (*OCMProvider, error) {
 	}
 
 	return &OCMProvider{
-		env:             env,
-		conn:            conn,
-		prodProvider:    prodProvider,
-		clusterCache:    make(map[string]*spi.Cluster),
-		credentialCache: make(map[string]string),
+		env:              env,
+		conn:             conn,
+		prodProvider:     prodProvider,
+		clusterCache:     make(map[string]*spi.Cluster),
+		credentialCache:  make(map[string]string),
+		versionGateLabel: "api.openshift.com/gate-ocp",
 	}, nil
 }
 
@@ -170,4 +171,9 @@ func errResp(resp *ocmerr.Error) error {
 // Type returns the provisioner type: ocm
 func (o *OCMProvider) Type() string {
 	return "ocm"
+}
+
+// VersionGateLabel returns the provider version gate label
+func (o *OCMProvider) VersionGateLabel() string {
+	return o.versionGateLabel
 }

--- a/pkg/common/providers/ocmprovider/upgrades.go
+++ b/pkg/common/providers/ocmprovider/upgrades.go
@@ -1,0 +1,95 @@
+package ocmprovider
+
+import (
+	"fmt"
+	"log"
+
+	v1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+)
+
+// VersionGates gets the list of available version gates from ocm
+func (o *OCMProvider) VersionGates() (*v1.VersionGateList, error) {
+	versionGatesClient := o.conn.ClustersMgmt().V1().VersionGates()
+
+	response, err := versionGatesClient.List().Send()
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving version gates: %v", err)
+	}
+
+	return response.Items(), nil
+}
+
+// GetVersionGateID checks to see if a version gate exists for the cluster version provided
+func (o *OCMProvider) GetVersionGateID(version string, label string) (string, error) {
+	versionGates, err := o.VersionGates()
+	if err != nil {
+		return "", err
+	}
+
+	for _, versionGate := range versionGates.Slice() {
+		if versionGate.VersionRawIDPrefix() == version && versionGate.Label() == label {
+			return versionGate.ID(), nil
+		}
+	}
+	return "", fmt.Errorf("%s version gate does not exist", version)
+}
+
+// GetVersionGate gets the version gate resource using the version gate id provided
+func (o *OCMProvider) GetVersionGate(id string) (*v1.VersionGate, error) {
+	versionGatesClient := o.conn.ClustersMgmt().V1().VersionGates()
+	versionGate := versionGatesClient.VersionGate(id)
+	response, err := versionGate.Get().Send()
+	if err != nil {
+		return nil, fmt.Errorf("unable to find version gate using id: %s, error: %v", id, err)
+	}
+	return response.Body(), nil
+}
+
+// GateAgreementExist checks to see if the gate agreement id is already applied to the
+// cluster provided
+func (o *OCMProvider) GateAgreementExist(clusterID string, gateAgreementID string) (bool, error) {
+	gateAgreementClient := o.conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).
+		GateAgreements()
+	response, err := gateAgreementClient.List().Send()
+	if err != nil {
+		return false, fmt.Errorf("error retrieving gate agreements for cluster: %v", err)
+	}
+
+	for _, gateAgreement := range response.Items().Slice() {
+		if gateAgreement.VersionGate().ID() == gateAgreementID {
+			log.Printf("Cluster gate agreement id: %s already exists", gateAgreementID)
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// AddGateAgreement adds the gate agreement to the cluster for cluster upgrades
+func (o *OCMProvider) AddGateAgreement(clusterID string, versionGateID string) error {
+	versionGate, err := o.GetVersionGate(versionGateID)
+	if err != nil {
+		return err
+	}
+
+	gateAgreement, err := v1.NewVersionGateAgreement().
+		VersionGate(v1.NewVersionGate().Copy(versionGate)).
+		Build()
+	if err != nil {
+		return fmt.Errorf("error building version gate agreement: %v", err)
+	}
+
+	gateAgreementExist, err := o.GateAgreementExist(clusterID, versionGateID)
+	if err != nil {
+		return err
+	}
+
+	if !gateAgreementExist {
+		_, err = o.conn.ClustersMgmt().V1().Clusters().Cluster(clusterID).
+			GateAgreements().Add().Body(gateAgreement).Send()
+		if err != nil {
+			return fmt.Errorf("error adding version gate agreement: %v", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/common/providers/rosaprovider/rosa.go
+++ b/pkg/common/providers/rosaprovider/rosa.go
@@ -17,9 +17,10 @@ func init() {
 
 // ROSAProvider will provision clusters via ROSA.
 type ROSAProvider struct {
-	ocmProvider    *ocmprovider.OCMProvider
-	awsCredentials *credentials.Value
-	awsRegion      string
+	ocmProvider      *ocmprovider.OCMProvider
+	awsCredentials   *credentials.Value
+	awsRegion        string
+	versionGateLabel string
 }
 
 // New will create a new ROSAProvider.
@@ -39,14 +40,25 @@ func New() (*ROSAProvider, error) {
 		return nil, fmt.Errorf("aws region is undefined")
 	}
 
+	versionGateLabel := "api.openshift.com/gate-ocp"
+	if viper.GetBool(STS) {
+		versionGateLabel = "api.openshift.com/gate-sts"
+	}
+
 	return &ROSAProvider{
-		ocmProvider:    ocmProvider,
-		awsCredentials: awsCredentials,
-		awsRegion:      region,
+		ocmProvider:      ocmProvider,
+		awsCredentials:   awsCredentials,
+		awsRegion:        region,
+		versionGateLabel: versionGateLabel,
 	}, nil
 }
 
 // Type returns the provisioner type: rosa
 func (m *ROSAProvider) Type() string {
 	return "rosa"
+}
+
+// VersionGateLabel returns the provider version gate label
+func (m *ROSAProvider) VersionGateLabel() string {
+	return m.versionGateLabel
 }

--- a/pkg/common/providers/rosaprovider/wrapped_calls.go
+++ b/pkg/common/providers/rosaprovider/wrapped_calls.go
@@ -131,3 +131,13 @@ func (m *ROSAProvider) RemoveUserCABundle(clusterId string) error {
 func (m *ROSAProvider) LoadUserCaBundleData(file string) (string, error) {
 	return m.ocmProvider.LoadUserCaBundleData(file)
 }
+
+// GetVersionGateID checks to see if a version gate exists for the cluster version provided
+func (m *ROSAProvider) GetVersionGateID(version string, label string) (string, error) {
+	return m.ocmProvider.GetVersionGateID(version, m.versionGateLabel)
+}
+
+// AddGateAgreement adds the gate agreement to the cluster for cluster upgrades
+func (m *ROSAProvider) AddGateAgreement(clusterID string, versionGateID string) error {
+	return m.ocmProvider.AddGateAgreement(clusterID, versionGateID)
+}

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -155,4 +155,13 @@ type Provider interface {
 
 	// LoadUserCaBundleData loads CA contents from CA cert file
 	LoadUserCaBundleData(file string) (string, error)
+
+	// VersionGateLabel returns the provider version gate label
+	VersionGateLabel() string
+
+	// GetVersionGateID checks to see if a version gate exists for the cluster version provided
+	GetVersionGateID(version string, label string) (string, error)
+
+	// AddGateAgreement adds gate agreement to the cluster to acknowledge cluster upgrade
+	AddGateAgreement(clusterID string, versionGateID string) error
 }

--- a/pkg/common/versions/common/utils.go
+++ b/pkg/common/versions/common/utils.go
@@ -19,7 +19,7 @@ func NextReleaseAfterGivenVersionFromVersionList(givenVersion *semver.Version, v
 	// Assemble a map that lists a release (x.y.0) to its latest version, with nightlies taking precedence over all else
 	for _, version := range versionList {
 		versionSemver := version.Version()
-		majorMinor := createMajorMinorStringFromSemver(versionSemver)
+		majorMinor := CreateMajorMinorStringFromSemver(versionSemver)
 		if _, ok := versionBuckets[majorMinor]; !ok {
 			versionBuckets[majorMinor] = versionSemver
 		} else {
@@ -53,7 +53,7 @@ func NextReleaseAfterGivenVersionFromVersionList(givenVersion *semver.Version, v
 	sort.Sort(semver.Collection(majorMinorList))
 
 	// Now that the list is sorted, we want to locate the major minor of the given version in the list.
-	givenMajorMinor, err := semver.NewVersion(createMajorMinorStringFromSemver(givenVersion))
+	givenMajorMinor, err := semver.NewVersion(CreateMajorMinorStringFromSemver(givenVersion))
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func NextReleaseAfterGivenVersionFromVersionList(givenVersion *semver.Version, v
 	if len(majorMinorList) <= nextMajorMinorIndex {
 		return nil, fmt.Errorf("there is no eligible next release from the list of available versions")
 	}
-	nextMajorMinor := createMajorMinorStringFromSemver(majorMinorList[nextMajorMinorIndex])
+	nextMajorMinor := CreateMajorMinorStringFromSemver(majorMinorList[nextMajorMinorIndex])
 
 	if _, ok := versionBuckets[nextMajorMinor]; !ok {
 		return nil, fmt.Errorf("no major/minor version found for %s", nextMajorMinor)
@@ -101,7 +101,7 @@ func SortVersions(availableVersions []*spi.Version) {
 	})
 }
 
-func createMajorMinorStringFromSemver(version *semver.Version) string {
+func CreateMajorMinorStringFromSemver(version *semver.Version) string {
 	if version == nil {
 		return ""
 	}


### PR DESCRIPTION
# Change
This change adds support to osde2e to be able to provide cluster acknowledgements prior to performing a cluster upgrade. Depending on the cluster upgrade path being performed. Cluster acknowledgement is performed for both OCM upgrades and local managed upgrade operator upgrades.

Cluster gate agreement is not performed if the upgrade is a z stream upgrade, only y stream. In the event a version gate does not exist for the version to upgrade to, it will still carry on and attempt to perform the upgrade. To present any errors that are helpful to the user to debug.

_Errors seen by current OSD upgrade job_

```
2023/04/12 13:47:45 pods.go:90: 0 pods are currently not running or complete:4112023/04/12 13:47:46 e2e.go:277: OSDE2E failed: error performing upgrade: failed triggering upgrade: can't initiate managed upgrade: error initiating upgrade from provider: status is 400, identifier is '400', code is 'CLUSTERS-MGMT-400' and operation identifier is '49a3e0b8-9b0d-414f-ba6f-35e500071495': There are missing version gate agreements for this cluster. See details. 
```

For [SDCICD-975](https://issues.redhat.com/browse/SDCICD-975)