### PR TITLE
Add the ability to toggle on/off pre upgrade tests

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -164,6 +164,9 @@ var Upgrade = struct {
 	// Reschedule the upgrade via provider before commence
 	ManagedUpgradeRescheduled string
 
+	// Toggle on/off running pre upgrade tests
+	RunPreUpgradeTests string
+
 	// Toggle on/off running post upgrade tests
 	RunPostUpgradeTests string
 }{
@@ -178,6 +181,7 @@ var Upgrade = struct {
 	ManagedUpgradeTestPodDisruptionBudgets: "upgrade.managedUpgradeTestPodDisruptionBudgets",
 	ManagedUpgradeTestNodeDrain:            "upgrade.managedUpgradeTestNodeDrain",
 	ManagedUpgradeRescheduled:              "upgrade.managedUpgradeRescheduled",
+	RunPreUpgradeTests:                     "upgrade.runPreUpgradeTests",
 	RunPostUpgradeTests:                    "upgrade.runPostUpgradeTests",
 }
 
@@ -670,8 +674,11 @@ func InitOSDe2eViper() {
 	viper.BindEnv(Upgrade.ManagedUpgradeRescheduled, "UPGRADE_MANAGED_TEST_RESCHEDULE")
 	viper.SetDefault(Upgrade.ManagedUpgradeRescheduled, false)
 
+	viper.BindEnv(Upgrade.RunPreUpgradeTests, "UPGRADE_RUN_PRE_TESTS")
+	viper.SetDefault(Upgrade.RunPreUpgradeTests, false)
+
 	viper.BindEnv(Upgrade.RunPostUpgradeTests, "UPGRADE_RUN_POST_TESTS")
-	viper.SetDefault(Upgrade.RunPostUpgradeTests, false)
+	viper.SetDefault(Upgrade.RunPostUpgradeTests, true)
 
 	// ----- Kubeconfig -----
 	viper.BindEnv(Kubeconfig.Path, "TEST_KUBECONFIG")


### PR DESCRIPTION
# Change
This change allows cluster upgrade workflows to skip running pre upgrade tests and just run post upgrade tests. OSDE2E currently has a limitation where it cannot run the test suite more than once (w/ginkgo).

Since its critical to verify the operator tests post upgrade, this change switches the behavior to always run post upgrade tests and skip running pre upgrade tests when cluster upgrades are enabled.

With this change, upgrade workflows will perform the following (by default):

1. Deploy cluster
2. Verify cluster health checks
3. Skip pre upgrade "install" tests
4. Perform cluster upgrade
5. Perform cluster upgrade post health checks
6. Run post upgrade tests
7. Destroy cluster

For [SDCICD-979](https://issues.redhat.com/browse/SDCICD-979)