### PR TITLE
adding missing required variables for rosa job script

### DIFF
--- a/scripts/parameterized-job.sh
+++ b/scripts/parameterized-job.sh
@@ -2,7 +2,7 @@
 
 set +e
 # ensure we have a clean environment
-docker rm -i osde2e-run
+docker rm osde2e-run
 
 # bind mounts run into permissions issues, this creates
 # the container and copies the secrets over to ensure it has perms


### PR DESCRIPTION
[sdcicd-972](https://issues.redhat.com//browse/sdcicd-972)

osde2e image needs region and ROSA_ENV variables which were missing. This change adds those. 