### PR TITLE
Add new install version selectors for supporting upgrade workflows

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -355,6 +355,12 @@ var Cluster = struct {
 	// InstallLatestXY will select the latest version available given an "X.Y" formatted string
 	InstallLatestXY string
 
+	// InstallLatestYFromDelta will select the latest Y from the delta (+/-) given
+	InstallLatestYFromDelta string
+
+	// InstallLatestZFromDelta will select the latest Z from the delta (+/-) given
+	InstallLatestZFromDelta string
+
 	// CleanCheckRuns lets us set the number of osd-verify checks we want to run before deeming a cluster "healthy"
 	// Env: CLEAN_CHECK_RUNS
 	CleanCheckRuns string
@@ -437,6 +443,8 @@ var Cluster = struct {
 	LatestZReleaseAfterProdDefault:      "cluster.latestZReleaseAfterProdDefault",
 	InstallSpecificNightly:              "cluster.installLatestNightly",
 	InstallLatestXY:                     "cluster.installLatestXY",
+	InstallLatestYFromDelta:             "cluster.installLatestYFromDelta",
+	InstallLatestZFromDelta:             "cluster.installLatestZFromDelta",
 	CleanCheckRuns:                      "cluster.cleanCheckRuns",
 	ID:                                  "cluster.id",
 	Name:                                "cluster.name",
@@ -774,6 +782,10 @@ func InitOSDe2eViper() {
 	viper.BindEnv(Cluster.InstallSpecificNightly, "INSTALL_LATEST_NIGHTLY")
 
 	viper.BindEnv(Cluster.InstallLatestXY, "INSTALL_LATEST_XY")
+
+	viper.BindEnv(Cluster.InstallLatestYFromDelta, "INSTALL_LATEST_Y_FROM_DELTA")
+
+	viper.BindEnv(Cluster.InstallLatestZFromDelta, "INSTALL_LATEST_Z_FROM_DELTA")
 
 	viper.SetDefault(Cluster.DeltaReleaseFromDefault, 0)
 	viper.BindEnv(Cluster.DeltaReleaseFromDefault, "DELTA_RELEASE_FROM_DEFAULT")

--- a/pkg/common/providers/ocmprovider/versions.go
+++ b/pkg/common/providers/ocmprovider/versions.go
@@ -97,7 +97,7 @@ func (o *OCMProvider) Versions() (*spi.VersionList, error) {
 	}
 
 	sort.Slice(versions, func(i, j int) bool {
-		return versions[i].Version().LessThan(versions[j].Version())
+		return versions[i].Version().GreaterThan(versions[j].Version())
 	})
 
 	var defaultVersionOverride *semver.Version = nil

--- a/pkg/common/versions/installselectors/latest_y_from_delta.go
+++ b/pkg/common/versions/installselectors/latest_y_from_delta.go
@@ -1,0 +1,49 @@
+package installselectors
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/spi"
+)
+
+func init() {
+	registerSelector(latestYFromDelta{})
+}
+
+type latestYFromDelta struct{}
+
+func (m latestYFromDelta) ShouldUse() bool {
+	return viper.GetInt(config.Cluster.InstallLatestYFromDelta) != 0
+}
+
+func (m latestYFromDelta) Priority() int {
+	return 70
+}
+
+func (m latestYFromDelta) SelectVersion(versionList *spi.VersionList) (*semver.Version, string, error) {
+	latestYFromDelta := viper.GetInt64(config.Cluster.InstallLatestYFromDelta)
+	versionType := fmt.Sprintf("latest Y from delta %d", latestYFromDelta)
+	versions := versionList.AvailableVersions()
+
+	if len(versions) == 0 {
+		return nil, versionType, fmt.Errorf("no versions supplied, unable to select version")
+	}
+
+	defaultVersion, err := findDefaultVersion(versions)
+	if err != nil {
+		return nil, versionType, err
+	}
+
+	versionType = fmt.Sprintf("latest Y '%s' from delta %d", defaultVersion.Version().String(), latestYFromDelta)
+
+	for _, version := range versions {
+		if defaultVersion.Version().Minor()+latestYFromDelta == version.Version().Minor() {
+			return version.Version(), versionType, nil
+		}
+	}
+
+	return nil, versionType, fmt.Errorf("no version found matching the selector")
+}

--- a/pkg/common/versions/installselectors/latest_z_from_delta.go
+++ b/pkg/common/versions/installselectors/latest_z_from_delta.go
@@ -1,0 +1,53 @@
+package installselectors
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/spi"
+)
+
+func init() {
+	registerSelector(latestZFromDelta{})
+}
+
+type latestZFromDelta struct{}
+
+func (m latestZFromDelta) ShouldUse() bool {
+	return viper.GetInt(config.Cluster.InstallLatestZFromDelta) != 0
+}
+
+func (m latestZFromDelta) Priority() int {
+	return 70
+}
+
+func (m latestZFromDelta) SelectVersion(versionList *spi.VersionList) (*semver.Version, string, error) {
+	latestZFromDelta := viper.GetInt64(config.Cluster.InstallLatestZFromDelta)
+	versionType := fmt.Sprintf("latest Z from delta %d", latestZFromDelta)
+	versions := versionList.AvailableVersions()
+
+	if len(versions) == 0 {
+		return nil, versionType, fmt.Errorf("no versions supplied, unable to select version")
+	}
+
+	defaultVersion, err := findDefaultVersion(versions)
+	if err != nil {
+		return nil, versionType, err
+	}
+
+	versionType = fmt.Sprintf("latest Z '%s' from delta %d", defaultVersion.Version().String(), latestZFromDelta)
+
+	for _, version := range versions {
+		if defaultVersion.Version().Minor() != version.Version().Minor() {
+			continue
+		}
+
+		if defaultVersion.Version().Patch()+latestZFromDelta == version.Version().Patch() {
+			return version.Version(), versionType, nil
+		}
+	}
+
+	return nil, versionType, fmt.Errorf("no version found matching the selector")
+}

--- a/pkg/common/versions/installselectors/utils.go
+++ b/pkg/common/versions/installselectors/utils.go
@@ -1,6 +1,8 @@
 package installselectors
 
 import (
+	"fmt"
+
 	"github.com/openshift/osde2e/pkg/common/spi"
 )
 
@@ -14,4 +16,14 @@ func removeDefaultVersion(versions []*spi.Version) []*spi.Version {
 	}
 
 	return versionsWithoutDefault
+}
+
+// findDefaultVersion returns the default version from the supplied versions
+func findDefaultVersion(versions []*spi.Version) (*spi.Version, error) {
+	for _, version := range versions {
+		if version.Default() {
+			return version, nil
+		}
+	}
+	return nil, fmt.Errorf("no default version found")
 }


### PR DESCRIPTION
# Change
This change brings two new install version selectors. They are added to support the following upgrade paths:
 * Latest Y-1 to latest Y
 * Latest Z-1 to latest Z

The selectors added are:
 * Install latest Y from delta
 * Install latest Z from delta

They allow the user to define a positive/negative delta to locate the version to install. These can be used outside of upgrade workflows as well.

In addition to these version selectors, when querying ocm for openshift versions, the sorting was switched to be in descending order.

For [SDCICD-981](https://issues.redhat.com/browse/SDCICD-981)

# Examples

1. Install latest Y-1

```
cat custom-config.yml
cluster:
  channel: stable
  installLatestYFromDelta: -1

2023/04/21 11:15:14 version.go:103: Using the latest Y '4.11.36' from delta -1 '4.10.56'
2023/04/21 11:15:14 version.go:130: No upgrade selector found. Not selecting an upgrade version.
```

2. Install latest Y+1

```
cat custom-config.yml
cluster:
  channel: stable
  installLatestYFromDelta: 1

2023/04/21 11:16:03 versions.go:34: Querying cluster versions endpoint.
2023/04/21 11:16:18 version.go:103: Using the latest Y '4.11.36' from delta 1 '4.12.12'
```

3. Install latest Z-1

```
cat custom-config.yml
cluster:
  channel: stable
  installLatestZFromDelta: -1

2023/04/21 11:17:28 version.go:103: Using the latest Z '4.11.36' from delta -1 '4.11.35'
2023/04/21 11:17:28 version.go:130: No upgrade selector found. Not selecting an upgrade version.
```

4. Install latest Z+1

```
cat custom-config.yml
cluster:
  channel: candidate
  installLatestZFromDelta: 1

2023/04/21 11:19:27 version.go:103: Using the latest Z '4.11.36' from delta 1 '4.11.37-candidate'
2023/04/21 11:19:27 version.go:130: No upgrade selector found. Not selecting an upgrade version.
```