### PR TITLE
fixed report dir name

### DIFF
--- a/scripts/parameterized-job.sh
+++ b/scripts/parameterized-job.sh
@@ -14,7 +14,7 @@ docker create --name osde2e-run -e OCM_TOKEN \
 	-e OCM_ENV="${ENVIRONMENT}" \
 	-e ROSA_STS="${STS}" \
 	-e INSTANCE_TYPE \
-	-e REPORT_DIR="${REPORT_DIR}" quay.io/app-sre/osde2e test --configs "${CONFIGS}"
+	-e REPORT_DIR="/tmp/${REPORT_DIR}" quay.io/app-sre/osde2e test --configs "${CONFIGS}"
 
 docker start -a osde2e-run
 


### PR DESCRIPTION
fixing report dir path - param under job config should be /osde2e-results  as job has it under /osde2e-results 
job log: https://ci.int.devshift.net/blue/organizations/jenkins/osde2e-parameterized-job/detail/osde2e-parameterized-job/9/pipeline/

jira: [sdcicd-972](https://issues.redhat.com//browse/sdcicd-972)

related job PR https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/65685/diffs 