### PR TITLE
Fix osd upgrade scenarios from being marked failed when all tests passed

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -423,7 +423,7 @@ func runGinkgoTests() (int, error) {
 		}
 	}
 
-	var testsPassed bool
+	testsPassed := true
 	var installTestCaseData []db.CreateTestcaseParams
 	if runInstallTests {
 		log.Println("Running e2e tests...")


### PR DESCRIPTION
# Change

Recent commit added support to toggle on/off running install tests prior to performing osd upgrade. Allowing for upgrade scenarios to just run post upgrade tests. With this change, it introduced a bug where after upgrade finishes and tests run without any failures. Osde2e marks the run as failed. Problem is related to a `testsPassed` variable not being properly initialized.

This commit initializes the `testsPassed` variable with a default value of true. Resulting in this bug no longer being reproducible.

Example job with the bug can be seen [here](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/38614/rehearse-38614-periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-y-minus-1-to-latest-y/1649529775389151232). Install tests are skipped, resulting in `testsPassed = false`, upgrade performed, runs post upgrade tests, then fails on the following conditional:

```go
	if !testsPassed || !upgradeTestsPassed {
		viper.Set(config.Cluster.Passing, false)
		return Failure, fmt.Errorf("tests failed, please inspect logs for more details")
	}
```