### PR TITLE
SDCICD-923: Add support to automatically create rosa account roles

### DIFF
--- a/pkg/common/providers/rosaprovider/accountroles.go
+++ b/pkg/common/providers/rosaprovider/accountroles.go
@@ -1,0 +1,114 @@
+package rosaprovider
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	createAccountRoles "github.com/openshift/rosa/cmd/create/accountroles"
+	rosaAws "github.com/openshift/rosa/pkg/aws"
+	"github.com/openshift/rosa/pkg/logging"
+)
+
+type AccountRoles struct {
+	ControlPlaneRoleARN string
+	InstallerRoleARN    string
+	SupportRoleARN      string
+	WorkerRoleARN       string
+}
+
+// createAccountRoles will create account roles if they do not already exist
+func (m *ROSAProvider) createAccountRoles(version string) error {
+	var accountRoles *AccountRoles
+
+	prefix := fmt.Sprintf("ManagedOpenShift-%s", version)
+
+	log.Printf("Checking if account roles exist with prefix %q", prefix)
+
+	accountRoles, err := m.getAccountRoles(prefix, version)
+	if err != nil && accountRoles != nil {
+		return fmt.Errorf("fetching account roles failed: %v", err)
+	}
+
+	if accountRoles == nil {
+		log.Printf("Account roles do not exist with prefix %s, creating them..", prefix)
+
+		cmd := createAccountRoles.Cmd
+		cmd.SetArgs([]string{
+			"--mode", "auto",
+			"--prefix", prefix,
+			"--version", version,
+			"--yes",
+		})
+
+		err := callAndSetAWSSession(func() error {
+			return cmd.Execute()
+		})
+		if err != nil {
+			return fmt.Errorf("error creating account roles with prefix %q, %v", prefix, err)
+		}
+
+		accountRoles, err = m.getAccountRoles(prefix, version)
+		if err != nil || accountRoles == nil {
+			return fmt.Errorf("fetching generated account roles with prefix failed %q, %v", prefix, err)
+		}
+
+		return nil
+	}
+
+	log.Printf("Account roles already exist with prefix %q", prefix)
+	return nil
+}
+
+// getAccountRoles gets exact account roles based on prefix/version provided
+func (m *ROSAProvider) getAccountRoles(prefix string, version string) (*AccountRoles, error) {
+	accountRoles := &AccountRoles{}
+
+	err := callAndSetAWSSession(func() error {
+		awsClient, err := rosaAws.NewClient().
+			Logger(logging.NewLogger()).
+			Region(m.awsRegion).
+			Build()
+		if err != nil {
+			return fmt.Errorf("error creating rosa aws client: %v", err)
+		}
+
+		roles, err := awsClient.ListAccountRoles(version)
+		if err != nil {
+			return fmt.Errorf("error listing account roles: %v", err)
+		}
+
+		count := 0
+		for _, role := range roles {
+			if !strings.HasPrefix(role.RoleName, prefix) {
+				continue
+			}
+
+			switch role.RoleType {
+			case "Control plane":
+				accountRoles.ControlPlaneRoleARN = role.RoleARN
+				count += 1
+			case "Installer":
+				accountRoles.InstallerRoleARN = role.RoleARN
+				count += 1
+			case "Support":
+				accountRoles.SupportRoleARN = role.RoleARN
+				count += 1
+			case "Worker":
+				accountRoles.WorkerRoleARN = role.RoleARN
+				count += 1
+			}
+		}
+
+		if count != 4 {
+			return fmt.Errorf("error one or more prefixed %q account roles does not exist: %+v", prefix, accountRoles)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return accountRoles, nil
+}

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -125,6 +125,15 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 		return "", fmt.Errorf("error determining region to use: %v", err)
 	}
 
+	// Auto create account roles if required
+	version, err := util.OpenshiftVersionToSemver(rosaClusterVersion)
+	if err != nil {
+		return "", fmt.Errorf("error parsing %s to semantic version: %v", rosaClusterVersion, err)
+	}
+	if err = m.createAccountRoles(fmt.Sprintf("%d.%d", version.Major(), version.Minor())); err != nil {
+		return "", err
+	}
+
 	createClusterArgs := []string{
 		"--cluster-name", clusterName,
 		"--region", m.awsRegion,

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -126,12 +126,14 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 	}
 
 	// Auto create account roles if required
-	version, err := util.OpenshiftVersionToSemver(rosaClusterVersion)
-	if err != nil {
-		return "", fmt.Errorf("error parsing %s to semantic version: %v", rosaClusterVersion, err)
-	}
-	if err = m.createAccountRoles(fmt.Sprintf("%d.%d", version.Major(), version.Minor())); err != nil {
-		return "", err
+	if viper.GetBool(STS) {
+		version, err := util.OpenshiftVersionToSemver(rosaClusterVersion)
+		if err != nil {
+			return "", fmt.Errorf("error parsing %s to semantic version: %v", rosaClusterVersion, err)
+		}
+		if err = m.createAccountRoles(fmt.Sprintf("%d.%d", version.Major(), version.Minor())); err != nil {
+			return "", err
+		}
 	}
 
 	createClusterArgs := []string{


### PR DESCRIPTION
# Change
This PR introduces support to auto create rosa account roles when creating rosa classic/rosa hcp clusters.

Prior to any account role creation, it will check the account first to see if any roles exist. Roles will only be created if they do not exist.

Roles to be created will be created using the default prefix "ManagedOpenShift-<version>". Which allows them to be reusable across clusters. With this approach, it keeps the roles clean/tidy in the account, resulting in less amount of roles (e.g. unique role per cluster created). This also eliminates the need to remove account roles at the end of an osde2e run. We can leave "ManagedOpenShift-<version>" prefixed roles in the account as they are global/used by multiple clusters.

For [SDCICD-923](https://issues.redhat.com//browse/SDCICD-923)