### PR TITLE
Bump go from 1.18 to 1.19

### DIFF
--- a/Dockerfile.osde2e
+++ b/Dockerfile.osde2e
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18
+FROM registry.ci.openshift.org/openshift/release:golang-1.19
 
 ENV GOFLAGS=
 ENV PKG=/go/src/github.com/openshift/osde2e/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/osde2e
 
-go 1.18
+go 1.19
 
 require (
 	cloud.google.com/go/kms v1.10.1


### PR DESCRIPTION
# Change
This PR bumps the go version from 1.18 to 1.19. 1.18 is [no longer supported](https://endoflife.date/go) now that 1.20 is available. As go supports 2 versions at a time.

In addition to being unsupported, 1.18 also does not support atomic pointers (which was made available in 1.19). For PR #1800 to pass PR checks, it will need to be bumped to use latest k8s packages.

```
[root@9c07ab4a60de osde2e]# go version
go version go1.18.1 linux/amd64
[root@9c07ab4a60de osde2e]# make build
mkdir -p "/go/src/github.com/openshift/origin/osde2e/out"
go build -o "/go/src/github.com/openshift/origin/osde2e/out" "/go/src/github.com/openshift/origin/osde2e/cmd/..."
# k8s.io/kube-openapi/pkg/cached
/go/pkg/mod/k8s.io/kube-openapi@v0.0.0-20230308215209-15aac26d736a/pkg/cached/cache.go:242:16: undefined: atomic.Pointer
make: *** [build] Error 2
```

```
[root@7a90b9e478aa osde2e]# go version
go version go1.19.4 linux/amd64
[root@7a90b9e478aa osde2e]# make build
mkdir -p "/go/src/github.com/openshift/origin/osde2e/out"
go build -o "/go/src/github.com/openshift/origin/osde2e/out" "/go/src/github.com/openshift/origin/osde2e/cmd/..."
[root@7a90b9e478aa osde2e]# echo $?
0
[root@7a90b9e478aa osde2e]# ./out/osde2e -h
Command line tool for osde2e.

Usage:
  osde2e [command]

Available Commands:
  alert       Generates alerts for OSDe2e test owners.
  cleanup     Cleans up expired clusters.
  completion  Generates bash completion scripts
  healthcheck Runs a healthcheck.
  help        Help about any command
  query       Queries Prometheus results.
  report      OSDe2e reporting.
  test        Runs end to end tests.

Flags:
      --debug    Enable debug mode.
  -h, --help     help for osde2e
      --update   Whether to update the binary before running.

Use "osde2e [command] --help" for more information about a command.
```
