### PR TITLE
Set cluster name var when creating through ROSA

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -553,6 +553,8 @@ func ProvisionCluster(logger *log.Logger) (*spi.Cluster, error) {
 				if err != nil {
 					fmt.Printf("an error occurred validating the cluster name %v\n", err)
 				} else if validName {
+					viper.Set(config.Cluster.Name, name)
+					log.Printf("cluster name set to %s\n", name)
 					break
 				} else {
 					fmt.Printf("cluster name %s already exists.\n", name)


### PR DESCRIPTION
[Slack Ref ](https://redhat-internal.slack.com/archives/CMK13BP4J/p1683062458966729?thread_ts=1683060230.475769&cid=CMK13BP4J)
[SDCICD-1003](https://issues.redhat.com/browse/SDCICD-1003)

This PR updates the viper variable for the cluster name when we create a fresh cluster using Rosa