### PR TITLE
Hotfix -Revert Rosa Back to v1.2.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/openshift/custom-domains-operator v0.0.0-20221118201157-bd1052dac818
 	github.com/openshift/managed-upgrade-operator v0.0.0-20230128000023-b30cca4aa2af
 	github.com/openshift/must-gather-operator v0.1.2-0.20221011152618-7805956e1ded
-	github.com/openshift/rosa v1.2.20
+	github.com/openshift/rosa v1.2.17
 	github.com/openshift/route-monitor-operator v0.0.0-20221118160357-3df1ed1fa1d2
 	github.com/openshift/splunk-forwarder-operator v0.0.0-20230216205147-c051d56cd298
 	github.com/operator-framework/api v0.17.4-0.20230223191600-0131a6301e42

--- a/go.sum
+++ b/go.sum
@@ -1218,8 +1218,8 @@ github.com/openshift/managed-upgrade-operator v0.0.0-20230128000023-b30cca4aa2af
 github.com/openshift/managed-upgrade-operator v0.0.0-20230128000023-b30cca4aa2af/go.mod h1:uB6QrG3Y6Y6Q2HjlOdTu15Bkwkln+XLr2HOwgLgznJA=
 github.com/openshift/must-gather-operator v0.1.2-0.20221011152618-7805956e1ded h1:ndSIrjtHq6DaEfQqtukaJ7PrX9f0X2V9WjnuiqBDGyw=
 github.com/openshift/must-gather-operator v0.1.2-0.20221011152618-7805956e1ded/go.mod h1:LHntdQf5jrwxpmyVMbwXUK491COBJ7buHvyi4YLlHho=
-github.com/openshift/rosa v1.2.20 h1:mFbCT2Oq8hZ7tzbuyamvrDqg8UPROCgNCqVQ+kEIaeM=
-github.com/openshift/rosa v1.2.20/go.mod h1:gUs+GsvYxDvvtS8U1BgIQjDCSd0yrTDLOGpdTTKnWpg=
+github.com/openshift/rosa v1.2.17 h1:M2YtvYJfOTwvwkMsbQGQOZZaTQNy0mUHxAbE8AkLr24=
+github.com/openshift/rosa v1.2.17/go.mod h1:SdJEQg19qTNbgX1k4LcPWSllHW9QCTSIzalfO9FARh0=
 github.com/openshift/route-monitor-operator v0.0.0-20221118160357-3df1ed1fa1d2 h1:s97F2fQ5r+XGVfWDy5wgH611iIvIDusQcHtv5jJ36uw=
 github.com/openshift/route-monitor-operator v0.0.0-20221118160357-3df1ed1fa1d2/go.mod h1:I/8znbaxMGRub27brm57UnkR48QZEWO26j2HRscy5bQ=
 github.com/openshift/splunk-forwarder-operator v0.0.0-20230216205147-c051d56cd298 h1:LOaO/QdBKrrNWiviOH6vq45V3GHq4sezPc9HQlMZOKo=


### PR DESCRIPTION
Reverts back from V1.2.20 which introduced an os.Exit(0) on cluster creation, that is causing OSDe2e to end abruptly. 
Refer to this [thread](https://redhat-internal.slack.com/archives/CMK13BP4J/p1683575571686559) for reference