### PR TITLE
e2e/operators/ocmagent: update configmap name

### DIFF
--- a/pkg/e2e/operators/ocmagent/ocmagent.go
+++ b/pkg/e2e/operators/ocmagent/ocmagent.go
@@ -51,7 +51,7 @@ var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.Operators, label.Inform
 	})
 
 	var (
-		configMapName      = "ocm-agent-config"
+		configMapName      = "ocm-agent-cm"
 		clusterRolePrefix  = "ocm-agent-operator"
 		deploymentName     = "ocm-agent"
 		namespace          = "openshift-ocm-agent-operator"


### PR DESCRIPTION
this was changed in https://github.com/openshift/ocm-agent-operator/commit/25ce50dfe89a1afd6879111a0b15f8ab76100abe

Signed-off-by: Brady Pratt <bpratt@redhat.com>
