### PR TITLE
Include channel group when creating rosa account roles

### DIFF
--- a/pkg/common/providers/rosaprovider/accountroles.go
+++ b/pkg/common/providers/rosaprovider/accountroles.go
@@ -18,7 +18,7 @@ type AccountRoles struct {
 }
 
 // createAccountRoles will create account roles if they do not already exist
-func (m *ROSAProvider) createAccountRoles(version string) error {
+func (m *ROSAProvider) createAccountRoles(version string, channelGroup string) error {
 	var accountRoles *AccountRoles
 
 	prefix := fmt.Sprintf("ManagedOpenShift-%s", version)
@@ -38,6 +38,7 @@ func (m *ROSAProvider) createAccountRoles(version string) error {
 			"--mode", "auto",
 			"--prefix", prefix,
 			"--version", version,
+			"--channel-group", channelGroup,
 			"--yes",
 		})
 

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -103,8 +103,9 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 	}
 
 	rosaClusterVersion := viper.GetString(config.Cluster.Version)
+	channelGroup := viper.GetString(config.Cluster.Channel)
 	rosaClusterVersion = strings.ReplaceAll(rosaClusterVersion, "openshift-v", "")
-	rosaClusterVersion = strings.ReplaceAll(rosaClusterVersion, fmt.Sprintf("-%s", viper.GetString(config.Cluster.Channel)), "")
+	rosaClusterVersion = strings.ReplaceAll(rosaClusterVersion, fmt.Sprintf("-%s", channelGroup), "")
 
 	log.Printf("ROSA cluster version: %s", rosaClusterVersion)
 
@@ -131,7 +132,8 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("error parsing %s to semantic version: %v", rosaClusterVersion, err)
 		}
-		if err = m.createAccountRoles(fmt.Sprintf("%d.%d", version.Major(), version.Minor())); err != nil {
+		majorMinor := fmt.Sprintf("%d.%d", version.Major(), version.Minor())
+		if err = m.createAccountRoles(majorMinor, channelGroup); err != nil {
 			return "", err
 		}
 	}


### PR DESCRIPTION
# Change
This PR supplies the channel group to rosa when creating account roles (its a hidden flag). Current jobs attempting to deploy sts clusters with version 4.13 have been failing to create roles. Since those jobs are using candidate channel group and stable channel group does not have 4.13 builds available. We need to supply the channel group so rosa/ocm can accordingly find the 4.13 version and proceed to create the roles.

_Error_

Example [job](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-rosa-stage-e2e-byo-vpc-proxy-install/1656011284635717632) failing.

```
2023/05/09 19:04:15 cluster.go:109: ROSA cluster version: 4.13.0-rc.7
2023/05/09 19:04:15 accountroles.go:26: Checking if account roles exist with prefix "ManagedOpenShift-4.13"
2023/05/09 19:04:15 util.go:31: AWS_PROFILE is not set
time=2023-05-09T19:04:17Z level=warning msg=Throttling Rate limit exceeded. Retrying the request again
2023/05/09 19:04:20 accountroles.go:34: Account roles do not exist with prefix ManagedOpenShift-4.13, creating them..
2023/05/09 19:04:20 util.go:31: AWS_PROFILE is not set
WARN: OpenShift command-line tool is not installed.
Run 'rosa download oc' to download the latest version, then add it to your PATH.
ERR: Error getting version: A valid policy version number must be specified
Valid versions: [4.7, 4.8, 4.9, 4.10, 4.11, 4.12]
```

_Fix with supplying channel group to rosa create account-roles_

```
2023/05/10 08:48:10 cluster.go:110: ROSA cluster version: 4.13.0-rc.7
2023/05/10 08:48:45 accountroles.go:26: Checking if account roles exist with prefix "ManagedOpenShift-4.13"
2023/05/10 08:48:46 util.go:31: AWS_PROFILE is not set
2023/05/10 08:48:58 accountroles.go:34: Account roles do not exist with prefix ManagedOpenShift-4.13, creating them..
2023/05/10 08:49:06 util.go:31: AWS_PROFILE is not set
INFO: Creating roles using 'arn:aws:iam::xxxx:user/sd-cicd'
INFO: Created role 'ManagedOpenShift-4.13-Installer-Role' with ARN 'arn:aws:iam::xxxx:role/ManagedOpenShift-4.13-Installer-Role'
INFO: Created role 'ManagedOpenShift-4.13-ControlPlane-Role' with ARN 'arn:aws:iam::xxxx:role/ManagedOpenShift-4.13-ControlPlane-Role'
INFO: Created role 'ManagedOpenShift-4.13-Worker-Role' with ARN 'arn:aws:iam::xxxx:role/ManagedOpenShift-4.13-Worker-Role'
INFO: Created role 'ManagedOpenShift-4.13-Support-Role' with ARN 'arn:aws:iam::xxxx:role/ManagedOpenShift-4.13-Support-Role'
INFO: To create a cluster with these roles, run the following command:
rosa create cluster --sts
2023/05/10 08:50:05 util.go:31: AWS_PROFILE is not set
Detaching and terminating target process
```