### PR TITLE
Update CI jobs doc to include ROSA Classic STS TRT nightly jobs

### DIFF
--- a/docs/CI-Jobs.md
+++ b/docs/CI-Jobs.md
@@ -52,13 +52,13 @@ The table below represents the periodic jobs that run to validate Managed
 OpenShift for new nightly OCP TRT builds and provide a *informing* signal
 to the release.
 
-| OCP Version | OSD AWS                       | OSD GCP                       | ROSA STS              | ROSA HCP |
-| ----------- | ----------------------------- | ----------------------------- | --------------------- | -------- |
-| 4.14        | [Test Grid][4.14 TRT OSD AWS] | [Test Grid][4.14 TRT OSD GCP] | Refer to [SDCICD-557] | -        |
-| 4.13        | [Test Grid][4.13 TRT OSD AWS] | [Test Grid][4.13 TRT OSD GCP] | Refer to [SDCICD-557] | -        |
-| 4.12        | [Test Grid][4.12 TRT OSD AWS] | [Test Grid][4.12 TRT OSD GCP] | Refer to [SDCICD-557] | -        |
-| 4.11        | [Test Grid][4.11 TRT OSD AWS] | [Test Grid][4.11 TRT OSD GCP] | Refer to [SDCICD-557] | -        |
-| 4.10        | [Test Grid][4.10 TRT OSD AWS] | [Test Grid][4.10 TRT OSD GCP] | Refer to [SDCICD-557] | -        |
+| OCP Version | OSD AWS                       | OSD GCP                       | ROSA Classic STS                       | ROSA HCP |
+| ----------- | ----------------------------- | ----------------------------- | -------------------------------------- | -------- |
+| 4.14        | [Test Grid][4.14 TRT OSD AWS] | [Test Grid][4.14 TRT OSD GCP] | -                                      | -        |
+| 4.13        | [Test Grid][4.13 TRT OSD AWS] | [Test Grid][4.13 TRT OSD GCP] | [Test Grid][4.13 TRT ROSA CLASSIC STS] | -        |
+| 4.12        | [Test Grid][4.12 TRT OSD AWS] | [Test Grid][4.12 TRT OSD GCP] | [Test Grid][4.12 TRT ROSA CLASSIC STS] | -        |
+| 4.11        | [Test Grid][4.11 TRT OSD AWS] | [Test Grid][4.11 TRT OSD GCP] | [Test Grid][4.11 TRT ROSA CLASSIC STS] | -        |
+| 4.10        | [Test Grid][4.10 TRT OSD AWS] | [Test Grid][4.10 TRT OSD GCP] | [Test Grid][4.10 TRT ROSA CLASSIC STS] | -        |
 
 These jobs send alerts to the following slack channel: [#sd-cicd-alerts].
 
@@ -73,7 +73,6 @@ These jobs send alerts to the following slack channel: [#sd-cicd-alerts].
 [SD CICD OSD AWS Upgrade Y To Y+1]: https://testgrid.k8s.io/redhat-openshift-osd#periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-y-to-latest-y-plus-1&width=90
 [SD CICD OSD AWS Upgrade Y+1 To Y]: https://testgrid.k8s.io/redhat-openshift-osd#periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-y-plus-1-to-latest-y&width=90
 
-
 [4.14 TRT OSD AWS]: https://testgrid.k8s.io/redhat-openshift-ocp-release-4.14-informing#release-openshift-ocp-osd-aws-nightly-4.14&width=90
 [4.14 TRT OSD GCP]: https://testgrid.k8s.io/redhat-openshift-ocp-release-4.14-informing#release-openshift-ocp-osd-gcp-nightly-4.14&width=90
 [4.13 TRT OSD AWS]: https://testgrid.k8s.io/redhat-openshift-ocp-release-4.13-informing#release-openshift-ocp-osd-aws-nightly-4.13&width=90
@@ -85,7 +84,10 @@ These jobs send alerts to the following slack channel: [#sd-cicd-alerts].
 [4.10 TRT OSD AWS]: https://testgrid.k8s.io/redhat-openshift-ocp-release-4.10-informing#release-openshift-ocp-osd-aws-nightly-4.10&width=90
 [4.10 TRT OSD GCP]: https://testgrid.k8s.io/redhat-openshift-ocp-release-4.10-informing#release-openshift-ocp-osd-gcp-nightly-4.10&width=90
 
-[SDCICD-557]: https://issues.redhat.com/browse/SDCICD-557
+[4.13 TRT ROSA CLASSIC STS]: https://testgrid.k8s.io/redhat-openshift-ocp-release-4.13-informing#release-openshift-ocp-rosa-classic-sts-nightly-4.13&width=90
+[4.12 TRT ROSA CLASSIC STS]: https://testgrid.k8s.io/redhat-openshift-ocp-release-4.12-informing#release-openshift-ocp-rosa-classic-sts-nightly-4.12&width=90
+[4.11 TRT ROSA CLASSIC STS]: https://testgrid.k8s.io/redhat-openshift-ocp-release-4.11-informing#release-openshift-ocp-rosa-classic-sts-nightly-4.11&width=90
+[4.10 TRT ROSA CLASSIC STS]: https://testgrid.k8s.io/redhat-openshift-ocp-release-4.10-informing#release-openshift-ocp-rosa-classic-sts-nightly-4.10&width=90
 
 [#sd-cicd-alerts]: https://app.slack.com/client/T027F3GAJ/CNYM6PB6X
 [#sd-hypershift-info]: https://app.slack.com/client/T027F3GAJ/C04FGSFUHF1


### PR DESCRIPTION
# Change
This PR updates the CI Jobs document to include the ROSA Classic STS jobs that were recently added by https://github.com/openshift/release/pull/38941.

https://prow.ci.openshift.org/?job=*rosa-classic-sts*

For [SDCICD-557](https://issues.redhat.com//browse/SDCICD-557)