### PR TITLE
Workload suite test - increased timeout

### DIFF
--- a/pkg/e2e/workloads/workloads.go
+++ b/pkg/e2e/workloads/workloads.go
@@ -48,7 +48,7 @@ var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.HyperShift, label.E2E, 
 
 		req := clientset.CoreV1().Services(h.CurrentProject()).ProxyGet("http", serviceName, "3000", "/", nil)
 		_, err = req.DoRaw(ctx)
-		expect.Error(err, "service %s/%s should not be reachable", serviceName, deploymentName)
+		expect.Error(err, "service %s/%s should not be reachable", serviceName, h.CurrentProject())
 
 		err = decoder.DecodeEachFile(ctx, workloadFS, "*", decoder.DeleteHandler(client), decoder.MutateNamespace(h.CurrentProject()))
 		expect.NoError(err)


### PR DESCRIPTION
Currently test is failing with error `deployment osde2e-n41al/redmine never became available`

Increasing timeout to 5 minutes.

Also included:
- added error message to service ping assertion