### PR TITLE
settings to create privatelink rosa cluster

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -39,6 +39,8 @@ Some environment variables commonly used for pipelines under osde2e are indicate
 | ROSA_ENV             | Environment for the e2e testing, default to prod.            |
 | ROSA_STS             | Boolean value to indicate the cluster is STS enabled or not. |
 | ROSA_REPLICAS        | Compute node count for the rosa cluster, default is 2.       |
+| ROSA_PRIVATELINK     | Boolean value to specify a privatelink cluster. If set true, a private subnet ID belonging to a non-RH managed VPC must be provided as ROSA_SUBNET_IDS") |
+| ROSA_SUBNET_IDS      | Subnet IDs to be used for the test cluster creation.  |                                                                                                     
 
 ### Hypershift cluster related:-
 

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -160,6 +160,14 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 		createClusterArgs = append(createClusterArgs, "--worker-iam-role", accountRoles.WorkerRoleARN)
 	}
 
+	if viper.GetBool(PrivateLink) {
+		if viper.GetString(config.AWSVPCSubnetIDs) == "" {
+			return "", fmt.Errorf("privatelink specified without providing private ROSA_SUBNET_IDS. Ensure the subnet is private and belongs to a non-RH managed VPC.")
+		} else {
+			createClusterArgs = append(createClusterArgs, "--private-link")
+		}
+	}
+
 	if viper.GetString(config.AWSVPCSubnetIDs) != "" {
 		subnetIDs := viper.GetString(config.AWSVPCSubnetIDs)
 		createClusterArgs = append(createClusterArgs, "--subnet-ids", subnetIDs)

--- a/pkg/common/providers/rosaprovider/config.go
+++ b/pkg/common/providers/rosaprovider/config.go
@@ -33,6 +33,9 @@ const (
 	// STS is a boolean tracking whether or not this cluster should be provisioned using the STS workflow
 	STS = "rosa.STS"
 
+	// PrivateLink is a boolean var to be specified for ROSA privatelink cluster. If this is true, a private subnet ID as ROSA_SUBNET_IDS must be provided.
+	PrivateLink = "rosa.privateLink"
+
 	// OIDCConfigID is the ID of the oidc-config created through ROSA CLI (required for HCP)
 	OIDCConfigID = "rosa.oidcConfigID"
 )
@@ -59,6 +62,9 @@ func init() {
 
 	viper.BindEnv(STS, "ROSA_STS")
 	viper.SetDefault(STS, false)
+
+	viper.BindEnv(PrivateLink, "ROSA_PRIVATELINK")
+	viper.SetDefault(PrivateLink, false)
 
 	viper.SetDefault(OIDCConfigID, "")
 	viper.BindEnv(OIDCConfigID, "ROSA_OIDC_CONFIG_ID")


### PR DESCRIPTION
Introduces boolean env var to specify rosa privatelink cluster 
Uses existing ROSA_SUBNET_IDS env var to allow creation of privatelink 