### PR TITLE
fixed SKIP_CLUSTER_HEALTH_CHECKS env var to read correctly

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -722,7 +722,7 @@ func InitOSDe2eViper() {
 	viper.BindEnv(Tests.OperatorSkip, "OPERATOR_SKIP")
 
 	viper.SetDefault(Tests.SkipClusterHealthChecks, false)
-	viper.BindEnv(Tests.OperatorSkip, "SKIP_CLUSTER_HEALTH_CHECKS")
+	viper.BindEnv(Tests.SkipClusterHealthChecks, "SKIP_CLUSTER_HEALTH_CHECKS")
 
 	viper.SetDefault(Tests.ClusterHealthChecksTimeout, "2h")
 	viper.BindEnv(Tests.ClusterHealthChecksTimeout, "CLUSTER_HEALTH_CHECKS_TIMEOUT")

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -131,7 +131,7 @@ func beforeSuite() bool {
 			log.Printf("Error while adding upgrade version property to cluster via OCM: %v", err)
 		}
 
-		if viper.GetString(config.Tests.SkipClusterHealthChecks) != "true" {
+		if !viper.GetBool(config.Tests.SkipClusterHealthChecks) {
 			if viper.GetBool(config.Cluster.Reused) {
 				// We should manually run all our health checks if the cluster is waking up
 				err = clusterutil.WaitForClusterReadyPostWake(cluster.ID(), nil)


### PR DESCRIPTION
- fixed SKIP_CLUSTER_HEALTH_CHECKS to be bound to the correct config var 
- updated to using the bool value of the flag instead of string  