### PR TITLE
Bump osde2e-common to latest commit sha

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/openshift/custom-domains-operator v0.0.0-20221118201157-bd1052dac818
 	github.com/openshift/managed-upgrade-operator v0.0.0-20230525042514-a9b8c1d2571c
 	github.com/openshift/must-gather-operator v0.1.2-0.20221011152618-7805956e1ded
-	github.com/openshift/osde2e-common v0.0.0-20230615193932-c983d1e234c9
+	github.com/openshift/osde2e-common v0.0.0-20230621125319-93f8f034f3aa
 	github.com/openshift/rosa v1.2.22
 	github.com/openshift/route-monitor-operator v0.0.0-20221118160357-3df1ed1fa1d2
 	github.com/openshift/splunk-forwarder-operator v0.0.0-20230525060151-2dc403aa8ff9

--- a/go.sum
+++ b/go.sum
@@ -751,8 +751,8 @@ github.com/openshift/managed-upgrade-operator v0.0.0-20230525042514-a9b8c1d2571c
 github.com/openshift/managed-upgrade-operator v0.0.0-20230525042514-a9b8c1d2571c/go.mod h1:W/ajjexZ/T50ZRpk48HbgbtOXD4rt0/wHlwdXu8arQE=
 github.com/openshift/must-gather-operator v0.1.2-0.20221011152618-7805956e1ded h1:ndSIrjtHq6DaEfQqtukaJ7PrX9f0X2V9WjnuiqBDGyw=
 github.com/openshift/must-gather-operator v0.1.2-0.20221011152618-7805956e1ded/go.mod h1:LHntdQf5jrwxpmyVMbwXUK491COBJ7buHvyi4YLlHho=
-github.com/openshift/osde2e-common v0.0.0-20230615193932-c983d1e234c9 h1:MCI19CPHx4W5yMQCC7UPOkz3TDO+G8Ts+fHYRs2SHk4=
-github.com/openshift/osde2e-common v0.0.0-20230615193932-c983d1e234c9/go.mod h1:qP+tI/gaFODlcRTSzD7IL3Z6Eh7C/eKdxK4z7J/bYNE=
+github.com/openshift/osde2e-common v0.0.0-20230621125319-93f8f034f3aa h1:qfj0cSkZ7Ja9+ahYmiQdXoT8lrH6tTcRV6jspyb5Q4I=
+github.com/openshift/osde2e-common v0.0.0-20230621125319-93f8f034f3aa/go.mod h1:qP+tI/gaFODlcRTSzD7IL3Z6Eh7C/eKdxK4z7J/bYNE=
 github.com/openshift/rosa v1.2.22 h1:9yJujtoHtlcKPxdb/XgmfZXNmbEoLv9k89/XQplWWkA=
 github.com/openshift/rosa v1.2.22/go.mod h1:DVAj0xmrKFiMzSln4M735Em5PrDNJO4fjjGZ6NXJObo=
 github.com/openshift/route-monitor-operator v0.0.0-20221118160357-3df1ed1fa1d2 h1:s97F2fQ5r+XGVfWDy5wgH611iIvIDusQcHtv5jJ36uw=

--- a/test/mcscupgrade/mcscupgrade_test.go
+++ b/test/mcscupgrade/mcscupgrade_test.go
@@ -215,7 +215,7 @@ var _ = Describe("HyperShift", Ordered, func() {
 				Version:      hcpCluster.version,
 				ChannelGroup: hcpCluster.channelGroup,
 				HostedCP:     true,
-				Properties:   fmt.Sprintf("provision_shard_id:%s", hcpCluster.provisionShardID),
+				Properties:   map[string]string{"provision_shard_id": hcpCluster.provisionShardID},
 				WorkingDir:   hcpCluster.reportDir,
 			})
 			Expect(err).ShouldNot(HaveOccurred(), "failed to create hosted control plane cluster")


### PR DESCRIPTION
# What

1. Bump osde2e-common to the latest commit sha ([PR](https://github.com/openshift/osde2e-common/pull/13))
2. Update MC/SC upgrade test suite to alter the data type for cluster properties when passed to ROSA provider `createCluster` method.