### PR TITLE
Fix the bug causing rosa cluster oidc config deletion to fail

### DIFF
--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -203,7 +203,7 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 		if rosaOIDCConfigID := viper.GetString(OIDCConfigID); rosaOIDCConfigID != "" {
 			createClusterArgs = append(createClusterArgs, "--oidc-config-id", rosaOIDCConfigID)
 		} else {
-			oidcConfigID, err := m.createOIDCConfig(clusterName)
+			oidcConfigID, err := m.createOIDCConfig(clusterName, accountRoles.InstallerRoleARN)
 			if err != nil {
 				return "", fmt.Errorf("failed to create oidc-config-id: %v", err)
 			}

--- a/pkg/common/providers/rosaprovider/oidcconfig.go
+++ b/pkg/common/providers/rosaprovider/oidcconfig.go
@@ -4,21 +4,18 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/openshift/osde2e/pkg/common/aws"
 	createOIDCConfig "github.com/openshift/rosa/cmd/create/oidcconfig"
 	deleteOIDCConfig "github.com/openshift/rosa/cmd/dlt/oidcconfig"
 )
 
 // createOIDCConfig will create a OIDC config to be used during cluster creation
-func (m *ROSAProvider) createOIDCConfig(prefix string) (string, error) {
+func (m *ROSAProvider) createOIDCConfig(prefix, installerRoleARN string) (string, error) {
 	cmd := createOIDCConfig.Cmd
-	// TODO: Get installer role ARN, prompts for one when multiple exist,
-	//	lets just automate the create/delete of account roles
 	args := []string{
 		"--mode", "auto",
 		"--prefix", prefix,
 		"--managed=false",
-		"--installer-role-arn", fmt.Sprintf("arn:aws:iam::%s:role/ManagedOpenShift-Installer-Role", aws.CcsAwsSession.GetAccountId()),
+		"--installer-role-arn", installerRoleARN,
 		"--yes",
 	}
 
@@ -65,6 +62,7 @@ func (m *ROSAProvider) deleteOIDCConfig(prefix string) error {
 	cmd := deleteOIDCConfig.Cmd
 	cmd.SetArgs([]string{
 		"--mode", "auto",
+		"--interactive=false",
 		"--oidc-config-id", oidcConfigID,
 		"--yes",
 	})


### PR DESCRIPTION
# What
This PR resolves the bug where after a rosa clusters operator roles and oidc provider are deleted, it hangs trying to delete the oidc config if one was auto created when the cluster was created. The issue seemed to be the rosa oidc config delete command was thinking it was in an interactive mode, waiting for user prompt. Issue looks to be related to a global variable being set from prior rosa command calls, resulting it being set to true, entering interactive mode.

The fix is to add an additional option to explicitly set interactive mode to false.

In addition to this fix, updated create oidc config to accept the installer role arn as a parameter over defining a static one.

## Bug

```
2023/06/28 12:21:21 cluster.go:366: Waiting for cluster 24kt65n1t9b7ehmqkcd0qeq4ke4gj2dq to be deleted
2023/06/28 12:23:22 cluster.go:366: Waiting for cluster 24kt65n1t9b7ehmqkcd0qeq4ke4gj2dq to be deleted
2023/06/28 12:25:22 cluster.go:366: Waiting for cluster 24kt65n1t9b7ehmqkcd0qeq4ke4gj2dq to be deleted
2023/06/28 12:27:22 cluster.go:366: Waiting for cluster 24kt65n1t9b7ehmqkcd0qeq4ke4gj2dq to be deleted
2023/06/28 12:29:22 cluster.go:366: Waiting for cluster 24kt65n1t9b7ehmqkcd0qeq4ke4gj2dq to be deleted
2023/06/28 12:31:22 cluster.go:366: Waiting for cluster 24kt65n1t9b7ehmqkcd0qeq4ke4gj2dq to be deleted
2023/06/28 12:33:22 cluster.go:366: Waiting for cluster 24kt65n1t9b7ehmqkcd0qeq4ke4gj2dq to be deleted
2023/06/28 12:33:22 util.go:31: AWS_PROFILE is not set
2023/06/28 12:33:22 cluster.go:384: [operator-roles --mode auto --yes --prefix osde2e-ap4yt-x4t3]
2023/06/28 12:33:22 cluster.go:396: [oidc-provider --mode auto --yes --oidc-config-id 24kt64a0mgmjqe6nhs0vterbu7dt48nj]
INFO: Deleting operator role 'osde2e-ap4yt-x4t3-kube-system-capa-controller-manager'
INFO: Deleting operator role 'osde2e-ap4yt-x4t3-kube-system-control-plane-operator'
INFO: Deleting operator role 'osde2e-ap4yt-x4t3-kube-system-kms-provider'
INFO: Deleting operator role 'osde2e-ap4yt-x4t3-kube-system-kube-controller-manager'
INFO: Deleting operator role 'osde2e-ap4yt-x4t3-openshift-cloud-network-config-controller-clou'
INFO: Deleting operator role 'osde2e-ap4yt-x4t3-openshift-cluster-csi-drivers-ebs-cloud-creden'
INFO: Deleting operator role 'osde2e-ap4yt-x4t3-openshift-image-registry-installer-cloud-crede'
INFO: Deleting operator role 'osde2e-ap4yt-x4t3-openshift-ingress-operator-cloud-credentials'
INFO: Successfully deleted the operator roles
2023/06/28 12:33:23 cluster.go:402: Deleted operator roles for cluster 24kt65n1t9b7ehmqkcd0qeq4ke4gj2dq
INFO: Successfully deleted the OIDC provider arn:aws:iam::XXXXXXXXXXXX:oidc-provider/osde2e-ap4yt-oidc-x0q1.s3.XXXXXXXXX.amazonaws.com
2023/06/28 12:33:24 cluster.go:408: Deleted OIDC provider for cluster 24kt65n1t9b7ehmqkcd0qeq4ke4gj2dq
2023/06/28 12:33:24 util.go:31: AWS_PROFILE is not set
7[?25l8? OIDC Config deletion mode:  [Use arrows to move, type to filter, ? for more help]
> auto
  manual
78[?25hERR: Expected a valid OIDC provider creation mode: EOF
{"component":"entrypoint","error":"wrapped process failed: exit status 1","file":"k8s.io/test-infra/prow/entrypoint/run.go:79","func":"k8s.io/test-infra/prow/entrypoint.Options.Run","level":"error","msg":"Error executing test process","severity":"error","time":"2023-06-28T12:33:24Z"} 
```

## Fix

```
2023/06/28 15:27:19 cluster.go:366: Waiting for cluster 24l373p362e731fggi3ef59a0gsnaar1 to be deleted
2023/06/28 15:27:19 util.go:31: AWS_SECRET_ACCESS_KEY is not set
2023/06/28 15:27:19 util.go:31: AWS_ACCESS_KEY_ID is not set
2023/06/28 15:27:24 cluster.go:384: [operator-roles --mode auto --yes --prefix rw-0628-i2q7]
2023/06/28 15:27:27 cluster.go:396: [oidc-provider --mode auto --yes --oidc-config-id 24l3709jfdu7m6grjekn98l8kt86658o]
INFO: Deleting operator role 'rw-0628-i2q7-kube-system-capa-controller-manager'
INFO: Deleting operator role 'rw-0628-i2q7-kube-system-control-plane-operator'
INFO: Deleting operator role 'rw-0628-i2q7-kube-system-kms-provider'
INFO: Deleting operator role 'rw-0628-i2q7-kube-system-kube-controller-manager'
INFO: Deleting operator role 'rw-0628-i2q7-openshift-cloud-network-config-controller-cloud-cre'
INFO: Deleting operator role 'rw-0628-i2q7-openshift-cluster-csi-drivers-ebs-cloud-credentials'
INFO: Deleting operator role 'rw-0628-i2q7-openshift-image-registry-installer-cloud-credential'
INFO: Deleting operator role 'rw-0628-i2q7-openshift-ingress-operator-cloud-credentials'
INFO: Successfully deleted the operator roles
2023/06/28 15:27:36 cluster.go:402: Deleted operator roles for cluster 24l373p362e731fggi3ef59a0gsnaar1
INFO: Successfully deleted the OIDC provider arn:aws:iam::xxxx:oidc-provider/rw-0628-oidc-e1r8.s3.xxxx.amazonaws.com
2023/06/28 15:27:42 cluster.go:408: Deleted OIDC provider for cluster 24l373p362e731fggi3ef59a0gsnaar1
2023/06/28 15:28:16 util.go:31: AWS_ACCESS_KEY_ID is not set
2023/06/28 15:28:16 util.go:31: AWS_SECRET_ACCESS_KEY is not set
INFO: Provider 'https://rw-0628-oidc-e1r8.s3.us-west-2.amazonaws.com' not found.
2023/06/28 15:29:07 vpc.go:126: Deleting ROSA HyperShift aws vpc
2023/06/28 15:29:07 util.go:31: AWS_ACCESS_KEY_ID is not set
2023/06/28 15:29:07 util.go:31: AWS_SECRET_ACCESS_KEY is not set
2023/06/28 15:30:10 vpc.go:139: ROSA HyperShift aws vpc deleted!
```

# Jira
- [SDCICD-1051](https://issues.redhat.com//browse/SDCICD-1051)