### PR TITLE
use describeTable for better running multi harness jobs SDCICD-955

### DIFF
--- a/pkg/common/helper/runner.go
+++ b/pkg/common/helper/runner.go
@@ -6,10 +6,23 @@ import (
 
 	. "github.com/onsi/gomega"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/templates"
 
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/runner"
 )
+
+// RunnerWithTemplateCommand creates an extended test suite runner for templated test harness pods, configures RBAC for it.
+func (h *H) RunnerWithTemplateCommand(timeout float64, harness string, suffix string, jobName string, serviceAccountDir string) *runner.Runner {
+	r := h.RunnerWithNoCommand()
+	r.PodSpec.ServiceAccountName = h.GetNamespacedServiceAccount()
+	latestImageStream, err := r.GetLatestImageStreamTag()
+	Expect(err).NotTo(HaveOccurred(), "Could not get latest imagestream tag")
+	cmd, err := getCommandString(h, timeout, latestImageStream, harness, suffix, jobName, serviceAccountDir)
+	Expect(err).NotTo(HaveOccurred(), "Could not create pod command from template")
+	r.Cmd = cmd
+	return r
+}
 
 // RunnerWithNoCommand creates an extended test suite runner and configure RBAC for it.
 func (h *H) RunnerWithNoCommand() *runner.Runner {
@@ -42,4 +55,50 @@ func (h *H) WriteResults(results map[string][]byte) {
 		err = os.WriteFile(dst, data, os.ModePerm)
 		Expect(err).NotTo(HaveOccurred())
 	}
+}
+
+// Generates templated command string to provide to test harness container
+func getCommandString(h *H, timeout float64, latestImageStream string, harness string, suffix string, jobName string, serviceAccountDir string) (string, error) {
+	values := struct {
+		Name                 string
+		JobName              string
+		Arguments            string
+		Timeout              int
+		Image                string
+		OutputDir            string
+		ServiceAccount       string
+		PushResultsContainer string
+		Suffix               string
+		Server               string
+		CA                   string
+		TokenFile            string
+		EnvironmentVariables []struct {
+			Name  string
+			Value string
+		}
+	}{
+		Name:                 jobName,
+		JobName:              jobName,
+		Timeout:              int(timeout),
+		Image:                harness,
+		OutputDir:            runner.DefaultRunner.OutputDir,
+		ServiceAccount:       h.GetNamespacedServiceAccount(),
+		PushResultsContainer: latestImageStream,
+		Suffix:               suffix,
+		Server:               "https://kubernetes.default",
+		CA:                   serviceAccountDir + "/ca.crt",
+		TokenFile:            serviceAccountDir + "/token",
+		EnvironmentVariables: []struct {
+			Name  string
+			Value string
+		}{
+			{
+				Name:  "OCM_CLUSTER_ID",
+				Value: viper.GetString(config.Cluster.ID),
+			},
+		},
+	}
+	testTemplate, err := templates.LoadTemplate("tests/tests-runner.template")
+	Expect(err).NotTo(HaveOccurred(), "Could not load pod template")
+	return h.ConvertTemplateToString(testTemplate, values)
 }

--- a/pkg/common/helper/runner.go
+++ b/pkg/common/helper/runner.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/templates"
@@ -59,6 +60,7 @@ func (h *H) WriteResults(results map[string][]byte) {
 
 // Generates templated command string to provide to test harness container
 func getCommandString(h *H, timeout float64, latestImageStream string, harness string, suffix string, jobName string, serviceAccountDir string) (string, error) {
+	ginkgo.GinkgoHelper()
 	values := struct {
 		Name                 string
 		JobName              string

--- a/pkg/common/helper/runner.go
+++ b/pkg/common/helper/runner.go
@@ -4,26 +4,12 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
-	"github.com/openshift/osde2e/pkg/common/templates"
 
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/runner"
 )
-
-// RunnerWithTemplateCommand creates an extended test suite runner for templated test harness pods, configures RBAC for it.
-func (h *H) RunnerWithTemplateCommand(timeout float64, harness string, suffix string, jobName string, serviceAccountDir string) *runner.Runner {
-	r := h.RunnerWithNoCommand()
-	r.PodSpec.ServiceAccountName = h.GetNamespacedServiceAccount()
-	latestImageStream, err := r.GetLatestImageStreamTag()
-	Expect(err).NotTo(HaveOccurred(), "Could not get latest imagestream tag")
-	cmd, err := getCommandString(h, timeout, latestImageStream, harness, suffix, jobName, serviceAccountDir)
-	Expect(err).NotTo(HaveOccurred(), "Could not create pod command from template")
-	r.Cmd = cmd
-	return r
-}
 
 // RunnerWithNoCommand creates an extended test suite runner and configure RBAC for it.
 func (h *H) RunnerWithNoCommand() *runner.Runner {
@@ -56,51 +42,4 @@ func (h *H) WriteResults(results map[string][]byte) {
 		err = os.WriteFile(dst, data, os.ModePerm)
 		Expect(err).NotTo(HaveOccurred())
 	}
-}
-
-// Generates templated command string to provide to test harness container
-func getCommandString(h *H, timeout float64, latestImageStream string, harness string, suffix string, jobName string, serviceAccountDir string) (string, error) {
-	ginkgo.GinkgoHelper()
-	values := struct {
-		Name                 string
-		JobName              string
-		Arguments            string
-		Timeout              int
-		Image                string
-		OutputDir            string
-		ServiceAccount       string
-		PushResultsContainer string
-		Suffix               string
-		Server               string
-		CA                   string
-		TokenFile            string
-		EnvironmentVariables []struct {
-			Name  string
-			Value string
-		}
-	}{
-		Name:                 jobName,
-		JobName:              jobName,
-		Timeout:              int(timeout),
-		Image:                harness,
-		OutputDir:            runner.DefaultRunner.OutputDir,
-		ServiceAccount:       h.GetNamespacedServiceAccount(),
-		PushResultsContainer: latestImageStream,
-		Suffix:               suffix,
-		Server:               "https://kubernetes.default",
-		CA:                   serviceAccountDir + "/ca.crt",
-		TokenFile:            serviceAccountDir + "/token",
-		EnvironmentVariables: []struct {
-			Name  string
-			Value string
-		}{
-			{
-				Name:  "OCM_CLUSTER_ID",
-				Value: viper.GetString(config.Cluster.ID),
-			},
-		},
-	}
-	testTemplate, err := templates.LoadTemplate("tests/tests-runner.template")
-	Expect(err).NotTo(HaveOccurred(), "Could not load pod template")
-	return h.ConvertTemplateToString(testTemplate, values)
 }

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -23,7 +23,6 @@ var (
 	TimeoutInSeconds  = viper.GetFloat64(config.Tests.PollingTimeout)
 	harnesses         = strings.Split(viper.GetString(config.Tests.TestHarnesses), ",")
 	h                 *helper.H
-	err               error
 	HarnessEntries    []ginkgo.TableEntry
 )
 
@@ -74,7 +73,7 @@ var _ = ginkgo.Describe("Test Harness", ginkgo.Ordered, label.TestHarness, func(
 func getCommandString(h *helper.H, harness string, r *runner.Runner, suffix string, jobName string) (string, error) {
 	// setup runner
 	latestImageStream, err := r.GetLatestImageStreamTag()
-	Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred(), "Could not get latest imagestream tag")
 
 	values := struct {
 		Name                 string
@@ -116,5 +115,6 @@ func getCommandString(h *helper.H, harness string, r *runner.Runner, suffix stri
 		},
 	}
 	testTemplate, err := templates.LoadTemplate("tests/tests-runner.template")
+	Expect(err).NotTo(HaveOccurred(), "Could not load pod template")
 	return h.ConvertTemplateToString(testTemplate, values)
 }

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"path/filepath"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
@@ -49,13 +48,6 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 		Expect(err).NotTo(HaveOccurred(), "Could not read results")
 		ginkgo.By("Writing results")
 		h.WriteResults(results)
-		for filename, data := range results {
-			match, err := filepath.Match("junit*.xml", filename)
-			if match {
-				ginkgo.AddReportEntry("Report", string(data))
-			}
-			Expect(err).NotTo(HaveOccurred())
-		}
 		ginkgo.By("Deleting test namespace")
 		h.Cleanup(ctx)
 	})

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -15,7 +15,6 @@ import (
 	"github.com/openshift/osde2e/pkg/common/runner"
 	"github.com/openshift/osde2e/pkg/common/templates"
 	"github.com/openshift/osde2e/pkg/common/util"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -71,10 +70,6 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			stopCh := make(chan struct{})
 			err = r.Run(int(TimeoutInSeconds), stopCh)
 			Expect(err).NotTo(HaveOccurred(), "Could not run pod")
-
-			// ensure job has not failed
-			_, err = h.Kube().BatchV1().Jobs(r.Namespace).Get(ctx, jobName, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred(), "Harness job pods failed")
 		},
 		HarnessEntries)
 })

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -24,9 +24,7 @@ var (
 	harnesses         = strings.Split(viper.GetString(config.Tests.TestHarnesses), ",")
 	h                 *helper.H
 	HarnessEntries    []ginkgo.TableEntry
-	harness           string
 	r                 *runner.Runner
-	jobName           string
 	suffix            string
 )
 

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -7,34 +7,131 @@ import (
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e/pkg/common/alert"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/prow"
+	"github.com/openshift/osde2e/pkg/common/runner"
+	"github.com/openshift/osde2e/pkg/common/templates"
+	"github.com/openshift/osde2e/pkg/common/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	serviceAccountDir = "/var/run/secrets/kubernetes.io/serviceaccount"
+	TimeoutInSeconds  = viper.GetFloat64(config.Tests.PollingTimeout)
+	harnesses         = strings.Split(viper.GetString(config.Tests.TestHarnesses), ",")
+	h                 *helper.H
+	failed            []string
+	err               error
+	HarnessEntries    []ginkgo.TableEntry
 )
 
 var _ = ginkgo.Describe("Test Harness", ginkgo.Ordered, label.TestHarness, func() {
-	var h *helper.H
-	ginkgo.BeforeAll(func() {
-		h = helper.New()
-	})
+	for _, harness := range harnesses {
+		HarnessEntries = append(HarnessEntries, ginkgo.Entry("should run "+harness+" successfully", harness))
+	}
+	ginkgo.DescribeTable("Executing Harness",
+		func(harness string) {
+			ginkgo.By("======= RUNNING HARNESS: " + harness + " =======")
+			log.Printf("======= RUNNING HARNESS: %s =======", harness)
+			viper.Set(config.Project, "")
+			//Run harness in new project
+			h = helper.New()
+			h.SetServiceAccount(context.TODO(), "system:serviceaccount:%s:cluster-admin")
+			harnessImageIndex := strings.LastIndex(harness, "/")
+			harnessImage := harness[harnessImageIndex+1:]
+			suffix := util.RandomStr(5)
+			jobName := fmt.Sprintf("%s-%s", harnessImage, suffix)
+			r := h.RunnerWithNoCommand()
+			testCommand, err := getCommandString(h, harness, r, suffix, jobName)
+			Expect(err).NotTo(HaveOccurred(), "Could not create test pod template")
+			r.Cmd = testCommand
 
-	TimeoutInSeconds := viper.GetFloat64(config.Tests.PollingTimeout)
-	ginkgo.It("should run until completion", func(ctx context.Context) {
-		ginkgo.GinkgoWriter.Write([]byte("Test harness timeout is " + fmt.Sprintf("%v", TimeoutInSeconds)))
-		h.SetServiceAccount(ctx, viper.GetString(config.Tests.TestUser))
-		harnesses := strings.Split(viper.GetString(config.Tests.TestHarnesses), ",")
-		failed := h.RunTests(ctx, "test-harness", int(TimeoutInSeconds), harnesses, []string{})
-		if len(failed) > 0 {
-			message := fmt.Sprintf("Tests failed: %v", failed)
-			if url, ok := prow.JobURL(); ok {
-				message += "\n" + url
+			// run tests
+			stopCh := make(chan struct{})
+			err = r.Run(int(TimeoutInSeconds), stopCh)
+			Expect(err).NotTo(HaveOccurred(), "Could not run pod")
+
+			// get results
+			results, err := r.RetrieveTestResults()
+			Expect(err).NotTo(HaveOccurred(), "Could not read results")
+
+			// write results
+			h.WriteResults(results)
+
+			// ensure job has not failed
+			job, err := h.Kube().BatchV1().Jobs(r.Namespace).Get(context.TODO(), jobName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Harness job pods failed")
+			if !Expect(job.Status.Failed).Should(BeNumerically("==", 0)) {
+				failed = append(failed, harness)
 			}
-			if err := alert.SendSlackMessage(viper.GetString(config.Tests.SlackChannel), message); err != nil {
-				log.Printf("Failed sending slack alert for test failure: %v", err)
-			}
+
+			h.Cleanup(context.TODO())
+			ginkgo.By("======= FINISHED HARNESS: " + harness + " =======")
+		},
+		HarnessEntries)
+
+	if len(failed) > 0 {
+		message := fmt.Sprintf("Tests failed: %v", failed)
+		if url, ok := prow.JobURL(); ok {
+			message += "\n" + url
 		}
-	}, TimeoutInSeconds+30)
+		if err := alert.SendSlackMessage(viper.GetString(config.Tests.SlackChannel), message); err != nil {
+			log.Printf("Failed sending slack alert for test failure: %v", err)
+		}
+	}
 })
+
+// Generates templated command string to provide to test harness container
+func getCommandString(h *helper.H, harness string, r *runner.Runner, suffix string, jobName string) (string, error) {
+	// setup runner
+	latestImageStream, err := r.GetLatestImageStreamTag()
+	Expect(err).NotTo(HaveOccurred())
+
+	values := struct {
+		Name                 string
+		JobName              string
+		Arguments            string
+		Timeout              int
+		Image                string
+		OutputDir            string
+		ServiceAccount       string
+		PushResultsContainer string
+		Suffix               string
+		Server               string
+		CA                   string
+		TokenFile            string
+		EnvironmentVariables []struct {
+			Name  string
+			Value string
+		}
+	}{
+		Name:                 jobName,
+		JobName:              jobName,
+		Timeout:              int(TimeoutInSeconds),
+		Image:                harness,
+		OutputDir:            runner.DefaultRunner.OutputDir,
+		ServiceAccount:       h.GetNamespacedServiceAccount(),
+		PushResultsContainer: latestImageStream,
+		Suffix:               suffix,
+		Server:               "https://kubernetes.default",
+		CA:                   serviceAccountDir + "/ca.crt",
+		TokenFile:            serviceAccountDir + "/token",
+		EnvironmentVariables: []struct {
+			Name  string
+			Value string
+		}{
+			{
+				Name:  "OCM_CLUSTER_ID",
+				Value: viper.GetString(config.Cluster.ID),
+			},
+		},
+	}
+	testTemplate, err := templates.LoadTemplate("tests/tests-runner.template")
+	return h.ConvertTemplateToString(testTemplate, values)
+
+}

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -89,6 +89,7 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 
 // Generates templated command string to provide to test harness container
 func getCommandString(timeout float64, latestImageStream string, harness string, suffix string, jobName string, serviceAccountDir string) string {
+	ginkgo.GinkgoHelper()
 	values := struct {
 		Name                 string
 		JobName              string

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -13,108 +13,65 @@ import (
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/runner"
-	"github.com/openshift/osde2e/pkg/common/templates"
 	"github.com/openshift/osde2e/pkg/common/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
 	serviceAccountDir = "/var/run/secrets/kubernetes.io/serviceaccount"
+	serviceAccount    = "system:serviceaccount:%s:cluster-admin"
 	TimeoutInSeconds  = viper.GetFloat64(config.Tests.PollingTimeout)
 	harnesses         = strings.Split(viper.GetString(config.Tests.TestHarnesses), ",")
 	h                 *helper.H
 	HarnessEntries    []ginkgo.TableEntry
+	harness           string
+	r                 *runner.Runner
+	jobName           string
+	suffix            string
 )
 
-var _ = ginkgo.Describe("Test Harness", ginkgo.Ordered, label.TestHarness, func() {
+var _ = ginkgo.Describe("Test Harness", ginkgo.Ordered, ginkgo.ContinueOnFailure, label.TestHarness, func() {
 	for _, harness := range harnesses {
 		HarnessEntries = append(HarnessEntries, ginkgo.Entry("should run "+harness+" successfully", harness))
 	}
+
+	ginkgo.BeforeEach(func(ctx context.Context) {
+		// Run harness in a new project
+		viper.Set(config.Project, "")
+		h = helper.New()
+		h.SetServiceAccount(ctx, serviceAccount)
+		suffix = util.RandomStr(5)
+	})
+
+	ginkgo.AfterEach(func(ctx context.Context) {
+		// get results
+		results, err := r.RetrieveTestResults()
+		Expect(err).NotTo(HaveOccurred(), "Could not read results")
+
+		// write results
+		h.WriteResults(results)
+		h.Cleanup(ctx)
+	})
+
 	ginkgo.DescribeTable("Executing Harness",
-		func(harness string) {
+		func(ctx context.Context, harness string) {
 			ginkgo.By("======= RUNNING HARNESS: " + harness + " =======")
 			log.Printf("======= RUNNING HARNESS: %s =======", harness)
-			viper.Set(config.Project, "")
-			// Run harness in new project
-			h = helper.New()
-			h.SetServiceAccount(context.TODO(), "system:serviceaccount:%s:cluster-admin")
 			harnessImageIndex := strings.LastIndex(harness, "/")
 			harnessImage := harness[harnessImageIndex+1:]
-			suffix := util.RandomStr(5)
 			jobName := fmt.Sprintf("%s-%s", harnessImage, suffix)
-			r := h.RunnerWithNoCommand()
-			testCommand, err := getCommandString(h, harness, r, suffix, jobName)
-			Expect(err).NotTo(HaveOccurred(), "Could not create test pod template")
-			r.Cmd = testCommand
+			r = h.RunnerWithTemplateCommand(TimeoutInSeconds, harness, suffix, jobName, serviceAccountDir)
 
 			// run tests
 			stopCh := make(chan struct{})
-			err = r.Run(int(TimeoutInSeconds), stopCh)
+			err := r.Run(int(TimeoutInSeconds), stopCh)
 			Expect(err).NotTo(HaveOccurred(), "Could not run pod")
 
-			// get results
-			results, err := r.RetrieveTestResults()
-			Expect(err).NotTo(HaveOccurred(), "Could not read results")
-
-			// write results
-			h.WriteResults(results)
-
 			// ensure job has not failed
-			_, err = h.Kube().BatchV1().Jobs(r.Namespace).Get(context.TODO(), jobName, metav1.GetOptions{})
+			_, err = h.Kube().BatchV1().Jobs(r.Namespace).Get(ctx, jobName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred(), "Harness job pods failed")
 
-			h.Cleanup(context.TODO())
 			ginkgo.By("======= FINISHED HARNESS: " + harness + " =======")
 		},
 		HarnessEntries)
 })
-
-// Generates templated command string to provide to test harness container
-func getCommandString(h *helper.H, harness string, r *runner.Runner, suffix string, jobName string) (string, error) {
-	// setup runner
-	latestImageStream, err := r.GetLatestImageStreamTag()
-	Expect(err).NotTo(HaveOccurred(), "Could not get latest imagestream tag")
-
-	values := struct {
-		Name                 string
-		JobName              string
-		Arguments            string
-		Timeout              int
-		Image                string
-		OutputDir            string
-		ServiceAccount       string
-		PushResultsContainer string
-		Suffix               string
-		Server               string
-		CA                   string
-		TokenFile            string
-		EnvironmentVariables []struct {
-			Name  string
-			Value string
-		}
-	}{
-		Name:                 jobName,
-		JobName:              jobName,
-		Timeout:              int(TimeoutInSeconds),
-		Image:                harness,
-		OutputDir:            runner.DefaultRunner.OutputDir,
-		ServiceAccount:       h.GetNamespacedServiceAccount(),
-		PushResultsContainer: latestImageStream,
-		Suffix:               suffix,
-		Server:               "https://kubernetes.default",
-		CA:                   serviceAccountDir + "/ca.crt",
-		TokenFile:            serviceAccountDir + "/token",
-		EnvironmentVariables: []struct {
-			Name  string
-			Value string
-		}{
-			{
-				Name:  "OCM_CLUSTER_ID",
-				Value: viper.GetString(config.Cluster.ID),
-			},
-		},
-	}
-	testTemplate, err := templates.LoadTemplate("tests/tests-runner.template")
-	Expect(err).NotTo(HaveOccurred(), "Could not load pod template")
-	return h.ConvertTemplateToString(testTemplate, values)
-}

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -47,17 +47,15 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 		ginkgo.By("Retrieving results from harness pod")
 		results, err := r.RetrieveTestResults()
 		Expect(err).NotTo(HaveOccurred(), "Could not read results")
-		ginkgo.By("Writing result files")
+		ginkgo.By("Writing results")
 		h.WriteResults(results)
 		for filename, data := range results {
 			match, err := filepath.Match("junit*.xml", filename)
 			if match {
-
 				ginkgo.AddReportEntry("Report", string(data))
 			}
 			Expect(err).NotTo(HaveOccurred())
 		}
-
 		ginkgo.By("Deleting harness namespace")
 		h.Cleanup(ctx)
 	})
@@ -87,7 +85,6 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			// ensure job has not failed
 			_, err = h.Kube().BatchV1().Jobs(r.Namespace).Get(ctx, jobName, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred(), "Harness job pods failed")
-
 		},
 		HarnessEntries)
 })


### PR DESCRIPTION
This change organizes test harnesses as describeTable specs, so that when more than one harness is provided, each runs as a separate spec. This can allow us to run them in parallel if needed. 



This also separates each spec into a different namespace and keeps logs from each harness separate from each other

https://issues.redhat.com/browse/SDCICD-955 

