### PR TITLE
ROSA provider: perform rosa login prior to deleting cluster/resources

### DIFF
--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -314,6 +314,11 @@ func (m *ROSAProvider) DeleteCluster(clusterID string) error {
 		reportDir = &value
 	}
 
+	_, err := m.ocmLogin()
+	if err != nil {
+		return err
+	}
+
 	if err := m.ocmProvider.DeleteCluster(clusterID); err != nil {
 		return err
 	}


### PR DESCRIPTION
# What
This change performs an ocm login and a rosa login prior to starting the process to delete the cluster.

This is required when a user of osde2e uses the cleanup command to delete the cluster (if they did not run osde2e test within the same container or machine). What happens is rosa is not logged in, resulting in operator role and oidc provider deletion commands to fail.

When osde2e test is called, prior to creating a cluster. Rosa login happens when checking for versions. Storing the login authentication details on the filesystem, resulting in following rosa calls to work.

```
osde2e cleanup ...
2023/07/13 20:14:12 cluster.go:366: Waiting for cluster 24uvja2q4uasmvme7eor4m3q61gshh07 to be deleted
2023/07/13 20:14:12 util.go:31: AWS_PROFILE is not set
2023/07/13 20:14:12 cluster.go:384: [operator-roles --mode auto --yes --cluster 24uvja2q4uasmvme7eor4m3q[61]
2023/07/13 20:14:12 cluster.go:396: [oidc-provider --mode auto --yes --cluster 24uvja2q4uasmvme7eor4m3q61gshh07]
ERR: Failed to create OCM connection: Not logged in, run the 'rosa login' command
```
