### PR TITLE
Adds a new config for enabling rosa sts to deploy clusters

### DIFF
--- a/configs/sts.yaml
+++ b/configs/sts.yaml
@@ -1,0 +1,2 @@
+rosa:
+  STS: true


### PR DESCRIPTION
# What
This PR adds a new pre-canned config for enabling STS for ROSA cluster creation/deletion. Instead of calling osde2e setting the environment variable `ROSA_STS=true` to enable STS. Users can now just provided this as a config:

```
--configs "rosa,sts,stage"
```

For [SDCICD-1058](https://issues.redhat.com//browse/SDCICD-1058)