### PR TITLE
Update self service doc for openshift release gate testing signal

### DIFF
--- a/docs/Self-Service-MOPs/TRT-OCP-Release-Gating.md
+++ b/docs/Self-Service-MOPs/TRT-OCP-Release-Gating.md
@@ -1,62 +1,70 @@
-# TRT Release Gating Jobs
+# TRT OpenShift Release Gating Jobs
 
 ## Introduction
 
-This page explains how SREP periodic CI jobs are included as part of the
-OpenShift release gates provided by the [Technical Release Team "TRT"][TRT].
-These jobs run on new OCP TRT nightly builds and verify the payload for a
-Managed OpenShift Platform.
+This page explains how SREP CI jobs are included as part of the
+OpenShift release gating provided by the [Technical Release Team "TRT"][TRT].
+These jobs run on new OpenShift nightly builds and verify the build for the
+supported Managed OpenShift Platforms (e.g. OSD, ROSA Classic, ROSA HCP).
 
 To learn more about OpenShift release gates, refer to this
 [page][OpenShift Release Gates].
 
-*Currently all SREP jobs are included as informative jobs. These jobs will
-not block the release but provide a valuable signal into the payload.
-Eventually these jobs can be moved into blocking at a later date.*
+*Currently all SREP jobs are included as informing jobs. These jobs will
+not block the release but provide a valuable signal into the nightly build.
+These jobs will eventually be moved into blocking signal at a later date.
+Requires [SDCICD-1058][SDCICD-1058] to be completed first.*
 
 ## Jobs
 
-TRT jobs live [here][Release Periodic Folder] within the
-[release][Release Repo] repository. Example test grid
-[dashboard][OpenShift 4.13 Informing Dashboard] for OpenShift 4.13
-informing jobs.
+The jobs verifying Managed OpenShift Platforms for new OpenShift nightly builds
+reside within [ci-operator/config/openshift/osde2e][OSDE2E Prowgen Job Configs].
+They are the multi step jobs and the actual jobs reside within
+[ci-operator/jobs/openshift/osde2e][OSDE2E Prowgen Jobs].
 
 ### Add Job
 
-To include a periodic job as part of the informing signal, refer to this
-[page][Add Informative Job] for TRT official documentation. 2 PR's will need
-to be opened to officially add the job to the informing signal:
+To include a new job to be part of the release signal (informing or blocking),
+you can refer to this [page][Add Job] for TRT official documentation. 2 PR's
+will need to be opened to officially add the job:
 
-1. PR to the [release][Release Repo] repository to add the periodic jobs.
+1. PR to the [release][Release Repo] repository to add the periodic job. An
+   example can be seen [here][Add SDCICD Job].
+   1. Add a new file under [ci-operator/config/openshift/osde2e][OSDE2E Prowgen Job Configs]
+   if the OpenShift version does not exist or add the new prowgen job to the
+   existing files.
+   2. Generate the actual job from the job configuration `make jobs`.
 2. PR to the [continuous-release-jobs][Continuous Release Jobs Repo] repository
    to add the signal notification. Refer to this [PR][Add Periodic Signal] as
    an example.
 
 ### Remove Job
 
-Once a periodic job has been added as part of the release gate jobs. It will
-continue to run once the OCP version has GA'd. After that, the cadence will be
-shortened to run less often. When a new OCP version is under development,
-the previous periodic job will be carried through.
+In the event a job needs to be removed (e.g. OCP version is EOL),
+a PR will need to be opened to the [release][Release Repo] repository to
+remove the job.
 
 To remove a periodic job (when OCP version goes EOL), 2 PR's need to be opened:
 
 1. PR to the [release][Release Repo] repository to remove the periodic job.
-   Refer to this [PR][Remove Periodic Informing Job] as an example.
+   1. Remove the file under [ci-operator/config/openshift/osde2e][OSDE2E Prowgen Job Configs]
+   if need to remove all jobs for the given OpenShift version or remove the prowgen
+   job from one of the existing files.
 2. PR to the [continuous-release-jobs][Continuous Release Jobs Repo] repository
    to remove the signal notification. Refer to this
    [PR][Remove Periodic Signal] as an example.
 
-Once both PR's are merged, the existing periodic job will be removed/no
+Once both PR's are merged, the previous periodic job will be removed/no
 longer run.
 
-[Add Informative Job]: https://docs.ci.openshift.org/docs/architecture/release-gating/#add-a-periodic-informative-job
+[Add Job]: https://docs.ci.openshift.org/docs/architecture/release-gating/
+[Add SDCICD Job]: https://github.com/openshift/release/pull/41245
 [Add Periodic Signal]: https://github.com/openshift/continuous-release-jobs/pull/1286
 [Continuous Release Jobs Repo]: https://github.com/openshift/continuous-release-jobs
-[OpenShift 4.13 Informing Dashboard]: https://testgrid.k8s.io/redhat-openshift-ocp-release-4.13-informing
 [OpenShift Release Gates]: https://docs.ci.openshift.org/docs/architecture/release-gating/
-[Release Periodic Folder]: https://github.com/openshift/release/tree/master/ci-operator/jobs/openshift/release
+[OSDE2E Prowgen Job Configs]: https://github.com/openshift/release/tree/master/ci-operator/config/openshift/osde2e
+[OSDE2E Prowgen Jobs]: https://github.com/openshift/release/tree/master/ci-operator/jobs/openshift/osde2e
 [Release Repo]: https://github.com/openshift/release
-[Remove Periodic Informing Job]: https://github.com/openshift/release/pull/37716
 [Remove Periodic Signal]: https://github.com/openshift/continuous-release-jobs/pull/1287
+[SDCICD-1058]: https://issues.redhat.com//browse/SDCICD-1058
 [TRT]: https://docs.ci.openshift.org/docs/release-oversight/the-technical-release-team/


### PR DESCRIPTION
# What
This PR updates the existing document explaining how to add/remove jobs that are triggered for every new OpenShift nightly build.

# Requires
- https://github.com/openshift/release/pull/41245
- https://github.com/openshift/continuous-release-jobs/pull/1330
- https://github.com/openshift/ci-tools/pull/3543

# For
- [SDCICD-1058](https://issues.redhat.com//browse/SDCICD-1058)