### PR TITLE
harness batch job related updates

### DIFF
--- a/configs/complete-e2e.yaml
+++ b/configs/complete-e2e.yaml
@@ -1,3 +1,13 @@
 tests:
   ginkgoLabelFilter: >
-    (E2E || Operators || TestHarness || ServiceDefinition || AppBuilds) && !Informing
+    (E2E || Operators || TestHarness || ServiceDefinition || AppBuilds) && !(Informing || MigratedHarness)
+  testHarnesses:
+  #    For migrated harnesses, remember to add "SkipHarness" label to existing suite in this repo, until they are removed from here.
+    - quay.io/app-sre/aws-vpce-operator-test-harness
+    - quay.io/app-sre/splunk-forwarder-operator-test-harness
+    - quay.io/app-sre/ocm-agent-operator-test-harness
+    - quay.io/app-sre/osd-metrics-exporter-test-harness
+    - quay.io/app-sre/custom-domains-operator-test-harness
+    - quay.io/app-sre/managed-node-metadata-operator-test-harness
+    - quay.io/app-sre/rbac-permissions-operator-test-harness
+  suiteTimeout: 900    

--- a/configs/complete-e2e.yaml
+++ b/configs/complete-e2e.yaml
@@ -2,7 +2,7 @@ tests:
   ginkgoLabelFilter: >
     (E2E || Operators || TestHarness || ServiceDefinition || AppBuilds) && !(Informing || MigratedHarness)
   testHarnesses:
-  #    For migrated harnesses, remember to add "SkipHarness" label to existing suite in this repo, until they are removed from here.
+  #    For migrated harnesses, remember to add "MigratedHarness" label to existing suite in this repo, until they are removed from here.
     - quay.io/app-sre/aws-vpce-operator-test-harness
     - quay.io/app-sre/splunk-forwarder-operator-test-harness
     - quay.io/app-sre/ocm-agent-operator-test-harness

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -92,21 +92,21 @@ Some environment variables commonly used for pipelines under osde2e are indicate
 
 ### General test related:-
 
-| Environment variable        | Usage                                                                                                           |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| POLLING_TIMEOUT             | PollingTimeout is how long (in seconds) to wait for an object to be created before failing the test.            |
-| TEST_HARNESSES:             | TestHarnesses is a comma separated list of container images with test harnesses to run.                         |
+| Environment variable        | Usage                                                                                                                                                                                                                                                                     |
+| --------------------------- |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| POLLING_TIMEOUT             | PollingTimeout is how long (in seconds) to wait for an object to be created before failing the test.                                                                                                                                                                      |
+| TEST_HARNESSES:             | TestHarnesses is a *space* separated list of container images with test harnesses to run.                                                                                                                                                                                 |
 | TEST_USER         | TestUser is the OpenShift user that the tests will run as. If "%s" is detected in the TestUser string, it will evaluate that as the project namespace. Ex. "system:serviceaccount:%s:dedicated-admin" . Evaluated : "system:serviceaccount:osde2e-abc123:dedicated-admin" |
-| GINKGO_SKIP                 | GinkgoSkip is a regex passed to Ginkgo that skips any test suites matching the regex. ex. "Operator"            |
-| GINKGO_FOCUS                | GinkgoFocus is a regex passed to Ginkgo that focus on any test suites matching the regex. ex. "Operator"        |
-| GINKGO_LOG_LEVEL            | GinkgoLogLevel allows controlling the Ginkgo reporter output                                                    |
-| TESTS_TO_RUN                | TestsToRun is a list of files which should be executed as part of a test suite                                  |
-| SUPPRESS_SKIP_NOTIFICATIONS | SuppressSkipNotifications suppresses the notifications of skipped tests                                         |
-| CLEAN_RUNS                  | CleanRuns is the number of times the test-version is run before skipping.                                       |
-| OPERATOR_SKIP               | OperatorSkip is a comma-delimited list of operator names to ignore health checks from. ex. "insights,telemetry" |
-| SKIP_CLUSTER_HEALTH_CHECKS  | SkipClusterHealthChecks skips the cluster health checks. Useful when developing against a running cluster.      |
-| METRICS_BUCKET              | MetricsBucket is the bucket that metrics data will be uploaded to.                                              |
-| SERVICE_ACCOUNT             | ServiceAccount defines what user the tests should run as. By default, osde2e uses system:admin                  |
+| GINKGO_SKIP                 | GinkgoSkip is a regex passed to Ginkgo that skips any test suites matching the regex. ex. "Operator"                                                                                                                                                                      |
+| GINKGO_FOCUS                | GinkgoFocus is a regex passed to Ginkgo that focus on any test suites matching the regex. ex. "Operator"                                                                                                                                                                  |
+| GINKGO_LOG_LEVEL            | GinkgoLogLevel allows controlling the Ginkgo reporter output                                                                                                                                                                                                              |
+| TESTS_TO_RUN                | TestsToRun is a list of files which should be executed as part of a test suite                                                                                                                                                                                            |
+| SUPPRESS_SKIP_NOTIFICATIONS | SuppressSkipNotifications suppresses the notifications of skipped tests                                                                                                                                                                                                   |
+| CLEAN_RUNS                  | CleanRuns is the number of times the test-version is run before skipping.                                                                                                                                                                                                 |
+| OPERATOR_SKIP               | OperatorSkip is a comma-delimited list of operator names to ignore health checks from. ex. "insights,telemetry"                                                                                                                                                           |
+| SKIP_CLUSTER_HEALTH_CHECKS  | SkipClusterHealthChecks skips the cluster health checks. Useful when developing against a running cluster.                                                                                                                                                                |
+| METRICS_BUCKET              | MetricsBucket is the bucket that metrics data will be uploaded to.                                                                                                                                                                                                        |
+| SERVICE_ACCOUNT             | ServiceAccount defines what user the tests should run as. By default, osde2e uses system:admin                                                                                                                                                                            |
 
 ### Addon test related:-
 

--- a/pkg/common/label/label.go
+++ b/pkg/common/label/label.go
@@ -77,6 +77,9 @@ var (
 
 	// Runs tests that are using the test harness functionality
 	TestHarness = ginkgo.Label("TestHarness")
+
+	// Excluding tests that are already moved to harness. Keeping through cutover to harness.
+	MigratedHarness = ginkgo.Label("MigratedHarness")
 )
 
 func AllCloudProviders() []ginkgo.Labels {

--- a/pkg/e2e/operators/customdomains.go
+++ b/pkg/e2e/operators/customdomains.go
@@ -55,7 +55,7 @@ func init() {
 	alert.RegisterGinkgoAlert(customDomainsOperatorTestName, "SD-SREP", "@custom-domains-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(customDomainsOperatorTestName, label.Operators, func() {
+var _ = ginkgo.Describe(customDomainsOperatorTestName, label.Operators, label.MigratedHarness, func() {
 	// custom dialer for use w/ resolver and http.client
 	dialer := &net.Dialer{
 		Resolver: &net.Resolver{

--- a/pkg/e2e/operators/ocmagent/ocmagent.go
+++ b/pkg/e2e/operators/ocmagent/ocmagent.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 // TODO: Separate PR to remove 'Informing' label from test suite
-var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.Operators, label.Informing, func() {
+var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.Operators, label.MigratedHarness, label.Informing, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(config.Hypershift) {
 			ginkgo.Skip("OCM Agent Operator is not supported on HyperShift")

--- a/pkg/e2e/operators/osdmetricsexporter.go
+++ b/pkg/e2e/operators/osdmetricsexporter.go
@@ -18,7 +18,7 @@ func init() {
 	alert.RegisterGinkgoAlert(osdMetricsExporterBasicTest, "SD_SREP", "@sre-platform-team-v1alpha1", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(osdMetricsExporterBasicTest, ginkgo.Ordered, label.Operators, func() {
+var _ = ginkgo.Describe(osdMetricsExporterBasicTest, ginkgo.Ordered, label.Operators, label.MigratedHarness, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(config.Hypershift) {
 			ginkgo.Skip("OSD Metrics Exporter is not supported on HyperShift")

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -28,7 +28,7 @@ func init() {
 	alert.RegisterGinkgoAlert(subjectPermissionsTestName, "SD-SREP", "@rbac-permissions-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(rbacOperatorBlocking, ginkgo.Ordered, label.Operators, func() {
+var _ = ginkgo.Describe(rbacOperatorBlocking, ginkgo.Ordered, label.Operators, label.MigratedHarness, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(config.Hypershift) {
 			ginkgo.Skip("RBAC Permissions Operator is not supported on HyperShift")

--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -31,7 +31,7 @@ func init() {
 }
 
 // Blocking SplunkForwarder Signal
-var _ = ginkgo.Describe(splunkForwarderBlocking, ginkgo.Ordered, label.Operators, func() {
+var _ = ginkgo.Describe(splunkForwarderBlocking, ginkgo.Ordered, label.Operators, label.MigratedHarness, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(config.Hypershift) {
 			ginkgo.Skip("Splunk Forwarder Operator is not deployed to a ROSA hosted-cp cluster (OSD-11605)")


### PR DESCRIPTION
* changed harness timeout to use shorter suite timeout per harness
* Moved result retrieval to test spec from afterEach to avoid execution for fail pods
* Adding harness list in complete-e2e config file instead of env var for batch job
* Skip migrated operator tests using new label - only for complete-e2e test config. This is a temporary stop gap till we can remove operator label and tests from osde2e