### PR TITLE
Update MVO e2e tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.16.0
 	github.com/tsenart/vegeta v12.7.0+incompatible
-	github.com/vmware-tanzu/velero v1.7.2
+	github.com/vmware-tanzu/velero v1.10.2
 	golang.org/x/net v0.12.0
 	golang.org/x/oauth2 v0.9.0
 	golang.org/x/tools v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -934,8 +934,8 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vladimirvivien/gexe v0.2.0 h1:nbdAQ6vbZ+ZNsolCgSVb9Fno60kzSuvtzVh6Ytqi/xY=
-github.com/vmware-tanzu/velero v1.7.2 h1:MGVezxXP0yju+zWyofcQJ08aQYmU6BsEh45l+rTACxE=
-github.com/vmware-tanzu/velero v1.7.2/go.mod h1:jFVzwrdnmECUqO/uMn7QSTZP5t0BCMxDQ2ZKWfvQbI8=
+github.com/vmware-tanzu/velero v1.10.2 h1:Vxao3R4wjmw6iR2W7ihdreKpqjuMA7Kjxne7ByjUQfQ=
+github.com/vmware-tanzu/velero v1.10.2/go.mod h1:FZJMmwYCeiE3lu/SBL/pP1bRGdju6zK4/vCE4s3A3Wo=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=

--- a/pkg/e2e/operators/managedvelero.go
+++ b/pkg/e2e/operators/managedvelero.go
@@ -62,23 +62,17 @@ var _ = ginkgo.Describe(veleroOperatorTestName, ginkgo.Ordered, label.Operators,
 	testDaCRdeleteBackupRequests(h)
 	testDaCRbackupStorageLocations(h)
 	testDaCRdownloadRequests(h)
-	testDaCRpodVolumeBackup(h)
-	testDaCRpodVolumeRestores(h)
 	testDaCRvolumeSnapshotLocation(h)
 	testDaCRschedules(h)
 	testDaCRserverStatusRequest(h)
-	testDaCRrestricRepository(h)
 	testCRbackups(h)
 	testCRrestore(h)
 	testCRdeleteBackupRequests(h)
 	testCRbackupStorageLocations(h)
 	testCRdownloadRequests(h)
-	testCRpodVolumeBackup(h)
-	testCRpodVolumeRestores(h)
 	testCRvolumeSnapshotLocation(h)
 	testCRschedules(h)
 	testCRserverStatusRequest(h)
-	testCRrestricRepository(h)
 	checkClusterRoles(h, clusterRoles, true)
 	checkClusterRoleBindings(h, clusterRoleBindings, true)
 })
@@ -195,44 +189,6 @@ func testDaCRdownloadRequests(h *helper.H) {
 	})
 }
 
-func testDaCRpodVolumeBackup(h *helper.H) {
-	ginkgo.Context("velero", func() {
-		ginkgo.It("Access should be forbidden to edit PodVolumeBackups", func(ctx context.Context) {
-			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
-			defer func() {
-				h.Impersonate(rest.ImpersonationConfig{})
-			}()
-
-			podVolumeBackup := velerov1.PodVolumeBackup{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "dedicated-admin-pod-volume-backup-test",
-				},
-			}
-			_, err := h.Velero().VeleroV1().PodVolumeBackups(h.CurrentProject()).Create(ctx, &podVolumeBackup, metav1.CreateOptions{})
-			Expect(apierrors.IsForbidden(err)).To(BeTrue())
-		})
-	})
-}
-
-func testDaCRpodVolumeRestores(h *helper.H) {
-	ginkgo.Context("velero", func() {
-		ginkgo.It("Access should be forbidden to edit PodVolumeRestores", func(ctx context.Context) {
-			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
-			defer func() {
-				h.Impersonate(rest.ImpersonationConfig{})
-			}()
-
-			podVolumeRestore := velerov1.PodVolumeRestore{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "dedicated-admin-pod-volume-restore-test",
-				},
-			}
-			_, err := h.Velero().VeleroV1().PodVolumeRestores(h.CurrentProject()).Create(ctx, &podVolumeRestore, metav1.CreateOptions{})
-			Expect(apierrors.IsForbidden(err)).To(BeTrue())
-		})
-	})
-}
-
 func testDaCRvolumeSnapshotLocation(h *helper.H) {
 	ginkgo.Context("velero", func() {
 		ginkgo.It("Access should be forbidden to edit VolumeSnapshotLocations", func(ctx context.Context) {
@@ -285,25 +241,6 @@ func testDaCRserverStatusRequest(h *helper.H) {
 				},
 			}
 			_, err := h.Velero().VeleroV1().ServerStatusRequests(h.CurrentProject()).Create(ctx, &serverStatusRequest, metav1.CreateOptions{})
-			Expect(apierrors.IsForbidden(err)).To(BeTrue())
-		})
-	})
-}
-
-func testDaCRrestricRepository(h *helper.H) {
-	ginkgo.Context("velero", func() {
-		ginkgo.It("Access should be forbidden to edit RestricRepository", func(ctx context.Context) {
-			h.SetServiceAccount(ctx, "system:serviceaccount:%s:dedicated-admin-project")
-			defer func() {
-				h.Impersonate(rest.ImpersonationConfig{})
-			}()
-
-			resticRepository := velerov1.ResticRepository{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "dedicated-admin-restric-repository-test",
-				},
-			}
-			_, err := h.Velero().VeleroV1().ResticRepositories(h.CurrentProject()).Create(ctx, &resticRepository, metav1.CreateOptions{})
 			Expect(apierrors.IsForbidden(err)).To(BeTrue())
 		})
 	})
@@ -412,40 +349,6 @@ func testCRdownloadRequests(h *helper.H) {
 	})
 }
 
-func testCRpodVolumeBackup(h *helper.H) {
-	ginkgo.Context("velero", func() {
-		ginkgo.It("Access should be allowed to edit PodVolumeBackups", func(ctx context.Context) {
-			podVolumeBackup := velerov1.PodVolumeBackup{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pod-volume-backup-test",
-				},
-			}
-			_, err := h.Velero().VeleroV1().PodVolumeBackups(h.CurrentProject()).Create(ctx, &podVolumeBackup, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			h.Velero().VeleroV1().PodVolumeBackups(h.CurrentProject()).Delete(ctx, "pod-volume-backup-test", metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-}
-
-func testCRpodVolumeRestores(h *helper.H) {
-	ginkgo.Context("velero", func() {
-		ginkgo.It("Access should be allowed to edit PodVolumeRestores", func(ctx context.Context) {
-			podVolumeRestore := velerov1.PodVolumeRestore{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pod-volume-restore-test",
-				},
-			}
-			_, err := h.Velero().VeleroV1().PodVolumeRestores(h.CurrentProject()).Create(ctx, &podVolumeRestore, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			h.Velero().VeleroV1().PodVolumeRestores(h.CurrentProject()).Delete(ctx, "pod-volume-restore-test", metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-}
-
 func testCRvolumeSnapshotLocation(h *helper.H) {
 	ginkgo.Context("velero", func() {
 		ginkgo.It("Access should be allowed to edit VolumeSnapshotLocations", func(ctx context.Context) {
@@ -492,23 +395,6 @@ func testCRserverStatusRequest(h *helper.H) {
 			Expect(err).NotTo(HaveOccurred())
 
 			h.Velero().VeleroV1().ServerStatusRequests(h.CurrentProject()).Delete(ctx, "server-status-request-test", metav1.DeleteOptions{})
-			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-}
-
-func testCRrestricRepository(h *helper.H) {
-	ginkgo.Context("velero", func() {
-		ginkgo.It("Access should be allowed to edit RestricRepository", func(ctx context.Context) {
-			resticRepository := velerov1.ResticRepository{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "restric-repository-test",
-				},
-			}
-			_, err := h.Velero().VeleroV1().ResticRepositories(h.CurrentProject()).Create(ctx, &resticRepository, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			h.Velero().VeleroV1().ResticRepositories(h.CurrentProject()).Delete(ctx, "restric-repository-test", metav1.DeleteOptions{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
Two changes:
- Bumps the velero dependency to match the version we are using in the MVO
- Removes some tests for CRs that have been removed or are otherwise unneeded. Seeing failures as the test expects these to be present and editable by folks, but some of these are internal CRs that have mandatory fields and don't need to be tested.

Failed test ref: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-nightly-4.12-osd-aws/1683846376716242944