### PR TITLE
Remove workload tests from hypershift/e2e test suites

### DIFF
--- a/pkg/e2e/workloads/workloads.go
+++ b/pkg/e2e/workloads/workloads.go
@@ -10,7 +10,6 @@ import (
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/expect"
 	"github.com/openshift/osde2e/pkg/common/helper"
-	"github.com/openshift/osde2e/pkg/common/label"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,7 +25,7 @@ func init() {
 	alert.RegisterGinkgoAlert(suiteName, "SD-SREP", "@sd-qe", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.HyperShift, label.E2E, func() {
+var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, func() {
 	var h *helper.H
 
 	ginkgo.BeforeAll(func() {


### PR DESCRIPTION
# Change
The workloads test has been flaky on and off and more so recently from prow ci runs. To better improve the ci signal, this commit removes this suite from being included for hypershift and e2e suites.

These tests are testing the standard functionality which OpenShift provides. From a Managed OpenShift perspective, we should ensure this functionality already is covered by OpenShift QE/Dev and only focus on actually testing Managed OpenShift aspects. When the OSD operators get deployed, they are creating deployments, pods, etc, which would fail if there was an actual problem. Making this test redundant/obsolete.

For [SDCICD-1038](https://issues.redhat.com//browse/SDCICD-1038)