### PR TITLE
Harness Runner: Handle Image Tags When Generating Job Name

### DIFF
--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -51,7 +51,7 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 		func(ctx context.Context, harness string) {
 			log.Printf("======= RUNNING HARNESS: %s =======", harness)
 			harnessImageIndex := strings.LastIndex(harness, "/")
-			harnessImage := harness[harnessImageIndex+1:]
+			harnessImage := strings.Split(harness[harnessImageIndex+1:], ":")[0]
 			jobName := fmt.Sprintf("%s-%s", harnessImage, suffix)
 
 			// Create templated runner pod


### PR DESCRIPTION
# Change
When a harness image provides a tag, the harness runner does not strip off the ':<tag>'. Which results in OpenShift failing to start the job. This commit updates generating the job name to take into account harness images that do or don't supply the image tag.

```
The Job "ci-tools-nvidia-gpu-operator:osde2e-9gxb5" is invalid: 
* metadata.name: Invalid value: "ci-tools-nvidia-gpu-operator:osde2e-9gxb5": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
* spec.template.labels: Invalid value: "ci-tools-nvidia-gpu-operator:osde2e-9gxb5": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```

# Jira
- [SDCICD-1064](https://issues.redhat.com//browse/SDCICD-1064)