### PR TITLE
Test Harness: support multiple reruns of osde2e against the same cluster

### DIFF
--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -306,6 +306,22 @@ func (h *H) CreateProject(ctx context.Context, name string) {
 	Expect(err).To(BeNil(), fmt.Sprintf("error creating project: %s", err))
 }
 
+// DeleteProject deletes the project provided
+func (h *H) DeleteProject(ctx context.Context, name string) error {
+	err := h.Project().ProjectV1().Projects().Delete(ctx, name, metav1.DeleteOptions{})
+	if err == nil {
+		return wait.PollImmediate(5*time.Second, 60*time.Second, func() (bool, error) {
+			project, err := h.Project().ProjectV1().Projects().Get(ctx, name, metav1.GetOptions{})
+			if err != nil && project.Name == "" {
+				return true, nil
+			}
+
+			return false, err
+		})
+	}
+	return err
+}
+
 // CurrentProject returns the project being used for testing.
 func (h *H) CurrentProject() string {
 	Expect(h.proj).NotTo(BeNil(), "no project is currently set")


### PR DESCRIPTION
# Change
Before this PR change, if a user was to run osde2e test harness, it creates a namespace for the secrets that the tests can access. The namespace continues to live on the cluster after osde2e finishes. New runs would fail before running test harness due to the namespace already exists.

This change deletes the secrets namespace as part of the clean up operations and also attempts to delete the secrets namespace prior to creating it.