### PR TITLE
fixes ` Found two adjacent labels.` error

### DIFF
--- a/configs/complete-e2e.yaml
+++ b/configs/complete-e2e.yaml
@@ -1,6 +1,6 @@
 tests:
   ginkgoLabelFilter: >
-    (E2E || Operators || TestHarness || ServiceDefinition || AppBuilds) && !(Informing || MigratedHarness)
+    (E2E || Operators || TestHarness || ServiceDefinition || AppBuilds) && !Informing && !MigratedHarness
   testHarnesses:
   #    For migrated harnesses, remember to add "MigratedHarness" label to existing suite in this repo, until they are removed from here.
     - quay.io/app-sre/aws-vpce-operator-test-harness


### PR DESCRIPTION
Fixes following error in multi harness job config

```
2023/07/25 23:54:39 cluster.go:1306: Successfully added property[Status] - healthy 
2023/07/25 23:54:39 e2e.go:148: Cluster is healthy and ready for testing
Ginkgo detected configuration issues:
Syntax Error Parsing Label Filter
  (E2E || Operators || TestHarness || ServiceDefinition || AppBuilds) &&
  !(Informing || MigratedHarness)
  
  Found two adjacent labels.  You need an operator between them.
```