### PR TITLE
use HARNESS_TIMEOUT var to specify individual harness timeout, POLLING_TIMEOUT if unspecified

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -206,6 +206,10 @@ var Tests = struct {
 	// Env: SUITE_TIMEOUT
 	SuiteTimeout string
 
+	// HarnessTimeout is how long (in seconds) to wait for the individual harness to finish before timing out. If unspecified, POLLING_TIMEOUT is used.
+	// Env: HARNESS_TIMEOUT
+	HarnessTimeout string
+
 	// TestHarnesses is a list of test harnesses to run.
 	// Env: TEST_HARNESSES
 	TestHarnesses string
@@ -278,6 +282,7 @@ var Tests = struct {
 }{
 	TestHarnesses:              "tests.testHarnesses",
 	SuiteTimeout:               "tests.suiteTimeout",
+	HarnessTimeout:             "tests.harnessTimeout",
 	PollingTimeout:             "tests.pollingTimeout",
 	ServiceAccount:             "tests.serviceAccount",
 	SlackChannel:               "tests.slackChannel",
@@ -696,6 +701,8 @@ func InitOSDe2eViper() {
 
 	viper.SetDefault(Tests.SuiteTimeout, 6)
 	viper.BindEnv(Tests.SuiteTimeout, "SUITE_TIMEOUT")
+
+	viper.BindEnv(Tests.HarnessTimeout, "HARNESS_TIMEOUT")
 
 	viper.SetDefault(Tests.PollingTimeout, 300)
 	viper.BindEnv(Tests.PollingTimeout, "POLLING_TIMEOUT")

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -29,8 +29,11 @@ var (
 
 var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure, label.TestHarness, func() {
 	harnesses := viper.GetStringSlice(config.Tests.TestHarnesses)
-	timeoutInSeconds = 3600 * viper.GetInt(config.Tests.SuiteTimeout)
-
+	if viper.IsSet(config.Tests.HarnessTimeout) {
+		timeoutInSeconds = viper.GetInt(config.Tests.HarnessTimeout)
+	} else {
+		timeoutInSeconds = viper.GetInt(config.Tests.PollingTimeout)
+	}
 	fmt.Println("Harnesses to run: ", harnesses)
 	for _, harness := range harnesses {
 		HarnessEntries = append(HarnessEntries, ginkgo.Entry("should run "+harness+" successfully", harness))

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -73,7 +73,6 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			//	today
 			ginkgo.By("Running harness pod")
 			stopCh := make(chan struct{})
-			fmt.Println("Will timeout in", timeoutInSeconds, " seconds")
 			err = r.Run(timeoutInSeconds, stopCh)
 			Expect(err).NotTo(HaveOccurred(), "Could not run pod")
 

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -73,6 +73,7 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			//	today
 			ginkgo.By("Running harness pod")
 			stopCh := make(chan struct{})
+			fmt.Println("Will timeout in", timeoutInSeconds, " seconds")
 			err = r.Run(timeoutInSeconds, stopCh)
 			Expect(err).NotTo(HaveOccurred(), "Could not run pod")
 


### PR DESCRIPTION
In a multi harness suite, individual harnesses must maintain short timeout limits, in order to allow other harnesses and other test suites to run within POLLING_TIMEOUT

Introducing HARNESS_TIMEOUT to use in such multi harness jobs. Current single harness jobs only specify POLLING_TIMEOUT. This PR allows that var to be used when HARNESS_TIMEOUT is not defined. 