### PR TITLE
Attempt cluster deletion when failing to create cleanup helper object

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -566,7 +566,11 @@ func ProvisionCluster(logger *log.Logger) (*spi.Cluster, error) {
 			}
 		}
 
-		if clusterID, err = provider.LaunchCluster(name); err != nil {
+		clusterID, err = provider.LaunchCluster(name)
+		if clusterID != "" {
+			viper.Set(config.Cluster.ID, clusterID)
+		}
+		if err != nil {
 			return nil, fmt.Errorf("could not launch cluster: %v", err)
 		}
 

--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -62,17 +62,17 @@ func New() *H {
 }
 
 // NewOutsideGinkgo instantiates a helper function while not within a Ginkgo Test Block
-func NewOutsideGinkgo() *H {
+func NewOutsideGinkgo() (*H, error) {
 	defer ginkgo.GinkgoRecover()
 
 	h := Init()
 	h.OutsideGinkgo = true
 	err := h.Setup()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 
-	return h
+	return h, nil
 }
 
 // H configures clients and sets up and destroys Projects for test isolation.

--- a/pkg/common/upgrade/upgrade.go
+++ b/pkg/common/upgrade/upgrade.go
@@ -48,9 +48,9 @@ func RunUpgrade() error {
 	var upgradeStarted time.Time
 
 	// setup helper
-	h := helper.NewOutsideGinkgo()
+	h, err := helper.NewOutsideGinkgo()
 	if h == nil {
-		return fmt.Errorf("Unable to generate helper outside ginkgo")
+		return fmt.Errorf("unable to generate helper outside ginkgo: %v", err)
 	}
 
 	image := viper.GetString(config.Upgrade.Image)

--- a/pkg/e2e/routemonitors/routemonitors.go
+++ b/pkg/e2e/routemonitors/routemonitors.go
@@ -51,10 +51,10 @@ type RouteMonData struct {
 
 // Detects the available routes in the cluster and initializes monitors for their availability
 func Create(ctx context.Context) (*RouteMonitors, error) {
-	h := helper.NewOutsideGinkgo()
+	h, err := helper.NewOutsideGinkgo()
 
 	if h == nil {
-		return nil, fmt.Errorf("unable to generate helper outside ginkgo")
+		return nil, fmt.Errorf("unable to generate helper outside ginkgo: %v", err)
 	}
 
 	// record all targeters created in a map, accessible via a key which is their URL


### PR DESCRIPTION
# What
This PR aims to address osde2e not properly destroying a cluster when it has the settings enabled to do so. Osde2e ends up never deleting the cluster due to it fails to construct the ginkgo helper object to perform clean up operations.

Examples:

* https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/osde2e-stage-aws-nvidia-gpu-addon/1686346108575420416
* https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_osde2e/1938/pull-ci-openshift-osde2e-main-rosa-pr-check/1686395505984147456

Before this change, an end to end run may exhibit the behavior where the cluster is launched and fails at a certain point where its unable to get the kubeconfig for it. Which results in failing to construct the cleanup helper object and cluster deletion is never performed. Leaving cloud resources up.

This commit will attempt cluster deletion if osde2e fails to construct the helper object to perform cleanup operations. Resolving the common case when there is no kubeconfig available. Cluster will be only deleted based on the skip cluster deletion setting.