### PR TITLE
Get rosa hcp cluster oidc config id from ocm cluster body

### DIFF
--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -684,7 +684,7 @@ func (o *OCMProvider) ScaleCluster(clusterID string, numComputeNodes int) error 
 	var resp *v1.ClusterUpdateResponse
 
 	// Get the current state of the cluster
-	ocmCluster, err := o.getOCMCluster(clusterID)
+	ocmCluster, err := o.GetOCMCluster(clusterID)
 	if err != nil {
 		return err
 	}
@@ -777,7 +777,7 @@ func (o *OCMProvider) ListClusters(query string) ([]*spi.Cluster, error) {
 
 // GetCluster returns a cluster from OCM.
 func (o *OCMProvider) GetCluster(clusterID string) (*spi.Cluster, error) {
-	ocmCluster, err := o.getOCMCluster(clusterID)
+	ocmCluster, err := o.GetOCMCluster(clusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -791,7 +791,7 @@ func (o *OCMProvider) GetCluster(clusterID string) (*spi.Cluster, error) {
 	return cluster, nil
 }
 
-func (o *OCMProvider) getOCMCluster(clusterID string) (*v1.Cluster, error) {
+func (o *OCMProvider) GetOCMCluster(clusterID string) (*v1.Cluster, error) {
 	var resp *v1.ClusterGetResponse
 
 	err := retryer().Do(func() error {
@@ -978,7 +978,7 @@ func (o *OCMProvider) InstallAddons(clusterID string, addonIDs []spi.AddOnID, ad
 					return err
 				}
 
-				ocmCluster, err := o.getOCMCluster(clusterID)
+				ocmCluster, err := o.GetOCMCluster(clusterID)
 				if err != nil {
 					return err
 				}
@@ -1130,7 +1130,7 @@ func (o *OCMProvider) ExtendExpiry(clusterID string, hours uint64, minutes uint6
 	var resp *v1.ClusterUpdateResponse
 
 	// Get the current state of the cluster
-	ocmCluster, err := o.getOCMCluster(clusterID)
+	ocmCluster, err := o.GetOCMCluster(clusterID)
 	if err != nil {
 		return err
 	}

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -314,7 +314,12 @@ func (m *ROSAProvider) DeleteCluster(clusterID string) error {
 		reportDir = &value
 	}
 
-	_, err := m.ocmLogin()
+	cluster, err := m.ocmProvider.GetOCMCluster(clusterID)
+	if err != nil {
+		return fmt.Errorf("unable to get cluster %s from ocm: %v", clusterID, err)
+	}
+
+	_, err = m.ocmLogin()
 	if err != nil {
 		return err
 	}
@@ -332,7 +337,7 @@ func (m *ROSAProvider) DeleteCluster(clusterID string) error {
 
 	if viper.GetBool(config.Hypershift) {
 		if viper.GetString(OIDCConfigID) == "" {
-			if err := m.deleteOIDCConfig(viper.GetString(config.Cluster.Name)); err != nil {
+			if err := m.deleteOIDCConfig(cluster.AWS().STS().OidcConfig().ID()); err != nil {
 				return err
 			}
 		}

--- a/pkg/common/providers/rosaprovider/oidcconfig.go
+++ b/pkg/common/providers/rosaprovider/oidcconfig.go
@@ -53,12 +53,7 @@ func (m *ROSAProvider) getOIDCConfigID(prefix string) (string, error) {
 }
 
 // deleteOIDCConfig deletes an existing oidc config that was used for cluster creation
-func (m *ROSAProvider) deleteOIDCConfig(prefix string) error {
-	oidcConfigID, err := m.getOIDCConfigID(prefix)
-	if err != nil {
-		return fmt.Errorf("unable to locate oidc config with prefix: %s", prefix)
-	}
-
+func (m *ROSAProvider) deleteOIDCConfig(oidcConfigID string) error {
 	cmd := deleteOIDCConfig.Cmd
 	cmd.SetArgs([]string{
 		"--mode", "auto",
@@ -66,7 +61,7 @@ func (m *ROSAProvider) deleteOIDCConfig(prefix string) error {
 		"--oidc-config-id", oidcConfigID,
 		"--yes",
 	})
-	err = callAndSetAWSSession(func() error {
+	err := callAndSetAWSSession(func() error {
 		return cmd.Execute()
 	})
 	if err != nil {


### PR DESCRIPTION
# Fix
Previously `DeleteCluster` method would query ocm for all odic configs and find the one pertaining to the cluster based on matching the cluster name is within the secretARN. In the event cluster name is not provided to osde2e (e.g. running `osde2e cleanup` command), this value is empty, resulting in unexpected behavior. Where it will attempt to delete another oidc config id.

This commit addresses this issue by directly getting the oidc config id from the cluster's ocm body response from the API. This will ensure us that we will always have the correct oidc config id.

Addresses failures with latest TRT ROSA HCP 4.12 and 4.13 runs ([example](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-nightly-4.13-rosa-hcp/1687055861177913344)).