### PR TITLE
Write rosa vpc terraform generated files to either report/shared dir

### DIFF
--- a/pkg/common/providers/rosaprovider/vpc.go
+++ b/pkg/common/providers/rosaprovider/vpc.go
@@ -44,11 +44,10 @@ func copyFile(srcFile string, destFile string) error {
 }
 
 // createHyperShiftVPC creates the vpc to provision HyperShift clusters
-func createHyperShiftVPC() (*HyperShiftVPC, error) {
+func createHyperShiftVPC(workingDir string) (*HyperShiftVPC, error) {
 	ctx := context.Background()
 
 	var vpc HyperShiftVPC
-	workingDir := viper.GetString(config.ReportDir)
 
 	tf, err := terraform.New(workingDir)
 	if err != nil {


### PR DESCRIPTION
# Change
Previously the generated terraform files for a rosa hcp cluster aws vpc were being written to the report directory for osde2e. When osde2e is being used by a mutli step prow job, a step to run osde2e cleanup command would not be able to properly locate the terraform files due to that report directory does not exist within the container for the step.

This commit addresses this issue, where osde2e can write the terraform files to the shared directory. Making the files available to any step within a mutli step job. That would allow `osde2e cleanup` step to properly clean up an auto generated aws vpc.