### PR TITLE
SDCICD-1069 clear deleted project name from config

### DIFF
--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -84,6 +84,10 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			h.WriteResults(results)
 		},
 		HarnessEntries)
+
+	ginkgo.AfterAll(func(ctx context.Context) {
+		viper.Set(config.Project, "")
+	})
 })
 
 // Generates templated command string to provide to test harness container


### PR DESCRIPTION
A new cleanup error is showing in the harness job

This is coming due to viper config contining a project name that harness-runner has already deleted, and helper erroring out here https://github.com/openshift/osde2e/blob/7194974b8cd0f600f98a3aea9eb75af950e0255e/pkg/e2e/e2e.go#L584C3-L584C3

Adding a After() function in harness runner to blank the deleted project name from viper

https://issues.redhat.com/browse/SDCICD-1069