### PR TITLE
Rosa 1.24 update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/openshift/managed-upgrade-operator v0.0.0-20230525042514-a9b8c1d2571c
 	github.com/openshift/must-gather-operator v0.1.2-0.20221011152618-7805956e1ded
 	github.com/openshift/osde2e-common v0.0.0-20230804144112-974a53599672
-	github.com/openshift/rosa v1.2.23
+	github.com/openshift/rosa v1.2.24
 	github.com/openshift/route-monitor-operator v0.0.0-20221118160357-3df1ed1fa1d2
 	github.com/openshift/splunk-forwarder-operator v0.0.0-20230525060151-2dc403aa8ff9
 	github.com/operator-framework/api v0.17.4-0.20230223191600-0131a6301e42
@@ -100,6 +100,7 @@ require (
 	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dchest/validator v0.0.0-20191217151620-8e45250f2371 // indirect
 	github.com/dgryski/go-gk v0.0.0-20200319235926-a69029f61654 // indirect
 	github.com/dgryski/go-lttb v0.0.0-20210302151804-4a713d71336c // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -184,6 +184,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
+github.com/dchest/validator v0.0.0-20191217151620-8e45250f2371 h1:BuLreR1acrosGsW+njS+RxyPgL06rYTkasZA2NAogEo=
+github.com/dchest/validator v0.0.0-20191217151620-8e45250f2371/go.mod h1:ZfpgrLR1i3mQWz5fIRfkyMIh9zLOy3MwTc7hUBVPlww=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-gk v0.0.0-20200319235926-a69029f61654 h1:XOPLOMn/zT4jIgxfxSsoXPxkrzz0FaCHwp33x5POJ+Q=
 github.com/dgryski/go-gk v0.0.0-20200319235926-a69029f61654/go.mod h1:qm+vckxRlDt0aOla0RYJJVeqHZlWfOm2UIxHaqPB46E=
@@ -752,8 +754,8 @@ github.com/openshift/must-gather-operator v0.1.2-0.20221011152618-7805956e1ded h
 github.com/openshift/must-gather-operator v0.1.2-0.20221011152618-7805956e1ded/go.mod h1:LHntdQf5jrwxpmyVMbwXUK491COBJ7buHvyi4YLlHho=
 github.com/openshift/osde2e-common v0.0.0-20230804144112-974a53599672 h1:A+jq/Pr8xwBfRzXn+hWA5Ulhwvt0p7QBa6kHLSnACps=
 github.com/openshift/osde2e-common v0.0.0-20230804144112-974a53599672/go.mod h1:bkreMB6T7SoOuEceXyXCvMHF4/9augfiWsixGaQ/Yo0=
-github.com/openshift/rosa v1.2.23 h1:0Q2kl3Bs1dKcrMn8SNtGSU0SYGYD16b/LS2z+sSxx1M=
-github.com/openshift/rosa v1.2.23/go.mod h1:nhEZMCq3aHx3uCPJdruCDge3xv+5Ir0ijdfEmhOFTCE=
+github.com/openshift/rosa v1.2.24 h1:vv0yYnWHx6CCPEAau/0rS54P2ksaf+uWXb1TQPWxiYE=
+github.com/openshift/rosa v1.2.24/go.mod h1:MVXB27O3PF8WoOic23I03mmq6/9kVxpFx6FKyLMCyrQ=
 github.com/openshift/route-monitor-operator v0.0.0-20221118160357-3df1ed1fa1d2 h1:s97F2fQ5r+XGVfWDy5wgH611iIvIDusQcHtv5jJ36uw=
 github.com/openshift/route-monitor-operator v0.0.0-20221118160357-3df1ed1fa1d2/go.mod h1:I/8znbaxMGRub27brm57UnkR48QZEWO26j2HRscy5bQ=
 github.com/openshift/splunk-forwarder-operator v0.0.0-20230525060151-2dc403aa8ff9 h1:u7XXBdFB+uoA+YcvDjqmfhAJsZTGGGQOBqIXSBT4EUQ=

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -576,7 +576,7 @@ func (m *ROSAProvider) Versions() (*spi.VersionList, error) {
 		return nil, err
 	}
 
-	versionResponse, err := ocmClient.GetVersions(viper.GetString(config.Cluster.Channel))
+	versionResponse, err := ocmClient.GetVersions(viper.GetString(config.Cluster.Channel), true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Changes for https://github.com/openshift/osde2e/pull/1983 to work. 
The getVersions() function changed to require a bool for a value that returns the default version first. 