### PR TITLE
Swap dependabot back to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-   interval: "daily"
+   interval: "weekly"
   labels:
     - "dependencies"
     - "ok-to-test"


### PR DESCRIPTION
Ref Slack Thread: https://redhat-internal.slack.com/archives/CMK13BP4J/p1686258843460609

Dependabot has gotten too noisy with daily PRs. Failing pipelines also tend to leave leftover resources. 
This PR swaps the interval back to weekly in hopes of quieting down Dependabot. 