### PR TITLE
Cleanup/revise writing tests document

### DIFF
--- a/docs/Writing-Tests.md
+++ b/docs/Writing-Tests.md
@@ -1,182 +1,64 @@
 # Writing Tests
 
-OSD end-to-end testing uses the [Ginkgo] testing framework and [Gomega]  matching libraries.
+This page provides you with resources/references to write tests
+to validate various aspects of Managed OpenShift clusters.
 
-## Designing e2e Tests
-We recommend the following basic principles in designing your e2e tests:
- - Map existing functionality to e2e test cases
- - Map any bugs found into e2e test cases 
- - Update e2e test cases as addon functionality is changed or added 
- - Ensure the assertions and logs output by tests reflect 
-   - the execution paths and 
-   - potential causes of failures  
-   
-It is highly recommended to read over the [kubernetes best practices](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/writing-good-e2e-tests.md ) for writing e2e tests. These principles should be taken into consideration for every new or existing test modified.
+Tests can be consumed by osde2e test framework in one of two ways:
 
+1. Runs tests outside of osde2e using its test harness runner (recommended)
+2. Runs tests that reside within osde2e (legacy mode/not recommended)
 
-## Writing first test
+For any new tests, they should be written in which osde2e consumes them using
+its test harness runner feature. *This applies to all OSD SREP operator tests.*
 
-### Informing vs. Blocking
-There are different suites of tests within OSDe2e with varying meanings and purposes. However, all new tests added should fall under the "informing" test suite.
+To learn more about the test harness runner of osde2e, refer to the following
+[document](Test-Harnesses.md).
 
-This test suite is used as a proving ground for new tests to validate their quality and to ensure a potentially new flaky test does not impact the overall CI Signal.
+## Test Standards "Best Practices"
 
-Once a test has run for over a week with quality results, it can then be graduated into its correct/respective suite.
+When writing new tests or enhancing existing tests, every test should strive
+to comply to the following standards:
 
-### Adding a new package of tests
-All Ginkgo tests that are imported in **[`/cmd/osde2e/test/cmd.go`]** are ran as part of the osde2e suite.
+* Follow the [kubernetes best practices guide] when writing end to end tests.
+* Review [Ginkgo] and [Gomega] as these are the core test frameworks when
+  writing OSD SREP operator tests.
+* Use [osde2e-common] module as much as possible when writing test cases. This
+  module provides common modules when working with Managed OpenShift. Which
+  aim to reduce code duplication across tests. Examples of this are:
+  clients for interfacing with OCM, OpenShift/prometheus client and much more.
+* Use the [e2e-framework] as much as possible and become familiar with it
+  when interfacing with OpenShift clusters.
+* Apply labels "tags" to your test cases allowing for easy classification
+  "grouping" of tests. This is helpful when certain tests would like to be run
+  over the entire test suite.
+* Keep test cases focused on their specific scope. Test cases are best to be
+  mapped to a given feature/functionality for the product or OSD SREP operator.
+* Ensure both positive/negative cases are covered for your test case.
+* Ensure every test case has proper error messages logged with using [Gomega]
+  matchers. This helps when it comes to troubleshooting/debugging failing tests.
 
-For example, to add the tests in the Go package `github.com/openshift/osde2e/test/verify` to the normal test suite, you would add the following to **[`/cmd/osde2e/test/cmd.go`]**:
-```go
-import (
-	_ "github.com/openshift/osde2e/pkg/e2e/verify"
-)
-```
+## Examples
 
-### Adding a test to an existing package
-This test from **[`/pkg/e2e/verify/imagestreams.go`]** provides a good example of setting up new ones:
+You can find well defined examples of existing tests following the test
+standards mentioned above below. The examples are showing how tests are written
+for OSD SREP operator tests:
 
-- Create new file in a package that is imported by  **[`/cmd/osde2e/test/cmd.go`]** as discussed [above]. For this example, we will call the file **imagestreams.go**.
+* [Managed Upgrade Operator Tests][managed-upgrade-operator-tests]
+* [OCM Agent Operator Tests][ocm-agent-operator-tests]
+* [RBAC Permissions Operator Tests][rbac-operator-tests]
 
-- Import [Ginkgo] testing framework and [Gomega] matching libraries:
+Another few examples can be found below:
 
-**imagestreams.go**
-```go
-import (
-	"github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega
-)
-```
+* [Cluster Difference Test Suite][cluster-diff-test-suite]
+* [Management/Service Cluster Upgrade Test Suite][mc-sc-upgrade-testsuite]
 
-- Create new Describe block. These are used to organize tests into groups:
-
-**imagestreams.go**
-```go
-var _ = ginkgo.Describe("[Suite: informing] ImageStreams", func() {
-	// tests go here
-})
-```
-**Note:** New tests must be initially added to the ["informing" test suite]. This allows existing signal to not be impacted by potentially flaky or unproven tests.
-
-- Import the [helper package] and create new helper instance in Describe block. This will setup a Project for each test run and can be used to access the cluster.
-
-**imagestreams.go**
-```go
-import (
-	"github.com/openshift/osde2e/pkg/common/helper"
-)
-
-var _ = ginkgo.Describe("[Suite: informing] ImageStreams", func() {
-	h := helper.New()
-
-	// tests go here
-})
-```
-
-- Perform a request on the cluster. The helper provides various clientsets:
-
-**imagestreams.go**
-```go
-import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
-
-var _ = ginkgo.Describe("[Suite: informing] ImageStreams", func() {
-	h := helper.New()
-
-	list, err := h.Image().ImageV1().ImageStreams(metav1.NamespaceAll).List(metav1.ListOptions{})
-})
-```
-
-- Using [Gomega] the results of the request can be validated. The following checks that the requests to the cluster completed successfully and at least 50 ImageStreams exist cluster-wide:
-
-**imagestreams.go**
-```go
-var _ = ginkgo.Describe("[Suite: informing] ImageStreams", func() {
-	h := helper.New()
-
-	ginkgo.It("should exist in the cluster", func() {
-		list, err := h.Image().ImageV1().ImageStreams(metav1.NamespaceAll).List(metav1.ListOptions{})
-		Expect(err).NotTo(HaveOccurred(), "couldn't list ImageStreams")
-		Expect(list).NotTo(BeNil())
-
-		numImages := len(list.Items)
-		minImages := 50
-		Expect(numImages).Should(BeNumerically(">", minImages), "need more images")
-	})
-})
-```
-
-All together this is a working and complete addition to the osde2e suite.
-
-The "ImageStreams should exist in the cluster" test will run as part of the suite:
-
-**imagestreams.go**
-```go
-package verify
-
-import (
-	"github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/openshift/osde2e/pkg/common/helper"
-)
-
-var _ = ginkgo.Describe("[Suite: informing] ImageStreams", func() {
-	h := helper.New()
-
-	ginkgo.It("should exist in the cluster", func() {
-		list, err := h.Image().ImageV1().ImageStreams(metav1.NamespaceAll).List(metav1.ListOptions{})
-		Expect(err).NotTo(HaveOccurred(), "couldn't list ImageStreams")
-		Expect(list).NotTo(BeNil())
-
-		numImages := len(list.Items)
-		minImages := 50
-		Expect(numImages).Should(BeNumerically(">", minImages), "need more images")
-	})
-})
-```
-
-## Ginkgo
-
-### Setup & Teardown
-[Ginkgo] has been configured to bring a cluster up in it's [`BeforeSuite`] and destroy it in it's [`AfterSuite`].
-
-**Cluster configuration**
-- Launched clusters are setup with the [osd package]
-	- Changes to the way test clusters are launched should be made there
-- [ocm-sdk-go] is used to launch clusters
-- Configuration for launching clusters is loaded from a [`config.Config`] instance
-
-## Helper
-A helper can be created in tests using [`helper.New()`]
-
-The helper:
-- Configures Ginkgo to create a Project before each test and delete it after
-- Provides access to OpenShift and Kubernetes clients configured for the test cluster
-- Provides commonly used test functions
-
-## Static files
-
-Static files for `OSDe2e`  such as YAML manifests are managed using the native
-Go embed feature. If your test has a static asset such as a manifest, add it
-into the **[`/assets/`]** directory. It can then be accessed through the
-`assets.FS` [embedded filesystem](https://pkg.go.dev/embed#hdr-File_Systems)
-
+[cluster-diff-test-suite]: https://github.com/openshift/osde2e/blob/main/test/cluster_diff/cluster_diff_test.go
+[e2e-framework]: https://github.com/kubernetes-sigs/e2e-framework
 [Ginkgo]:https://onsi.github.io/ginkgo/
 [Gomega]:https://onsi.github.io/gomega/
-[`/cmd/osde2e/test/cmd.go`]:/cmd/osde2e/test/cmd.go
-[above]:#adding-a-new-package-of-tests
-[`/pkg/e2e/verify/imagestreams.go`]:/pkg/e2e/verify/imagestreams.go
-["informing" test suite]:/configs/informing-suite.yaml
-[helper package]:/pkg/common/helper/
-[osd package]:/pkg/common/osd
-[`BeforeSuite`]:https://onsi.github.io/ginkgo/#global-setup-and-teardown-beforesuite-and-aftersuite
-[`AfterSuite`]:https://onsi.github.io/ginkgo/#global-setup-and-teardown-beforesuite-and-aftersuite
-[ocm-sdk-go]:https://github.com/openshift-online/ocm-sdk-go
-[`config.Config`]:https://godoc.org/github.com/openshift/osde2e/common/pkg/config#Config
-[`helper.New()`]:https://godoc.org/github.com/openshift/osde2e/pkg/common/helper#New
-[`/assets/`]:/assets/
-[Hive]:https://github.com/openshift/hive
+[kubernetes best practices guide]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/writing-good-e2e-tests.md
+[managed-upgrade-operator-tests]: https://github.com/openshift/managed-upgrade-operator/blob/master/osde2e/managed_upgrade_operator_tests.go
+[mc-sc-upgrade-testsuite]: https://github.com/openshift/osde2e/blob/main/test/mcscupgrade/mcscupgrade_test.go
+[ocm-agent-operator-tests]: https://github.com/openshift/ocm-agent-operator/blob/master/osde2e/ocm_agent_operator_tests.go
+[osde2e-common]: https://github.com/openshift/osde2e-common
+[rbac-operator-tests]: https://github.com/openshift/rbac-permissions-operator/blob/master/osde2e/rbac_permissions_operator_tests.go

--- a/docs/Writing-Tests.md
+++ b/docs/Writing-Tests.md
@@ -19,13 +19,13 @@ To learn more about the test harness runner of osde2e, refer to the following
 When writing new tests or enhancing existing tests, every test should strive
 to comply to the following standards:
 
-* Follow the [kubernetes best practices guide] when writing end to end tests.
-* Review [Ginkgo] and [Gomega] as these are the core test frameworks when
-  writing OSD SREP operator tests.
+* Follow the [Kubernetes best practices guide] when writing end to end tests.
+* Review [Ginkgo] and [Gomega] documentation as these are the core test
+  frameworks when writing OSD SREP operator tests.
 * Use [osde2e-common] module as much as possible when writing test cases. This
-  module provides common modules when working with Managed OpenShift. Which
-  aim to reduce code duplication across tests. Examples of this are:
-  clients for interfacing with OCM, OpenShift/prometheus client and much more.
+  module provides common modules when working with Managed OpenShift which
+  aim to reduce code duplication across tests such as
+  clients for interfacing with OCM, OpenShift, Prometheus and more.
 * Use the [e2e-framework] as much as possible and become familiar with it
   when interfacing with OpenShift clusters.
 * Apply labels "tags" to your test cases allowing for easy classification
@@ -35,7 +35,8 @@ to comply to the following standards:
   mapped to a given feature/functionality for the product or OSD SREP operator.
 * Ensure both positive/negative cases are covered for your test case.
 * Ensure every test case has proper error messages logged with using [Gomega]
-  matchers. This helps when it comes to troubleshooting/debugging failing tests.
+  matchers. This helps when it comes to
+  [troubleshooting/debugging failing tests][debugging tests].
 
 ## Examples
 
@@ -47,16 +48,17 @@ for OSD SREP operator tests:
 * [OCM Agent Operator Tests][ocm-agent-operator-tests]
 * [RBAC Permissions Operator Tests][rbac-operator-tests]
 
-Another few examples can be found below:
+Additional examples can be found below:
 
 * [Cluster Difference Test Suite][cluster-diff-test-suite]
 * [Management/Service Cluster Upgrade Test Suite][mc-sc-upgrade-testsuite]
 
 [cluster-diff-test-suite]: https://github.com/openshift/osde2e/blob/main/test/cluster_diff/cluster_diff_test.go
+[debugging tests]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/writing-good-e2e-tests.md#debuggability
 [e2e-framework]: https://github.com/kubernetes-sigs/e2e-framework
 [Ginkgo]:https://onsi.github.io/ginkgo/
 [Gomega]:https://onsi.github.io/gomega/
-[kubernetes best practices guide]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/writing-good-e2e-tests.md
+[Kubernetes best practices guide]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/writing-good-e2e-tests.md
 [managed-upgrade-operator-tests]: https://github.com/openshift/managed-upgrade-operator/blob/master/osde2e/managed_upgrade_operator_tests.go
 [mc-sc-upgrade-testsuite]: https://github.com/openshift/osde2e/blob/main/test/mcscupgrade/mcscupgrade_test.go
 [ocm-agent-operator-tests]: https://github.com/openshift/ocm-agent-operator/blob/master/osde2e/ocm_agent_operator_tests.go


### PR DESCRIPTION
# Change
This PR revises the existing _Writing Tests_ document to better align with the recent changes/standards that are being pushed as part of the OSD operator test decentralization effort.

The goal of this document is to act as a guide to follow when writing tests and should not be super long. It provides a set of standards to follow and branches out to other documentation/pages about test frameworks, etc that should be used when writing tests. It also references to existing test suites following these standards as examples. Removing the need to include inline code examples that can become out of date/stale as things change over time.