### PR TITLE
misc: add version selector logging

### DIFF
--- a/pkg/common/versions/installselectors/default_version.go
+++ b/pkg/common/versions/installselectors/default_version.go
@@ -32,3 +32,7 @@ func (d defaultVersion) SelectVersion(versionList *spi.VersionList) (*semver.Ver
 	}
 	return versionDefault, versionType, nil
 }
+
+func (d defaultVersion) String() string {
+	return "default"
+}

--- a/pkg/common/versions/installselectors/delta_release_from_default.go
+++ b/pkg/common/versions/installselectors/delta_release_from_default.go
@@ -48,6 +48,10 @@ func (d deltaReleaseFromDefault) SelectVersion(versionList *spi.VersionList) (*s
 	return availableVersions[targetIndex].Version(), versionType, nil
 }
 
+func (d deltaReleaseFromDefault) String() string {
+	return "delta from default"
+}
+
 func findDefaultVersionIndex(versions []*spi.Version) int {
 	for index, version := range versions {
 		if version.Default() {

--- a/pkg/common/versions/installselectors/interface.go
+++ b/pkg/common/versions/installselectors/interface.go
@@ -16,4 +16,6 @@ type Interface interface {
 
 	// SelectVersion will select a version to install.
 	SelectVersion(versionList *spi.VersionList) (*semver.Version, string, error)
+
+	String() string
 }

--- a/pkg/common/versions/installselectors/latest_version_selector.go
+++ b/pkg/common/versions/installselectors/latest_version_selector.go
@@ -38,3 +38,7 @@ func (l latestVersion) SelectVersion(versionList *spi.VersionList) (*semver.Vers
 
 	return availableVersions[len(availableVersions)-1].Version(), versionType, nil
 }
+
+func (l latestVersion) String() string {
+	return "latest"
+}

--- a/pkg/common/versions/installselectors/latest_xy.go
+++ b/pkg/common/versions/installselectors/latest_xy.go
@@ -41,3 +41,7 @@ func (m latestXYVersion) SelectVersion(versionList *spi.VersionList) (*semver.Ve
 
 	return nil, versionType, fmt.Errorf("unable to locate latest version for %s", latestXY)
 }
+
+func (m latestXYVersion) String() string {
+	return "latest XY"
+}

--- a/pkg/common/versions/installselectors/latest_y_from_default_selector.go
+++ b/pkg/common/versions/installselectors/latest_y_from_default_selector.go
@@ -67,3 +67,7 @@ func (l latestYVersion) SelectVersion(versionList *spi.VersionList) (*semver.Ver
 
 	return latestYVersion.Version(), versionType, nil
 }
+
+func (l latestYVersion) String() string {
+	return "latest Y from default"
+}

--- a/pkg/common/versions/installselectors/latest_y_from_delta.go
+++ b/pkg/common/versions/installselectors/latest_y_from_delta.go
@@ -47,3 +47,7 @@ func (m latestYFromDelta) SelectVersion(versionList *spi.VersionList) (*semver.V
 
 	return nil, versionType, fmt.Errorf("no version found matching the selector")
 }
+
+func (m latestYFromDelta) String() string {
+	return "latest Y from delta"
+}

--- a/pkg/common/versions/installselectors/latest_z_from_default_selector.go
+++ b/pkg/common/versions/installselectors/latest_z_from_default_selector.go
@@ -62,3 +62,7 @@ func (l latestZVersion) SelectVersion(versionList *spi.VersionList) (*semver.Ver
 
 	return latestZVersion.Version(), versionType, nil
 }
+
+func (l latestZVersion) String() string {
+	return "latest Z from default"
+}

--- a/pkg/common/versions/installselectors/latest_z_from_delta.go
+++ b/pkg/common/versions/installselectors/latest_z_from_delta.go
@@ -51,3 +51,7 @@ func (m latestZFromDelta) SelectVersion(versionList *spi.VersionList) (*semver.V
 
 	return nil, versionType, fmt.Errorf("no version found matching the selector")
 }
+
+func (m latestZFromDelta) String() string {
+	return "latest Z from delta"
+}

--- a/pkg/common/versions/installselectors/middle_cluster_image_set.go
+++ b/pkg/common/versions/installselectors/middle_cluster_image_set.go
@@ -39,3 +39,7 @@ func (m middleClusterImageSet) SelectVersion(versionList *spi.VersionList) (*sem
 
 	return versionsWithoutDefault[numVersions/2].Version(), versionType, nil
 }
+
+func (m middleClusterImageSet) String() string {
+	return "middle"
+}

--- a/pkg/common/versions/installselectors/next_version_after_prod_default.go
+++ b/pkg/common/versions/installselectors/next_version_after_prod_default.go
@@ -31,3 +31,7 @@ func (n nextVersionAfterProdDefault) SelectVersion(versionList *spi.VersionList)
 	selectedVersion, err := common.NextReleaseAfterGivenVersionFromVersionList(defaultVersion, versionList.AvailableVersions(), numReleasesAfterProdDefault)
 	return selectedVersion, fmt.Sprintf("%d release(s) from the default version in prod", numReleasesAfterProdDefault), err
 }
+
+func (n nextVersionAfterProdDefault) String() string {
+	return "next version(s) after default"
+}

--- a/pkg/common/versions/installselectors/oldest_cluster_image_set.go
+++ b/pkg/common/versions/installselectors/oldest_cluster_image_set.go
@@ -39,3 +39,7 @@ func (o oldestClusterImageSet) SelectVersion(versionList *spi.VersionList) (*sem
 
 	return versionsWithoutDefault[0].Version(), versionType, nil
 }
+
+func (o oldestClusterImageSet) String() string {
+	return "oldest"
+}

--- a/pkg/common/versions/installselectors/specific_image.go
+++ b/pkg/common/versions/installselectors/specific_image.go
@@ -20,6 +20,7 @@ func init() {
 type specificImage struct{}
 
 func (m specificImage) ShouldUse() bool {
+	log.Printf("specific image value: %q", viper.GetString(config.Cluster.ReleaseImageLatest))
 	return viper.GetString(config.Cluster.ReleaseImageLatest) != ""
 }
 
@@ -58,4 +59,8 @@ func (m specificImage) SelectVersion(versionList *spi.VersionList) (*semver.Vers
 	}
 
 	return nil, versionType, fmt.Errorf("no valid nightly found for version %s", specificImage)
+}
+
+func (m specificImage) String() string {
+	return "specific image"
 }

--- a/pkg/common/versions/installselectors/specific_nightlies.go
+++ b/pkg/common/versions/installselectors/specific_nightlies.go
@@ -2,6 +2,7 @@ package installselectors
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -19,6 +20,7 @@ func init() {
 type specificNightlies struct{}
 
 func (m specificNightlies) ShouldUse() bool {
+	log.Printf("specific nightly value: %q", viper.GetString(config.Cluster.InstallSpecificNightly))
 	return viper.GetString(config.Cluster.InstallSpecificNightly) != ""
 }
 
@@ -51,4 +53,8 @@ func (m specificNightlies) SelectVersion(versionList *spi.VersionList) (*semver.
 	}
 
 	return nil, versionType, fmt.Errorf("no valid nightly found for version %s", specificNightly)
+}
+
+func (m specificNightlies) String() string {
+	return "specific nightly"
 }

--- a/pkg/common/versions/versionselector.go
+++ b/pkg/common/versions/versionselector.go
@@ -161,6 +161,8 @@ func (v *VersionSelector) getInstallVersion() (*semver.Version, string, error) {
 		return nil, "", fmt.Errorf("unable to find an install version selector")
 	}
 
+	log.Printf("Using version selector %q", selectedVersionSelector)
+
 	version, selector, err := selectedVersionSelector.SelectVersion(v.versionList)
 	if err != nil {
 		log.Printf("Unable to find image using selector `%s`. Error: %v", selector, err)


### PR DESCRIPTION
adding additional logging to debug the nightly jobs picking up the wrong
version selector.

In the current nightly jobs, the wrong version selector is being picked
leading to the provided nightly image not being used. The specific image
selector has higher priority but it seems that the specific nightly
selector is somehow being picked instead.

Signed-off-by: Brady Pratt <bpratt@redhat.com>
