### PR TITLE
installselectors: only use specific img when triggered for nightly jobs

### DIFF
--- a/pkg/common/versions/installselectors/specific_image.go
+++ b/pkg/common/versions/installselectors/specific_image.go
@@ -20,8 +20,13 @@ func init() {
 type specificImage struct{}
 
 func (m specificImage) ShouldUse() bool {
-	log.Printf("specific image value: %q", viper.GetString(config.Cluster.ReleaseImageLatest))
-	return viper.GetString(config.Cluster.ReleaseImageLatest) != ""
+	// When running a /pj-rehearse, the `RELEASE_IMAGE_LATEST` provided is not
+	// in a format that can be used by rosa so don't use this selector unless
+	// the image contains nightly in the name:
+	// `4.13.0-0.nightly-2023-08-24-052924`
+	releaseImageLatest := viper.GetString(config.Cluster.ReleaseImageLatest)
+	log.Printf("specific image value: %q", releaseImageLatest)
+	return releaseImageLatest != "" && strings.Contains(releaseImageLatest, "nightly")
 }
 
 func (m specificImage) Priority() int {


### PR DESCRIPTION
this selector can't be used when running from /pj-rehearse

a few weeks ago, work was done to fix the nightly jobs picking up the correct
selector [here](https://github.com/openshift/release/pull/42029) and Ryan was
able to demonstrate that the value provided when running /pj-rehearse is not
one that can be used by the `rosa` cli:

```
RELEASE_IMAGE_LATEST=registry.build03.ci.openshift.org/ci-op-q7xmji6y/release@sha256:65aaf49a90dabd30139f5dae1fc53f35d96d7cbee784be7f6c74fafed7d549ff
```
- https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/42029/rehearse-42029-periodic-ci-openshift-osde2e-main-nightly-4.13-rosa-hcp/1687550926727942144/artifacts/rosa-hcp/osde2e-test/build-log.txt

We know the format provided when triggered for a nightly job is actually:

```
RELEASE_IMAGE_LATEST=registry.ci.openshift.org/ocp/release:4.13.0-0.nightly-2023-08-24-052924
```

which we can handle.

Signed-off-by: Brady Pratt <bpratt@redhat.com>
