### PR TITLE
e2e: fix logger panic

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	ctrlog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	pd "github.com/PagerDuty/go-pagerduty"
 	"github.com/onsi/ginkgo/v2"
@@ -78,6 +79,7 @@ var provider spi.Provider
 // beforeSuite attempts to populate several required cluster fields (either by provisioning a new cluster, or re-using an existing one)
 // If there is an issue with provisioning, retrieving, or getting the kubeconfig, this will return `false`.
 func beforeSuite() bool {
+	ctrlog.SetLogger(ginkgo.GinkgoLogr)
 	// Skip provisioning if we already have a kubeconfig
 	var err error
 


### PR DESCRIPTION
controller-runtime is throwing a panic because we don't call SetLogger with a log sink

```
I0824 11:33:01.678216      13 cluster.go:519]  "msg"="Cluster is ready!" "cluster_id"="25qejcte4njk2mpl65ph5e6entn9itip" "cluster_name"="osde2e-86jli" "ocm_environment"="https://api.stage.openshift.com"
[controller-runtime] log.SetLogger(...) was never called, logs will not be displayed:
goroutine 1 [running]:
runtime/debug.Stack()
...
```

```
2023/08/24 12:11:54 cluster.go:1306: Successfully added property[UpgradeVersion] -
2023/08/24 12:11:54 e2e.go:154: Cluster is healthy and ready for testing
Harnesses to run:  []
2023/08/24 12:11:55 helper.go:116: Setup called for osde2e-ma08t
2023/08/24 12:11:55 helper.go:202: Created SA: dedicated-admin-project
2023/08/24 12:11:55 helper.go:212: Created SA: dedicated-admin-cluster
```

:partying_face: no longer panicking! 