### PR TITLE
fix: increase the delay for expiring clusters

### DIFF
--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -268,7 +268,7 @@ func (m *MockProvider) ExtendExpiry(clusterID string, hours uint64, minutes uint
 }
 
 // Expire mocks an expire cluster expiry operation.
-func (m *MockProvider) Expire(clusterID string) error {
+func (m *MockProvider) Expire(clusterID string, duration time.Duration) error {
 	return fmt.Errorf("Expire is unsupported by mock clusters")
 }
 

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -322,7 +322,7 @@ func (o *OCMProvider) FindRecycledCluster(originalVersion, cloudProvider, produc
 				log.Printf("Error adding `expiring` to job name: %s", err.Error())
 				return ""
 			}
-			err = o.Expire(spiRecycledCluster.ID())
+			err = o.Expire(spiRecycledCluster.ID(), 1*time.Minute)
 			if err != nil {
 				log.Printf("Error expiring cluster %s: %s", spiRecycledCluster.ID(), err.Error())
 				return ""
@@ -1197,11 +1197,11 @@ func (o *OCMProvider) ExtendExpiry(clusterID string, hours uint64, minutes uint6
 	return nil
 }
 
-// Expire sets the expiration time of an existing cluster to the current time
-func (o *OCMProvider) Expire(clusterID string) error {
+// Expire sets the expiration time of an existing cluster to the current time + N minutes
+func (o *OCMProvider) Expire(clusterID string, duration time.Duration) error {
 	var resp *v1.ClusterUpdateResponse
 
-	now := time.Now().Add(1 * time.Minute)
+	now := time.Now().Add(duration)
 
 	extendexpiryCluster, err := v1.NewCluster().ExpirationTimestamp(now).Build()
 	if err != nil {

--- a/pkg/common/providers/rosaprovider/wrapped_calls.go
+++ b/pkg/common/providers/rosaprovider/wrapped_calls.go
@@ -69,8 +69,8 @@ func (m *ROSAProvider) ExtendExpiry(clusterID string, hours uint64, minutes uint
 }
 
 // Expire will call Expire from the OCM provider.
-func (m *ROSAProvider) Expire(clusterID string) error {
-	return m.ocmProvider.Expire(clusterID)
+func (m *ROSAProvider) Expire(clusterID string, duration time.Duration) error {
+	return m.ocmProvider.Expire(clusterID, duration)
 }
 
 // AddProperty will call AddProperty from the OCM provider.

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -114,7 +114,7 @@ type Provider interface {
 	ExtendExpiry(clusterID string, hours uint64, minutes uint64, seconds uint64) error
 
 	// Expire sets the expiration of an existing cluster to the current time.
-	Expire(clusterID string) error
+	Expire(clusterID string, duration time.Duration) error
 
 	// AddProperty adds a new property to the properties field of an existing cluster.
 	AddProperty(cluster *Cluster, tag string, value string) error

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -748,7 +748,7 @@ func cleanupAfterE2E(ctx context.Context, h *helper.H) (errors []error) {
 	if viper.GetString(config.Cluster.InstallSpecificNightly) != "" || viper.GetString(config.Cluster.ReleaseImageLatest) != "" {
 		viper.Set(config.Cluster.HibernateAfterUse, false)
 		if viper.GetString(config.Cluster.ID) != "" {
-			provider.Expire(viper.GetString(config.Cluster.ID))
+			provider.Expire(viper.GetString(config.Cluster.ID), 10*time.Minute)
 		}
 	}
 


### PR DESCRIPTION
In nightly jobs, with the changes to run as a multi-step job, must-gather is now ran after the first osde2e process has completed. This introduced a bug due to osde2e setting an expiration time of 1 minute in the future which is not enough time for the must-gather to finish.

```
2023/08/25 06:23:49 cluster.go:1241: Successfully set cluster expiry time to Friday, 25 Aug 2023 06:24:48 UTC
```

Increase the time to 10 minutes to be sure that must-gather can run. If anything fails, the cluster will expire, otherwise osde2e will clean up the cluster in the post step.

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-nightly-4.14-rosa-classic-sts/1694933384087736320