### PR TITLE
osde2e-common to different dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,13 @@ updates:
     - "dependencies"
     - "ok-to-test"
   open-pull-requests-limit: 20
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+   interval: "daily"
+  filter:
+    - name: "github.com/openshift/osde2e-common"
+  labels:
+    - "dependencies"
+    - "ok-to-test"
+  open-pull-requests-limit: 1


### PR DESCRIPTION
Test PR
If this works it should check on a daily interval if osde2e-common has been updated