### PR TITLE
versions: fix specific nightly selector polling

### DIFF
--- a/pkg/common/versions/installselectors/specific_image.go
+++ b/pkg/common/versions/installselectors/specific_image.go
@@ -30,7 +30,7 @@ func (m specificImage) ShouldUse() bool {
 }
 
 func (m specificImage) Priority() int {
-	return 100
+	return 90
 }
 
 func (m specificImage) SelectVersion(versionList *spi.VersionList) (*semver.Version, string, error) {

--- a/pkg/common/versions/installselectors/triggered_nightlies.go
+++ b/pkg/common/versions/installselectors/triggered_nightlies.go
@@ -1,0 +1,52 @@
+package installselectors
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/openshift/osde2e/pkg/common/spi"
+)
+
+func init() {
+	registerSelector(triggeredNightlies{})
+}
+
+type triggeredNightlies struct{}
+
+func (t triggeredNightlies) ShouldUse() bool {
+	return strings.Contains(os.Getenv("PROW_JOB_ID"), "nightly")
+}
+
+func (t triggeredNightlies) Priority() int {
+	return 100
+}
+
+func (t triggeredNightlies) SelectVersion(versionList *spi.VersionList) (*semver.Version, string, error) {
+	prowJobID := os.Getenv("PROW_JOB_ID")
+	jobNameSafe := os.Getenv("JOB_NAME_SAFE")
+	payloadName := strings.ReplaceAll(prowJobID, "-"+jobNameSafe, "")
+
+	versionsWithoutDefault := removeDefaultVersion(versionList.AvailableVersions())
+
+	versionToMatch, err := semver.NewVersion(payloadName)
+	if err != nil {
+		return nil, t.String(), fmt.Errorf("error parsing semver version for %s", payloadName)
+	}
+
+	log.Printf("Looking to match %s", versionToMatch)
+
+	for _, version := range versionsWithoutDefault {
+		if version.Version().Original() == versionToMatch.Original() {
+			return version.Version(), t.String(), nil
+		}
+	}
+
+	return nil, t.String(), fmt.Errorf("failed to find version %q", payloadName)
+}
+
+func (t triggeredNightlies) String() string {
+	return "triggered nightly"
+}

--- a/pkg/common/versions/versionselector.go
+++ b/pkg/common/versions/versionselector.go
@@ -48,7 +48,7 @@ func (v *VersionSelector) SelectClusterVersions() error {
 			if err != nil {
 				return false, err
 			}
-			if v.clusterVersion == nil && (versionSelector == "specific image" || versionSelector == "specific nightly") {
+			if v.clusterVersion == nil && (versionSelector == "specific image" || versionSelector == "specific nightly" || versionSelector == "triggered nightly") {
 				log.Println("Waiting for CIS to sync with the Release Controller")
 				return false, nil
 			}

--- a/pkg/common/versions/versionselector.go
+++ b/pkg/common/versions/versionselector.go
@@ -48,8 +48,8 @@ func (v *VersionSelector) SelectClusterVersions() error {
 			if err != nil {
 				return false, err
 			}
-			if v.clusterVersion == nil && versionSelector == "specific image" {
-				log.Printf("Waiting for %s CIS to sync with the Release Controller", viper.GetString(config.Cluster.ReleaseImageLatest))
+			if v.clusterVersion == nil && (versionSelector == "specific image" || versionSelector == "specific nightly") {
+				log.Println("Waiting for CIS to sync with the Release Controller")
 				return false, nil
 			}
 


### PR DESCRIPTION
this selector is currently not polling for an additional period waiting for the image to be synced to CIS. This is just a hack until installing from a specific date is implemented or the ADR for installing from a specific image is accepted and implemented.

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-nightly-4.14-rosa-classic-sts/1696469596409696256

```
2023/08/29 10:30:10 specific_nightlies.go:23: specific nightly value: "4.14"
2023/08/29 10:30:10 versionselector.go:164: Using version selector "specific nightly"
2023/08/29 10:30:10 versionselector.go:168: Unable to find image using selector `specific nightly`. Error: no valid nightly found for version 4.14
2023/08/29 10:30:10 versionselector.go:120: No install version found, skipping upgrade.
2023/08/29 10:30:10 e2e.go:295: OSDE2E failed: no valid install version found 
```

[SDCICD-1103](https://issues.redhat.com//browse/SDCICD-1103)