### PR TITLE
versions: triggered nightly versions need -nightly appended

### DIFF
--- a/pkg/common/versions/installselectors/triggered_nightlies.go
+++ b/pkg/common/versions/installselectors/triggered_nightlies.go
@@ -28,6 +28,7 @@ func (t triggeredNightlies) SelectVersion(versionList *spi.VersionList) (*semver
 	prowJobID := os.Getenv("PROW_JOB_ID")
 	jobNameSafe := os.Getenv("JOB_NAME_SAFE")
 	payloadName := strings.ReplaceAll(prowJobID, "-"+jobNameSafe, "")
+	payloadName += "-nightly"
 
 	versionsWithoutDefault := removeDefaultVersion(versionList.AvailableVersions())
 


### PR DESCRIPTION
the nightly job failed to find the version because it is meant to have `-nightly` appended to it

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-nightly-4.14-rosa-classic-sts/1697169102356877312