### PR TITLE
e2e: increase hibernation time for nightly clusters

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -748,7 +748,7 @@ func cleanupAfterE2E(ctx context.Context, h *helper.H) (errors []error) {
 	if viper.GetString(config.Cluster.InstallSpecificNightly) != "" || viper.GetString(config.Cluster.ReleaseImageLatest) != "" {
 		viper.Set(config.Cluster.HibernateAfterUse, false)
 		if viper.GetString(config.Cluster.ID) != "" {
-			provider.Expire(viper.GetString(config.Cluster.ID), 10*time.Minute)
+			provider.Expire(viper.GetString(config.Cluster.ID), 30*time.Minute)
 		}
 	}
 


### PR DESCRIPTION
10 minutes seems to be too short, the cluster was already not found by the time cleanup was running

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-nightly-4.14-rosa-classic-sts/1701907186206117888/artifacts/rosa-classic-sts/osde2e-cleanup/build-log.txt

```
2023/09/13 14:12:13 retryer.go:25: error during OCM attempt: couldn't retrieve cluster '267k8n40rj3rea58jf44virq0363kmlh': status is 404, identifier is '404', code is 'CLUSTERS-MGMT-404' and operation identifier is '34680996-a3d2-4ef5-acc6-511a693e3ee7': Cluster '267k8n40rj3rea58jf44virq0363kmlh' not found
```

This will be one cause on why things are getting left up since hibernation will not delete the additional resources