### PR TITLE
added rosa.env to int config

### DIFF
--- a/configs/int.yaml
+++ b/configs/int.yaml
@@ -1,2 +1,4 @@
 ocm:
   env: int
+rosa:
+  env: int


### PR DESCRIPTION
added rosa.env=int  config to  int config file. This goes similar to stage.yaml config file. 

Why? : Without this config, rosa provider env is set to prod by default, which also gets copied to ocm provider. To fix this, it has to be specified here. 