### PR TITLE
debug: fix getLastJobID

### DIFF
--- a/pkg/debug/diff.go
+++ b/pkg/debug/diff.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -132,7 +133,11 @@ func GetCurrentMCCHash() (hash string, err error) {
 
 func getLastJobID(baseProwURL, jobName string) (int, error) {
 	// Look up the list of previous jobs with a given name
-	var url string
+	url := fmt.Sprintf("%s/job-history/gs/origin-ci-test/logs/%s", baseProwURL, jobName)
+	if os.Getenv("JOB_TYPE") == "presubmit" {
+		url = fmt.Sprintf("%s/job-history/gs/origin-ci-test/pr-logs/directory/%s", baseProwURL, jobName)
+	}
+
 	log.Printf("Looking up job history from %s", url)
 	res, err := http.Get(url)
 	if err != nil {


### PR DESCRIPTION
this was broken in fb6fe3d88f255f983f354ff1415a9632077e2e09 which caused us to curl an empty string which results in a failure. Put back the logic to handle the URL based on periodic or PR check.