### PR TITLE
Bump to go 1.20

### DIFF
--- a/Dockerfile.osde2e
+++ b/Dockerfile.osde2e
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.19
+FROM registry.ci.openshift.org/openshift/release:golang-1.20
 
 ENV GOFLAGS=
 ENV PKG=/go/src/github.com/openshift/osde2e/

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ fmt:
 	gofmt -s -w .
 
 lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.50.1
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v1.54.2
 	(cd "$(DIR)"; golangci-lint run -c .golang-ci.yml ./...)
 
 check: lint shellcheck vipercheck diffproviders.txt diffreporters.txt

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/osde2e
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/kms v1.15.2

--- a/pkg/debug/diff.go
+++ b/pkg/debug/diff.go
@@ -99,7 +99,6 @@ func GenerateDependencies(kube kubernetes.Interface) (dependencies string, err e
 // GetImageList gathers all images used in a PodList
 func GetImageList(list *v1.PodList) (images map[string]string, err error) {
 	tmp := make(map[string]string)
-	images = make(map[string]string)
 
 	for _, pod := range list.Items {
 		// Default to Unknown for the name

--- a/test/mcscupgrade/Dockerfile
+++ b/test/mcscupgrade/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.20 AS builder
 WORKDIR /tmp/src
 COPY . .
 RUN make build


### PR DESCRIPTION
1.19 is EOL https://endoflife.date/go

/hold

requires a release PR as well