### PR TITLE
e2e: remove hibernation for periodic nightly jobs

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -711,14 +711,6 @@ func cleanupAfterE2E(ctx context.Context, h *helper.H) (errors []error) {
 	// We need to clean up our helper tests manually.
 	h.Cleanup(ctx)
 
-	// If this is a nightly test, we don't want to expire this immediately
-	if viper.GetString(config.Cluster.InstallSpecificNightly) != "" || viper.GetString(config.Cluster.ReleaseImageLatest) != "" {
-		viper.Set(config.Cluster.HibernateAfterUse, false)
-		if viper.GetString(config.Cluster.ID) != "" {
-			provider.Expire(viper.GetString(config.Cluster.ID), 30*time.Minute)
-		}
-	}
-
 	// We need a provider to hibernate
 	// We need a cluster to hibernate
 	// We need to check that the test run wants to hibernate after this run


### PR DESCRIPTION
the must-gather audit log took longer than 30 minutes to run and the cluster was deleted while it was executing. Remove the hibernation entirely to allow post steps to execute allowing the cleanup to destroy the cluster. Resources are left up when a cluster is destroyed with hibernation anyway

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-nightly-4.14-rosa-classic-sts/1705723819374678016

