### PR TITLE
e2e: only generate deps on periodic jobs

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -1013,7 +1013,7 @@ func runTestsInPhase(
 		}
 		clusterState = cluster.State()
 	}
-	if !suiteConfig.DryRun && clusterState == spi.ClusterStateReady && viper.GetString(config.JobName) != "" {
+	if !suiteConfig.DryRun && clusterState == spi.ClusterStateReady && viper.GetString(config.JobName) != "" && viper.GetString(config.JobType) == "periodic" {
 		h, err := helper.NewOutsideGinkgo()
 		if h == nil {
 			log.Println("Unable to generate helper outside of ginkgo: %w", err)


### PR DESCRIPTION
the functionality isn't needed during presubmit jobs