### PR TITLE
common/runner: use ginkgo logr by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go v1.45.3
 	github.com/fatih/color v1.15.0
 	github.com/fsnotify/fsnotify v1.6.0
+	github.com/go-logr/logr v1.2.4
 	github.com/golang-migrate/migrate/v4 v4.16.2
 	github.com/google/go-github/v31 v31.0.0
 	github.com/google/uuid v1.3.1
@@ -106,7 +107,6 @@ require (
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
-	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect

--- a/pkg/common/helper/pods.go
+++ b/pkg/common/helper/pods.go
@@ -2,9 +2,11 @@ package helper
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"time"
 
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	kubev1 "k8s.io/api/core/v1"
@@ -26,7 +28,7 @@ func (h *H) WaitForPodPhase(ctx context.Context, pod *kubev1.Pod, target kubev1.
 			}
 		}
 
-		log.Printf("Waiting for Pod '%s/%s' to be %s, currently %s...", pod.Namespace, pod.Name, target, phase)
+		ginkgo.GinkgoLogr.Info(fmt.Sprintf("Waiting for Pod '%s/%s' to be %s, currently %s...", pod.Namespace, pod.Name, target, phase))
 		time.Sleep(dur)
 	}
 

--- a/pkg/common/runner/pod.go
+++ b/pkg/common/runner/pod.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"path/filepath"
 	"time"
 
@@ -119,7 +118,7 @@ func (r *Runner) createPod() (pod *kubev1.Pod, err error) {
 		// Verify the configMap has been created before proceeding
 		err = wait.PollImmediate(fastPoll, configMapCreateTimeout, func() (done bool, err error) {
 			if configMap, err = r.Kube.CoreV1().ConfigMaps(r.Namespace).Get(context.TODO(), configMap.Name, metav1.GetOptions{}); err != nil {
-				log.Printf("Error creating %s config map: %v", configMap.Name, err)
+				r.Error(err, fmt.Sprintf("error creating %s config map", configMap.Name))
 			}
 			return err == nil, nil
 		})
@@ -157,7 +156,7 @@ func (r *Runner) createPod() (pod *kubev1.Pod, err error) {
 	var createdPod *kubev1.Pod
 	err = wait.PollImmediate(fastPoll, podCreateTimeout, func() (done bool, err error) {
 		if createdPod, err = r.Kube.CoreV1().Pods(r.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
-			log.Printf("Error creating %s runner Pod: %v", r.Name, err)
+			r.Error(err, fmt.Sprintf("error creating %s/%s runner Pod", r.Namespace, r.Name))
 		}
 		return err == nil, nil
 	})
@@ -182,7 +181,7 @@ func (r *Runner) waitForPodRunning(pod *kubev1.Pod) error {
 			if pendingCount > podPendingTimeout {
 				err = errors.New("timed out waiting for pod to start")
 			}
-			r.Printf("Waiting for Pod '%s/%s' to start Running...", pod.Namespace, pod.Name)
+			r.Info(fmt.Sprintf("Waiting for Pod '%s/%s' to start Running...", pod.Namespace, pod.Name))
 		}
 		return
 	})

--- a/pkg/e2e/operators/dvo.go
+++ b/pkg/e2e/operators/dvo.go
@@ -129,7 +129,7 @@ func checkPodLogs(h *helper.H, namespace string, testNamespace string, name stri
 	ginkgo.Context("pods", func() {
 		ginkgo.It(fmt.Sprintf("Check logs in test namespace %s", testNamespace), func(ctx context.Context) {
 			// wait for graceperiod
-			fmt.Println("Waiting for grace period")
+			ginkgo.GinkgoLogr.Info("Waiting for grace period")
 			// Wait for graceperiod
 			time.Sleep(time.Duration(gracePeriod) * time.Second)
 			// Retrieve pods
@@ -137,7 +137,7 @@ func checkPodLogs(h *helper.H, namespace string, testNamespace string, name stri
 			Expect(err).ToNot(HaveOccurred(), "failed fetching pods")
 
 			// Grab logs of pods
-			fmt.Println("Grabbing Logs for pod")
+			ginkgo.GinkgoLogr.Info("Grabbing Logs for pod")
 
 			for _, pod := range pods.Items {
 				logs := h.Kube().CoreV1().Pods(namespace).GetLogs(pod.Name, &podLogOptions)


### PR DESCRIPTION
this allows for controlling the output based on test failure as to not spam the output for successful tests. Just naively swap the loggers around.