### PR TITLE
misc: create openshift client once within helper

### DIFF
--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -18,6 +18,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	projectv1 "github.com/openshift/api/project/v1"
 	cloudcredentialv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"github.com/openshift/osde2e-common/pkg/clients/openshift"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -78,6 +79,7 @@ type H struct {
 	OutsideGinkgo  bool
 
 	// internal
+	client     *openshift.Client
 	restConfig *rest.Config
 	proj       *projectv1.Project
 	mutex      sync.Mutex
@@ -100,6 +102,12 @@ func (h *H) Setup() error {
 	}
 
 	Expect(err).ShouldNot(HaveOccurred(), "failed to configure client")
+
+	h.client, err = openshift.NewFromRestConfig(h.restConfig, ginkgo.GinkgoLogr)
+	if h.OutsideGinkgo && err != nil {
+		return fmt.Errorf("failed to create openshift client: %w", err)
+	}
+	Expect(err).ShouldNot(HaveOccurred(), "failed to configure openshift client")
 
 	project := viper.GetString(config.Project)
 	if project == "" {
@@ -493,4 +501,8 @@ func (h *H) WithToken(token string) *H {
 
 func (h *H) GetConfig() *rest.Config {
 	return h.restConfig
+}
+
+func (h *H) GetClient() *openshift.Client {
+	return h.client
 }

--- a/pkg/e2e/operators/configurealertmanager/configurealertmanager.go
+++ b/pkg/e2e/operators/configurealertmanager/configurealertmanager.go
@@ -51,7 +51,6 @@ var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.Operators, func() {
 		configMapLockFile = "configure-alertmanager-operator-lock"
 		namespaceName     = "openshift-monitoring"
 		operatorName      = "configure-alertmanager-operator"
-		operatorRegistry  = "configure-alertmanager-operator-registry"
 		secrets           = []string{"pd-secret", "dms-secret"}
 		serviceAccounts   = []string{"configure-alertmanager-operator"}
 	)
@@ -168,7 +167,7 @@ var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.Operators, func() {
 	})
 
 	ginkgo.It("can be upgraded from previous version", label.Upgrade, func(ctx context.Context) {
-		err := operators.PerformUpgrade(ctx, h, namespaceName, operatorName, operatorName, operatorRegistry, 5, 30)
+		err := operators.PerformUpgrade(ctx, h, namespaceName, operatorName)
 		expect.NoError(err)
 	})
 })

--- a/pkg/e2e/operators/ocmagent/ocmagent.go
+++ b/pkg/e2e/operators/ocmagent/ocmagent.go
@@ -57,7 +57,6 @@ var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.Operators, label.Migrat
 		namespace          = "openshift-ocm-agent-operator"
 		networkPolicyName  = "ocm-agent-allow-only-alertmanager"
 		operatorName       = "ocm-agent-operator"
-		operatorRegistry   = "ocm-agent-operator-registry"
 		secretName         = "ocm-access-token"
 		serviceMonitorName = "ocm-agent-metrics"
 		serviceName        = "ocm-agent"
@@ -238,7 +237,7 @@ var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.Operators, label.Migrat
 	})
 
 	ginkgo.It("can be upgraded from previous version", label.Upgrade, func(ctx context.Context) {
-		err := operators.PerformUpgrade(ctx, h, namespace, operatorName, operatorName, operatorRegistry, 5, 30)
+		err := operators.PerformUpgrade(ctx, h, namespace, operatorName)
 		expect.NoError(err)
 	})
 })

--- a/pkg/e2e/operators/operators.go
+++ b/pkg/e2e/operators/operators.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift/osde2e-common/pkg/clients/openshift"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
@@ -160,22 +159,14 @@ func checkRoleBindings(h *helper.H, namespace string, roleBindings []string) {
 	})
 }
 
-func PerformUpgrade(
-	ctx context.Context, h *helper.H,
-	subNamespace string, subName string, packageName string, regServiceName string,
-	installPlanPollCount time.Duration, upgradePollCount time.Duration,
-) error {
-	client, err := openshift.New(ginkgo.GinkgoLogr)
-	if err != nil {
-		return err
-	}
-	return client.UpgradeOperator(ctx, subName, subNamespace)
+func PerformUpgrade(ctx context.Context, h *helper.H, subNamespace string, subName string) error {
+	return h.GetClient().UpgradeOperator(ctx, subName, subNamespace)
 }
 
 func checkUpgrade(h *helper.H, subNamespace string, subName string, packageName string, regServiceName string) {
 	ginkgo.Context("Operator Upgrade", func() {
 		ginkgo.It("should upgrade from the replaced version", func(ctx context.Context) {
-			err := PerformUpgrade(ctx, h, subNamespace, subName, packageName, regServiceName, 5, 15)
+			err := PerformUpgrade(ctx, h, subNamespace, subName)
 			Expect(err).NotTo(HaveOccurred(), "unable to upgrade operator %s", subName)
 		})
 	})


### PR DESCRIPTION
a few of the latest jobs are failing to upgrade an operator when trying to create the openshift client. Only create it once in setup and reuse it whenever needed. Also clean up params for the function.

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-nightly-4.13-rosa-classic-sts/1706489463795879936

requires https://github.com/openshift/osde2e-common/pull/48