### PR TITLE
debug: fix pathing to dependencies.txt

### DIFF
--- a/pkg/debug/diff.go
+++ b/pkg/debug/diff.go
@@ -28,13 +28,14 @@ func GenerateDiff(phase, dependencies string) error {
 	baseJobURL := viper.GetString(config.BaseJobURL)
 	baseProwURL := viper.GetString(config.BaseProwURL)
 	jobName := viper.GetString(config.JobName)
+	jobNameSafe := os.Getenv("JOB_NAME_SAFE")
 
 	jobID, err := getLastJobID(baseProwURL, jobName)
 	if err != nil {
 		return err
 	}
 
-	url := fmt.Sprintf("%s/%s/%d/artifacts/%s/dependencies.txt", baseJobURL, jobName, jobID, phase)
+	url := fmt.Sprintf("%s/%s/%d/artifacts/%s/osde2e-test/artifacts/%s/dependencies.txt", baseJobURL, jobName, jobID, jobNameSafe, phase)
 	log.Printf("Grabbing diff from %s", url)
 	resp, err := http.Get(url)
 	if err != nil {


### PR DESCRIPTION
the structure of artifacts changed when the job became multi-step

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-nightly-4.15-rosa-classic-sts/1706851512031907840

the job is diffing the HTML page against the new deps, we just need to format in the JOB_NAME_SAFE variable and the step name. `JOB_NAME_SAFE` can be found as an environment variable in the pod here https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-nightly-4.15-rosa-classic-sts/1706851512031907840/artifacts/build-resources/pods.json

the file should be https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-nightly-4.15-rosa-classic-sts/1706851512031907840/artifacts/rosa-classic-sts/osde2e-test/artifacts/install/dependencies.txt