### PR TITLE
e2e/operators/customdomains: rm ns check

### DIFF
--- a/pkg/e2e/operators/customdomains.go
+++ b/pkg/e2e/operators/customdomains.go
@@ -79,11 +79,7 @@ var _ = ginkgo.Describe(customDomainsOperatorTestName, ginkgo.Ordered, label.Ope
 		Expect(err).ShouldNot(HaveOccurred(), "failed to build semver clusterVersion object")
 
 		if clusterversion.Major() == 4 && clusterversion.Minor() >= 13 {
-			ns, err := h.Kube().CoreV1().Namespaces().Get(ctx, "openshift-custom-domains-operator", metav1.GetOptions{})
-			Expect(err).ShouldNot(HaveOccurred(), "unable to get namespace")
-			if ns.Labels["ext-managed.openshift.io/legacy-ingress-support"] == "false" {
-				ginkgo.Skip("CustomDomain Operator has been deprecated: https://github.com/openshift/custom-domains-operator#deprecation")
-			}
+			ginkgo.Skip("CustomDomain Operator has been deprecated: https://github.com/openshift/custom-domains-operator#deprecation")
 		}
 	})
 


### PR DESCRIPTION
The tests are sporadically being executed and failing. I can only guess that this label isn't set on the namespace by the time the tests run so we execute when we shouldn't

https://testgrid.k8s.io/redhat-openshift-ocp-release-4.14-informing#periodic-ci-openshift-osde2e-main-nightly-4.14-rosa-classic-sts