### PR TITLE
rosaprovider: allow controlling when to use the default account role prefix

### DIFF
--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -106,7 +106,7 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 			MultiAZ:                      viper.GetBool(config.Cluster.MultiAZ),
 			ExpirationDuration:           viper.GetDuration(config.Cluster.ExpiryInMinutes),
 			SkipHealthCheck:              viper.GetBool(config.Tests.SkipClusterHealthChecks),
-			UseDefaultAccountRolesPrefix: true,
+			UseDefaultAccountRolesPrefix: viper.GetBool(STSUseDefaultAccountRolesPrefix),
 			InstallTimeout:               time.Duration(installTimeout) * time.Minute,
 			HealthCheckTimeout:           healthCheckTimeout,
 		},

--- a/pkg/common/providers/rosaprovider/config.go
+++ b/pkg/common/providers/rosaprovider/config.go
@@ -35,6 +35,11 @@ const (
 
 	// OIDCConfigID is the ID of the oidc-config created through ROSA CLI (required for HCP)
 	OIDCConfigID = "rosa.oidcConfigID"
+
+	// STSUseDefaultAccountRolesPrefix controls whether to use the default
+	// "Managed-*" account roles or create unique roles based on the cluster
+	// name
+	STSUseDefaultAccountRolesPrefix = "rosa.stsUseDefaultAccountRolesPrefix"
 )
 
 func init() {
@@ -63,4 +68,7 @@ func init() {
 	viper.SetDefault(OIDCConfigID, "")
 	viper.BindEnv(OIDCConfigID, "ROSA_OIDC_CONFIG_ID")
 	config.RegisterSecret(OIDCConfigID, "rosa-oidc-config-id")
+
+	viper.BindEnv(STSUseDefaultAccountRolesPrefix, "ROSA_STS_USE_DEFAULT_ACCOUNT_ROLES_PREFIX")
+	viper.SetDefault(STSUseDefaultAccountRolesPrefix, true)
 }


### PR DESCRIPTION
this will allow obo to create unique roles based on the cluster name as seen here:

https://github.com/openshift/osde2e-common/blob/8fc51be35b41a45e8e206dd70279e80619fadd8a/pkg/openshift/rosa/cluster.go#L124-L127

https://redhat-internal.slack.com/archives/CMK13BP4J/p1696942947257909?thread_ts=1694780540.450649&cid=CMK13BP4J

[SDCICD-1149](https://issues.redhat.com//browse/SDCICD-1149)