### PR TITLE
e2e/operators: stop checking for olm clusterroles

### DIFF
--- a/pkg/e2e/operators/dvo.go
+++ b/pkg/e2e/operators/dvo.go
@@ -46,19 +46,12 @@ var _ = ginkgo.Describe(deploymentValidationOperatorTestName, label.Informing, g
 		defaultDesiredReplicas int32 = 1
 	)
 
-	clusterRoles := []string{
-		"deployment-validation-operator-og-admin",
-		"deployment-validation-operator-og-edit",
-		"deployment-validation-operator-og-view",
-	}
-
 	h := helper.New()
 	nodeLabels := make(map[string]string)
 
 	checkDeployment(h, operatorNamespace, operatorDeploymentName, defaultDesiredReplicas)
 	checkService(h, operatorNamespace, operatorServiceName, 8383)
 	checkPod(h, operatorNamespace, operatorDeploymentName, 2, 3)
-	checkClusterRoles(h, clusterRoles, false)
 
 	ginkgo.It("Create and test deployment for DVO functionality", func(ctx context.Context) {
 		// Create and check test deployment

--- a/pkg/e2e/operators/mustgather.go
+++ b/pkg/e2e/operators/mustgather.go
@@ -39,17 +39,10 @@ var _ = ginkgo.Describe(mustGatherOperatorTest, ginkgo.Ordered, label.Operators,
 	operatorLockFile := "must-gather-operator-lock"
 	var defaultDesiredReplicas int32 = 1
 
-	clusterRoles := []string{
-		"must-gather-operator-admin",
-		"must-gather-operator-edit",
-		"must-gather-operator-view",
-	}
-
 	h := helper.New()
 	checkClusterServiceVersion(h, operatorNamespace, operatorName)
 	checkConfigMapLockfile(h, operatorNamespace, operatorLockFile)
 	checkDeployment(h, operatorNamespace, operatorName, defaultDesiredReplicas)
-	checkClusterRoles(h, clusterRoles, false)
 
 	checkUpgrade(h, "openshift-must-gather-operator", "must-gather-operator",
 		"must-gather-operator", "must-gather-operator-registry")

--- a/pkg/e2e/operators/rbac.go
+++ b/pkg/e2e/operators/rbac.go
@@ -38,17 +38,10 @@ var _ = ginkgo.Describe(rbacOperatorBlocking, ginkgo.Ordered, label.Operators, l
 	operatorLockFile := "rbac-permissions-operator-lock"
 	var defaultDesiredReplicas int32 = 1
 
-	clusterRoles := []string{
-		"rbac-permissions-operator-admin",
-		"rbac-permissions-operator-edit",
-		"rbac-permissions-operator-view",
-	}
-
 	h := helper.New()
 	checkClusterServiceVersion(h, operatorNamespace, operatorName)
 	checkConfigMapLockfile(h, operatorNamespace, operatorLockFile)
 	checkDeployment(h, operatorNamespace, operatorName, defaultDesiredReplicas)
-	checkClusterRoles(h, clusterRoles, false)
 
 	checkUpgrade(helper.New(), "openshift-rbac-permissions", "rbac-permissions-operator",
 		"rbac-permissions-operator", "rbac-permissions-operator-registry")

--- a/pkg/e2e/operators/routemonitor.go
+++ b/pkg/e2e/operators/routemonitor.go
@@ -47,18 +47,11 @@ var _ = ginkgo.Describe(routeMonitorOperatorTestName, ginkgo.Ordered, label.Info
 		defaultDesiredReplicas int32 = 1
 	)
 
-	clusterRoles := []string{
-		"route-monitor-operator-admin",
-		"route-monitor-operator-edit",
-		"route-monitor-operator-view",
-	}
-
 	h := helper.New()
 
 	checkClusterServiceVersion(h, operatorNamespace, operatorCsvDisplayName)
 	// checkConfigMapLockfile(h,operatorNamespace, operatorLockFile)
 	checkDeployment(h, operatorNamespace, operatorDeploymentName, defaultDesiredReplicas)
-	checkClusterRoles(h, clusterRoles, false)
 
 	// should I create a new helper here? seems everyone else does but I am not sure
 	checkUpgrade(helper.New(),

--- a/pkg/e2e/operators/splunkforwarder.go
+++ b/pkg/e2e/operators/splunkforwarder.go
@@ -48,9 +48,6 @@ var _ = ginkgo.Describe(splunkForwarderBlocking, ginkgo.Ordered, label.Operators
 
 	clusterRoles := []string{
 		"splunk-forwarder-operator",
-		"splunk-forwarder-operator-og-admin",
-		"splunk-forwarder-operator-og-edit",
-		"splunk-forwarder-operator-og-view",
 	}
 
 	splunkforwarder_names := []string{


### PR DESCRIPTION
the rolename scheme has changed in 4.15 so it makes testing that these are there more difficult. That brings the question of value in testing that the clusterroles exist, which is just something managed by OLM.

remove any checks for OLM created clusterroles

[SDCICD-1151](https://issues.redhat.com//browse/SDCICD-1151)