### PR TITLE
include migrated harnesses in suite, exclude from legacy tests with label

### DIFF
--- a/configs/complete-e2e.yaml
+++ b/configs/complete-e2e.yaml
@@ -4,10 +4,11 @@ tests:
   testHarnesses:
   #    For migrated harnesses, remember to add "MigratedHarness" label to existing suite in this repo, until they are removed from here.
     - quay.io/app-sre/aws-vpce-operator-test-harness
-    - quay.io/app-sre/splunk-forwarder-operator-test-harness
-    - quay.io/app-sre/ocm-agent-operator-test-harness
-    - quay.io/app-sre/osd-metrics-exporter-test-harness
     - quay.io/app-sre/custom-domains-operator-test-harness
     - quay.io/app-sre/managed-node-metadata-operator-test-harness
+    - quay.io/app-sre/managed-upgrade-operator-test-harness
+    - quay.io/app-sre/must-gather-operator-test-harness
+    - quay.io/app-sre/ocm-agent-operator-test-harness
     - quay.io/app-sre/rbac-permissions-operator-test-harness
-  suiteTimeout: 900    
+    - quay.io/app-sre/splunk-forwarder-operator-test-harness
+  suiteTimeout: 900

--- a/configs/complete-e2e.yaml
+++ b/configs/complete-e2e.yaml
@@ -9,6 +9,7 @@ tests:
     - quay.io/app-sre/managed-upgrade-operator-test-harness
     - quay.io/app-sre/must-gather-operator-test-harness
     - quay.io/app-sre/ocm-agent-operator-test-harness
+    - quay.io/app-sre/osd-metrics-exporter-test-harness
     - quay.io/app-sre/rbac-permissions-operator-test-harness
     - quay.io/app-sre/splunk-forwarder-operator-test-harness
   suiteTimeout: 900

--- a/pkg/e2e/operators/managedupgrade.go
+++ b/pkg/e2e/operators/managedupgrade.go
@@ -32,7 +32,7 @@ func init() {
 	alert.RegisterGinkgoAlert(managedUpgradeOperatorTestName, "SD-SREP", "@managed-upgrade-operator", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(managedUpgradeOperatorTestName, ginkgo.Ordered, label.Operators, func() {
+var _ = ginkgo.Describe(managedUpgradeOperatorTestName, ginkgo.Ordered, label.Operators, label.MigratedHarness, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(config.Hypershift) {
 			ginkgo.Skip("Managed Upgrade Operator is not supported on HyperShift")

--- a/pkg/e2e/operators/mustgather.go
+++ b/pkg/e2e/operators/mustgather.go
@@ -27,7 +27,7 @@ func init() {
 	alert.RegisterGinkgoAlert(mustGatherOperatorTest, "SD-SREP", "@sd-sre-aurora-team", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(mustGatherOperatorTest, ginkgo.Ordered, label.Operators, func() {
+var _ = ginkgo.Describe(mustGatherOperatorTest, ginkgo.Ordered, label.Operators, label.MigratedHarness, func() {
 	ginkgo.BeforeEach(func() {
 		if viper.GetBool(config.Hypershift) {
 			ginkgo.Skip("Must Gather Operator is not supported on HyperShift")


### PR DESCRIPTION
- includes managed upgrade operator and MGO in harness
- added MigratedHarness to MUO and MGO to exclude from legacy tests


[SDCICD-1142](https://issues.redhat.com//browse/SDCICD-1142)