### PR TITLE
e2e: only create helper once in upgrade path

### DIFF
--- a/pkg/common/upgrade/managed.go
+++ b/pkg/common/upgrade/managed.go
@@ -587,7 +587,7 @@ func scheduleOCMUpgrade() error {
 
 	err = upgradeManager.clusterProvider.Upgrade(upgradeManager.clusterID, upgradeManager.upgradeVersion.String(), t)
 	if err != nil {
-		return fmt.Errorf("error initiating upgrade from provider: %v", err)
+		return fmt.Errorf("error initiating upgrade from provider: %w", err)
 	}
 
 	return nil

--- a/pkg/common/upgrade/upgrade.go
+++ b/pkg/common/upgrade/upgrade.go
@@ -41,17 +41,11 @@ var (
 )
 
 // RunUpgrade uses the OpenShift extended suite to upgrade a cluster to the image provided in cfg.
-func RunUpgrade() error {
+func RunUpgrade(h *helper.H) error {
 	var done bool
 	var msg string
 	var err error
 	var upgradeStarted time.Time
-
-	// setup helper
-	h, err := helper.NewOutsideGinkgo()
-	if h == nil {
-		return fmt.Errorf("unable to generate helper outside ginkgo: %v", err)
-	}
 
 	image := viper.GetString(config.Upgrade.Image)
 	if image != "" {

--- a/pkg/e2e/routemonitors/routemonitors.go
+++ b/pkg/e2e/routemonitors/routemonitors.go
@@ -50,13 +50,7 @@ type RouteMonData struct {
 }
 
 // Detects the available routes in the cluster and initializes monitors for their availability
-func Create(ctx context.Context) (*RouteMonitors, error) {
-	h, err := helper.NewOutsideGinkgo()
-
-	if h == nil {
-		return nil, fmt.Errorf("unable to generate helper outside ginkgo: %v", err)
-	}
-
+func Create(ctx context.Context, h *helper.H) (*RouteMonitors, error) {
 	// record all targeters created in a map, accessible via a key which is their URL
 	targeters := make(map[string]vegeta.Targeter, 0)
 


### PR DESCRIPTION
current upgrade jobs are panicking when trying to create multiple helpers in the routemonitor launched goroutines

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-osd-aws-upgrade-latest-default-z-minus-1-to-latest-default-z/1715359690713468928