### PR TITLE
change runner to run pods in any given namespace

### DIFF
--- a/pkg/common/helper/runner.go
+++ b/pkg/common/helper/runner.go
@@ -25,6 +25,18 @@ func (h *H) RunnerWithNoCommand() *runner.Runner {
 	return r
 }
 
+// SetRunnerProject sets namespace for runner pod
+func (h *H) SetRunnerProject(project string, r *runner.Runner) *runner.Runner {
+	r.Namespace = project
+	return r
+}
+
+// SetRunnerCommand sets given command to a pod runner
+func (h *H) SetRunnerCommand(cmd string, r *runner.Runner) *runner.Runner {
+	r.Cmd = cmd
+	return r
+}
+
 // Runner creates an extended test suite runner and configure RBAC for it and runs cmd in it.
 func (h *H) Runner(cmd string) *runner.Runner {
 	r := h.RunnerWithNoCommand()

--- a/pkg/e2e/operators/dvo.go
+++ b/pkg/e2e/operators/dvo.go
@@ -62,16 +62,12 @@ var _ = ginkgo.Describe(deploymentValidationOperatorTestName, label.Informing, g
 
 	ginkgo.It("Create and test deployment for DVO functionality", func(ctx context.Context) {
 		// Create and check test deployment
-		h.CreateProject(ctx, "dvo-test")
-		h.SetProjectByName(ctx, "osde2e-dvo-test")
-
-		// Set it to a wildcard dedicated-admin
-		h.CreateServiceAccounts(ctx)
-		h.SetServiceAccount(ctx, "system:serviceaccount:osde2e-dvo-test:cluster-admin")
+		_, err := h.SetupNewProject(ctx, "dvo-test")
+		Expect(err).NotTo(HaveOccurred(), "error creating project")
 
 		// Test creating a basic deployment
-		ds := makeDeployment("dvo-test-case", h.GetNamespacedServiceAccount(), nodeLabels)
-		_, err := h.Kube().AppsV1().Deployments(h.CurrentProject()).Create(ctx, &ds, metav1.CreateOptions{})
+		ds := makeDeployment("dvo-test-case", "cluster-admin", nodeLabels)
+		_, err = h.Kube().AppsV1().Deployments("osde2e-dvo-test").Create(ctx, &ds, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 	})
 


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/SDCICD-1070

What:
- project creation is decoupled from helper setup
- A project can be initialized with given suffix and a runner instance can be set to use that project
- Implemented this in harness runner. Initialize project, assign namespace to it and run job in it, gather results and remove namespace


Why:
- This does not touch the main osde2e runner namespace, removes dependency from it, 
- does not use or overwrite viper configs for execution, as it is doing now, only uses the defined project instance

