### PR TITLE
fix: remove junit xml error if test errors out

### DIFF
--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -81,7 +81,7 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 
 			// Retrieve and write results
 			ginkgo.By("Retrieving results from test pod")
-			results, err := r.RetrieveTestResults()
+			results, err := r.RetrieveResults()
 			Expect(err).NotTo(HaveOccurred(), "Could not read results")
 			ginkgo.By("Writing results")
 			h.WriteResults(results)


### PR DESCRIPTION
What:

Replaces RetrieveTestResults by RetrieveResults for reading harness pod results



Why: 

Removes the additional junit xml read error if a test spec has error. 
Also keeps pod artifacts even if test spec fails. 

  example: 
CustomDomain Operator in this result 
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/44563/rehearse-44563-periodic-ci-openshift-osde2e-main-rosa-stage-complete-e2e/1717226050116653056


[SDCICD-1142](https://issues.redhat.com//browse/SDCICD-1142)
