### PR TITLE
pass OCM token env var to harness pod to fix some tests

### DIFF
--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
@@ -136,6 +137,10 @@ func getCommandString(timeout int, latestImageStream string, harness string, suf
 			{
 				Name:  "OCM_CLUSTER_ID",
 				Value: viper.GetString(config.Cluster.ID),
+			},
+			{
+				Name:  "OCM_TOKEN",
+				Value: os.Getenv("OCM_TOKEN"),
 			},
 		},
 	}


### PR DESCRIPTION
Some test harnesses directly use OCM_TOKEN env var to establish ocm client connection,  and are failing to get connection as it does not exist in pod.

PAssing this var to the pod

harness tests using this:
https://github.com/openshift/managed-node-metadata-operator/blob/ae83ee6f0ddf975cb7d61d2d9a78e5a00d40cd76/osde2e/managed_node_metadata_operator_tests.go#L41C2-L41C2

https://github.com/openshift/osd-metrics-exporter/blob/4f2abc0fd6522accda20c02751b84f69c3a1bca2/osde2e/osd_metrics_exporter_tests.go#L54



failure log
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/44563/rehearse-44563-periodic-ci-openshift-osde2e-main-rosa-stage-complete-e2e/1717658209818251264

[SDCICD-1142](https://issues.redhat.com//browse/SDCICD-1142)