### PR TITLE
pass correct OCM token from viper to harness pods to fix   tests

### DIFF
--- a/pkg/common/load/load.go
+++ b/pkg/common/load/load.go
@@ -70,8 +70,8 @@ func Configs(configs []string, customConfig string, secretLocations []string) er
 			passthruSecrets := viper.GetStringMapString(config.NonOSDe2eSecrets)
 			// Omit the osde2e secrets from going to the pass through secrets.
 			if strings.Contains(folder, "osde2e-credentials") || strings.Contains(folder, "osde2e-common") {
-				// If this is an addon test we will want to pass the ocm-token through.
-				if viper.Get(config.Addons.IDs) != nil {
+				// If this is a test harness, we will want to pass the ocm-token through.
+				if viper.Get(config.Tests.TestHarnesses) != nil {
 					_, exist := passthruSecrets["ocm-token-refresh"]
 					if !exist {
 						passthruSecrets["ocm-token-refresh"] = viper.GetString("ocm.token")

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -93,7 +93,7 @@ func beforeSuite() bool {
 		viper.Set(config.Cluster.Channel, cluster.ChannelGroup())
 
 		log.Printf("CLUSTER_ID set to %s from OCM.", viper.GetString(config.Cluster.ID))
-		if viper.Get(config.Addons.IDs) != nil {
+		if viper.Get(config.Tests.TestHarnesses) != nil {
 			passthruSecrets := viper.GetStringMapString(config.NonOSDe2eSecrets)
 			passthruSecrets["CLUSTER_ID"] = viper.GetString(config.Cluster.ID)
 			viper.Set(config.NonOSDe2eSecrets, passthruSecrets)

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -13,7 +13,6 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
-	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
 	"github.com/openshift/osde2e/pkg/common/runner"
 	"github.com/openshift/osde2e/pkg/common/templates"
 	"github.com/openshift/osde2e/pkg/common/util"
@@ -137,10 +136,6 @@ func getCommandString(timeout int, latestImageStream string, harness string, suf
 			{
 				Name:  "OCM_CLUSTER_ID",
 				Value: viper.GetString(config.Cluster.ID),
-			},
-			{
-				Name:  "OCM_TOKEN",
-				Value: viper.GetString(ocmprovider.Token),
 			},
 		},
 	}


### PR DESCRIPTION
OCM_TOKEN env var is not being passed correctly using `os.Getenv("OCM_TOKEN")`
(Example pod https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/44563/rehearse-44563-periodic-ci-openshift-osde2e-main-rosa-stage-complete-e2e/1719403516964900864/artifacts/test/artifacts/install/containerLogs/osde2e-runner-0068l-osde2e-runner.log ) 


Pass it using passthough secrets instead. 

Follow up needed: Update test harnesses to use secret instead of env var OCM_TOKEN.



[SDCICD-1142](https://issues.redhat.com//browse/SDCICD-1142)