### PR TITLE
update how ocm token passthrough is loaded for harness

### DIFF
--- a/pkg/common/load/load.go
+++ b/pkg/common/load/load.go
@@ -61,14 +61,6 @@ func Configs(configs []string, customConfig string, secretLocations []string) er
 
 	// 4. Secrets. These will override all previous entries.
 	passthruSecrets := viper.GetStringMapString(config.NonOSDe2eSecrets)
-	// Load ocm-token and ENV from viper for harnesses
-	if viper.Get(config.Tests.TestHarnesses) != nil {
-		_, exist := passthruSecrets["ocm-token-refresh"]
-		if !exist {
-			passthruSecrets["ocm-token-refresh"] = viper.GetString("ocm.token")
-			passthruSecrets["ENV"] = viper.GetString("ocm.env")
-		}
-	}
 	// Load secrets from folders
 	if len(secretLocations) > 0 {
 		secrets := config.GetAllSecrets()
@@ -98,6 +90,14 @@ func Configs(configs []string, customConfig string, secretLocations []string) er
 			if err != nil {
 				log.Printf("Error loading secret: %s", err.Error())
 			}
+		}
+	}
+	// Load ocm-token and ENV as passthrough secrets for harnesses
+	if viper.Get(config.Tests.TestHarnesses) != nil {
+		_, exist := passthruSecrets["ocm-token-refresh"]
+		if !exist {
+			passthruSecrets["ocm-token-refresh"] = viper.GetString("ocm.token")
+			passthruSecrets["ENV"] = viper.GetString("ocm.env")
 		}
 	}
 	if len(passthruSecrets) > 0 {


### PR DESCRIPTION
- Loads ocm token passthrough secret for harnesses

This code is designed to do this, but fails to do so, unless SECRET_LOCATIONS are provided. This env var is not set and is not necessary in tekton environment.

After removing this condition, ocm refresh token secret loads in osde2e-ci-secrets namespace for harnesses correctly. 

[SDCICD-1142](https://issues.redhat.com//browse/SDCICD-1142)