### PR TITLE
e2e/osd/machinehealthcheck: bump infra timeout to 10m

### DIFF
--- a/pkg/e2e/osd/machinehealthcheck.go
+++ b/pkg/e2e/osd/machinehealthcheck.go
@@ -68,7 +68,7 @@ var _ = ginkgo.Describe(machineHealthTestName, label.E2E, func() {
 			machineV1beta1.UnhealthyCondition{
 				Type:    corev1.NodeReady,
 				Status:  corev1.ConditionUnknown,
-				Timeout: metav1.Duration{Duration: 480 * time.Second},
+				Timeout: metav1.Duration{Duration: 600 * time.Second},
 			},
 		))
 	})


### PR DESCRIPTION
follow up required to https://github.com/openshift/managed-cluster-config/pull/1916 to fix failing test

https://issues.redhat.com/browse/OSD-19449

/cc @tnierman @AlexVulaj @openshift/openshift-team-sd-cicada

https://testgrid.k8s.io/redhat-openshift-ocp-release-4.15-informing#periodic-ci-openshift-osde2e-main-nightly-4.15-rosa-classic-sts

https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-nightly-4.15-rosa-classic-sts/1721700980438863872