### PR TITLE
load token in harness pod

### DIFF
--- a/assets/tests/tests-runner.template
+++ b/assets/tests/tests-runner.template
@@ -23,6 +23,13 @@ spec:
         - name: {{ $env.Name }}
           value: {{ $env.Value }}
         {{- end }}
+        {{- range $envSec := .EnvironmentVariablesFromSecret }}
+        - name: {{ $envSec.SecretKey }}
+          valueFrom: 
+            secretKeyRef:
+              name: {{ $envSec.SecretName }}
+              key: {{ $envSec.SecretKey }}
+        {{- end }}
         volumeMounts:
         - mountPath: {{.OutputDir}}
           name: test-output

--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -172,6 +172,20 @@ func (h *H) SetupNewProject(ctx context.Context, suffix string) (*projectv1.Proj
 	return v1project, nil
 }
 
+// Adds essential secrets to harness namespace
+func (h *H) SetPassthruSecretInProject(ctx context.Context, project *projectv1.Project) error {
+	passthruSecrets := make(map[string]string)
+	passthruSecrets["OCM_TOKEN"] = viper.GetString("ocm.token")
+	err := h.GetClient().Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ci-secrets",
+			Namespace: project.Name,
+		},
+		StringData: passthruSecrets,
+	})
+	return err
+}
+
 // Cleanup deletes a Project after tests have been ran.
 func (h *H) Cleanup(ctx context.Context) {
 	var err error

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -51,6 +51,8 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 		suffix = "h-" + util.RandomStr(5)
 		subProject, err = h.SetupNewProject(ctx, suffix)
 		Expect(err).NotTo(HaveOccurred(), "Could not set up harness namespace")
+		err = h.SetPassthruSecretInProject(ctx, subProject)
+		Expect(err).NotTo(HaveOccurred(), "Could not set up passthru secrets")
 	})
 
 	ginkgo.DescribeTable("execution",
@@ -117,6 +119,10 @@ func getCommandString(timeout int, latestImageStream string, harness string, suf
 			Name  string
 			Value string
 		}
+		EnvironmentVariablesFromSecret []struct {
+			SecretName string
+			SecretKey  string
+		}
 	}{
 		Name:                 jobName,
 		JobName:              jobName,
@@ -136,6 +142,15 @@ func getCommandString(timeout int, latestImageStream string, harness string, suf
 			{
 				Name:  "OCM_CLUSTER_ID",
 				Value: viper.GetString(config.Cluster.ID),
+			},
+		},
+		EnvironmentVariablesFromSecret: []struct {
+			SecretName string
+			SecretKey  string
+		}{
+			{
+				SecretName: "ci-secrets",
+				SecretKey:  "OCM_TOKEN",
 			},
 		},
 	}


### PR DESCRIPTION
Load ci-secrets secret in harness namespace

Load the OCM_TOKEN from ci-secrets secret as env var on harness pod. 

Removes the need to query secrets from osde2e-ci-secrets namespace. 

Tested locally with osde2e / mnmo harness

Triggered by [SDCICD-1142](https://issues.redhat.com//browse/SDCICD-1142)

