### PR TITLE
e2e/osd/machinehealthcheck: bump expected worker timeout duration

### DIFF
--- a/pkg/e2e/osd/machinehealthcheck.go
+++ b/pkg/e2e/osd/machinehealthcheck.go
@@ -108,7 +108,7 @@ var _ = ginkgo.Describe(machineHealthTestName, label.E2E, func() {
 			machineV1beta1.UnhealthyCondition{
 				Type:    corev1.NodeReady,
 				Status:  corev1.ConditionUnknown,
-				Timeout: metav1.Duration{Duration: 480 * time.Second},
+				Timeout: metav1.Duration{Duration: 600 * time.Second},
 			},
 		))
 	})


### PR DESCRIPTION
https://github.com/openshift/managed-cluster-config/pull/1919

https://issues.redhat.com/browse/OSD-19449