### PR TITLE
Upload results to s3 bucket if LOG_BUCKET is set

### DIFF
--- a/pkg/common/aws/s3.go
+++ b/pkg/common/aws/s3.go
@@ -8,20 +8,16 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
-// ReadFromS3 reads a key from S3 using the global AWS context.
-func ReadFromS3(inputKey string) ([]byte, error) {
+// ReadFromS3Session reads a key from S3 using given AWS context.
+func ReadFromS3Session(session *session.Session, inputKey string) ([]byte, error) {
 	bucket, key, err := ParseS3URL(inputKey)
 	if err != nil {
 		return nil, fmt.Errorf("error trying to parse S3 URL: %v", err)
-	}
-
-	session, err := MetricsAWSSession.getSession()
-	if err != nil {
-		return nil, err
 	}
 
 	downloader := s3manager.NewDownloader(session)
@@ -40,16 +36,11 @@ func ReadFromS3(inputKey string) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-// WriteToS3 writes the given byte array to S3.
-func WriteToS3(outputKey string, data []byte) error {
+// WriteToS3Session writes the given byte array to S3.
+func WriteToS3Session(session *session.Session, outputKey string, data []byte) error {
 	bucket, key, err := ParseS3URL(outputKey)
 	if err != nil {
 		return fmt.Errorf("error trying to parse S3 URL: %v", err)
-	}
-
-	session, err := MetricsAWSSession.getSession()
-	if err != nil {
-		return err
 	}
 
 	uploader := s3manager.NewUploader(session)

--- a/pkg/common/aws/s3_session.go
+++ b/pkg/common/aws/s3_session.go
@@ -41,7 +41,7 @@ func init() {
 	config.RegisterSecret(metricsAWSRegion, "metrics-aws-region")
 }
 
-func (a *metricsAWSSession) getSession() (*session.Session, error) {
+func (a *metricsAWSSession) GetSession() (*session.Session, error) {
 	var err error
 
 	// Initialize this once, and initialize it in getSession so that osde2e capabilities that don't use S3

--- a/pkg/common/aws/session.go
+++ b/pkg/common/aws/session.go
@@ -58,6 +58,11 @@ func (CcsAwsSession *ccsAwsSession) GetAWSSessions() error {
 	return nil
 }
 
+func (CcsAwsSession *ccsAwsSession) GetSession() (*session.Session, error) {
+	err := CcsAwsSession.GetAWSSessions()
+	return CcsAwsSession.session, err
+}
+
 // GetCredentials returns the credentials for the current aws session
 func (CcsAwsSession *ccsAwsSession) GetCredentials() (*credentials.Value, error) {
 	if err := CcsAwsSession.GetAWSSessions(); err != nil {

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -276,6 +276,10 @@ var Tests = struct {
 	// Env: METRICS_BUCKET
 	MetricsBucket string
 
+	// LogBucket is the s3 bucket that log file/s will be uploaded to.
+	// Env: LOG_BUCKET
+	LogBucket string
+
 	// ServiceAccount defines what user the tests should run as. By default, osde2e uses system:admin
 	// Env: SERVICE_ACCOUNT
 	ServiceAccount string
@@ -296,6 +300,7 @@ var Tests = struct {
 	OperatorSkip:               "tests.operatorSkip",
 	SkipClusterHealthChecks:    "tests.skipClusterHealthChecks",
 	MetricsBucket:              "tests.metricsBucket",
+	LogBucket:                  "tests.logBucket",
 	ClusterHealthChecksTimeout: "tests.clusterHealthChecksTimeout",
 }
 
@@ -726,6 +731,8 @@ func InitOSDe2eViper() {
 
 	viper.SetDefault(Tests.MetricsBucket, "osde2e-metrics")
 	viper.BindEnv(Tests.MetricsBucket, "METRICS_BUCKET")
+
+	viper.BindEnv(Tests.LogBucket, "LOG_BUCKET")
 
 	viper.BindEnv(Tests.ServiceAccount, "SERVICE_ACCOUNT")
 

--- a/pkg/common/helper/runner.go
+++ b/pkg/common/helper/runner.go
@@ -1,10 +1,12 @@
 package helper
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
 	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e/pkg/common/aws"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 
 	"github.com/openshift/osde2e/pkg/common/config"
@@ -54,4 +56,19 @@ func (h *H) WriteResults(results map[string][]byte) {
 		err = os.WriteFile(dst, data, os.ModePerm)
 		Expect(err).NotTo(HaveOccurred())
 	}
+}
+
+// UploadResultsToS3 dumps runner results into the s3 bucket in given aws session. Session provided as metrics uploader uses different aws session than log uploads which use test aws session.
+func (h *H) UploadResultsToS3(results map[string][]byte, key string) error {
+	for filename, data := range results {
+		session, err := aws.CcsAwsSession.GetSession()
+		if err != nil {
+			return fmt.Errorf("error getting aws session: %v", err)
+		}
+		err = aws.WriteToS3Session(session, aws.CreateS3URL(viper.GetString(config.Tests.LogBucket), key, filepath.Base(filename)), data)
+		if err != nil {
+			return fmt.Errorf("error while uploading log files to s3: %v", err)
+		}
+	}
+	return nil
 }

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -1263,9 +1263,13 @@ func (o *OCMProvider) AddProperty(cluster *spi.Cluster, tag string, value string
 	}
 
 	if viper.GetString(config.JobName) != "" {
+		session, err := aws.MetricsAWSSession.GetSession()
+		if err != nil {
+			return fmt.Errorf("failed to create metrics s3 session: %v", err)
+		}
 		propertyFilename := fmt.Sprintf("%s.osde2e-cluster-property-update.metrics.prom", cluster.ID())
 		data := fmt.Sprintf("# TYPE cicd_cluster_properties gauge\ncicd_cluster_properties{cluster_id=\"%s\",environment=\"%s\",job_id=\"%s\",property=\"%s\",region=\"%s\",value=\"%s\",version=\"%s\"} 0\n", cluster.ID(), o.Environment(), viper.GetString(config.JobID), tag, cluster.Region(), value, cluster.Version())
-		err = aws.WriteToS3(aws.CreateS3URL(viper.GetString(config.Tests.MetricsBucket), "incoming", propertyFilename), []byte(data))
+		err = aws.WriteToS3Session(session, aws.CreateS3URL(viper.GetString(config.Tests.MetricsBucket), "incoming", propertyFilename), []byte(data))
 		if err != nil {
 			return fmt.Errorf("failed to upload cluster property metrics: %v", err)
 		}

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -1043,12 +1043,17 @@ func checkBeforeMetricsGeneration() error {
 
 // uploadFileToMetricsBucket uploads the given file (with absolute path) to the metrics S3 bucket "incoming" directory.
 func uploadFileToMetricsBucket(filename string) error {
+	session, err := aws.MetricsAWSSession.GetSession()
+	if err != nil {
+		return fmt.Errorf("failed to create metrics s3 session: %v", err)
+	}
+
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}
 
-	return aws.WriteToS3(aws.CreateS3URL(viper.GetString(config.Tests.MetricsBucket), "incoming", filepath.Base(filename)), data)
+	return aws.WriteToS3Session(session, aws.CreateS3URL(viper.GetString(config.Tests.MetricsBucket), "incoming", filepath.Base(filename)), data)
 }
 
 // setupRouteMonitors initializes performance+availability monitoring of cluster routes,

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			ginkgo.By("Writing results")
 			h.WriteResults(results)
 			if config.Tests.LogBucket != "" {
-				err = h.UploadResultsToS3(results, harnessImage+time.DateTime)
+				err = h.UploadResultsToS3(results, harnessImage+time.Now().Format(time.DateOnly+"_"+time.TimeOnly))
 				if err != nil {
 					ginkgo.GinkgoLogr.Error(err, fmt.Sprintf("reporting error"))
 				}

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -87,6 +88,12 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			Expect(err).NotTo(HaveOccurred(), "Could not read results")
 			ginkgo.By("Writing results")
 			h.WriteResults(results)
+			if config.Tests.LogBucket != "" {
+				err = h.UploadResultsToS3(results, harnessImage+time.DateTime)
+				if err != nil {
+					ginkgo.GinkgoLogr.Error(err, fmt.Sprintf("reporting error"))
+				}
+			}
 		},
 		HarnessEntries)
 

--- a/pkg/reporting/generate_report.go
+++ b/pkg/reporting/generate_report.go
@@ -55,8 +55,12 @@ func GenerateReport(reporterName string, reportType string) ([]byte, error) {
 
 // WriteReport will write the raw report to a given output.
 func WriteReport(report []byte, output string) error {
+	session, err := aws.MetricsAWSSession.GetSession()
+	if err != nil {
+		return fmt.Errorf("failed to create metrics s3 session: %v", err)
+	}
 	if strings.HasPrefix(output, "s3") {
-		aws.WriteToS3(output, report)
+		aws.WriteToS3Session(session, output, report)
 	} else {
 		writer, err := createWriter(output)
 		if err != nil {


### PR DESCRIPTION
Why?:

- E2e harness jobs running on tekton do not provide any useful logs nor junit result files. Result files are immediately destroyed after job runs, pod logs are destroyed on hive on next run. 
- This s3 PR is a viable option to persist pod logs from tekton jobs at this point.

What?:

- IF “LOG_BUCKET” is provided, result files will get uploaded under job folder in s3
- Files will be deleted after one month, this is set by a Lifecycle Rule on the bucket.
- Reuses existing code to upload things to s3 


Alternative solution to blocking card https://issues.redhat.com/browse/APPSRE-8362 