### PR TITLE
Update e2e-suite config to use migrated operators' test harnesses

### DIFF
--- a/configs/e2e-suite.yaml
+++ b/configs/e2e-suite.yaml
@@ -1,3 +1,15 @@
 tests:
   ginkgoLabelFilter: >
-    (E2E || Operators || ServiceDefinition || AppBuilds) && !Informing
+    (E2E || Operators || TestHarness || ServiceDefinition || AppBuilds) && !Informing && !MigratedHarness
+  testHarnesses:
+  #    For migrated harnesses, remember to add "MigratedHarness" label to existing suite in this repo, until they are removed from here.
+    - quay.io/app-sre/aws-vpce-operator-test-harness
+    - quay.io/app-sre/custom-domains-operator-test-harness
+    - quay.io/app-sre/managed-node-metadata-operator-test-harness
+    - quay.io/app-sre/managed-upgrade-operator-test-harness
+    - quay.io/app-sre/must-gather-operator-test-harness
+    - quay.io/app-sre/ocm-agent-operator-test-harness
+    - quay.io/app-sre/osd-metrics-exporter-test-harness
+    - quay.io/app-sre/rbac-permissions-operator-test-harness
+    - quay.io/app-sre/splunk-forwarder-operator-test-harness
+  suiteTimeout: 900


### PR DESCRIPTION
In preparation to this change, an identical config named complete-e2e.yaml is [tested  reliably](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-osde2e-main-rosa-stage-complete-e2e/1724336521005240320) over last few weeks. 

This change updates e2e-suite.yaml config to use test harnesses (only) for the migrated operators. Provides all migrated harnesses, labels and a timeout. 


https://issues.redhat.com/browse/SDCICD-1161 

Converted to draft pending https://github.com/openshift/osde2e/pull/2247 