### PR TITLE
Fix false positive in harness osde2e runs

### DIFF
--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/joshdk/go-junit"
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	projectv1 "github.com/openshift/api/project/v1"
@@ -40,7 +41,7 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 	}
 	fmt.Println("Harnesses to run: ", harnesses)
 	for _, harness := range harnesses {
-		HarnessEntries = append(HarnessEntries, ginkgo.Entry("should run "+harness+" successfully", harness))
+		HarnessEntries = append(HarnessEntries, ginkgo.Entry(harness+" should pass", harness))
 	}
 
 	ginkgo.BeforeAll(func(ctx context.Context) {
@@ -85,6 +86,15 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			ginkgo.By("Retrieving results from test pod")
 			results, err := r.RetrieveResults()
 			Expect(err).NotTo(HaveOccurred(), "Could not read results")
+			// Adding harness report failures to top level junit report
+			for _, data := range results {
+				suites, _ := junit.Ingest(data)
+				for _, suite := range suites {
+					for _, testcase := range suite.Tests {
+						Expect(testcase.Error).To(BeNil(), "Assertion failed: "+testcase.Name)
+					}
+				}
+			}
 			ginkgo.By("Writing results")
 			h.WriteResults(results)
 		},


### PR DESCRIPTION
What: Adding harness report failures to top level junit report. Adding snippet in harness result handling to insert failures for respective harnesses in the main junit report file. 


Why:
Currently failed harness test specs don't reflect in the main result file giving a false overall positive/green tho a harness assertion fails. 

--

Blocks https://issues.redhat.com/browse/SDCICD-1161