### PR TITLE
fix config name for harness timeout - for another config file

### DIFF
--- a/configs/e2e-suite.yaml
+++ b/configs/e2e-suite.yaml
@@ -12,4 +12,4 @@ tests:
     - quay.io/app-sre/osd-metrics-exporter-test-harness
     - quay.io/app-sre/rbac-permissions-operator-test-harness
     - quay.io/app-sre/splunk-forwarder-operator-test-harness
-  suiteTimeout: 900
+  harnessTimeout: 900


### PR DESCRIPTION
harness timeout should be tests.harnessTimeout not suiteTimeout as specified here https://github.com/openshift/osde2e/blob/9e6a51260aef0717635ea43448cbbc8e8f1baae4/pkg/e2e/harness_runner/harness_runner.go#L38

This is causing MNMO harness to timeout at 300 seconds 

Fixing this issue


