### PR TITLE
osde2e cleanup command for iam resources

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -28,8 +28,8 @@ var args struct {
 	secretLocations string
 	clusterID       string
 	iam             bool
-	olderThan       int
-	dryrun          bool
+	iamOlderThan    int
+	iamDryRun       bool
 }
 
 func init() {
@@ -66,14 +66,14 @@ func init() {
 		"Cleanup iam resources",
 	)
 	flags.IntVar(
-		&args.olderThan,
-		"older-than",
+		&args.iamOlderThan,
+		"iam-older-than",
 		1,
 		"Cleanup iam resources older than this number of days",
 	)
 	flags.BoolVar(
-		&args.dryrun,
-		"dry-run",
+		&args.iamDryRun,
+		"iam-dry-run",
 		true,
 		"Show dry run log of deleting iam resources",
 	)
@@ -126,20 +126,20 @@ func run(cmd *cobra.Command, argv []string) error {
 			}
 		}
 	} else {
-		hours := strconv.Itoa(args.olderThan * 24)
+		hours := strconv.Itoa(args.iamOlderThan * 24)
 		fmthours, err := time.ParseDuration(hours + "h")
 		if err != nil {
 			return fmt.Errorf("Could not parse older-than value to time duration. Please provide a number.")
 		}
-		err = aws.CcsAwsSession.CleanupOpenIDConnectProviders(fmthours, args.dryrun)
+		err = aws.CcsAwsSession.CleanupOpenIDConnectProviders(fmthours, args.iamDryRun)
 		if err != nil {
 			return fmt.Errorf("Could not delete OIDC providers: %s", err.Error())
 		}
-		err = aws.CcsAwsSession.CleanupRoles(fmthours, args.dryrun)
+		err = aws.CcsAwsSession.CleanupRoles(fmthours, args.iamDryRun)
 		if err != nil {
 			return fmt.Errorf("Could not delete IAM roles: %s", err.Error())
 		}
-		err = aws.CcsAwsSession.CleanupPolicies(fmthours, args.dryrun)
+		err = aws.CcsAwsSession.CleanupPolicies(fmthours, args.iamDryRun)
 		if err != nil {
 			return fmt.Errorf("Could not delete IAM policies: %s", err.Error())
 		}

--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -3,9 +3,11 @@ package cleanup
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/openshift/osde2e/cmd/osde2e/common"
+	"github.com/openshift/osde2e/pkg/common/aws"
 	"github.com/openshift/osde2e/pkg/common/metadata"
 	"github.com/openshift/osde2e/pkg/common/providers"
 	"github.com/openshift/osde2e/pkg/common/spi"
@@ -25,6 +27,9 @@ var args struct {
 	customConfig    string
 	secretLocations string
 	clusterID       string
+	iam             bool
+	olderThan       int
+	dryrun          bool
 }
 
 func init() {
@@ -54,54 +59,90 @@ func init() {
 		"",
 		"A specific cluster id to cleanup",
 	)
-
+	flags.BoolVar(
+		&args.iam,
+		"iam",
+		false,
+		"Cleanup iam resources",
+	)
+	flags.IntVar(
+		&args.olderThan,
+		"older-than",
+		1,
+		"Cleanup iam resources older than this number of days",
+	)
+	flags.BoolVar(
+		&args.dryrun,
+		"dry-run",
+		true,
+		"Show dry run log of deleting iam resources",
+	)
 	Cmd.RegisterFlagCompletionFunc("output-format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json", "prom"}, cobra.ShellCompDirectiveDefault
 	})
 }
 
 func run(cmd *cobra.Command, argv []string) error {
-	var provider spi.Provider
-	var err error
-	if err = common.LoadConfigs(args.configString, args.customConfig, args.secretLocations); err != nil {
-		return fmt.Errorf("error loading initial state: %v", err)
-	}
-
-	if provider, err = providers.ClusterProvider(); err != nil {
-		return fmt.Errorf("could not setup cluster provider: %v", err)
-	}
-
-	metadata.Instance.SetEnvironment(provider.Environment())
-
-	if args.clusterID == "" {
-		clusters, err := provider.ListClusters("properties.MadeByOSDe2e='true'")
-		if err != nil {
-			return err
+	if !args.iam {
+		var provider spi.Provider
+		var err error
+		if err = common.LoadConfigs(args.configString, args.customConfig, args.secretLocations); err != nil {
+			return fmt.Errorf("error loading initial state: %v", err)
 		}
 
-		now := time.Now()
+		if provider, err = providers.ClusterProvider(); err != nil {
+			return fmt.Errorf("could not setup cluster provider: %v", err)
+		}
 
-		for _, cluster := range clusters {
-			if !cluster.ExpirationTimestamp().IsZero() && now.UTC().After(cluster.ExpirationTimestamp().UTC()) {
-				log.Printf("%s %s has expired. Deleting cluster...", cluster.ID(), cluster.Name())
-				if err := provider.DeleteCluster(cluster.ID()); err != nil {
-					log.Printf("Error deleting cluster: %s", err.Error())
+		metadata.Instance.SetEnvironment(provider.Environment())
+
+		if args.clusterID == "" {
+			clusters, err := provider.ListClusters("properties.MadeByOSDe2e='true'")
+			if err != nil {
+				return err
+			}
+
+			now := time.Now()
+
+			for _, cluster := range clusters {
+				if !cluster.ExpirationTimestamp().IsZero() && now.UTC().After(cluster.ExpirationTimestamp().UTC()) {
+					log.Printf("%s %s has expired. Deleting cluster...", cluster.ID(), cluster.Name())
+					if err := provider.DeleteCluster(cluster.ID()); err != nil {
+						log.Printf("Error deleting cluster: %s", err.Error())
+					}
 				}
+			}
+		} else {
+			cluster, err := provider.GetCluster(args.clusterID)
+			if err != nil {
+				log.Printf("Cluster id: %s not found, unable to delete it", args.clusterID)
+				return err
+			}
+
+			log.Printf("Deleting cluster id: %s, name: %s", cluster.ID(), cluster.Name())
+			if err = provider.DeleteCluster(cluster.ID()); err != nil {
+				log.Printf("Failed to delete cluster id: %s, error: %v", cluster.ID(), err)
+				return err
 			}
 		}
 	} else {
-		cluster, err := provider.GetCluster(args.clusterID)
+		hours := strconv.Itoa(args.olderThan * 24)
+		fmthours, err := time.ParseDuration(hours + "h")
 		if err != nil {
-			log.Printf("Cluster id: %s not found, unable to delete it", args.clusterID)
-			return err
+			return fmt.Errorf("Could not parse older-than value to time duration. Please provide a number.")
 		}
-
-		log.Printf("Deleting cluster id: %s, name: %s", cluster.ID(), cluster.Name())
-		if err = provider.DeleteCluster(cluster.ID()); err != nil {
-			log.Printf("Failed to delete cluster id: %s, error: %v", cluster.ID(), err)
-			return err
+		err = aws.CcsAwsSession.CleanupOpenIDConnectProviders(fmthours, args.dryrun)
+		if err != nil {
+			return fmt.Errorf("Could not delete OIDC providers: %s", err.Error())
+		}
+		err = aws.CcsAwsSession.CleanupRoles(fmthours, args.dryrun)
+		if err != nil {
+			return fmt.Errorf("Could not delete IAM roles: %s", err.Error())
+		}
+		err = aws.CcsAwsSession.CleanupPolicies(fmthours, args.dryrun)
+		if err != nil {
+			return fmt.Errorf("Could not delete IAM policies: %s", err.Error())
 		}
 	}
-
 	return nil
 }

--- a/pkg/common/aws/iam.go
+++ b/pkg/common/aws/iam.go
@@ -27,7 +27,6 @@ func (CcsAwsSession *ccsAwsSession) CleanupOpenIDConnectProviders(olderthan time
 	}
 
 	for _, provider := range result.OpenIDConnectProviderList {
-		// Create GetOpenIDConnectProviderInput struct
 		input := &iam.GetOpenIDConnectProviderInput{
 			OpenIDConnectProviderArn: provider.Arn,
 		}
@@ -43,7 +42,6 @@ func (CcsAwsSession *ccsAwsSession) CleanupOpenIDConnectProviders(olderthan time
 			fmt.Printf("Provider will be deleted: %s\n", *provider.Arn)
 
 			if !dryrun {
-				// Create DeleteOpenIDConnectProviderInput struct
 				input := &iam.DeleteOpenIDConnectProviderInput{
 					OpenIDConnectProviderArn: provider.Arn,
 				}
@@ -91,7 +89,6 @@ func (CcsAwsSession *ccsAwsSession) CleanupRoles(olderthan time.Duration, dryrun
 				fmt.Println("Removing role from instance profile: ", *instanceProfile.InstanceProfileName)
 
 				if !dryrun {
-					// Create RemoveRoleFromInstanceProfileInput struct
 					removeRoleFromInstanceProfileInput := &iam.RemoveRoleFromInstanceProfileInput{
 						InstanceProfileName: instanceProfile.InstanceProfileName,
 						RoleName:            role.RoleName,

--- a/pkg/common/aws/iam.go
+++ b/pkg/common/aws/iam.go
@@ -1,0 +1,209 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+)
+
+var (
+	rolesubstr     = "osde2e"
+	providersubstr = "cloudfront"
+)
+
+func (CcsAwsSession *ccsAwsSession) CleanupOpenIDConnectProviders(olderthan time.Duration, dryrun bool) error {
+	err := CcsAwsSession.GetAWSSessions()
+	if err != nil {
+		return err
+	}
+
+	input := &iam.ListOpenIDConnectProvidersInput{}
+	result, err := CcsAwsSession.iam.ListOpenIDConnectProviders(input)
+	if err != nil {
+		return err
+	}
+
+	for _, provider := range result.OpenIDConnectProviderList {
+		// Create GetOpenIDConnectProviderInput struct
+		input := &iam.GetOpenIDConnectProviderInput{
+			OpenIDConnectProviderArn: provider.Arn,
+		}
+
+		// Get the provider
+		result, err := CcsAwsSession.iam.GetOpenIDConnectProvider(input)
+		if err != nil {
+			return err
+		}
+
+		// If provider name contains "cloudfront" and is older than given days, delete it
+		if strings.Contains(*result.Url, providersubstr) && time.Since(*result.CreateDate) > olderthan {
+			fmt.Printf("Provider will be deleted: %s\n", *provider.Arn)
+
+			if !dryrun {
+				// Create DeleteOpenIDConnectProviderInput struct
+				input := &iam.DeleteOpenIDConnectProviderInput{
+					OpenIDConnectProviderArn: provider.Arn,
+				}
+				_, err := CcsAwsSession.iam.DeleteOpenIDConnectProvider(input)
+				if err != nil {
+					return err
+				}
+				fmt.Println("Deleted")
+			}
+		}
+	}
+
+	return nil
+}
+
+func (CcsAwsSession *ccsAwsSession) CleanupRoles(olderthan time.Duration, dryrun bool) error {
+	err := CcsAwsSession.GetAWSSessions()
+	if err != nil {
+		return err
+	}
+
+	input := &iam.ListRolesInput{
+		MaxItems: aws.Int64(1000),
+	}
+	result, err := CcsAwsSession.iam.ListRoles(input)
+	if err != nil {
+		return err
+	}
+
+	for _, role := range result.Roles {
+		if strings.Contains(*role.Arn, rolesubstr) && time.Since(*role.CreateDate) > olderthan {
+			fmt.Printf("Role will be deleted: %s\n", *role.RoleName)
+
+			// Remove Roles from Instance Profiles
+			instanceProfilesForRoleInputinput := &iam.ListInstanceProfilesForRoleInput{
+				RoleName: role.RoleName,
+			}
+			instanceProfiles, errInstanceProfiles := CcsAwsSession.iam.ListInstanceProfilesForRole(instanceProfilesForRoleInputinput)
+
+			if errInstanceProfiles != nil {
+				return fmt.Errorf("error getting instance profiles for role: %s", errInstanceProfiles)
+			}
+
+			for _, instanceProfile := range instanceProfiles.InstanceProfiles {
+				fmt.Println("Removing role from instance profile: ", *instanceProfile.InstanceProfileName)
+
+				if !dryrun {
+					// Create RemoveRoleFromInstanceProfileInput struct
+					removeRoleFromInstanceProfileInput := &iam.RemoveRoleFromInstanceProfileInput{
+						InstanceProfileName: instanceProfile.InstanceProfileName,
+						RoleName:            role.RoleName,
+					}
+					_, errRemoveRoleFromInstanceProfile := CcsAwsSession.iam.RemoveRoleFromInstanceProfile(removeRoleFromInstanceProfileInput)
+					if errRemoveRoleFromInstanceProfile != nil {
+						return fmt.Errorf("error removing role from instance profile: %s", errRemoveRoleFromInstanceProfile)
+					}
+					fmt.Println("Removed")
+				}
+
+			}
+
+			// Delete policy inline to the role
+			inlineRolePoliciesInput := &iam.ListRolePoliciesInput{
+				RoleName: role.RoleName,
+			}
+			inlinePolicies, errInlineRolePoliciesInput := CcsAwsSession.iam.ListRolePolicies(inlineRolePoliciesInput)
+
+			if errInlineRolePoliciesInput != nil {
+				return errInlineRolePoliciesInput
+			}
+
+			for _, policy := range inlinePolicies.PolicyNames {
+				fmt.Println("Inline policy will be deleted: ", *policy)
+
+				if !dryrun {
+					input := &iam.DeleteRolePolicyInput{
+						PolicyName: policy,
+						RoleName:   role.RoleName,
+					}
+					_, errInlinePolicies := CcsAwsSession.iam.DeleteRolePolicy(input)
+					if errInlinePolicies != nil {
+						return fmt.Errorf("error deleting inline policy: %s", errInlinePolicies)
+					}
+					fmt.Println("Deleted")
+				}
+			}
+
+			// Delete policy attached to the role
+			attachedRolePoliciesInput := &iam.ListAttachedRolePoliciesInput{
+				RoleName: role.RoleName,
+			}
+			attachedPolicies, errAttachedRolePoliciesInput := CcsAwsSession.iam.ListAttachedRolePolicies(attachedRolePoliciesInput)
+			if errAttachedRolePoliciesInput != nil {
+				return errAttachedRolePoliciesInput
+			}
+
+			for _, policy := range attachedPolicies.AttachedPolicies {
+				fmt.Println("Policy will be detached: ", *policy.PolicyName)
+
+				if !dryrun {
+					detachInput := &iam.DetachRolePolicyInput{
+						PolicyArn: policy.PolicyArn,
+						RoleName:  role.RoleName,
+					}
+					_, errAttachedPolicies := CcsAwsSession.iam.DetachRolePolicy(detachInput)
+					if errAttachedPolicies != nil {
+						return errAttachedPolicies
+					}
+					time.Sleep(2 * time.Second)
+					fmt.Println("Detached")
+				}
+			}
+
+			if !dryrun {
+				roleInput := &iam.DeleteRoleInput{
+					RoleName: role.RoleName,
+				}
+				// Delete the role
+				_, err = CcsAwsSession.iam.DeleteRole(roleInput)
+				if err != nil {
+					return err
+				}
+				fmt.Println("Deleted role")
+			}
+		}
+	}
+
+	return nil
+}
+
+func (CcsAwsSession *ccsAwsSession) CleanupPolicies(olderthan time.Duration, dryrun bool) error {
+	err := CcsAwsSession.GetAWSSessions()
+	if err != nil {
+		return err
+	}
+	input := &iam.ListPoliciesInput{
+		MaxItems: aws.Int64(1000),
+	}
+	result, err := CcsAwsSession.iam.ListPolicies(input)
+	if err != nil {
+		return err
+	}
+
+	for _, policy := range result.Policies {
+		if strings.Contains(*policy.Arn, rolesubstr) && time.Since(*policy.CreateDate) > olderthan {
+			fmt.Printf("Policy will be deleted: %s", *policy.PolicyName)
+
+			if !dryrun {
+				input := &iam.DeletePolicyInput{
+					PolicyArn: policy.Arn,
+				}
+				// Delete the policy
+				_, err := CcsAwsSession.iam.DeletePolicy(input)
+				if err != nil {
+					return err
+				}
+				fmt.Println("Deleted")
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Note to reviewers: Please view diff with w=1 (by default the diff is space-based and shows code replaced rather moved/indented) 
https://github.com/openshift/osde2e/pull/2300/files?w=1

- Added following iam cleanup related flags to existing osde2e cleanup command
```
      --iam-dry-run                   Show dry run log of deleting iam resources (default true)
      --iam                          Cleanup iam resources
      --iam-older-than int         Cleanup iam resources older than this number of days (default 1)
```

 `./osde2e cleanup --iam`   deletes 

- oidc provider
- role (and detaches any policies) 
- policy 

 older than 24 hours
 
  `./osde2e cleanup --iam --iam-older-than 0`   deletes 

all the above osde2e-related resources without time filter

  `./osde2e cleanup --iam --iam-dry-run`   shows what will be deleted 


https://issues.redhat.com/browse/SDCICD-1206

 