### PR TITLE
Update osde2e-common

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/openshift/custom-domains-operator v0.0.0-20221118201157-bd1052dac818
 	github.com/openshift/managed-upgrade-operator v0.0.0-20230525042514-a9b8c1d2571c
 	github.com/openshift/must-gather-operator v0.1.2-0.20221011152618-7805956e1ded
-	github.com/openshift/osde2e-common v0.0.0-20240111205449-2d6094e0e389
+	github.com/openshift/osde2e-common v0.0.0-20240122091653-ac2a77b4ad4d
 	github.com/openshift/route-monitor-operator v0.0.0-20221118160357-3df1ed1fa1d2
 	github.com/openshift/splunk-forwarder-operator v0.0.0-20230525060151-2dc403aa8ff9
 	github.com/operator-framework/api v0.17.7

--- a/go.sum
+++ b/go.sum
@@ -679,6 +679,8 @@ github.com/openshift/must-gather-operator v0.1.2-0.20221011152618-7805956e1ded h
 github.com/openshift/must-gather-operator v0.1.2-0.20221011152618-7805956e1ded/go.mod h1:LHntdQf5jrwxpmyVMbwXUK491COBJ7buHvyi4YLlHho=
 github.com/openshift/osde2e-common v0.0.0-20240111205449-2d6094e0e389 h1:RuqZWven2AKLwOCWGBagVEv/4adWbmYIyZNE8eUPxCs=
 github.com/openshift/osde2e-common v0.0.0-20240111205449-2d6094e0e389/go.mod h1:lzmkYjtdf0EgPnoujLNAzorq/7vygGCcgceo/dQI1d0=
+github.com/openshift/osde2e-common v0.0.0-20240122091653-ac2a77b4ad4d h1:QKnQTXXOF/fHSr1vyY1TEmag6X3Hk1XErllqQQVxYqs=
+github.com/openshift/osde2e-common v0.0.0-20240122091653-ac2a77b4ad4d/go.mod h1:lzmkYjtdf0EgPnoujLNAzorq/7vygGCcgceo/dQI1d0=
 github.com/openshift/route-monitor-operator v0.0.0-20221118160357-3df1ed1fa1d2 h1:s97F2fQ5r+XGVfWDy5wgH611iIvIDusQcHtv5jJ36uw=
 github.com/openshift/route-monitor-operator v0.0.0-20221118160357-3df1ed1fa1d2/go.mod h1:I/8znbaxMGRub27brm57UnkR48QZEWO26j2HRscy5bQ=
 github.com/openshift/splunk-forwarder-operator v0.0.0-20230525060151-2dc403aa8ff9 h1:u7XXBdFB+uoA+YcvDjqmfhAJsZTGGGQOBqIXSBT4EUQ=


### PR DESCRIPTION
This version fixes a bug with hypershift-pr-check that was preventing us from provisioning ROSA HCP clusters that required managed policies.

The related osde2e-common PR was: https://github.com/openshift/osde2e-common/pull/60

OSD-20366