### PR TITLE
skip cleanup, return early for provision only

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -442,6 +442,10 @@ func runGinkgoTests() (int, error) {
 		getLogs()
 		viper.Set(config.Cluster.Passing, testsPassed)
 	}
+	if viper.GetBool(config.Cluster.ProvisionOnly) {
+		log.Println("Provision only execution finished, exiting.")
+		return Success, nil
+	}
 	upgradeTestsPassed := true
 	var upgradeTestCaseData []db.CreateTestcaseParams
 
@@ -576,7 +580,7 @@ func runGinkgoTests() (int, error) {
 			}
 		}
 	}
-
+	// Cleanup
 	if !suiteConfig.DryRun {
 		getLogs()
 


### PR DESCRIPTION
provision only excution update: skip cleanup and metrics steps for a "provision only" job.  



[SDCICD-1201](https://issues.redhat.com//browse/SDCICD-1201)