### PR TITLE
logging to debug shared-dir

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -544,20 +544,24 @@ func ProvisionCluster(logger *log.Logger) (*spi.Cluster, error) {
 	// get cluster ID from env
 	clusterID := viper.GetString(config.Cluster.ID)
 	// get cluster id from shared_dir (used in prow multi-step jobs
+	log.Printf("cluster id:%s shared dir:%s", clusterID, viper.GetString(config.SharedDir))
 	if clusterID != "" && viper.GetString(config.SharedDir) != "" {
 		sharedClusterIdPath := viper.GetString(config.SharedDir) + "/cluster-id"
 		_, err := os.Stat(sharedClusterIdPath)
 		if err == nil {
 			clusteridbytes, err := os.ReadFile(sharedClusterIdPath)
 			if err == nil {
-				fmt.Printf("cluster-id found in SHARED_DIR")
 				clusterID = string(clusteridbytes)
+				fmt.Printf("cluster-id found in SHARED_DIR %s", clusterID)
 				viper.Set(config.Cluster.ID, clusterID)
+			} else {
+				log.Printf("could not read from shared cluster-id: %s", err.Error())
 			}
 		}
 	}
 	// create a new cluster if no ID is specified
 	if clusterID == "" {
+		fmt.Printf("no clusterid found, provisioning cluster")
 		name := viper.GetString(config.Cluster.Name)
 		if name == "" || name == "random" {
 			attemptLimit := 10

--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -545,7 +545,7 @@ func ProvisionCluster(logger *log.Logger) (*spi.Cluster, error) {
 	clusterID := viper.GetString(config.Cluster.ID)
 	// get cluster id from shared_dir (used in prow multi-step jobs
 	log.Printf("cluster id:%s shared dir:%s", clusterID, viper.GetString(config.SharedDir))
-	if clusterID != "" && viper.GetString(config.SharedDir) != "" {
+	if clusterID == "" && viper.GetString(config.SharedDir) != "" {
 		sharedClusterIdPath := viper.GetString(config.SharedDir) + "/cluster-id"
 		_, err := os.Stat(sharedClusterIdPath)
 		if err == nil {

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -102,7 +102,11 @@ func beforeSuite() bool {
 		if viper.GetString(config.SharedDir) != "" {
 			if err = os.WriteFile(fmt.Sprintf("%s/cluster-id", viper.GetString(config.SharedDir)), []byte(cluster.ID()), 0o644); err != nil {
 				log.Printf("Error writing cluster ID to shared directory: %v", err)
+			} else {
+				log.Printf("Wrote cluster ID to shared dir: %v", cluster.ID())
 			}
+		} else {
+			log.Printf("No shared directory provided, skip writing cluster ID")
 		}
 
 		viper.Set(config.Cluster.Name, cluster.Name())


### PR DESCRIPTION
added log statements to ensure osde2e is writing to and reading from shared-dir in multi step job 