### PR TITLE
reuse existing osd-cluster-ready loop from osde2e-common

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -119,11 +119,6 @@ func WaitForClusterReadyPostInstall(clusterID string, logger *log.Logger) error 
 		return fmt.Errorf("error generating Kube Clientset: %w", err)
 	}
 
-	duration, err := time.ParseDuration(viper.GetString(config.Tests.ClusterHealthChecksTimeout))
-	if err != nil {
-		return fmt.Errorf("failed parsing health check timeout: %w", err)
-	}
-
 	if viper.GetBool(config.Hypershift) {
 		logger.Println("Waiting for nodes to be ready (up to 10 minutes)")
 		err := wait.PollImmediate(30*time.Second, 10*time.Minute, func() (bool, error) {
@@ -151,9 +146,7 @@ func WaitForClusterReadyPostInstall(clusterID string, logger *log.Logger) error 
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), duration)
-	defer cancel()
-	err = healthchecks.CheckHealthcheckJob(kubeClient, ctx, nil)
+	err = healthchecks.CheckHealthcheckJob(kubeClient, context.Background(), nil)
 	if err != nil {
 		return fmt.Errorf("cluster failed health check: %w", err)
 	}

--- a/pkg/e2e/openshift/osdclusterready.go
+++ b/pkg/e2e/openshift/osdclusterready.go
@@ -3,12 +3,13 @@ package openshift
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/openshift/osde2e-common/pkg/clients/openshift"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -32,15 +33,7 @@ var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.OCPNightlyBlocking, fun
 	})
 
 	ginkgo.It("should verify cluster is ready", func(ctx context.Context) {
-		joberr := k8s.WatchJob(ctx, namespace, jobname)
-		if joberr != nil {
-			logs, err := k8s.GetJobLogs(ctx, jobname, namespace)
-			if err != nil {
-				ginkgo.GinkgoLogr.Error(fmt.Errorf("could not get osd-cluster-ready logs"), err.Error())
-			} else {
-				ginkgo.GinkgoLogr.Info("job log:", logs)
-			}
-		}
+		joberr := k8s.OSDClusterHealthy(ctx, jobname, viper.GetString(config.ReportDir), timeout)
 		Expect(joberr).ShouldNot(HaveOccurred(), "osd-cluster-ready job did not succeed")
-	}, ginkgo.SpecTimeout(timeout))
+	})
 })


### PR DESCRIPTION
Reusing existing logic in osde2e-common for osdClusterReady check

Rewrite of this logic in osde2e is redundant. 