### PR TITLE
Update timeout to 60 mins for cluster ready check

### DIFF
--- a/pkg/e2e/openshift/osdclusterready.go
+++ b/pkg/e2e/openshift/osdclusterready.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	suiteName = "OSD Cluster Ready"
-	timeout   = 30 * time.Minute
+	timeout   = 60 * time.Minute
 	namespace = "openshift-monitoring"
 	jobname   = "osd-cluster-ready"
 )


### PR DESCRIPTION
Increase the timeout to 60 minutes for the cluster ready check. 

The current setting caused the cluster health check to fail at the 38 min in the `periodic-ci-openshift-osde2e-main-nightly-4.15-conformance-rosa-classic-sts` rehearse job.

[SDCICD-1200](https://issues.redhat.com/browse/SDCICD-1200)