### PR TITLE
load secret locations from vault when running on prow jobs

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -82,13 +82,12 @@ func init() {
 }
 
 func run(cmd *cobra.Command, argv []string) error {
+	var err error
+	if err = common.LoadConfigs(args.configString, args.customConfig, args.secretLocations); err != nil {
+		return fmt.Errorf("error loading initial state: %v", err)
+	}
 	if !args.iam {
 		var provider spi.Provider
-		var err error
-		if err = common.LoadConfigs(args.configString, args.customConfig, args.secretLocations); err != nil {
-			return fmt.Errorf("error loading initial state: %v", err)
-		}
-
 		if provider, err = providers.ClusterProvider(); err != nil {
 			return fmt.Errorf("could not setup cluster provider: %v", err)
 		}


### PR DESCRIPTION
[sdcicd-1206](https://issues.redhat.com//browse/sdcicd-1206)

osdctl cleanup --iam  command should load configs so that AWS creds can be read into  aws session