### PR TITLE
option 2: spike running ocp conformance with osde2e  

### DIFF
--- a/cmd/osde2e/test/cmd.go
+++ b/cmd/osde2e/test/cmd.go
@@ -53,6 +53,7 @@ var args struct {
 	focusTests         string
 	skipTests          string
 	labelFilter        string
+	ocpTestSuite       string
 }
 
 func init() {
@@ -123,6 +124,12 @@ func init() {
 		"Only run any Ginkgo tests whose names matching the regular expression",
 	)
 	pfs.StringVar(
+		&args.ocpTestSuite,
+		"ocp-test-suite",
+		"",
+		"The type of openshift-test conformance suite to run.",
+	)
+	pfs.StringVar(
 		&args.skipTests,
 		"skip-tests",
 		"",
@@ -148,6 +155,7 @@ func init() {
 	viper.BindPFlag(config.Cluster.ProvisionOnly, Cmd.PersistentFlags().Lookup("provision-only"))
 	viper.BindPFlag(config.Tests.SkipClusterHealthChecks, Cmd.PersistentFlags().Lookup("skip-health-check"))
 	viper.BindPFlag(config.Tests.GinkgoFocus, Cmd.PersistentFlags().Lookup("focus-tests"))
+	viper.BindPFlag(config.Tests.OCPTestSuite, Cmd.PersistentFlags().Lookup("ocp-test-suite"))
 	viper.BindPFlag(config.Tests.GinkgoSkip, Cmd.PersistentFlags().Lookup("skip-tests"))
 	viper.BindPFlag(config.SkipMustGather, Cmd.PersistentFlags().Lookup("skip-must-gather"))
 	viper.BindPFlag(config.Tests.GinkgoLabelFilter, Cmd.PersistentFlags().Lookup("label-filter"))

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -250,6 +250,11 @@ var Tests = struct {
 	// Env: TESTS_TO_RUN
 	TestsToRun string
 
+	// OCPTestSuite Is the conformance suite to pass to "openshift-test" command. ex. "Operator"
+	// Env: OCP_TEST_SUITE
+	// arg --ocp-test-suite
+	OCPTestSuite string
+
 	// SuppressSkipNotifications suppresses the notifications of skipped tests
 	// Env: SUPPRESS_SKIP_NOTIFICATIONS
 	SuppressSkipNotifications string
@@ -295,6 +300,7 @@ var Tests = struct {
 	GinkgoLogLevel:             "tests.ginkgoLogLevel",
 	GinkgoLabelFilter:          "tests.ginkgoLabelFilter",
 	TestsToRun:                 "tests.testsToRun",
+	OCPTestSuite:               "tests.ocpTestSuite",
 	SuppressSkipNotifications:  "tests.suppressSkipNotifications",
 	CleanRuns:                  "tests.cleanRuns",
 	OperatorSkip:               "tests.operatorSkip",
@@ -719,6 +725,8 @@ func InitOSDe2eViper() {
 	viper.BindEnv(Tests.GinkgoLabelFilter, "GINKGO_LABEL_FILTER")
 
 	viper.BindEnv(Tests.TestsToRun, "TESTS_TO_RUN")
+
+	viper.BindEnv(Tests.OCPTestSuite, "OCP_TEST_SUITE")
 
 	viper.SetDefault(Tests.SuppressSkipNotifications, true)
 	viper.BindEnv(Tests.SuppressSkipNotifications, "SUPPRESS_SKIP_NOTIFICATIONS")

--- a/pkg/e2e/openshift/conformance.go
+++ b/pkg/e2e/openshift/conformance.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/label"
 
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
@@ -71,16 +74,21 @@ var _ = ginkgo.Describe(conformanceK8sTestName, func() {
 	})
 })
 
-var _ = ginkgo.Describe(conformanceOpenshiftTestName, func() {
+var _ = ginkgo.Describe(conformanceOpenshiftTestName, ginkgo.Ordered, label.OCPNightlyBlocking, func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 
 	e2eTimeoutInSeconds := 7200
 	ginkgo.It("should run until completion", func(ctx context.Context) {
+		suite := "suite"
+		testType := "openshift/conformance/parallel"
 		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 		// configure tests
 		cfg := DefaultE2EConfig
-		cfg.Suite = "openshift/conformance/parallel suite"
+		if viper.GetString(config.Tests.OCPTestSuite) != "" {
+			suite = viper.GetString(config.Tests.OCPTestSuite)
+		}
+		cfg.Suite = testType + " " + suite
 		cfg.Name = "openshift-conformance"
 		cmd := cfg.Cmd()
 


### PR DESCRIPTION
Run ocp conformance tests as osde2e test suite in blocking/conformance job

1. `openshift test` is under osde2e "conformance" test suite. 
2. Label "OCPNightlyBlocking" is added to it
3. Suite name can be passed to osde2e, defaulted to "suite"
4. Test type is set to "openshift/conformance/parallel", same as openshift-e2e-test step default. 

[sdcicd-1224](https://issues.redhat.com//browse/sdcicd-1224)