### PR TITLE
added s3 bucket cleanup to osde2e cleanup command

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -27,8 +27,9 @@ var args struct {
 	secretLocations string
 	clusterID       string
 	iam             bool
-	iamOlderThan    string
-	iamDryRun       bool
+	s3              bool
+	olderThan       string
+	dryRun          bool
 }
 
 func init() {
@@ -64,15 +65,21 @@ func init() {
 		false,
 		"Cleanup iam resources",
 	)
+	flags.BoolVar(
+		&args.s3,
+		"s3",
+		false,
+		"Cleanup s3 buckets",
+	)
 	flags.StringVar(
-		&args.iamOlderThan,
-		"iam-older-than",
+		&args.olderThan,
+		"older-than",
 		"24h",
 		"Cleanup iam resources older than this duration. Accepts a sequence of decimal numbers with a unit suffix, such as '2h45m'",
 	)
 	flags.BoolVar(
-		&args.iamDryRun,
-		"iam-dry-run",
+		&args.dryRun,
+		"dry-run",
 		true,
 		"Show dry run log of deleting iam resources",
 	)
@@ -86,7 +93,9 @@ func run(cmd *cobra.Command, argv []string) error {
 	if err = common.LoadConfigs(args.configString, args.customConfig, args.secretLocations); err != nil {
 		return fmt.Errorf("error loading initial state: %v", err)
 	}
-	if !args.iam {
+	// If neither s3 nor iam resources are specified, cluster cleanup is done as follows:
+	// If cluster-id is provided, deletes given cluster. If not, deletes all expired, osde2e owned clusters.
+	if !args.iam && !args.s3 {
 		var provider spi.Provider
 		if provider, err = providers.ClusterProvider(); err != nil {
 			return fmt.Errorf("could not setup cluster provider: %v", err)
@@ -124,21 +133,29 @@ func run(cmd *cobra.Command, argv []string) error {
 			}
 		}
 	} else {
-		fmtDuration, err := time.ParseDuration(args.iamOlderThan)
+		fmtDuration, err := time.ParseDuration(args.olderThan)
 		if err != nil {
 			return fmt.Errorf("Please provide a valid duration string. Valid units are 'm', 'h':  %s", err.Error())
 		}
-		err = aws.CcsAwsSession.CleanupOpenIDConnectProviders(fmtDuration, args.iamDryRun)
-		if err != nil {
-			return fmt.Errorf("Could not delete OIDC providers: %s", err.Error())
+		if args.iam {
+			err = aws.CcsAwsSession.CleanupOpenIDConnectProviders(fmtDuration, args.dryRun)
+			if err != nil {
+				return fmt.Errorf("Could not delete OIDC providers: %s", err.Error())
+			}
+			err = aws.CcsAwsSession.CleanupRoles(fmtDuration, args.dryRun)
+			if err != nil {
+				return fmt.Errorf("Could not delete IAM roles: %s", err.Error())
+			}
+			err = aws.CcsAwsSession.CleanupPolicies(fmtDuration, args.dryRun)
+			if err != nil {
+				return fmt.Errorf("Could not delete IAM policies: %s", err.Error())
+			}
 		}
-		err = aws.CcsAwsSession.CleanupRoles(fmtDuration, args.iamDryRun)
-		if err != nil {
-			return fmt.Errorf("Could not delete IAM roles: %s", err.Error())
-		}
-		err = aws.CcsAwsSession.CleanupPolicies(fmtDuration, args.iamDryRun)
-		if err != nil {
-			return fmt.Errorf("Could not delete IAM policies: %s", err.Error())
+		if args.s3 {
+			err = aws.CcsAwsSession.CleanupS3Buckets(fmtDuration, args.dryRun)
+			if err != nil {
+				return fmt.Errorf("Could not delete s3 buckets: %s", err.Error())
+			}
 		}
 	}
 	return nil

--- a/pkg/common/aws/session.go
+++ b/pkg/common/aws/session.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/s3"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 )
@@ -18,6 +19,7 @@ type ccsAwsSession struct {
 	session   *session.Session
 	accountId string
 	iam       *iam.IAM
+	s3        *s3.S3
 	ec2       *ec2.EC2
 	once      sync.Once
 }
@@ -48,6 +50,7 @@ func (CcsAwsSession *ccsAwsSession) GetAWSSessions() error {
 
 		CcsAwsSession.session, err = session.NewSessionWithOptions(options)
 		CcsAwsSession.iam = iam.New(CcsAwsSession.session)
+		CcsAwsSession.s3 = s3.New(CcsAwsSession.session)
 		CcsAwsSession.ec2 = ec2.New(CcsAwsSession.session)
 		CcsAwsSession.accountId = viper.GetString(config.AWSAccountId)
 	})


### PR DESCRIPTION
`osde2e cleanup --s3 --dry-run=false` 

 finds buckets with prefix "osde2e-" or "managed-velreo" older than given duration, then deletes bucket objects and then buckets

repurposes dry-run and older-than flags from existing command by removing prefix "iam" 

[SDCICD-1225](https://issues.redhat.com//browse/SDCICD-1225)