### PR TITLE
fix error to give provider-neutral error on install fail

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -279,7 +279,7 @@ func waitForOCMProvisioning(provider spi.Provider, clusterID string, installTime
 			readinessStarted = time.Now()
 			return true, nil
 		} else if cluster.State() == spi.ClusterStateError {
-			log.Print("cluster is in error state, check AWS for more details")
+			log.Print("cluster is in error state, check cloud provider for more details")
 		}
 		logger.Printf("cluster is not ready, state is: %v", cluster.State())
 		return false, nil


### PR DESCRIPTION
clusterutil currently prints out following confusing message for GCP clusters on install failure. Change message to remove AWS specific reference. 


`2024/02/15 14:31:24 clusterutil.go:282: cluster is in error state, check AWS for more details` 


Discovered during https://issues.redhat.com/browse/OSD-20127 
