### PR TITLE
osdclusterready: use given kubeconfig path to create oc client

### DIFF
--- a/pkg/e2e/openshift/osdclusterready.go
+++ b/pkg/e2e/openshift/osdclusterready.go
@@ -28,7 +28,7 @@ var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.OCPNightlyBlocking, fun
 	ginkgo.BeforeAll(func(ctx context.Context) {
 		log.SetLogger(ginkgo.GinkgoLogr)
 		var err error
-		k8s, err = openshift.New(ginkgo.GinkgoLogr)
+		k8s, err = openshift.NewFromKubeconfig(viper.GetString(config.Kubeconfig.Path), ginkgo.GinkgoLogr)
 		Expect(err).ShouldNot(HaveOccurred(), "Unable to setup k8s client")
 	})
 


### PR DESCRIPTION
[SDCICD-1192](https://issues.redhat.com//browse/SDCICD-1192)

osdclusterready does not load given kubeconfig . This will correctly pass custom kubeconfig file when provided. 