### PR TITLE
wait until ocm reports cluster install "ready" before proceeding with tests

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -91,12 +91,6 @@ func WaitForClusterReadyPostInstall(clusterID string, logger *log.Logger) error 
 		return fmt.Errorf("error getting cluster provisioning client: %v", err)
 	}
 
-	_, err = WaitForOCMProvisioning(provider, clusterID, logger, false)
-	if err != nil {
-		return fmt.Errorf("OCM never became ready: %w", err)
-	}
-	logger.Println("Cluster is provisioned in OCM")
-
 	cluster, err := provider.GetCluster(clusterID)
 	if err != nil {
 		return fmt.Errorf("failed getting cluster from provider: %w", err)

--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -98,7 +98,7 @@ func WaitForClusterReadyPostInstall(clusterID string, logger *log.Logger) error 
 	}
 	logger.Printf("Waiting %v minutes for cluster '%s' to be ready...\n", installTimeout, clusterID)
 
-	_, err = waitForOCMProvisioning(provider, clusterID, installTimeout, logger, false)
+	_, err = WaitForOCMProvisioning(provider, clusterID, installTimeout, logger, false)
 	if err != nil {
 		return fmt.Errorf("OCM never became ready: %w", err)
 	}
@@ -236,7 +236,7 @@ func WaitForClusterReadyPostWake(clusterID string, logger *log.Logger) error {
 	return waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID, logger, false, false)
 }
 
-func waitForOCMProvisioning(provider spi.Provider, clusterID string, installTimeout int64, logger *log.Logger, isUpgrade bool) (becameReadyAt time.Time, err error) {
+func WaitForOCMProvisioning(provider spi.Provider, clusterID string, installTimeout int64, logger *log.Logger, isUpgrade bool) (becameReadyAt time.Time, err error) {
 	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 	readinessSet := false
 	var readinessStarted time.Time
@@ -311,7 +311,7 @@ func waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID string, l
 	cleanRuns := 0
 	errRuns := 0
 
-	readinessStarted, err := waitForOCMProvisioning(provider, clusterID, installTimeout, logger, isUpgrade)
+	readinessStarted, err := WaitForOCMProvisioning(provider, clusterID, installTimeout, logger, isUpgrade)
 	if err != nil {
 		return fmt.Errorf("OCM never became ready: %w", err)
 	}

--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/go-multierror"
+	"github.com/onsi/ginkgo/v2"
 	osconfig "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/osde2e/pkg/common/cluster/healthchecks"
 	"github.com/openshift/osde2e/pkg/common/clusterproperties"
@@ -229,7 +230,7 @@ func WaitForOCMProvisioning(provider spi.Provider, clusterID string, logger *log
 		// Install timeout 30 minutes for hypershift
 		installTimeout = 30
 	}
-	fmt.Printf("Waiting %v minutes for cluster to be ready...\n", installTimeout)
+	ginkgo.GinkgoLogr.Info("Waiting %v minutes for cluster to be ready...\n", installTimeout)
 
 	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 	readinessSet := false

--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/go-multierror"
-	"github.com/onsi/ginkgo/v2"
 	osconfig "github.com/openshift/client-go/config/clientset/versioned"
 	"github.com/openshift/osde2e/pkg/common/cluster/healthchecks"
 	"github.com/openshift/osde2e/pkg/common/clusterproperties"
@@ -230,9 +229,11 @@ func WaitForOCMProvisioning(provider spi.Provider, clusterID string, logger *log
 		// Install timeout 30 minutes for hypershift
 		installTimeout = 30
 	}
-	ginkgo.GinkgoLogr.Info("Waiting %v minutes for cluster to be ready...\n", installTimeout)
 
 	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
+
+	logger.Printf("Waiting %v minutes for cluster to be ready...\n", installTimeout)
+
 	readinessSet := false
 	var readinessStarted time.Time
 	clusterStarted := time.Now()
@@ -274,7 +275,7 @@ func WaitForOCMProvisioning(provider spi.Provider, clusterID string, logger *log
 			readinessStarted = time.Now()
 			return true, nil
 		} else if cluster.State() == spi.ClusterStateError {
-			log.Print("cluster is in error state, check cloud provider for more details")
+			logger.Print("cluster is in error state, check cloud provider for more details")
 		}
 		logger.Printf("cluster is not ready, state is: %v", cluster.State())
 		return false, nil

--- a/pkg/common/cluster/healthchecks/healthcheckjob.go
+++ b/pkg/common/cluster/healthchecks/healthcheckjob.go
@@ -11,12 +11,11 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/logging"
-	"k8s.io/client-go/kubernetes"
 )
 
 // CheckHealthcheckJob uses the `osd-cluster-ready` healthcheck job to determine cluster readiness. If the cluster
 // is not ready, it will return an error.
-func CheckHealthcheckJob(k8sClient *kubernetes.Clientset, ctx context.Context, logger *log.Logger) error {
+func CheckHealthcheckJob(ctx context.Context, logger *log.Logger) error {
 	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 	var k8s *openshift.Client
 

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -887,11 +887,11 @@ func (o *OCMProvider) ClusterKubeconfig(clusterID string) ([]byte, error) {
 func getLocalKubeConfig(path string) ([]byte, error) {
 	fileReader, err := os.Open(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error opening provided kubeconfig: %v", err)
 	}
 	f, err := io.ReadAll(fileReader)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error reading provided kubeconfig: %v", err)
 	}
 	return []byte(f), nil
 }

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -169,7 +169,7 @@ func beforeSuite() bool {
 		clusterConfigerr := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
 			kubeconfigBytes, err = provider.ClusterKubeconfig(viper.GetString(config.Cluster.ID))
 			if err != nil {
-				log.Printf("Failed to get kubeconfig from OCM: %v\nWaiting two seconds before retrying", err)
+				log.Printf("Failed to retrieve kubeconfig: %v\nWaiting two seconds before retrying", err)
 				return false, nil
 			} else {
 				log.Printf("Successfully retrieved kubeconfig from OCM.")

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -452,14 +452,7 @@ func runGinkgoTests() (int, error) {
 		viper.Set(config.Cluster.Passing, testsPassed)
 	}
 	if viper.GetBool(config.Cluster.ProvisionOnly) {
-		installTimeout := viper.GetInt64(config.Cluster.InstallTimeout)
-		if viper.GetBool(config.Hypershift) {
-			// Install timeout 30 minutes for hypershift
-			installTimeout = 30
-		}
-		fmt.Printf("Waiting %v minutes for cluster to be ready...\n", installTimeout)
-
-		_, err = clusterutil.WaitForOCMProvisioning(provider, viper.GetString(config.Cluster.ID), installTimeout, nil, false)
+		_, err = clusterutil.WaitForOCMProvisioning(provider, viper.GetString(config.Cluster.ID), nil, false)
 		if err != nil {
 			return Failure, fmt.Errorf("OCM never became ready: %w", err)
 		}


### PR DESCRIPTION
1. Polling cluster ocm status "ready" is moved immediately after provision, outside of healthcheck.

There should be no use case of osde2e that skips cluster becoming "ready" prior to any processing. 

Therefore, adding basic ocm ready wait immediately after provision, outside of old healthcheck logic. Healthcheck can still be skipped.  


2. Function cleanup: removing unused arg from ClusterHEalthcheck function
3. Function cleanup: Moving "install Timeout" initializing inside  WaitForOCMProvisioning instead of 4 duplicate lines everytime it's invoked. 

 https://issues.redhat.com/browse/SDCICD-1192 