### PR TITLE
remove kubeconfig from conformance command

### DIFF
--- a/pkg/e2e/openshift/config.go
+++ b/pkg/e2e/openshift/config.go
@@ -12,7 +12,6 @@ import (
 )
 
 const testCmd = `
-export KUBECONFIG=/tmp/kubeconfig
 
 REGION={{region}}
 ZONE="$(oc get -o jsonpath='{.items[0].metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}' nodes)"


### PR DESCRIPTION
Conformance test errors with
`error converting to options: stat /tmp/kubeconfig: no such file or directoryerror: stat /tmp/kubeconfig: no such file or directory` 

This var is set after provision and doesn't need to be overridden here. 

[sdcicd-1192](https://issues.redhat.com//browse/sdcicd-1192)