### PR TITLE
SDCICD-1228 fix env vars proper binding for gcp creds

### DIFF
--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -142,7 +142,7 @@ func (o *OCMProvider) LaunchCluster(clusterName string) (string, error) {
 			if err != nil {
 				return "", fmt.Errorf("error unmarshalling GCP credentials: %v", err)
 			}
-			viper.Set(GCPCredsJSON, gcp.Type())
+			viper.Set(GCPCredsType, gcp.Type())
 			viper.Set(GCPProjectID, gcp.ProjectID())
 			viper.Set(GCPPrivateKeyID, gcp.PrivateKeyID())
 			viper.Set(GCPPrivateKey, gcp.PrivateKey())

--- a/pkg/common/providers/ocmprovider/config.go
+++ b/pkg/common/providers/ocmprovider/config.go
@@ -39,8 +39,10 @@ const (
 	// CCS defines whether the cluster should expect cloud credentials or not
 	CCS = "ocm.ccs"
 
-	// GCP CCS Credentials
-	GCPCredsJSON               = "ocm.gcp.credsJSON"
+	// GCP CCS Credential json
+	// Env: GCP_CREDS_JSON, OCM_GCP_CREDS_JSON
+	GCPCredsJSON = "ocm.gcp.credsJSON"
+	// GCP creds json internals
 	GCPCredsType               = "ocm.gcp.credsType"
 	GCPProjectID               = "ocm.gcp.projectID"
 	GCPPrivateKey              = "ocm.gcp.privateKey"
@@ -86,6 +88,7 @@ func init() {
 	viper.SetDefault(CCS, false)
 	viper.BindEnv(CCS, "OCM_CCS", "CCS")
 
+	viper.BindEnv(GCPCredsJSON, "OCM_GCP_CREDS_JSON", "GCP_CREDS_JSON")
 	viper.BindEnv(GCPCredsType, "OCM_GCP_CREDS_TYPE", "GCP_CREDS_TYPE")
 	viper.BindEnv(GCPProjectID, "OCM_GCP_PROJECT_ID", "GCP_PROJECT_ID")
 	viper.BindEnv(GCPPrivateKey, "OCM_GCP_PRIVATE_KEY", "GCP_PRIVATE_KEY")


### PR DESCRIPTION
- bind gcp creds json correctly to config
- fix setting "type" value in gcp creds object. 


Testing:

Tested provisioning gcp ccs cluster locally with env: 

GCP_CREDS_JSON=my cred json
OCM_CCS=true

command and args:
./osde2e test --configs=gcp,stage --provision-only