### PR TITLE
SDCICD-1192 Fix conformance job

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -531,22 +531,6 @@ func ProvisionCluster(logger *log.Logger) (*spi.Cluster, error) {
 	var cluster *spi.Cluster
 	// get cluster ID from env
 	clusterID := viper.GetString(config.Cluster.ID)
-	// get cluster id from shared_dir (used in prow multi-step jobs
-	log.Printf("cluster id:%s shared dir:%s", clusterID, viper.GetString(config.SharedDir))
-	if clusterID == "" && viper.GetString(config.SharedDir) != "" {
-		sharedClusterIdPath := viper.GetString(config.SharedDir) + "/cluster-id"
-		_, err := os.Stat(sharedClusterIdPath)
-		if err == nil {
-			clusteridbytes, err := os.ReadFile(sharedClusterIdPath)
-			if err == nil {
-				clusterID = string(clusteridbytes)
-				fmt.Printf("cluster-id found in SHARED_DIR %s", clusterID)
-				viper.Set(config.Cluster.ID, clusterID)
-			} else {
-				log.Printf("could not read from shared cluster-id: %s", err.Error())
-			}
-		}
-	}
 	// create a new cluster if no ID is specified
 	if clusterID == "" {
 		fmt.Printf("no clusterid found, provisioning cluster")

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -976,3 +976,24 @@ func LoadKubeconfig() error {
 	})
 	return err
 }
+
+// LoadClusterId  given a path to a shared directoru, if a cluster id is written to it, will attempt to load it into the Viper config.
+// No error if shared cluster-id file doesn't exist.
+func LoadClusterId() error {
+	// get cluster id from shared_dir (used in prow multi-step jobs
+	if viper.GetString(Cluster.ID) == "" && viper.GetString(SharedDir) != "" {
+		sharedClusterIdPath := viper.GetString(SharedDir) + "/cluster-id"
+		_, err := os.Stat(sharedClusterIdPath)
+		if err == nil {
+			clusteridbytes, err := os.ReadFile(sharedClusterIdPath)
+			if err == nil {
+				clusterID := string(clusteridbytes)
+				fmt.Printf("cluster-id found in SHARED_DIR %s", clusterID)
+				viper.Set(Cluster.ID, clusterID)
+			} else {
+				return fmt.Errorf("will not load shared cluster-id: %s", err.Error())
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -82,6 +82,13 @@ func beforeSuite() bool {
 		log.Printf("Not loading kubeconfig: %v", err)
 	}
 
+	// populate viper clusterID if shared dir contains one.
+	// Important to do this beforeSuite for multi step jobs.
+	if err := config.LoadClusterId(); err != nil {
+		log.Printf("Not loading cluster id: %v", err)
+		return false
+	}
+
 	if viper.GetString(config.Kubeconfig.Contents) == "" {
 		cluster, err := clusterutil.ProvisionCluster(nil)
 		events.HandleErrorWithEvents(err, events.InstallSuccessful, events.InstallFailed)

--- a/pkg/e2e/openshift/config.go
+++ b/pkg/e2e/openshift/config.go
@@ -12,6 +12,7 @@ import (
 )
 
 const testCmd = `
+export KUBECONFIG={{kubeconfigPath}}
 
 REGION={{region}}
 ZONE="$(oc get -o jsonpath='{.items[0].metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}' nodes)"
@@ -31,10 +32,11 @@ export TEST_PROVIDER="{\"type\":\"aws\",\"region\":\"${REGION}\",\"zone\":\"${ZO
 
 var cmdTemplate = template.Must(template.New("testCmd").
 	Funcs(template.FuncMap{
-		"printTests":  printTests,
-		"selectTests": selectTests,
-		"unwrap":      unwrap,
-		"region":      region,
+		"kubeconfigPath": kubeconfigPath,
+		"printTests":     printTests,
+		"selectTests":    selectTests,
+		"unwrap":         unwrap,
+		"region":         region,
 	}).Parse(testCmd))
 
 // E2EConfig defines the behavior of the extended test suite.
@@ -76,6 +78,13 @@ func (c E2EConfig) Cmd() string {
 func printTests(strs []string) string {
 	testList := strings.Join(strs, "\"\n\"")
 	return fmt.Sprintf("printf '\"%s\"'", testList)
+}
+
+func kubeconfigPath() string {
+	if viper.GetString(config.SharedDir) != "" {
+		return viper.GetString(config.SharedDir) + "/kubeconfig"
+	}
+	return ""
 }
 
 func region() string {


### PR DESCRIPTION
1. move shared clusterId loading to the top, after kubeconfig loading.
2. provide shared kubeconfig path to conformance command if one exists ( For this part, the conformance cmd has never been ran from current prow jobs so more things may need to be set for this command in followup PRs, through trial and error.) 

includes fix for [sdcicd-1192](https://issues.redhat.com//browse/sdcicd-1192)