### PR TITLE
Conformance command fixes

### DIFF
--- a/pkg/e2e/openshift/config.go
+++ b/pkg/e2e/openshift/config.go
@@ -12,7 +12,12 @@ import (
 )
 
 const testCmd = `
-export KUBECONFIG={{kubeconfigPath}}
+oc config set-cluster cluster --server=https://kubernetes.default.svc --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+oc config set-credentials user --token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+oc config set-context cluster --cluster=cluster --user=user
+oc config use-context cluster
+oc config view --raw=true > /tmp/kubeconfig
+export KUBECONFIG=/tmp/kubeconfig
 
 REGION={{region}}
 ZONE="$(oc get -o jsonpath='{.items[0].metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}' nodes)"

--- a/pkg/e2e/openshift/conformance.go
+++ b/pkg/e2e/openshift/conformance.go
@@ -31,8 +31,8 @@ var DefaultE2EConfig = E2EConfig{
 }
 
 var (
-	conformanceK8sTestName       string = "[Suite: conformance][k8s]"
-	conformanceOpenshiftTestName string = "[Suite: conformance][openshift]"
+	conformanceK8sTestName       = "[Suite: conformance][k8s]"
+	conformanceOpenshiftTestName = "[Suite: conformance][openshift]"
 )
 
 func init() {
@@ -105,10 +105,9 @@ var _ = ginkgo.Describe(conformanceOpenshiftTestName, ginkgo.Ordered, label.OCPN
 		// get results
 		results, err := r.RetrieveTestResults()
 
-		// write results
+		// write results, including non-xml log files
 		h.WriteResults(results)
 
-		// evaluate results
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "Error reading xml results, test may have exited abruptly. Check conformance logs for errors")
 	})
 })


### PR DESCRIPTION
- Added back test command settings, 
- Better error message for conformance xml result reading error

Testing - 

Run test command locally with osde2e 
create rosa cluster
copy admin kubeconfig to base dir/tmp 

with env:
SHARED_DIR=tmp
TEST_KUBECONFIG=tmp/kubeconfig

run osde2e with 
./osde2e test --configs=rosa,stage,blocking-suite

-- 

This should fail successfully, with log file indicating a panic at nodeLabel checks

[SDCICD-1192](https://issues.redhat.com//browse/SDCICD-1192)