### PR TITLE
sdcicd-945 eliminate error log related to hidden vault key `..data`

### DIFF
--- a/pkg/common/load/load.go
+++ b/pkg/common/load/load.go
@@ -86,7 +86,9 @@ func loadPassthruSecrets(secretLocations []string) {
 				continue
 			}
 			err := filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {
-				if info.IsDir() {
+				// exclude directories and hidden paths. Hidden directory `/..data` is created from vault's hidden key `...data`.
+				// IsDir() does not exclude it as directory, and we get error messages.
+				if info.IsDir() || strings.HasPrefix(strings.TrimSpace(info.Name()), ".") {
 					return nil
 				}
 				data, err := os.ReadFile(path)


### PR DESCRIPTION
Fixes [sdcicd-945](https://issues.redhat.com//browse/sdcicd-945)

- We receive error message in the log:

`error loading passthru-secret file /usr/local/osde2e-dev/..data: read /usr/local/osde2e-dev/..data: is a directory`

- This is not mitigated by skipping directories, which we are doing currently.

https://github.com/openshift/osde2e/blob/3859fc4ad322b4d78aba89cfebe47c9986f1b659/pkg/common/load/load.go#L89

- The origin of this `..data` directory is in vault backend adding hidden keys to vault https://github.com/hashicorp/vault/blob/012c3422f8e1d5fa8d564010683fd9487c00f41f/ui/app/adapters/keymgmt/key.js#L80

- This solution will skip all hidden paths starting with ".",  and remove distracting passthrough key error message. 