### PR TITLE
sdcicd-1255 add new instance types in MHC

### DIFF
--- a/pkg/e2e/osd/machinehealthcheck.go
+++ b/pkg/e2e/osd/machinehealthcheck.go
@@ -20,8 +20,9 @@ const (
 )
 
 var (
-	machineHealthTestName string = "[Suite: e2e] MachineHealthChecks"
-	metalInstanceTypes           = []string{"m5.metal", "m5d.metal", "m5n.metal", "m5dn.metal", "m5zn.metal", "m6a.metal", "m6i.metal", "m6id.metal", "r5.metal", "r5d.metal", "r5n.metal", "r5dn.metal", "r6a.metal", "r6i.metal", "r6id.metal", "x2iezn.metal", "z1d.metal", "c5.metal", "c5d.metal", "c5n.metal", "c6a.metal", "c6i.metal", "c6id.metal", "i3.metal", "i3en.metal"}
+	machineHealthTestName = "[Suite: e2e] MachineHealthChecks"
+	// metalInstanceTypes should match what's specified in MCC in hack/00-osd-managed-cluster-config-stage.yaml.tmpl
+	metalInstanceTypes = []string{"m5.metal", "m5d.metal", "m5n.metal", "m5dn.metal", "m5zn.metal", "m6a.metal", "m6i.metal", "m6id.metal", "r5.metal", "r5d.metal", "r5n.metal", "r5dn.metal", "r6a.metal", "r6i.metal", "r6id.metal", "x2iezn.metal", "z1d.metal", "c5.metal", "c5d.metal", "c5n.metal", "c6a.metal", "c6i.metal", "c6id.metal", "i3.metal", "i3en.metal", "r7i.48xlarge", "r7i.metal-48xl"}
 )
 
 func init() {


### PR DESCRIPTION
new instance types were added here https://github.com/openshift/managed-cluster-config/pull/2061 

test is failing due to these 2 missing from expected instance types. updating test.

[SDCICD-1255](https://issues.redhat.com//browse/SDCICD-1255) 

 