### PR TITLE
[WIP] SDCICD-1260 label ocp tests and skip them in full e2e-suite

### DIFF
--- a/configs/e2e-suite.yaml
+++ b/configs/e2e-suite.yaml
@@ -1,6 +1,6 @@
 tests:
   ginkgoLabelFilter: >
-    (E2E || Operators || TestHarness || ServiceDefinition || AppBuilds) && !Informing && !MigratedHarness
+    (E2E || Operators || TestHarness || ServiceDefinition || AppBuilds) && !Informing && !MigratedHarness && !Origin
   testHarnesses:
   #    For migrated harnesses, remember to add "MigratedHarness" label to existing suite in this repo, until they are removed from here.
     - quay.io/app-sre/aws-vpce-operator-test-harness

--- a/pkg/common/label/label.go
+++ b/pkg/common/label/label.go
@@ -71,6 +71,9 @@ var (
 	// Operator tests supported on all cluster types
 	Operators = ginkgo.Label("Operators")
 
+	// Origin tests - hook to openshift tests
+	Origin = ginkgo.Label("Origin")
+
 	// Service definition tests verifying openshift dedicated policies
 	// https://docs.openshift.com/dedicated/osd_architecture/osd_policy/osd-service-definition.html
 	ServiceDefinition = ginkgo.Label("ServiceDefinition")

--- a/pkg/e2e/openshift/disruptive.go
+++ b/pkg/e2e/openshift/disruptive.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/label"
 
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
@@ -20,7 +21,7 @@ func init() {
 }
 
 // Disruptive tests require SSH access to nodes.
-var _ = ginkgo.Describe(disruptiveTestName, func() {
+var _ = ginkgo.Describe(disruptiveTestName, ginkgo.Ordered, label.Origin, func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/pkg/e2e/openshift/images.go
+++ b/pkg/e2e/openshift/images.go
@@ -8,14 +8,15 @@ import (
 	. "github.com/onsi/gomega"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/label"
 
 	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
 )
 
 var (
-	imageRegistryTestName  string = "[Suite: openshift][image-registry]"
-	imageEcosystemTestName string = "[Suite: openshift][image-ecosystem]"
+	imageRegistryTestName  = "[Suite: openshift][image-registry]"
+	imageEcosystemTestName = "[Suite: openshift][image-ecosystem]"
 )
 
 func init() {
@@ -23,7 +24,7 @@ func init() {
 	alert.RegisterGinkgoAlert(imageEcosystemTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(imageRegistryTestName, func() {
+var _ = ginkgo.Describe(imageRegistryTestName, ginkgo.Ordered, label.Origin, func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 

--- a/pkg/e2e/openshift/osdclusterready.go
+++ b/pkg/e2e/openshift/osdclusterready.go
@@ -22,7 +22,7 @@ const (
 )
 
 // Assert osd-cluster-ready status
-var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.OCPNightlyBlocking, func() {
+var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.OCPNightlyBlocking, label.Origin, func() {
 	var k8s *openshift.Client
 
 	ginkgo.BeforeAll(func(ctx context.Context) {


### PR DESCRIPTION
4.15 regular nightly has started showing results from origin-tests aka ocp-tests aka openshift-e2e-test, since March 7 .
 
It only started showing in nightly results as they were recently correctly configured to be fully run. (March 7) 

To skip them as expected, this PR labels them and excludes them from nightlies. 