### PR TITLE
SDCICD-1260 remove workload ocp test from e2e-suite

### DIFF
--- a/configs/e2e-suite.yaml
+++ b/configs/e2e-suite.yaml
@@ -1,6 +1,6 @@
 tests:
   ginkgoLabelFilter: >
-    (E2E || Operators || TestHarness || ServiceDefinition || AppBuilds) && !Informing && !MigratedHarness
+    (E2E || Operators || TestHarness || ServiceDefinition) && !Informing && !MigratedHarness
   testHarnesses:
   #    For migrated harnesses, remember to add "MigratedHarness" label to existing suite in this repo, until they are removed from here.
     - quay.io/app-sre/aws-vpce-operator-test-harness


### PR DESCRIPTION
Remove [Suite: app-builds] from e2e-suite 

What does this suite test? - customer workload build (requested in [OSD-2132](https://issues.redhat.com//browse/OSD-2132)) 

Why exclude it? - This suite never ran correctly for the past several months. It recently started running due to conformance test updates, and has been perma failing ever since. 

osde2e doesn't own the test and there;s no clear owner monitoring this test. 

It doesn't have a proper set up at this point. We also have a simpler workload test which would be the first step before testing more complicated customer workloads in regular nightlies https://github.com/openshift/osde2e/tree/main/pkg/e2e/workloads 



 