### PR TITLE
rosaprovider: klogr -> textlogger

### DIFF
--- a/pkg/common/providers/rosaprovider/rosa.go
+++ b/pkg/common/providers/rosaprovider/rosa.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
 	"github.com/openshift/osde2e/pkg/common/spi"
-	"k8s.io/klog/v2/klogr"
+	"k8s.io/klog/v2/textlogger"
 )
 
 var rosaProvider *rosaprovider.Provider
@@ -60,7 +60,7 @@ func New() (*ROSAProvider, error) {
 				ctx,
 				viper.GetString("ocm.token"),
 				ocmEnv,
-				klogr.New(),
+				textlogger.NewLogger(textlogger.NewConfig()),
 			)
 			return err
 		})


### PR DESCRIPTION
klogr.New has been deprecated in favor of a new textlogger package

https://pkg.go.dev/k8s.io/klog/v2/klogr#New

```
pkg/common/providers/rosaprovider/rosa.go:63:5: klogr.New is deprecated: this uses a custom, out-dated output format. Use textlogger.NewLogger instead.  (SA1019)
```

[SDCICD-1266](https://issues.redhat.com//browse/SDCICD-1266)