### PR TITLE
cmd/osde2e: error strings should not be capitalized (ST1005)

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -135,26 +135,26 @@ func run(cmd *cobra.Command, argv []string) error {
 	} else {
 		fmtDuration, err := time.ParseDuration(args.olderThan)
 		if err != nil {
-			return fmt.Errorf("Please provide a valid duration string. Valid units are 'm', 'h':  %s", err.Error())
+			return fmt.Errorf("please provide a valid duration string. Valid units are 'm', 'h':  %s", err.Error())
 		}
 		if args.iam {
 			err = aws.CcsAwsSession.CleanupOpenIDConnectProviders(fmtDuration, args.dryRun)
 			if err != nil {
-				return fmt.Errorf("Could not delete OIDC providers: %s", err.Error())
+				return fmt.Errorf("could not delete OIDC providers: %s", err.Error())
 			}
 			err = aws.CcsAwsSession.CleanupRoles(fmtDuration, args.dryRun)
 			if err != nil {
-				return fmt.Errorf("Could not delete IAM roles: %s", err.Error())
+				return fmt.Errorf("could not delete IAM roles: %s", err.Error())
 			}
 			err = aws.CcsAwsSession.CleanupPolicies(fmtDuration, args.dryRun)
 			if err != nil {
-				return fmt.Errorf("Could not delete IAM policies: %s", err.Error())
+				return fmt.Errorf("could not delete IAM policies: %s", err.Error())
 			}
 		}
 		if args.s3 {
 			err = aws.CcsAwsSession.CleanupS3Buckets(fmtDuration, args.dryRun)
 			if err != nil {
-				return fmt.Errorf("Could not delete s3 buckets: %s", err.Error())
+				return fmt.Errorf("could not delete s3 buckets: %s", err.Error())
 			}
 		}
 	}

--- a/cmd/osde2e/completion/cmd.go
+++ b/cmd/osde2e/completion/cmd.go
@@ -25,7 +25,7 @@ To configure your bash shell to load completions for each session add to your ba
 func run(cmd *cobra.Command, argv []string) error {
 	err := cmd.Root().GenBashCompletion(os.Stdout)
 	if err != nil {
-		return fmt.Errorf("Unable to generate bash completions: %v", err)
+		return fmt.Errorf("unable to generate bash completions: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
resolve staticcheck lint ST1005 in cmd/osde2e. Error strings should not be capitalized as they can (and should) be used to build up a string of an error message when printed. No error is standalone and provides context to other errors messages.

```
cmd/osde2e/cleanup/cmd.go:138:11: error strings should not be capitalized (ST1005)
cmd/osde2e/cleanup/cmd.go:143:12: error strings should not be capitalized (ST1005)
cmd/osde2e/cleanup/cmd.go:147:12: error strings should not be capitalized (ST1005)
cmd/osde2e/cleanup/cmd.go:151:12: error strings should not be capitalized (ST1005)
cmd/osde2e/cleanup/cmd.go:157:12: error strings should not be capitalized (ST1005)
cmd/osde2e/completion/cmd.go:28:10: error strings should not be capitalized (ST1005)
```

https://staticcheck.io/docs/checks/#ST1005

[SDCICD-1266](https://issues.redhat.com//browse/SDCICD-1266)