### PR TITLE
do not fail test for errors coming from metrics bucket

### DIFF
--- a/pkg/common/aws/s3.go
+++ b/pkg/common/aws/s3.go
@@ -40,10 +40,11 @@ func ReadFromS3Session(session *session.Session, inputKey string) ([]byte, error
 }
 
 // WriteToS3Session writes the given byte array to S3.
-func WriteToS3Session(session *session.Session, outputKey string, data []byte) error {
+func WriteToS3Session(session *session.Session, outputKey string, data []byte) {
 	bucket, key, err := ParseS3URL(outputKey)
 	if err != nil {
-		return fmt.Errorf("error trying to parse S3 URL: %v", err)
+		log.Printf("error trying to parse S3 URL %s: %v", outputKey, err)
+		return
 	}
 
 	uploader := s3manager.NewUploader(session)
@@ -56,12 +57,11 @@ func WriteToS3Session(session *session.Session, outputKey string, data []byte) e
 	})
 
 	if err != nil {
-		return err
+		log.Printf("Failed to upload to s3 %s", err.Error())
+		return
 	}
-
 	log.Printf("Uploaded to %s", outputKey)
-
-	return nil
+	return
 }
 
 // CreateS3URL creates an S3 URL from a bucket and a key string.

--- a/pkg/common/helper/runner.go
+++ b/pkg/common/helper/runner.go
@@ -65,10 +65,7 @@ func (h *H) UploadResultsToS3(results map[string][]byte, key string) error {
 		if err != nil {
 			return fmt.Errorf("error getting aws session: %v", err)
 		}
-		err = aws.WriteToS3Session(session, aws.CreateS3URL(viper.GetString(config.Tests.LogBucket), key, filepath.Base(filename)), data)
-		if err != nil {
-			return fmt.Errorf("error while uploading log files to s3: %v", err)
-		}
+		aws.WriteToS3Session(session, aws.CreateS3URL(viper.GetString(config.Tests.LogBucket), key, filepath.Base(filename)), data)
 	}
 	return nil
 }

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -1269,10 +1269,8 @@ func (o *OCMProvider) AddProperty(cluster *spi.Cluster, tag string, value string
 		}
 		propertyFilename := fmt.Sprintf("%s.osde2e-cluster-property-update.metrics.prom", cluster.ID())
 		data := fmt.Sprintf("# TYPE cicd_cluster_properties gauge\ncicd_cluster_properties{cluster_id=\"%s\",environment=\"%s\",job_id=\"%s\",property=\"%s\",region=\"%s\",value=\"%s\",version=\"%s\"} 0\n", cluster.ID(), o.Environment(), viper.GetString(config.JobID), tag, cluster.Region(), value, cluster.Version())
-		err = aws.WriteToS3Session(session, aws.CreateS3URL(viper.GetString(config.Tests.MetricsBucket), "incoming", propertyFilename), []byte(data))
-		if err != nil {
-			return fmt.Errorf("failed to upload cluster property metrics: %v", err)
-		}
+		aws.WriteToS3Session(session, aws.CreateS3URL(viper.GetString(config.Tests.MetricsBucket), "incoming", propertyFilename), []byte(data))
+
 		log.Println(data)
 	}
 


### PR DESCRIPTION
write logs when metrics upload to s3 fails. do not fail full test run or obstruct test execution. with current code, test never executes, times out after 3 hours (or preset timeout) wait.

Nightlies are currently reporting this error due to possible misconfiguration of metrics aws account.

```
2024/04/09 10:04:29 clusterutil.go:260: Error adding property to cluster: failed to upload cluster property metrics: AccessDenied: Access Denied
	status code: 403, request id: 497BD0N97CWWVV40, host id: qBhmokwZcEYOqf3+2BN8t1UMaNeUFxfh2Z5uoZwRWeqT6r8k+vF7TtovHiOGYjy6z+nGvJpTB+8EZZ7EZ+Zq4A==
{"component":"entrypoint","file":"k8s.io/test-infra/prow/entrypoint/run.go:169","func":"k8s.io/test-infra/prow/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 3h0m0s timeout","severity":"error","time":"2024-04-09T10:04:36Z"}
{"component":"entrypoint","file":"k8s.io/test-infra/prow/entrypoint/run.go:264","func":"k8s.io/test-infra/prow/entrypoint.gracefullyTerminate","level":"error","msg":"Process gracefully exited before 15s grace period","severity":"error","time":"2024-04-09T10:04:36Z"}
{"component":"entrypoint","error":"process timed out","file":"k8s.io/test-infra/prow/entrypoint/run.go:84","func":"k8s.io/test-infra/prow/entrypoint.Options.internalRun","level":"error","msg":"Error executing test process","severity":"error","time":"2024-04-09T10:04:36Z"}
error: failed to execute wrapped command: exit status 127
---
Link to step on registry info site: https://steps.ci.openshift.org/reference/osde2e-test
Link to job on registry info site: https://steps.ci.openshift.org/job?org=openshift&repo=osde2e&branch=main&test=rosa-classic-sts&variant=nightly-4.15, "rosa-classic-sts" post steps failed: "rosa-classic-sts" pod "rosa-classic-sts-osde2e-cleanup" failed: could not watch pod: the pod ci-op-q27th6x8/rosa-classic-sts-osde2e-cleanup failed after 12s (failed containers: test): ContainerFailed one or more containers exited
Container test exited with code 1, reason Error
---
```

This PR logs such issues and continues test execution. 

https://issues.redhat.com/browse/SDCICD-1274