### PR TITLE
SDCICD-1266: resolve lint issues in pkg/reporting

### DIFF
--- a/pkg/reporting/generate_report.go
+++ b/pkg/reporting/generate_report.go
@@ -34,7 +34,7 @@ func ListReportTypes(reportName string) ([]string, error) {
 	// We always support JSON.
 	reportTypes := append(templates.ListTemplates(reportName), "json")
 
-	sort.Sort(sort.StringSlice(reportTypes))
+	sort.Strings(reportTypes)
 	return reportTypes, nil
 }
 

--- a/pkg/reporting/report_to_slack.go
+++ b/pkg/reporting/report_to_slack.go
@@ -21,7 +21,7 @@ func SendReportToSlack(title string, report []byte) error {
 
 	msg := &slack.WebhookMessage{
 		Text:        title,
-		Attachments: append([]slack.Attachment{summaryAttachment}),
+		Attachments: []slack.Attachment{summaryAttachment},
 	}
 	return slack.PostWebhook(slackWebhook, msg)
 }

--- a/pkg/reporting/reporters/weather/weather_reporter.go
+++ b/pkg/reporting/reporters/weather/weather_reporter.go
@@ -308,7 +308,7 @@ func generateSummaryTable(summary map[string]*summaryReportData) string {
 		environments = append(environments, environment)
 	}
 
-	sort.Sort(sort.StringSlice(environments))
+	sort.Strings(environments)
 
 	summaryTable := strings.Builder{}
 


### PR DESCRIPTION
```
pkg/reporting/generate_report.go:37:2: should use sort.Strings(...) instead of sort.Sort(sort.StringSlice(...)) (S1032)
pkg/reporting/report_to_slack.go:24:16: x = append(y) is equivalent to x = y (SA4021)
pkg/reporting/reporters/weather/weather_reporter.go:311:2: should use sort.Strings(...) instead of sort.Sort(sort.StringSlice(...)) (S1032)
```

resolve the linting failures in `pkg/reporting`. We should investigate if the `weather` stuff can be removed later on