### PR TITLE
SDCICD-1266: duplicate import - pkg/common/cluster

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -25,7 +25,6 @@ import (
 	ctrlog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/onsi/ginkgo/v2/reporters"
-	"github.com/openshift/osde2e/pkg/common/cluster"
 	clusterutil "github.com/openshift/osde2e/pkg/common/cluster"
 	"github.com/openshift/osde2e/pkg/common/clusterproperties"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
@@ -282,7 +281,7 @@ func installAddons() (err error) {
 		return fmt.Errorf("could not install addons: %s", err.Error())
 	}
 	if num > 0 {
-		if err = cluster.WaitForClusterReadyPostInstall(clusterID, nil); err != nil {
+		if err = clusterutil.WaitForClusterReadyPostInstall(clusterID, nil); err != nil {
 			return fmt.Errorf("failed waiting for cluster ready: %v", err)
 		}
 	}


### PR DESCRIPTION
we already carry around a variable named `cluster` while provisioning and testing the cluster, this was imported at somepoint and used without it's alias only in this case. Use the `clusterutil` import to be consistent

```
pkg/e2e/e2e.go:29:2: package "github.com/openshift/osde2e/pkg/common/cluster" is being imported more than once (ST1019)
    pkg/e2e/e2e.go:30:2: other import of "github.com/openshift/osde2e/pkg/common/cluster"
```