### PR TITLE
SDCICD-1255 updating instance type list to match MCC

### DIFF
--- a/pkg/e2e/osd/machinehealthcheck.go
+++ b/pkg/e2e/osd/machinehealthcheck.go
@@ -21,8 +21,8 @@ const (
 
 var (
 	machineHealthTestName = "[Suite: e2e] MachineHealthChecks"
-	// metalInstanceTypes should match what's specified in MCC in hack/00-osd-managed-cluster-config-stage.yaml.tmpl
-	metalInstanceTypes = []string{"m5.metal", "m5d.metal", "m5n.metal", "m5dn.metal", "m5zn.metal", "m6a.metal", "m6i.metal", "m6id.metal", "r5.metal", "r5d.metal", "r5n.metal", "r5dn.metal", "r6a.metal", "r6i.metal", "r6id.metal", "x2iezn.metal", "z1d.metal", "c5.metal", "c5d.metal", "c5n.metal", "c6a.metal", "c6i.metal", "c6id.metal", "i3.metal", "i3en.metal", "r7i.48xlarge", "r7i.metal-48xl"}
+	// metalInstanceTypes should match what's specified in MCC in hack/00-osd-managed-cluster-config-stage.yaml.tmpl and prod.yaml.tmpl, depending
+	metalInstanceTypes = []string{"m5.metal", "m5d.metal", "m5n.metal", "m5dn.metal", "m5zn.metal", "m6a.metal", "m6i.metal", "m6id.metal", "r5.metal", "r5d.metal", "r5n.metal", "r5dn.metal", "r6a.metal", "r6i.metal", "r6id.metal", "x2iezn.metal", "z1d.metal", "c5.metal", "c5d.metal", "c5n.metal", "c6a.metal", "c6i.metal", "c6id.metal", "i3.metal", "i3en.metal", "r7i.48xlarge"}
 )
 
 func init() {


### PR DESCRIPTION
  instance type r7i.metal-48xl was removed here  https://github.com/openshift/managed-cluster-config/commit/db422a977e93598a49cc9e8fdb6ef3c860df8718

test is failing due to this https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-osde2e-main-nightly-4.16-rosa-classic-sts/1780152469666402304

updating expected instance type list .

[SDCICD-1255](https://issues.redhat.com//browse/SDCICD-1255)