### PR TITLE
SDCICD-1266: PollImmediate -> PollUntilContextTimeout

### DIFF
--- a/pkg/common/helper/crud.go
+++ b/pkg/common/helper/crud.go
@@ -70,7 +70,7 @@ func CreateRouteMonitor(ctx context.Context, routeMonitor *routemonitorv1alpha1.
 	}
 
 	// Wait for the pod to create.
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
 		if _, err := RouteMonitorResource(h).Namespace(namespace).Get(ctx, routeMonitor.Name, metav1.GetOptions{}); err != nil {
 			return false, nil
 		}
@@ -88,7 +88,7 @@ func DeleteRouteMonitor(ctx context.Context, nsName types.NamespacedName, waitFo
 
 	// Deleting a namespace can take a while. If desired, wait for the namespace to delete before returning.
 	if waitForDelete {
-		err = wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
 			rmo, err := RouteMonitorResource(h).Namespace(namespace).Get(ctx, name, metav1.GetOptions{})
 			// not sure on that
 			if rmo != nil && err == nil {
@@ -139,7 +139,7 @@ func CreateRoute(ctx context.Context, route *routev1.Route, namespace string, h 
 	}
 
 	// Wait for the pod to create.
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
 		if _, err := h.Route().RouteV1().Routes(namespace).Get(ctx, uwm.Name, metav1.GetOptions{}); err != nil {
 			return false, nil
 		}
@@ -172,7 +172,7 @@ func CreatePod(ctx context.Context, pod *kv1.Pod, namespace string, h *H) error 
 	}
 
 	// Wait for the pod to create.
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
 		if _, err := h.Kube().CoreV1().Pods(namespace).Get(ctx, uwm.Name, metav1.GetOptions{}); err != nil {
 			return false, nil
 		}
@@ -232,7 +232,7 @@ func CreateService(ctx context.Context, svc *kv1.Service, h *H) error {
 	}
 
 	// Wait for the pod to create.
-	err = wait.PollImmediate(5*time.Second, 1*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
 		if _, err := h.Kube().CoreV1().Services(uwm.Namespace).Get(ctx, uwm.Name, metav1.GetOptions{}); err != nil {
 			return false, nil
 		}
@@ -257,7 +257,7 @@ func CreateNamespace(ctx context.Context, namespace string, h *H) (*kv1.Namespac
 	h.Kube().CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 
 	// Wait for the namespace to create. This is usually pretty quick.
-	err = wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 2*time.Minute, false, func(ctx context.Context) (bool, error) {
 		if _, err := h.Kube().CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{}); err != nil {
 			return false, nil
 		}
@@ -276,7 +276,7 @@ func DeleteNamespace(ctx context.Context, namespace string, waitForDelete bool, 
 
 	// Deleting a namespace can take a while. If desired, wait for the namespace to delete before returning.
 	if waitForDelete {
-		err = wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(ctx, 2*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
 			ns, _ := h.Kube().CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
 			if ns != nil && ns.Status.Phase == "Terminating" {
 				return false, nil

--- a/pkg/common/helper/projects.go
+++ b/pkg/common/helper/projects.go
@@ -25,7 +25,7 @@ func (h *H) createProject(ctx context.Context, suffix string) (*projectv1.Projec
 		return project, err
 	}
 
-	wait.PollImmediate(5*time.Second, 60*time.Second, func() (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, 5*time.Second, 60*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		ns, err := h.Kube().CoreV1().Namespaces().Get(ctx, project.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, err

--- a/pkg/common/helper/utilities.go
+++ b/pkg/common/helper/utilities.go
@@ -10,20 +10,20 @@ import (
 
 // WaitTimeoutForDaemonSetInNamespace waits the given timeout duration for the specified ds.
 func (h *H) WaitTimeoutForDaemonSetInNamespace(ctx context.Context, daemonSetName string, namespace string, timeout time.Duration, poll time.Duration) error {
-	return (wait.PollImmediate(poll, timeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, poll, timeout, false, func(ctx context.Context) (bool, error) {
 		if _, err := h.Kube().AppsV1().DaemonSets(namespace).Get(ctx, daemonSetName, metav1.GetOptions{}); err != nil {
 			return false, err
 		}
 		return true, nil
-	}))
+	})
 }
 
 // WaitTimeoutForServiceInNamespace waits the given timeout duration for the specified service.
 func (h *H) WaitTimeoutForServiceInNamespace(ctx context.Context, serviceName string, namespace string, timeout time.Duration, poll time.Duration) error {
-	return (wait.PollImmediate(poll, timeout, func() (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, poll, timeout, false, func(ctx context.Context) (bool, error) {
 		if _, err := h.Kube().CoreV1().Services(namespace).Get(ctx, serviceName, metav1.GetOptions{}); err != nil {
 			return false, err
 		}
 		return true, nil
-	}))
+	})
 }

--- a/pkg/common/helper/workloads.go
+++ b/pkg/common/helper/workloads.go
@@ -108,8 +108,8 @@ func CreateRuntimeObject(obj runtime.Object, ns string, kube kubernetes.Interfac
 		// Need to wait till the namespace is actually created/active before proceeding
 		// Namespace creation is fairly swift, so these numbers are arbitrary.
 		// If this times out, there's something wrong.
-		wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
-			if _, err := kube.CoreV1().Namespaces().Get(context.TODO(), ns, metav1.GetOptions{}); err != nil {
+		_ = wait.PollUntilContextTimeout(context.TODO(), 2*time.Second, 1*time.Minute, false, func(ctx context.Context) (bool, error) {
+			if _, err := kube.CoreV1().Namespaces().Get(ctx, ns, metav1.GetOptions{}); err != nil {
 				return false, nil
 			}
 			return true, nil


### PR DESCRIPTION
PollImmediate is deprecated, swap to using with context version for proper cancelation. Resolved all within the `pkg/common/helper` package.

A few places we weren't handling errors. Where it is obvious, use the return value; where it isn't (gcp) continue to ignore them but explicitly.