### PR TITLE
SDCICD-1266: pass context down through the runner

### DIFF
--- a/pkg/common/runner/pod.go
+++ b/pkg/common/runner/pod.go
@@ -57,7 +57,7 @@ var DefaultContainer = kubev1.Container{
 		PeriodSeconds: 7,
 	},
 	SecurityContext: &kubev1.SecurityContext{
-		RunAsUser: pointer.Int64Ptr(0),
+		RunAsUser: pointer.Int64(0),
 	},
 }
 
@@ -81,7 +81,7 @@ func volumes(name string) []kubev1.Volume {
 					LocalObjectReference: kubev1.LocalObjectReference{
 						Name: name,
 					},
-					DefaultMode: pointer.Int32Ptr(0o755),
+					DefaultMode: pointer.Int32(0o755),
 				},
 			},
 		},
@@ -89,7 +89,7 @@ func volumes(name string) []kubev1.Volume {
 }
 
 // createPod for creates a runner-based pod and typically collects generated artifacts from it.
-func (r *Runner) createPod() (pod *kubev1.Pod, err error) {
+func (r *Runner) createPod(ctx context.Context) (pod *kubev1.Pod, err error) {
 	// configure pod to run workload
 	cmName := fmt.Sprintf("%s-%s", osde2ePayload, util.RandomStr(5))
 	pod = &kubev1.Pod{
@@ -103,7 +103,7 @@ func (r *Runner) createPod() (pod *kubev1.Pod, err error) {
 			return nil, fmt.Errorf("couldn't template cmd: %v", err)
 		}
 
-		configMap, err := r.Kube.CoreV1().ConfigMaps(r.Namespace).Create(context.TODO(), &kubev1.ConfigMap{
+		configMap, err := r.Kube.CoreV1().ConfigMaps(r.Namespace).Create(ctx, &kubev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: cmName,
 			},
@@ -116,7 +116,7 @@ func (r *Runner) createPod() (pod *kubev1.Pod, err error) {
 		}
 
 		// Verify the configMap has been created before proceeding
-		err = wait.PollUntilContextTimeout(context.TODO(), fastPoll, configMapCreateTimeout, false, func(ctx context.Context) (done bool, err error) {
+		err = wait.PollUntilContextTimeout(ctx, fastPoll, configMapCreateTimeout, false, func(ctx context.Context) (done bool, err error) {
 			if configMap, err = r.Kube.CoreV1().ConfigMaps(r.Namespace).Get(ctx, configMap.Name, metav1.GetOptions{}); err != nil {
 				r.Error(err, fmt.Sprintf("error creating %s config map", configMap.Name))
 			}
@@ -154,7 +154,7 @@ func (r *Runner) createPod() (pod *kubev1.Pod, err error) {
 
 	// retry until Pod can be created or timeout occurs
 	var createdPod *kubev1.Pod
-	err = wait.PollUntilContextTimeout(context.TODO(), fastPoll, podCreateTimeout, false, func(ctx context.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(ctx, fastPoll, podCreateTimeout, false, func(ctx context.Context) (done bool, err error) {
 		if createdPod, err = r.Kube.CoreV1().Pods(r.Namespace).Create(ctx, pod, metav1.CreateOptions{}); err != nil {
 			r.Error(err, fmt.Sprintf("error creating %s/%s runner Pod", r.Namespace, r.Name))
 		}
@@ -164,9 +164,9 @@ func (r *Runner) createPod() (pod *kubev1.Pod, err error) {
 }
 
 // waitForRunningPod, given a v1.Pod, will wait for 3 minutes for a pod to enter the running phase or return an error.
-func (r *Runner) waitForPodRunning(pod *kubev1.Pod) error {
+func (r *Runner) waitForPodRunning(ctx context.Context, pod *kubev1.Pod) error {
 	pendingCount := 0
-	return wait.PollUntilContextTimeout(context.TODO(), fastPoll, 3*time.Minute, false, func(ctx context.Context) (done bool, err error) {
+	return wait.PollUntilContextTimeout(ctx, fastPoll, 3*time.Minute, false, func(ctx context.Context) (done bool, err error) {
 		pod, err = r.Kube.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 		if err != nil && !kerror.IsNotFound(err) {
 			return

--- a/pkg/common/runner/results_test.go
+++ b/pkg/common/runner/results_test.go
@@ -150,7 +150,7 @@ func TestRetrieveTestResults(t *testing.T) {
 			r.Kube = client
 
 			// create results service
-			svc, err := r.createService(new(kubev1.Pod))
+			svc, err := r.createService(context.Background(), new(kubev1.Pod))
 			if err != nil {
 				t.Fatalf("Failed to create example service: %v", err)
 			}

--- a/pkg/common/runner/service.go
+++ b/pkg/common/runner/service.go
@@ -23,7 +23,7 @@ const (
 )
 
 // createService returns a v1.Service pointing to a given v1.Pod object
-func (r *Runner) createService(pod *kubev1.Pod) (svc *kubev1.Service, err error) {
+func (r *Runner) createService(ctx context.Context, pod *kubev1.Pod) (svc *kubev1.Service, err error) {
 	var ports []kubev1.ServicePort
 	for _, c := range pod.Spec.Containers {
 		for _, p := range c.Ports {
@@ -35,7 +35,7 @@ func (r *Runner) createService(pod *kubev1.Pod) (svc *kubev1.Service, err error)
 		}
 	}
 
-	return r.Kube.CoreV1().Services(r.Namespace).Create(context.TODO(), &kubev1.Service{
+	return r.Kube.CoreV1().Services(r.Namespace).Create(ctx, &kubev1.Service{
 		ObjectMeta: r.meta(),
 		Spec: kubev1.ServiceSpec{
 			Selector: pod.Labels,
@@ -45,10 +45,10 @@ func (r *Runner) createService(pod *kubev1.Pod) (svc *kubev1.Service, err error)
 }
 
 // waitForCompletion will wait for a runner's pod to have a valid v1.Endpoint available
-func (r *Runner) waitForCompletion(podName string, timeoutInSeconds int) error {
+func (r *Runner) waitForCompletion(ctx context.Context, podName string, timeoutInSeconds int) error {
 	var endpoints *kubev1.Endpoints
 	pendingCount := 0
-	return wait.PollUntilContextTimeout(context.TODO(), slowPoll, time.Duration(timeoutInSeconds)*time.Second, false, func(ctx context.Context) (done bool, err error) {
+	return wait.PollUntilContextTimeout(ctx, slowPoll, time.Duration(timeoutInSeconds)*time.Second, false, func(ctx context.Context) (done bool, err error) {
 		endpoints, err = r.Kube.CoreV1().Endpoints(r.svc.Namespace).Get(ctx, r.svc.Name, metav1.GetOptions{})
 		if err != nil && !kerror.IsNotFound(err) {
 			r.Error(err, fmt.Sprintf("unable to get endpoint '%s/%s'", r.svc.Namespace, r.svc.Name))
@@ -90,8 +90,8 @@ func (r *Runner) waitForCompletion(podName string, timeoutInSeconds int) error {
 	})
 }
 
-func (r *Runner) getAllLogsFromPod(podName string) error {
-	pod, err := r.Kube.CoreV1().Pods(r.svc.Namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+func (r *Runner) getAllLogsFromPod(ctx context.Context, podName string) error {
+	pod, err := r.Kube.CoreV1().Pods(r.svc.Namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -102,7 +102,7 @@ func (r *Runner) getAllLogsFromPod(podName string) error {
 			r.Info(fmt.Sprintf("Trying to get logs for %s:%s", podName, containerStatus.Name))
 			request := r.Kube.CoreV1().Pods(r.svc.Namespace).GetLogs(podName, &kubev1.PodLogOptions{Container: containerStatus.Name})
 
-			logStream, err := request.Stream(context.TODO())
+			logStream, err := request.Stream(ctx)
 			if err != nil {
 				allErrors = multierror.Append(allErrors, err)
 				return

--- a/pkg/common/runner/service_test.go
+++ b/pkg/common/runner/service_test.go
@@ -19,15 +19,16 @@ func TestResultsService(t *testing.T) {
 	def := *DefaultRunner
 	r := &def
 	r.Kube = client
+	ctx := context.Background()
 
 	// create pod
-	pod, err := r.createPod()
+	pod, err := r.createPod(ctx)
 	if err != nil {
 		t.Fatalf("Failed to create example  pod: %v", err)
 	}
 
 	// create results service
-	r.svc, err = r.createService(pod)
+	r.svc, err = r.createService(ctx, pod)
 	if err != nil {
 		t.Fatalf("Failed to create example service: %v", err)
 	}
@@ -36,7 +37,7 @@ func TestResultsService(t *testing.T) {
 	done := make(chan struct{})
 	errs := make(chan error, 1)
 	go func() {
-		err := r.waitForCompletion(pod.Name, 1800)
+		err := r.waitForCompletion(ctx, pod.Name, 1800)
 		if err != nil {
 			errs <- fmt.Errorf("Failed waiting for endpoints: %v", err)
 		} else {


### PR DESCRIPTION
pass down a context from the entrypoint of runner to each place it is used to allow taking advantage of context management with ginkgo in the future (cancelation/timeout on failure of test for example)

also resolve Int64Ptr/Int32Ptr deprecations while here

[SDCICD-1266](https://issues.redhat.com//browse/SDCICD-1266)

https://go.dev/blog/context