### PR TITLE
SDCICD-1266: switch kms import out

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	golang.org/x/sync v0.7.0
 	golang.org/x/tools v0.19.0
 	google.golang.org/api v0.172.0
-	google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9
+	google.golang.org/genproto v0.0.0-20240213162025-012b6fc9bca9 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.1
 	k8s.io/api v0.28.4

--- a/pkg/e2e/verify/encrypted_storage.go
+++ b/pkg/e2e/verify/encrypted_storage.go
@@ -34,11 +34,11 @@ import (
 	"k8s.io/client-go/rest"
 
 	kmsv1 "cloud.google.com/go/kms/apiv1"
+	kmsprotov1 "cloud.google.com/go/kms/apiv1/kmspb"
 	cloudresourcemanagerv1 "google.golang.org/api/cloudresourcemanager/v1"
 	computev1 "google.golang.org/api/compute/v1"
 	"google.golang.org/api/option"
 	serviceusagev1 "google.golang.org/api/serviceusage/v1"
-	kmsprotov1 "google.golang.org/genproto/googleapis/cloud/kms/v1"
 )
 
 const (


### PR DESCRIPTION
the other import is deprecated in favor of this path

```
pkg/e2e/verify/encrypted_storage.go:41:13: "google.golang.org/genproto/googleapis/cloud/kms/v1" is deprecated: Please use types in: cloud.google.com/go/kms/apiv1/kmspb. Please read https://github.com/googleapis/google-cloud-go/blob/main/migration.md for more details.  (SA1019)
pkg/e2e/verify/encrypted_storage.go:256:45: kmsprotov1.GetKeyRingRequest is deprecated: Please use types in: cloud.google.com/go/kms/apiv1/kmspb  (SA1019)
pkg/e2e/verify/encrypted_storage.go:263:49: kmsprotov1.CreateKeyRingRequest is deprecated: Please use types in: cloud.google.com/go/kms/apiv1/kmspb  (SA1019)
pkg/e2e/verify/encrypted_storage.go:279:43: kmsprotov1.GetCryptoKeyRequest is deprecated: Please use types in: cloud.google.com/go/kms/apiv1/kmspb  (SA1019)
pkg/e2e/verify/encrypted_storage.go:286:45: kmsprotov1.CreateCryptoKeyRequest is deprecated: Please use types in: cloud.google.com/go/kms/apiv1/kmspb  (SA1019)
pkg/e2e/verify/encrypted_storage.go:289:15: kmsprotov1.CryptoKey is deprecated: Please use types in: cloud.google.com/go/kms/apiv1/kmspb  (SA1019)
pkg/e2e/verify/encrypted_storage.go:290:13: kmsprotov1.CryptoKey_ENCRYPT_DECRYPT is deprecated: Please use consts in: cloud.google.com/go/kms/apiv1/kmspb  (SA1019)
pkg/e2e/verify/encrypted_storage.go:291:22: kmsprotov1.CryptoKeyVersionTemplate is deprecated: Please use types in: cloud.google.com/go/kms/apiv1/kmspb  (SA1019)
pkg/e2e/verify/encrypted_storage.go:292:16: kmsprotov1.CryptoKeyVersion_GOOGLE_SYMMETRIC_ENCRYPTION is deprecated: Please use consts in: cloud.google.com/go/kms/apiv1/kmspb  (SA1019)
```

all the types are the same, nothing has changed besides the import path