### PR TITLE
SDCICD-1266: resolve all error strings capitalized

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -313,7 +313,7 @@ func waitForClusterReadyWithOverrideAndExpectedNumberOfNodes(clusterID string, l
 
 	cluster, err := provider.GetCluster(clusterID)
 	if err != nil {
-		return fmt.Errorf("Error fetching cluster details from provider: %w", err)
+		return fmt.Errorf("error fetching cluster details from provider: %w", err)
 	}
 
 	if pollErr := wait.PollUntilContextTimeout(context.TODO(), 30*time.Second, time.Duration(installTimeout)*time.Minute, false, func(_ context.Context) (bool, error) {

--- a/pkg/common/cluster/healthchecks/healthcheckjob.go
+++ b/pkg/common/cluster/healthchecks/healthcheckjob.go
@@ -23,7 +23,7 @@ func CheckHealthcheckJob(ctx context.Context, logger *log.Logger) error {
 
 	k8s, err := openshift.New(ginkgo.GinkgoLogr)
 	if err != nil {
-		return fmt.Errorf("Unable to setup k8s client: %w", err)
+		return fmt.Errorf("unable to setup k8s client: %w", err)
 	}
 
 	timeout, err := time.ParseDuration(viper.GetString(config.Tests.ClusterHealthChecksTimeout))

--- a/pkg/common/cluster/healthchecks/machines.go
+++ b/pkg/common/cluster/healthchecks/machines.go
@@ -33,7 +33,7 @@ func CheckMachinesObjectState(dynamicClient dynamic.Interface, logger *log.Logge
 		return false, err
 	}
 	if len(obj.Items) == 0 {
-		return false, fmt.Errorf("No machines found in the %s namespace", machinesNamespace)
+		return false, fmt.Errorf("no machines found in the %s namespace", machinesNamespace)
 	}
 
 	var metadataState []string
@@ -43,7 +43,7 @@ func CheckMachinesObjectState(dynamicClient dynamic.Interface, logger *log.Logge
 		err = runtime.DefaultUnstructuredConverter.
 			FromUnstructured(item.UnstructuredContent(), &machine)
 		if err != nil {
-			return false, fmt.Errorf("Error casting object: %s", err.Error())
+			return false, fmt.Errorf("error casting object: %s", err.Error())
 		}
 
 		if machine.Status.Phase == nil || *machine.Status.Phase != runningPhase {

--- a/pkg/common/helper/olm.go
+++ b/pkg/common/helper/olm.go
@@ -18,12 +18,12 @@ func (h *H) InspectOLM(ctx context.Context) error {
 
 	err := r.Run(inspectTimeoutInSeconds, stopCh)
 	if err != nil {
-		return fmt.Errorf("Error running OLM inspection: %s", err.Error())
+		return fmt.Errorf("error running OLM inspection: %s", err.Error())
 	}
 
 	gatherResults, err := r.RetrieveResults()
 	if err != nil {
-		return fmt.Errorf("Error retrieving OLM inspection results: %s", err.Error())
+		return fmt.Errorf("error retrieving OLM inspection results: %s", err.Error())
 	}
 
 	h.WriteResults(gatherResults)

--- a/pkg/common/helper/workloads.go
+++ b/pkg/common/helper/workloads.go
@@ -73,7 +73,7 @@ func ReadK8sYaml(file string) (runtime.Object, error) {
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 	obj, _, err := decode([]byte(f), nil, nil)
 	if err != nil {
-		return nil, fmt.Errorf("Error while decoding YAML object. Err was: %s", err)
+		return nil, fmt.Errorf("error while decoding YAML object. Err was: %s", err)
 	}
 
 	return obj, nil
@@ -87,7 +87,7 @@ func CreateRuntimeObject(obj runtime.Object, ns string, kube kubernetes.Interfac
 		err    error
 	)
 	if obj == nil {
-		return nil, fmt.Errorf("Nil object passed in")
+		return nil, fmt.Errorf("nil object passed in")
 	}
 
 	if _, err := kube.CoreV1().Namespaces().Get(context.TODO(), ns, metav1.GetOptions{}); err != nil {
@@ -102,7 +102,7 @@ func CreateRuntimeObject(obj runtime.Object, ns string, kube kubernetes.Interfac
 			Spec: corev1.NamespaceSpec{},
 		}, metav1.CreateOptions{})
 		if err != nil {
-			return nil, fmt.Errorf("Error creating namespace: %s", err.Error())
+			return nil, fmt.Errorf("error creating namespace: %s", err.Error())
 		}
 
 		// Need to wait till the namespace is actually created/active before proceeding
@@ -120,7 +120,7 @@ func CreateRuntimeObject(obj runtime.Object, ns string, kube kubernetes.Interfac
 	switch obj.GetObjectKind().GroupVersionKind().Kind {
 	case "Pod":
 		if _, ok = obj.(*corev1.Pod); !ok {
-			return nil, fmt.Errorf("Error casting object to pod")
+			return nil, fmt.Errorf("error casting object to pod")
 		}
 
 		if newObj, err = kube.CoreV1().Pods(ns).Create(context.TODO(), obj.(*corev1.Pod), metav1.CreateOptions{}); err != nil {
@@ -129,7 +129,7 @@ func CreateRuntimeObject(obj runtime.Object, ns string, kube kubernetes.Interfac
 		return newObj, nil
 	case "Service":
 		if _, ok = obj.(*corev1.Service); !ok {
-			return nil, fmt.Errorf("Error casting object to service")
+			return nil, fmt.Errorf("error casting object to service")
 		}
 		if newObj, err = kube.CoreV1().Services(ns).Create(context.TODO(), obj.(*corev1.Service), metav1.CreateOptions{}); err != nil {
 			return nil, err
@@ -153,7 +153,7 @@ func CreateRuntimeObject(obj runtime.Object, ns string, kube kubernetes.Interfac
 		return newObj, nil
 	case "PersistentVolume":
 		if _, ok = obj.(*corev1.PersistentVolume); !ok {
-			return nil, fmt.Errorf("Error casting object to PersistentVolume")
+			return nil, fmt.Errorf("error casting object to PersistentVolume")
 		}
 
 		if newObj, err = kube.CoreV1().PersistentVolumes().Create(context.TODO(), obj.(*corev1.PersistentVolume), metav1.CreateOptions{}); err != nil {
@@ -162,7 +162,7 @@ func CreateRuntimeObject(obj runtime.Object, ns string, kube kubernetes.Interfac
 		return newObj, nil
 	case "PersistentVolumeClaim":
 		if _, ok = obj.(*corev1.PersistentVolumeClaim); !ok {
-			return nil, fmt.Errorf("Error casting object to PersistentVolumeClaim")
+			return nil, fmt.Errorf("error casting object to PersistentVolumeClaim")
 		}
 
 		if newObj, err = kube.CoreV1().PersistentVolumeClaims(ns).Create(context.TODO(), obj.(*corev1.PersistentVolumeClaim), metav1.CreateOptions{}); err != nil {
@@ -171,7 +171,7 @@ func CreateRuntimeObject(obj runtime.Object, ns string, kube kubernetes.Interfac
 		return newObj, nil
 	case "Secret":
 		if _, ok = obj.(*corev1.Secret); !ok {
-			return nil, fmt.Errorf("Error casting object to Secret")
+			return nil, fmt.Errorf("error casting object to Secret")
 		}
 
 		if newObj, err = kube.CoreV1().Secrets(ns).Create(context.TODO(), obj.(*corev1.Secret), metav1.CreateOptions{}); err != nil {
@@ -180,7 +180,7 @@ func CreateRuntimeObject(obj runtime.Object, ns string, kube kubernetes.Interfac
 		return newObj, nil
 	case "PodDisruptionBudget":
 		if _, ok = obj.(*policyv1.PodDisruptionBudget); !ok {
-			return nil, fmt.Errorf("Error casting object to PodDisruptionBudget")
+			return nil, fmt.Errorf("error casting object to PodDisruptionBudget")
 		}
 		if newObj, err = kube.PolicyV1().PodDisruptionBudgets(ns).Create(context.TODO(), obj.(*policyv1.PodDisruptionBudget), metav1.CreateOptions{}); err != nil {
 			return nil, err
@@ -188,6 +188,6 @@ func CreateRuntimeObject(obj runtime.Object, ns string, kube kubernetes.Interfac
 		return newObj, nil
 
 	default:
-		return nil, fmt.Errorf("Unable to handle object type %s", obj.GetObjectKind().GroupVersionKind().Kind)
+		return nil, fmt.Errorf("unable to handle object type %s", obj.GetObjectKind().GroupVersionKind().Kind)
 	}
 }

--- a/pkg/common/prometheus/connect.go
+++ b/pkg/common/prometheus/connect.go
@@ -95,7 +95,7 @@ func getClusterPrometheusHost(h *helper.H) (*string, error) {
 func getClusterPrometheusToken(h *helper.H) (*string, error) {
 	secrets, err := h.Kube().CoreV1().Secrets("openshift-monitoring").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("Unable to fetch secrets in openshift-monitoring")
+		return nil, fmt.Errorf("unable to fetch secrets in openshift-monitoring")
 	}
 
 	stringToken := ""
@@ -107,7 +107,7 @@ func getClusterPrometheusToken(h *helper.H) (*string, error) {
 		}
 	}
 	if len(stringToken) == 0 {
-		return nil, fmt.Errorf("Failed to find token secret for prometheus-k8s SA")
+		return nil, fmt.Errorf("failed to find token secret for prometheus-k8s SA")
 	}
 
 	return &stringToken, nil

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -75,7 +75,7 @@ func (m *MockProvider) IsValidClusterName(clusterName string) (bool, error) {
 	if m.env == "fail" {
 		switch clusterName {
 		case "error":
-			return false, fmt.Errorf("Fake IsValidClusterName error")
+			return false, fmt.Errorf("fake IsValidClusterName error")
 		case "false":
 			return false, nil
 		}
@@ -189,7 +189,7 @@ func (m *MockProvider) InstallAddons(clusterID string, addonIDs []spi.AddOnID, p
 
 	cluster, err := m.GetCluster(clusterID)
 	if err != nil {
-		return 0, fmt.Errorf("Unable to retrieve cluster: %s", err.Error())
+		return 0, fmt.Errorf("unable to retrieve cluster: %s", err.Error())
 	}
 	// We can't access the addons field directly so we have to rebuild the cluster object from scratch
 	// This is fine as any real provider would call an external API to update or retrieve addons and
@@ -212,7 +212,7 @@ func (m *MockProvider) InstallAddons(clusterID string, addonIDs []spi.AddOnID, p
 // Versions mocks a versions operation.
 func (m *MockProvider) Versions() (*spi.VersionList, error) {
 	if m.env == "fail" {
-		return nil, fmt.Errorf("Fake error returning version list")
+		return nil, fmt.Errorf("fake error returning version list")
 	}
 
 	return m.versions, nil
@@ -264,42 +264,42 @@ func (m *MockProvider) Type() string {
 
 // ExtendExpiry mocks an extend cluster expiry operation.
 func (m *MockProvider) ExtendExpiry(clusterID string, hours uint64, minutes uint64, seconds uint64) error {
-	return fmt.Errorf("ExtendExpiry is unsupported by mock clusters")
+	return fmt.Errorf("unsupported by mock clusters")
 }
 
 // Expire mocks an expire cluster expiry operation.
 func (m *MockProvider) Expire(clusterID string, duration time.Duration) error {
-	return fmt.Errorf("Expire is unsupported by mock clusters")
+	return fmt.Errorf("unsupported by mock clusters")
 }
 
 // AddProperty mocks an add new cluster property operation.
 func (m *MockProvider) AddProperty(cluster *spi.Cluster, tag string, value string) error {
-	return fmt.Errorf("AddProperty is unsupported by mock clusters")
+	return fmt.Errorf("unsupported by mock clusters")
 }
 
 // GetProperty mocks getting a property from the properties field of an existing cluster.
 func (m *MockProvider) GetProperty(clusterID string, property string) (string, error) {
-	return "GetProperty is unsupported by mock clusters", nil
+	return "unsupported by mock clusters", nil
 }
 
 // Upgrade mocks initiates a cluster upgrade to the given version
 func (m *MockProvider) Upgrade(clusterID string, version string, t time.Time) error {
-	return fmt.Errorf("Upgrade is unsupported by mock clusters")
+	return fmt.Errorf("unsupported by mock clusters")
 }
 
 // Get upgrade policy ID mocks fetch the upgrade policy for a cluster
 func (m *MockProvider) GetUpgradePolicyID(clusterID string) (string, error) {
-	return "mock", fmt.Errorf("Get mock upgrade policy failed")
+	return "mock", fmt.Errorf("get mock upgrade policy failed")
 }
 
 // UpdateSchedule mocks reschedule the upgrade
 func (m *MockProvider) UpdateSchedule(clusterID string, version string, t time.Time, policyID string) error {
-	return fmt.Errorf("Upgrade Schedule is not supported by mock clusters")
+	return fmt.Errorf("not supported by mock clusters")
 }
 
 // DetermineMachineType returns a random machine type for a given cluster
 func (m *MockProvider) DetermineMachineType(cloudProvider string) (string, error) {
-	return "mock", fmt.Errorf("DetermineMachineType is not supported by mock clusters")
+	return "mock", fmt.Errorf("not supported by mock clusters")
 }
 
 // Resume resumes a cluster via OCM

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -45,7 +45,7 @@ func (o *OCMProvider) IsValidClusterName(clusterName string) (bool, error) {
 			Page(page).
 			SendContext(ctx)
 		if err != nil {
-			return false, fmt.Errorf("Can't retrieve page %d: %s\n", page, err)
+			return false, fmt.Errorf("can't retrieve page %d: %w", page, err)
 		}
 
 		if response.Total() != 0 {

--- a/pkg/common/providers/ocmprovider/quota.go
+++ b/pkg/common/providers/ocmprovider/quota.go
@@ -17,7 +17,7 @@ func (o *OCMProvider) CheckQuota(skuRuleID string) (bool, error) {
 	err := retryer().Do(func() error {
 		var err error
 		if skuRuleID == "" {
-			return fmt.Errorf("No valid SKU selected")
+			return fmt.Errorf("no valid SKU selected")
 		}
 		skuResp, err = o.conn.AccountsMgmt().V1().SkuRules().SkuRule(skuRuleID).Get().Send()
 
@@ -100,7 +100,7 @@ func (o *OCMProvider) currentAccountQuota() (*accounts.QuotaCostList, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting quota list: %v", err)
 	} else if quotaList == nil {
-		return nil, errors.New("QuotaList can't be nil")
+		return nil, errors.New("quotaList can't be nil")
 	}
 
 	return quotaList.Items(), nil

--- a/pkg/common/runner/results.go
+++ b/pkg/common/runner/results.go
@@ -31,7 +31,7 @@ func ensurePassingXML(results map[string][]byte) (hadXML bool, err error) {
 		log.Println("checking", filename)
 		match, err = filepath.Match("junit*.xml", filename)
 		if err != nil {
-			err = fmt.Errorf("Failed matching filename %s: %w", filename, err)
+			err = fmt.Errorf("failed matching filename %s: %w", filename, err)
 			return
 		}
 		if match {
@@ -39,7 +39,7 @@ func ensurePassingXML(results map[string][]byte) (hadXML bool, err error) {
 			// Use Ginkgo's JUnitTestSuite to unmarshal the JUnit XML file
 			suites, e := junit.Ingest(data)
 			if e != nil {
-				err = fmt.Errorf("Failed parsing junit xml in %s: %w", filename, e)
+				err = fmt.Errorf("failed parsing junit xml in %s: %w", filename, e)
 				return
 			}
 			for _, suite := range suites {

--- a/pkg/common/upgrade/upgrade.go
+++ b/pkg/common/upgrade/upgrade.go
@@ -123,7 +123,7 @@ func RunUpgrade(h *helper.H) error {
 	if viper.GetBool(config.Upgrade.ManagedUpgradeTestNodeDrain) {
 		list, err := h.Kube().CoreV1().Pods(h.CurrentProject()).List(context.TODO(), metav1.ListOptions{LabelSelector: "app=node-drain-test"})
 		if err != nil {
-			return fmt.Errorf("Error listing pods: %s", err.Error())
+			return fmt.Errorf("error listing pods: %s", err.Error())
 		}
 		if len(list.Items) != 0 {
 			for _, item := range list.Items {

--- a/pkg/common/versions/upgradeselectors/latest_version_selector.go
+++ b/pkg/common/versions/upgradeselectors/latest_version_selector.go
@@ -39,7 +39,7 @@ func (l latestVersion) SelectVersion(installVersion *spi.Version, versionList *s
 	}
 
 	if !newestVersion.Version().GreaterThan(installVersion.Version()) {
-		return nil, "latest version", fmt.Errorf("No available upgrade path for version %s", installVersion.Version().Original())
+		return nil, "latest version", fmt.Errorf("no available upgrade path for version %s", installVersion.Version().Original())
 	}
 	return newestVersion, "latest version", nil
 }

--- a/pkg/common/versions/upgradeselectors/latest_y_selector.go
+++ b/pkg/common/versions/upgradeselectors/latest_y_selector.go
@@ -43,7 +43,7 @@ func (l latestYVersion) SelectVersion(installVersion *spi.Version, versionList *
 	}
 
 	if !newestVersion.Version().GreaterThan(installVersion.Version()) {
-		return nil, "latest y version", fmt.Errorf("No available upgrade path for version %s", installVersion.Version().Original())
+		return nil, "latest y version", fmt.Errorf("no available upgrade path for version %s", installVersion.Version().Original())
 	}
 	return newestVersion, "latest y version", nil
 }

--- a/pkg/common/versions/upgradeselectors/latest_z_selector.go
+++ b/pkg/common/versions/upgradeselectors/latest_z_selector.go
@@ -49,7 +49,7 @@ func (l latestZVersion) SelectVersion(installVersion *spi.Version, versionList *
 		}
 	}
 	if newestVersion.Version().Equal(installVersion.Version()) {
-		return nil, "latest z version", fmt.Errorf("No available upgrade path for version %s", installVersion.Version().Original())
+		return nil, "latest z version", fmt.Errorf("no available upgrade path for version %s", installVersion.Version().Original())
 	}
 	return newestVersion, "latest z version", nil
 }

--- a/pkg/debug/diff.go
+++ b/pkg/debug/diff.go
@@ -130,7 +130,7 @@ func GetCurrentMCCHash() (hash string, err error) {
 		return commits[0].GetSHA(), nil
 	}
 
-	return "", fmt.Errorf("No commits found for openshift/machine-cluster-config")
+	return "", fmt.Errorf("no commits found for openshift/machine-cluster-config")
 }
 
 func getLastJobID(baseProwURL, jobName string) (int, error) {

--- a/pkg/e2e/operators/managedvelero.go
+++ b/pkg/e2e/operators/managedvelero.go
@@ -410,17 +410,17 @@ func checkVeleroBackups(h *helper.H, operatorNamespace string) {
 					Resource: "backups",
 				}).Namespace(operatorNamespace).List(ctx, metav1.ListOptions{})
 				if err != nil {
-					return false, fmt.Errorf("Error getting backups: %s", err.Error())
+					return false, fmt.Errorf("error getting backups: %s", err.Error())
 				}
 				for _, item := range us.Items {
 					var backup velerov1.Backup
 					err = runtime.DefaultUnstructuredConverter.
 						FromUnstructured(item.UnstructuredContent(), &backup)
 					if err != nil {
-						return false, fmt.Errorf("Error casting object: %s", err.Error())
+						return false, fmt.Errorf("error casting object: %s", err.Error())
 					}
 					if backup.Status.Phase == velerov1.BackupPhaseFailed {
-						return false, fmt.Errorf("Backup failed for %s", backup.Name)
+						return false, fmt.Errorf("backup failed for %s", backup.Name)
 					}
 					if backup.Status.Phase != velerov1.BackupPhaseCompleted {
 						return false, nil

--- a/pkg/e2e/operators/operators.go
+++ b/pkg/e2e/operators/operators.go
@@ -221,7 +221,7 @@ Loop:
 				log.Printf("Waiting %v for %s roleBinding to exist", (timeoutDuration - elapsed), roleBindingName)
 				time.Sleep(intervalDuration)
 			} else {
-				err = fmt.Errorf("Failed to get rolebinding %s before timeout", roleBindingName)
+				err = fmt.Errorf("failed to get rolebinding %s before timeout", roleBindingName)
 				break Loop
 			}
 		}
@@ -263,7 +263,7 @@ Loop:
 				log.Printf("Waiting %v for %s configMap to exist", (timeoutDuration - elapsed), operatorLockFile)
 				time.Sleep(intervalDuration)
 			} else {
-				err = fmt.Errorf("Failed to get configMap %s before timeout", operatorLockFile)
+				err = fmt.Errorf("failed to get configMap %s before timeout", operatorLockFile)
 				break Loop
 			}
 		}
@@ -307,7 +307,7 @@ Loop:
 				time.Sleep(intervalDuration)
 			} else {
 				deployment = nil
-				err = fmt.Errorf("Failed to get %s Deployment before timeout", deploymentName)
+				err = fmt.Errorf("failed to get %s Deployment before timeout", deploymentName)
 				break Loop
 			}
 		}


### PR DESCRIPTION
change all error strings that start with a capital letter to lowercase. Errors are meant to be joined and wrapped, giving context to other errors. Capitalization and punctuation interupt the flow and lead to poorly formatted error messages.

```
$ staticcheck ./... | grep "error strings"
pkg/common/cluster/clusterutil.go:316:10: error strings should not be capitalized (ST1005)
pkg/common/cluster/healthchecks/healthcheckjob.go:26:10: error strings should not be capitalized (ST1005)
pkg/common/cluster/healthchecks/machines.go:36:17: error strings should not be capitalized (ST1005)
pkg/common/cluster/healthchecks/machines.go:46:18: error strings should not be capitalized (ST1005)
pkg/common/helper/olm.go:21:10: error strings should not be capitalized (ST1005)
pkg/common/helper/olm.go:26:10: error strings should not be capitalized (ST1005)
pkg/common/helper/workloads.go:76:15: error strings should not be capitalized (ST1005)
pkg/common/helper/workloads.go:90:15: error strings should not be capitalized (ST1005)
pkg/common/helper/workloads.go:105:16: error strings should not be capitalized (ST1005)
pkg/common/helper/workloads.go:123:16: error strings should not be capitalized (ST1005)
pkg/common/helper/workloads.go:132:16: error strings should not be capitalized (ST1005)
pkg/common/helper/workloads.go:156:16: error strings should not be capitalized (ST1005)
pkg/common/helper/workloads.go:165:16: error strings should not be capitalized (ST1005)
pkg/common/helper/workloads.go:174:16: error strings should not be capitalized (ST1005)
pkg/common/helper/workloads.go:183:16: error strings should not be capitalized (ST1005)
pkg/common/helper/workloads.go:191:15: error strings should not be capitalized (ST1005)
pkg/common/prometheus/connect.go:98:15: error strings should not be capitalized (ST1005)
pkg/common/prometheus/connect.go:110:15: error strings should not be capitalized (ST1005)
pkg/common/providers/mock/mock.go:78:18: error strings should not be capitalized (ST1005)
pkg/common/providers/mock/mock.go:192:13: error strings should not be capitalized (ST1005)
pkg/common/providers/mock/mock.go:215:15: error strings should not be capitalized (ST1005)
pkg/common/providers/mock/mock.go:292:17: error strings should not be capitalized (ST1005)
pkg/common/providers/ocmprovider/cluster.go:48:18: error strings should not be capitalized (ST1005)
pkg/common/providers/ocmprovider/cluster.go:48:18: error strings should not end with punctuation or newlines (ST1005)
pkg/common/providers/ocmprovider/quota.go:20:11: error strings should not be capitalized (ST1005)
pkg/common/runner/results.go:34:10: error strings should not be capitalized (ST1005)
pkg/common/runner/results.go:42:11: error strings should not be capitalized (ST1005)
pkg/common/upgrade/upgrade.go:126:11: error strings should not be capitalized (ST1005)
pkg/common/versions/upgradeselectors/latest_version_selector.go:42:33: error strings should not be capitalized (ST1005)
pkg/common/versions/upgradeselectors/latest_y_selector.go:46:35: error strings should not be capitalized (ST1005)
pkg/common/versions/upgradeselectors/latest_z_selector.go:52:35: error strings should not be capitalized (ST1005)
pkg/debug/diff.go:133:13: error strings should not be capitalized (ST1005)
pkg/e2e/operators/managedvelero.go:413:20: error strings should not be capitalized (ST1005)
pkg/e2e/operators/managedvelero.go:420:21: error strings should not be capitalized (ST1005)
pkg/e2e/operators/managedvelero.go:423:21: error strings should not be capitalized (ST1005)
pkg/e2e/operators/operators.go:224:11: error strings should not be capitalized (ST1005)
pkg/e2e/operators/operators.go:266:11: error strings should not be capitalized (ST1005)
pkg/e2e/operators/operators.go:310:11: error strings should not be capitalized (ST1005)
```