### PR TITLE
SDCICD-1266: resolve unnecessary actions lint

### DIFF
--- a/pkg/common/metadata/metadata.go
+++ b/pkg/common/metadata/metadata.go
@@ -210,11 +210,7 @@ func (m *Metadata) ResetLogMetrics() {
 // IncrementLogMetric adds a supplied number to a log metric or sets the metric to
 // the value if it doesn't exist already
 func (m *Metadata) IncrementLogMetric(metric string, value int) {
-	if _, ok := m.LogMetrics[metric]; ok {
-		m.LogMetrics[metric] += value
-	} else {
-		m.LogMetrics[metric] = value
-	}
+	m.LogMetrics[metric] += value
 
 	m.WriteToJSON(m.ReportDir)
 }
@@ -229,11 +225,7 @@ func (m *Metadata) ResetBeforeSuiteMetrics() {
 // IncrementBeforeSuiteMetric adds a supplied number to a before suite metric or sets the metric to
 // the value if it doesn't exist already
 func (m *Metadata) IncrementBeforeSuiteMetric(metric string, value int) {
-	if _, ok := m.BeforeSuiteMetrics[metric]; ok {
-		m.BeforeSuiteMetrics[metric] += value
-	} else {
-		m.BeforeSuiteMetrics[metric] = value
-	}
+	m.BeforeSuiteMetrics[metric] += value
 
 	m.WriteToJSON(m.ReportDir)
 }

--- a/pkg/common/upgrade/managed.go
+++ b/pkg/common/upgrade/managed.go
@@ -275,7 +275,7 @@ func isManagedUpgradeDone(h *helper.H) (done bool, msg string, err error) {
 		}
 		if policyID != "" {
 			// The provider has an upgrade policy. MUO might be waiting to sync it into an upgradeconfig
-			return false, fmt.Sprintf("cluster provider has an upgrade policy, but cluster has no upgradeconfig yet"), nil
+			return false, "cluster provider has an upgrade policy, but cluster has no upgradeconfig yet", nil
 		}
 		if policyID == "" {
 			// The provider successfully returned that it contains no upgrade policies.
@@ -306,7 +306,7 @@ func isManagedUpgradeDone(h *helper.H) (done bool, msg string, err error) {
 
 	// If the Upgrade History is empty, the upgrade hasn't started, try again later
 	if upgradeHistory == nil {
-		return false, fmt.Sprintf("upgrade yet to commence"), nil
+		return false, "upgrade yet to commence", nil
 	}
 
 	// If the Upgrade History phase indicates the upgrade has failed, we can bail out here
@@ -322,7 +322,7 @@ func isManagedUpgradeDone(h *helper.H) (done bool, msg string, err error) {
 	// Otherwise, report back what current phase and upgrade condition the upgrade is at
 	upgradeConditions := upgradeHistory.Conditions
 	if len(upgradeConditions) == 0 {
-		return false, fmt.Sprintf("current upgrade status is pending"), nil
+		return false, "current upgrade status is pending", nil
 	}
 	statusMsg := upgradeConditions[0].Message
 	statusTimeStr := "unknown"

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -500,7 +500,7 @@ func runGinkgoTests() (int, error) {
 			// close route monitors
 			if viper.GetBool(config.Upgrade.MonitorRoutesDuringUpgrade) && !suiteConfig.DryRun {
 				close(routeMonitorChan)
-				_ = <-closeMonitorChan
+				<-closeMonitorChan
 				log.Println("Route monitors reconciled")
 			}
 		} else {

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			if config.Tests.LogBucket != "" {
 				err = h.UploadResultsToS3(results, harnessImage+time.Now().Format(time.DateOnly+"_"+time.TimeOnly))
 				if err != nil {
-					ginkgo.GinkgoLogr.Error(err, fmt.Sprintf("reporting error"))
+					ginkgo.GinkgoLogr.Error(err, "reporting error")
 				}
 			}
 			// Adding harness report failures to top level junit report

--- a/pkg/e2e/osd/dedicatedadmin.go
+++ b/pkg/e2e/osd/dedicatedadmin.go
@@ -240,7 +240,7 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, label.Informing, func() {
 				h.Impersonate(rest.ImpersonationConfig{})
 			}()
 
-			patchData := []byte(fmt.Sprintf(`{"spec":{"plugins":["test"]}}`))
+			patchData := []byte(`{"spec":{"plugins":["test"]}}`)
 
 			_, err := h.Dynamic().Resource(schema.GroupVersionResource{
 				Group: "operator.openshift.io", Version: "v1",
@@ -248,7 +248,7 @@ var _ = ginkgo.Describe(dedicatedAdminTestName, label.Informing, func() {
 			}).Patch(ctx, "cluster", types.MergePatchType, patchData, metav1.PatchOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			// revret the changes
-			patchEmpty := []byte(fmt.Sprintf(`{"spec":{"plugins":[""]}}`))
+			patchEmpty := []byte(`{"spec":{"plugins":[""]}}`)
 
 			_, err = h.Dynamic().Resource(schema.GroupVersionResource{
 				Group: "operator.openshift.io", Version: "v1",


### PR DESCRIPTION
Resolve the lints below: S1036, S1039, S1005

```
❯ staticcheck ./... | grep unnecessary
pkg/common/metadata/metadata.go:213:2: unnecessary guard around map access (S1036)
pkg/common/metadata/metadata.go:232:2: unnecessary guard around map access (S1036)
pkg/common/upgrade/managed.go:278:18: unnecessary use of fmt.Sprintf (S1039)
pkg/common/upgrade/managed.go:309:17: unnecessary use of fmt.Sprintf (S1039)
pkg/common/upgrade/managed.go:325:17: unnecessary use of fmt.Sprintf (S1039)
pkg/e2e/e2e.go:503:5: unnecessary assignment to the blank identifier (S1005)
pkg/e2e/harness_runner/harness_runner.go:95:35: unnecessary use of fmt.Sprintf (S1039)
pkg/e2e/osd/dedicatedadmin.go:243:24: unnecessary use of fmt.Sprintf (S1039)
pkg/e2e/osd/dedicatedadmin.go:251:25: unnecessary use of fmt.Sprintf (S1039)
```

[SDCICD-1266](https://issues.redhat.com//browse/SDCICD-1266)

Signed-off-by: Brady Pratt <bpratt@redhat.com>
