### PR TITLE
SDCICD-1271 add elasticIP release process to cleanup command

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -25,6 +25,7 @@ var args struct {
 	secretLocations string
 	clusterID       string
 	iam             bool
+	elasticIP       bool
 	s3              bool
 	olderThan       string
 	dryRun          bool
@@ -63,6 +64,12 @@ func init() {
 		"iam",
 		false,
 		"Cleanup iam resources",
+	)
+	flags.BoolVar(
+		&args.elasticIP,
+		"elastic-ip",
+		false,
+		"Cleanup elastic IPs",
 	)
 	flags.BoolVar(
 		&args.s3,
@@ -172,6 +179,13 @@ func run(cmd *cobra.Command, argv []string) error {
 		err = aws.CcsAwsSession.CleanupS3Buckets(fmtDuration, args.dryRun)
 		if err != nil {
 			return fmt.Errorf("could not delete s3 buckets: %s", err.Error())
+		}
+	}
+
+	if args.elasticIP {
+		err = aws.CcsAwsSession.ReleaseElasticIPs(args.dryRun)
+		if err != nil {
+			return fmt.Errorf("could not release ips: %s", err.Error())
 		}
 	}
 


### PR DESCRIPTION
Adds "--elastic-ip" flag to cleanup subcommand. Accepts "--dry-run"

ReleaseElasticIPs releases elastic IPs from loaded aws session. If an instance is
 associated with it, we skip its deletion and log tag name. Dryrun returns aws Error
 from AWS api and is logged.

Dry run output:
```
Addresses found: 34
Address 35.153.58.98 not deleted: DryRunOperation: Request would have succeeded, but DryRun flag is set.
        status code: 412, request id: 890746c9-6229-463a-80aa-df5e3804f4ed
Address 35.169.191.91 not deleted: DryRunOperation: Request would have succeeded, but DryRun flag is set.
        status code: 412, request id: 76245cc6-5bbf-4373-833f-fec5f909de01
        [....]
Finished elastic IP cleanup. Deleted 0 addresses.
```

Active run output
```
Addresses found: 34
Address deleted: 107.22.98.140
Address deleted: 18.204.190.60
[....]
Finished elastic IP cleanup. Deleted 34 addresses.
```

Associated IP output

```
Addresses found: 1
Skipping address 44.218.237.110 still allocated to cluster [Tag: rm-2024-04-17-klp4h-eip-us-east-1a].
Finished elastic IP cleanup. Deleted 0 addresses.
```