### PR TITLE
dependabot: create k8s group to bump together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     - "dependencies"
     - "ok-to-test"
   open-pull-requests-limit: 20
+  groups:
+    kubernetes:
+      patterns:
+        - "k8s.io/*"
+        - "sigs.k8s.io/*"


### PR DESCRIPTION
This is the recommended way to bump related dependencies which should allow for less churn and getting PRs stuck on bad builds. The PR will include all k8s deps to allow them to be bumped in lockstep

https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/