### PR TITLE
SDCICD-1271 update log for skipping deletion of associated ips

### DIFF
--- a/pkg/common/aws/ec2.go
+++ b/pkg/common/aws/ec2.go
@@ -49,7 +49,6 @@ func (CcsAwsSession *ccsAwsSession) ReleaseElasticIPs(dryrun bool) error {
 	}
 	fmt.Printf("Addresses found: %d\n", len(results.Addresses))
 	deleted := 0
-	name := ""
 
 	for _, address := range results.Addresses {
 		if address.AssociationId == nil {
@@ -64,12 +63,7 @@ func (CcsAwsSession *ccsAwsSession) ReleaseElasticIPs(dryrun bool) error {
 				fmt.Printf("Address %s not deleted: %s\n", *address.PublicIp, err.Error())
 			}
 		} else {
-			for _, v := range address.Tags {
-				if *v.Key == "Name" {
-					name = *v.Value
-				}
-			}
-			fmt.Printf("Skipping address %s still allocated to cluster [Tag: %s].\n", *address.PublicIp, name)
+			fmt.Printf("Skipping address %s still allocated to network interface id %s \n", *address.PublicIp, *address.NetworkInterfaceId)
 		}
 	}
 	fmt.Printf("Finished elastic IP cleanup. Deleted %d addresses.", deleted)


### PR DESCRIPTION
some associations are not linked to instances resulting in empty values in logs. Use assoc id instead, which is always present.