### PR TITLE
SDCICD-1198 ocp test skip regex

### DIFF
--- a/cmd/osde2e/test/cmd.go
+++ b/cmd/osde2e/test/cmd.go
@@ -52,6 +52,7 @@ var args struct {
 	skipTests          string
 	labelFilter        string
 	ocpTestSuite       string
+	ocpTestSkipRegex   string
 }
 
 func init() {
@@ -128,6 +129,12 @@ func init() {
 		"The type of openshift-test conformance suite to run.",
 	)
 	pfs.StringVar(
+		&args.ocpTestSkipRegex,
+		"ocp-test-skip-regex",
+		"",
+		"Regex for openshift-test conformance test specs to skip.",
+	)
+	pfs.StringVar(
 		&args.skipTests,
 		"skip-tests",
 		"",
@@ -154,6 +161,7 @@ func init() {
 	viper.BindPFlag(config.Tests.SkipClusterHealthChecks, Cmd.PersistentFlags().Lookup("skip-health-check"))
 	viper.BindPFlag(config.Tests.GinkgoFocus, Cmd.PersistentFlags().Lookup("focus-tests"))
 	viper.BindPFlag(config.Tests.OCPTestSuite, Cmd.PersistentFlags().Lookup("ocp-test-suite"))
+	viper.BindPFlag(config.Tests.OCPTestSkipRegex, Cmd.PersistentFlags().Lookup("ocp-test-skip-regex"))
 	viper.BindPFlag(config.Tests.GinkgoSkip, Cmd.PersistentFlags().Lookup("skip-tests"))
 	viper.BindPFlag(config.SkipMustGather, Cmd.PersistentFlags().Lookup("skip-must-gather"))
 	viper.BindPFlag(config.Tests.GinkgoLabelFilter, Cmd.PersistentFlags().Lookup("label-filter"))

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -255,6 +255,11 @@ var Tests = struct {
 	// arg --ocp-test-suite
 	OCPTestSuite string
 
+	// OCPTestSkipRegex Regex to skip ocp test specs.
+	// Env: OCP_TEST_SKIP_REGEX
+	// arg --ocp-test-skip-regex
+	OCPTestSkipRegex string
+
 	// SuppressSkipNotifications suppresses the notifications of skipped tests
 	// Env: SUPPRESS_SKIP_NOTIFICATIONS
 	SuppressSkipNotifications string
@@ -297,6 +302,7 @@ var Tests = struct {
 	GinkgoLabelFilter:          "tests.ginkgoLabelFilter",
 	TestsToRun:                 "tests.testsToRun",
 	OCPTestSuite:               "tests.ocpTestSuite",
+	OCPTestSkipRegex:           "tests.ocpTestSkipRegex",
 	SuppressSkipNotifications:  "tests.suppressSkipNotifications",
 	CleanRuns:                  "tests.cleanRuns",
 	OperatorSkip:               "tests.operatorSkip",
@@ -722,6 +728,7 @@ func InitOSDe2eViper() {
 	viper.BindEnv(Tests.TestsToRun, "TESTS_TO_RUN")
 
 	viper.BindEnv(Tests.OCPTestSuite, "OCP_TEST_SUITE")
+	viper.BindEnv(Tests.OCPTestSkipRegex, "OCP_TEST_SKIP_REGEX")
 
 	viper.SetDefault(Tests.SuppressSkipNotifications, true)
 	viper.BindEnv(Tests.SuppressSkipNotifications, "SUPPRESS_SKIP_NOTIFICATIONS")


### PR DESCRIPTION
ocp tests dry run is currently the only way to skip tests. A list of all tests is generated using dry run and a test list file is created by inverse grepping it with the skipped test specs regex.

