### PR TITLE
[closed] run ocp tests with harness-like templating instead of go template engine

### DIFF
--- a/assets/tests/ocp-tests-runner.template
+++ b/assets/tests/ocp-tests-runner.template
@@ -1,0 +1,89 @@
+cat <<WORKLOAD > workload.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{.JobName}}
+spec:
+  parallelism: 1
+  completions: 1
+  activeDeadlineSeconds: {{.Timeout}}
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccount: {{.ServiceAccount}}
+      containers:
+      - name: test-harness
+        image: {{.Image}}
+        imagePullPolicy: Always
+        command: [ /bin/sh, /test-cmd/test-cmd.sh ]
+        {{ if .Arguments }}
+        args: {{.Arguments}}
+        {{ end }}
+        env:
+        {{- range $env := .EnvironmentVariables }}
+        - name: {{ $env.Name }}
+          value: {{ $env.Value }}
+        {{- end }}
+        volumeMounts:
+        - mountPath: {{.OutputDir}}
+          name: test-output
+        - mountPath: /test-cmd
+          name: test-cmd
+      - name: push-results
+        image: {{.PushResultsContainer}}
+        imagePullPolicy: Always
+        command: [/bin/sh, /push-results/push-results.sh]
+        volumeMounts:
+        - mountPath: {{.OutputDir}}
+          name: test-output
+        - mountPath: /push-results
+          name: push-results
+        - mountPath: /test-cmd
+          name: test-cmd
+      volumes:
+      - name: test-output
+        emptyDir: {}
+      - name: push-results
+        configMap:
+          name: push-results-{{.Suffix}}
+      - name: test-cmd
+        configMap:
+          name: test-cmd-{{.Suffix}}
+      restartPolicy: Never
+WORKLOAD
+
+set -e
+
+cat <<TEST_CMD > test-cmd.sh
+{{.Command}}
+TEST_CMD
+
+
+cat <<PUSH_RESULTS > push-results.sh
+#!/usr/bin/env bash
+
+JOB_POD=\$(oc get pods -l job-name={{.JobName}} -o=jsonpath='{.items[0].metadata.name}')
+echo "Found Job Pod: \$JOB_POD"
+while ! oc get pod \$JOB_POD -o jsonpath='{.status.containerStatuses[?(@.name=="test-harness")].state}' | grep -q terminated; do sleep 1; done
+for i in {1..5}; do oc rsync {{.OutputDir}}/. $(hostname):{{.OutputDir}} && break; sleep 10; done
+PUSH_RESULTS
+
+cat workload.yaml
+cat push-results.sh
+cat test-cmd.sh
+
+oc create configmap push-results-{{.Suffix}} --from-file=push-results.sh
+oc create configmap test-cmd-{{.Suffix}} --from-file=test-cmd.sh
+
+oc apply -f workload.yaml
+
+sleep 5
+
+set +e
+
+while oc get job/{{.JobName}} -o=jsonpath='{.status}' | grep -q active; do sleep 1; done
+
+mkdir -p "{{.OutputDir}}/containerLogs"
+JOB_POD=$(oc get pods -l job-name={{.JobName}} -o=jsonpath='{.items[0].metadata.name}')
+oc logs $JOB_POD -c test-harness > "{{.OutputDir}}/containerLogs/${JOB_POD}-test-harness.log"
+oc logs $JOB_POD -c push-results > "{{.OutputDir}}/containerLogs/${JOB_POD}-push-results.log"

--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -21,6 +21,8 @@ import (
 	"github.com/openshift/osde2e-common/pkg/clients/openshift"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/runner"
+	"github.com/openshift/osde2e/pkg/common/templates"
 	"github.com/openshift/osde2e/pkg/common/util"
 	"golang.org/x/oauth2/google"
 	computev1 "google.golang.org/api/compute/v1"
@@ -531,4 +533,69 @@ func (h *H) GetConfig() *rest.Config {
 
 func (h *H) GetClient() *openshift.Client {
 	return h.client
+}
+
+// GetRunnerCommandString Generates templated command string to provide to test harness container
+func (h *H) GetRunnerCommandString(templatePath string, timeout int, latestImageStream string, harness string, suffix string, jobName string, serviceAccountDir string, command string, serviceAccountNamespacedName string) string {
+	ginkgo.GinkgoHelper()
+	values := struct {
+		Name                 string
+		JobName              string
+		Arguments            string
+		Timeout              int
+		Image                string
+		Command              string
+		OutputDir            string
+		ServiceAccount       string
+		PushResultsContainer string
+		Suffix               string
+		Server               string
+		CA                   string
+		TokenFile            string
+		EnvironmentVariables []struct {
+			Name  string
+			Value string
+		}
+		EnvironmentVariablesFromSecret []struct {
+			SecretName string
+			SecretKey  string
+		}
+	}{
+		Name:                 jobName,
+		JobName:              jobName,
+		Timeout:              timeout,
+		Image:                harness,
+		OutputDir:            runner.DefaultRunner.OutputDir,
+		ServiceAccount:       serviceAccountNamespacedName,
+		PushResultsContainer: latestImageStream,
+		Suffix:               suffix,
+		Server:               "https://kubernetes.default",
+		CA:                   serviceAccountDir + "/ca.crt",
+		TokenFile:            serviceAccountDir + "/token",
+		EnvironmentVariables: []struct {
+			Name  string
+			Value string
+		}{
+			{
+				Name:  "OCM_CLUSTER_ID",
+				Value: viper.GetString(config.Cluster.ID),
+			},
+		},
+
+		EnvironmentVariablesFromSecret: []struct {
+			SecretName string
+			SecretKey  string
+		}{
+			{
+				SecretName: "ci-secrets",
+				SecretKey:  "OCM_TOKEN",
+			},
+		},
+		Command: command,
+	}
+	testTemplate, err := templates.LoadTemplate(templatePath)
+	Expect(err).NotTo(HaveOccurred(), "Could not load pod template")
+	cmd, err := h.ConvertTemplateToString(testTemplate, values)
+	Expect(err).NotTo(HaveOccurred(), "Could not convert pod template")
+	return cmd
 }

--- a/pkg/e2e/openshift/app_builds.go
+++ b/pkg/e2e/openshift/app_builds.go
@@ -23,8 +23,6 @@ import (
 // BuildE2EConfig is the base configuration for the E2E run.
 var BuildE2EConfig = E2EConfig{
 	OutputDir: "/test-run-results",
-	TestCmd:   "run",
-	Tarball:   true,
 	Suite:     "openshift/image-ecosystem",
 	Env: []string{
 		"DELETE_NAMESPACE=false",
@@ -92,7 +90,7 @@ var _ = ginkgo.Describe(appBuildsTestName, label.AppBuilds, func() {
 			// Add run flags for the testing apps
 			cfg.Flags = append(cfg.Flags, "--run \"Building ("+strings.Join(testApplications, "|")+") app\"")
 
-			cmd := cfg.Cmd()
+			cmd := cfg.GenerateOcpTestCmdBlock()
 
 			// setup runner
 			r := h.Runner(cmd)

--- a/pkg/e2e/openshift/config.go
+++ b/pkg/e2e/openshift/config.go
@@ -1,139 +1,111 @@
 package openshift
 
 import (
-	"bytes"
+	"context"
 	"fmt"
 	"strings"
-	"text/template"
 
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e-common/pkg/clients/openshift"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-// Returns go template https://pkg.go.dev/text/template
-const testCmd = `
-oc config set-cluster cluster --server=https://kubernetes.default.svc --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-oc config set-credentials user --token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
-oc config set-context cluster --cluster=cluster --user=user
-oc config use-context cluster
-oc config view --raw=true > /tmp/kubeconfig
-export KUBECONFIG=/tmp/kubeconfig
-oc registry login
-
-REGION={{region}}
-CLOUD={{cloud}}
-GCPPROJECT={{gcpproject}}
-ZONE="$(oc get -o jsonpath='{.items[0].metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}' nodes)"
-export TEST_PROVIDER="{\"type\":\"${CLOUD}\",\"region\":\"${REGION}\",\"zone\":\"${ZONE}\",\"multizone\":true,\"multimaster\":true ${GCPPROJECT}}"
-{{if testSkipRegex}}
-	openshift-tests run --dry-run --provider "${TEST_PROVIDER}" openshift/conformance/parallel suite  | grep -v "{{testSkipRegex}}" > /tmp/tests
-	{{printTests .TestNames}} | {{unwrap .Env}} openshift-tests {{.TestCmd}} --file=/tmp/tests {{unwrap .Flags}} --provider "${TEST_PROVIDER}"
-{{else}}
-	{{printTests .TestNames}} | {{unwrap .Env}} openshift-tests {{.TestCmd}} {{selectTests .Suite .TestNames}} {{unwrap .Flags}} --provider "${TEST_PROVIDER}"
-{{end}}
-
-# create a Tarball of OutputDir if requested
-{{$outDir := .OutputDir}}
-{{if .Tarball}}
-	{{$outDir = "/tmp/out"}}
-        mkdir -p {{$outDir}}
-	tar cvfz {{$outDir}}/{{.Name}}.tgz {{.OutputDir}}
-{{end}}
-
-`
-
-var cmdTemplate = template.Must(template.New("testCmd").
-	Funcs(template.FuncMap{
-		"kubeconfigPath": kubeconfigPath,
-		"printTests":     printTests,
-		"selectTests":    selectTests,
-		"unwrap":         unwrap,
-		"region":         region,
-		"cloud":          cloud,
-		"testSkipRegex":  testSkipRegex,
-		"gcpproject":     gcpproject,
-	}).Parse(testCmd))
 
 // E2EConfig defines the behavior of the extended test suite.
 type E2EConfig struct {
 	// Env defines any environment variable settings in name=value pairs to control the test process
 	Env []string
-
-	// TestCmd determines which suite the runner executes.
-	TestCmd string
-
 	// Tarball determines whether the results should be tar'd or not
 	Tarball bool
-
 	// Suite to be run inside the runner.
 	Suite string
-
 	// TestNames explicitly specify which tests to run as part of the suite. No other tests will be run.
 	TestNames []string
-
 	// Flags to run the suite with.
 	Flags []string
-
 	// Output Dir is where e2e tests serve up results
 	OutputDir string
-
-	Name      string
-	TokenFile string
-	CA        string
+	// Directory with SA creds
+	ServiceAccountDir string
 }
 
 // Cmd returns a shell command which runs the suite.
-func (c E2EConfig) Cmd() string {
-	var cmd bytes.Buffer
-	err := cmdTemplate.Execute(&cmd, c)
-	Expect(err).NotTo(HaveOccurred(), "failed templating command")
-	return cmd.String()
+func (c E2EConfig) GenerateOcpTestCmdBlock() string {
+	cmd := fmt.Sprintf(`
+oc config set-cluster cluster --server=https://kubernetes.default.svc --certificate-authority=%s/ca.crt
+oc config set-credentials user --token=$(cat %s/token)
+oc config set-context cluster --cluster=cluster --user=user
+oc config use-context cluster
+oc config view --raw=true > %s
+export KUBECONFIG=%s
+oc registry login
+ 
+openshift-tests run --dry-run --provider "%s" openshift/conformance/parallel suite  | grep -v "%s" > /tmp/tests
+
+%s openshift-tests run --provider "%s" --file=/tmp/tests %s
+`, c.ServiceAccountDir,
+		c.ServiceAccountDir,
+		getKubeconfigPath(),
+		getKubeconfigPath(),
+		getTestProvider(),
+		getTestSkipRegex(),
+		unwrap(c.Env),
+		getTestProvider(),
+		unwrap(c.Flags))
+	return cmd
 }
 
-func printTests(strs []string) string {
-	testList := strings.Join(strs, "\"\n\"")
-	return fmt.Sprintf("printf '\"%s\"'", testList)
+func getKubeconfigPath() string {
+	return "/tmp/kubeconfig"
 }
 
-func kubeconfigPath() string {
-	if viper.GetString(config.SharedDir) != "" {
-		return viper.GetString(config.SharedDir) + "/kubeconfig"
-	}
-	return ""
-}
-
-func region() string {
-	return viper.GetString(config.CloudProvider.Region)
-}
-
-func cloud() string {
-	if viper.GetString(config.CloudProvider.CloudProviderID) == "gcp" {
-		return "gce"
-	}
-	return viper.GetString(config.CloudProvider.CloudProviderID)
-}
-
-func testSkipRegex() string {
+func getTestSkipRegex() string {
 	return viper.GetString(config.Tests.OCPTestSkipRegex)
-}
-
-func gcpproject() string {
-	if viper.GetString(config.CloudProvider.CloudProviderID) == "gcp" {
-		return fmt.Sprintf(`,"projectid":%q`, viper.GetString(ocmprovider.GCPProjectID))
-	}
-	return ""
-}
-
-// runs a suite unless tests are specified
-func selectTests(suite string, tests []string) string {
-	if len(tests) == 0 {
-		return suite
-	}
-	return "--file=-"
 }
 
 func unwrap(flags []string) string {
 	return strings.Join(flags, " ")
+}
+
+// gets zone of cluster. Inferred from node zone of a single zone cluster.
+func getZone() string {
+	zone := ""
+	var k8s *openshift.Client
+	log.SetLogger(ginkgo.GinkgoLogr)
+	var err error
+	k8s, err = openshift.NewFromKubeconfig(viper.GetString(config.Kubeconfig.Path), ginkgo.GinkgoLogr)
+	Expect(err).ShouldNot(HaveOccurred(), "Unable to setup k8s client")
+	kclient, _ := kubernetes.NewForConfig(k8s.GetConfig())
+	nodes, _ := kclient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	for _, node := range nodes.Items {
+		for key, val := range node.Labels {
+			if key == `failure-domain.beta.kubernetes.io/zone` {
+				zone = val
+			}
+		}
+	}
+	return zone
+}
+
+// Creates testprovider arg string for ocp test command
+func getTestProvider() string {
+	var cloud string
+	if viper.GetString(config.CloudProvider.CloudProviderID) == "gcp" {
+		cloud = "gce"
+	} else {
+		cloud = viper.GetString(config.CloudProvider.CloudProviderID)
+	}
+	region := viper.GetString(config.CloudProvider.Region)
+	gcpproject := ""
+	if viper.GetString(config.CloudProvider.CloudProviderID) == "gcp" {
+		gcpproject = fmt.Sprintf(`,"projectid":\"%s\"`, viper.GetString(ocmprovider.GCPProjectID))
+	}
+	c := fmt.Sprintf(`{\"type\":\"%s\",\"region\":\"%s\",\"zone\":\"%s\",\"multizone\":false,\"multimaster\":true %s}`, cloud, region, getZone(), gcpproject)
+	return c
 }

--- a/pkg/e2e/openshift/conformance.go
+++ b/pkg/e2e/openshift/conformance.go
@@ -8,98 +8,49 @@ import (
 	. "github.com/onsi/gomega"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
-	"github.com/openshift/osde2e/pkg/common/label"
-
-	"github.com/openshift/osde2e/pkg/common/alert"
 	"github.com/openshift/osde2e/pkg/common/helper"
-	"github.com/openshift/osde2e/pkg/common/runner"
+	"github.com/openshift/osde2e/pkg/common/label"
+	"github.com/openshift/osde2e/pkg/common/util"
 )
 
 // DefaultE2EConfig is the base configuration for E2E runs.
 var DefaultE2EConfig = E2EConfig{
 	OutputDir: "/test-run-results",
-	TestCmd:   "run",
 	Tarball:   false,
 	Suite:     "kubernetes/conformance",
 	Flags: []string{
 		"--include-success",
-		"--junit-dir=" + runner.DefaultRunner.OutputDir,
+		"--junit-dir=/test-run-results",
 	},
-	Name:      "kubernetes-conformance",
-	CA:        "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
-	TokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token",
+	ServiceAccountDir: "/var/run/secrets/kubernetes.io/serviceaccount",
 }
 
-var (
-	conformanceK8sTestName       = "[Suite: conformance][k8s]"
-	conformanceOpenshiftTestName = "[Suite: conformance][openshift]"
-)
-
-func init() {
-	alert.RegisterGinkgoAlert(conformanceK8sTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
-	alert.RegisterGinkgoAlert(conformanceOpenshiftTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
-}
-
-var _ = ginkgo.Describe(conformanceK8sTestName, func() {
+var _ = ginkgo.Describe("[Suite: conformance][openshift]", ginkgo.Ordered, label.OCPNightlyBlocking, func() {
 	defer ginkgo.GinkgoRecover()
 	h := helper.New()
 
 	e2eTimeoutInSeconds := 7200
 	ginkgo.It("should run until completion", func(ctx context.Context) {
-		// configure tests
-		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
-
-		cfg := DefaultE2EConfig
-		cmd := cfg.Cmd()
-
-		// setup runner
-		r := h.Runner(cmd)
-
-		r.Name = "k8s-conformance"
-
-		// run tests
-		stopCh := make(chan struct{})
-
-		err := r.Run(e2eTimeoutInSeconds, stopCh)
-		Expect(err).NotTo(HaveOccurred())
-
-		// get results
-		results, err := r.RetrieveTestResults()
-
-		// write results
-		h.WriteResults(results)
-
-		// evaluate results
-		Expect(err).NotTo(HaveOccurred())
-	})
-})
-
-var _ = ginkgo.Describe(conformanceOpenshiftTestName, ginkgo.Ordered, label.OCPNightlyBlocking, func() {
-	defer ginkgo.GinkgoRecover()
-	h := helper.New()
-
-	e2eTimeoutInSeconds := 7200
-	ginkgo.It("should run until completion", func(ctx context.Context) {
-		suite := "suite"
-		testType := "openshift/conformance/parallel"
 		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 		// configure tests
 		cfg := DefaultE2EConfig
 		if viper.GetString(config.Tests.OCPTestSuite) != "" {
-			suite = viper.GetString(config.Tests.OCPTestSuite)
+			cfg.Suite = "openshift/conformance/parallel " + viper.GetString(config.Tests.OCPTestSuite)
+		} else {
+			cfg.Suite = "openshift/conformance/parallel suite"
 		}
-		cfg.Suite = testType + " " + suite
-		cfg.Name = "openshift-conformance"
-		cmd := cfg.Cmd()
 
 		// setup runner
-		r := h.Runner(cmd)
-
-		r.Name = "openshift-conformance"
+		r := h.RunnerWithNoCommand()
+		latestImageStream, err := r.GetLatestImageStreamTag()
+		Expect(err).NotTo(HaveOccurred(), "Could not get latest imagestream tag")
+		testcmd := cfg.GenerateOcpTestCmdBlock()
+		cmd := h.GetRunnerCommandString("tests/ocp-tests-runner.template", e2eTimeoutInSeconds, latestImageStream, latestImageStream, util.RandomStr(5), "openshift-conformance", cfg.ServiceAccountDir, testcmd, "cluster-admin")
+		r = h.SetRunnerCommand(cmd, r)
 
 		// run tests
 		stopCh := make(chan struct{})
-		err := r.Run(e2eTimeoutInSeconds, stopCh)
+		err = r.Run(e2eTimeoutInSeconds, stopCh)
 		Expect(err).NotTo(HaveOccurred())
 
 		// get results

--- a/pkg/e2e/openshift/disruptive.go
+++ b/pkg/e2e/openshift/disruptive.go
@@ -29,7 +29,7 @@ var _ = ginkgo.Describe(disruptiveTestName, func() {
 		// configure tests
 		cfg := DefaultE2EConfig
 		cfg.Suite = "openshift/disruptive"
-		cmd := cfg.Cmd()
+		cmd := cfg.GenerateOcpTestCmdBlock()
 		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 
 		// setup runner

--- a/pkg/e2e/openshift/images.go
+++ b/pkg/e2e/openshift/images.go
@@ -33,7 +33,7 @@ var _ = ginkgo.Describe(imageRegistryTestName, func() {
 		// configure tests
 		cfg := DefaultE2EConfig
 		cfg.Suite = "openshift/image-registry"
-		cmd := cfg.Cmd()
+		cmd := cfg.GenerateOcpTestCmdBlock()
 
 		// setup runner
 		r := h.Runner(cmd)
@@ -65,7 +65,7 @@ var _ = ginkgo.Describe(imageEcosystemTestName, func() {
 		// configure tests
 		cfg := DefaultE2EConfig
 		cfg.Suite = "openshift/image-ecosystem"
-		cmd := cfg.Cmd()
+		cmd := cfg.GenerateOcpTestCmdBlock()
 
 		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
 		// setup runner


### PR DESCRIPTION
simplifies and conforms to current test pod templating practice.
- Similar to harness pods, uses a template containing pod resource templates.
- Populates values using go functions instead of go template engine.
- Removing variables which do not vary, or are never used

resulting from [SDCICD-1198](https://issues.redhat.com//browse/SDCICD-1198) 

[SDCICD-1275](https://issues.redhat.com//browse/SDCICD-1275)


  