### PR TITLE
fix pod-disruption test

### DIFF
--- a/pkg/e2e/webhooks/webhooks.go
+++ b/pkg/e2e/webhooks/webhooks.go
@@ -151,8 +151,8 @@ var _ = ginkgo.Describe(suiteName, ginkgo.Ordered, label.E2E, label.ROSA, label.
 			expect.Forbidden(err)
 		}, ginkgo.SpecTimeout(createPodWaitDuration.Seconds()+deletePodWaitDuration.Seconds()))
 
-		ginkgo.It("allows cluster-admin to schedule pods onto master/infra nodes", func(ctx context.Context) {
-			client := h.AsServiceAccount(fmt.Sprintf("system:serviceaccount:%s:dedicated-admin-project", h.CurrentProject()))
+		ginkgo.It("allows backplane-cluster-admin to schedule pods onto privileged namespace", func(ctx context.Context) {
+			client := h.AsServiceAccount(fmt.Sprintf("system:serviceaccount:%s:backplane-cluster-admin", h.CurrentProject()))
 			pod = withNamespace(pod, privilegedNamespace)
 			err := client.Create(ctx, pod)
 			expect.NoError(err)


### PR DESCRIPTION
- currently test is using dedicated-admin which should not be able to manage resources in openshift-backplane 

- backplane-cluster-admin should be able to create pods in privileged namespace

- testing the allowed used specified in rules here https://github.com/cblecker/managed-cluster-validating-webhooks/blob/b1ef152d21cce5174aa5532f9dbbbcb5f0f6fbc3/pkg/webhooks/serviceaccount/serviceaccount.go#L42  