### PR TITLE
misc: add build root image config

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: golang-1.21


### PR DESCRIPTION
we can configure the build root from our repository instead of having to
bump in both places for go version bumps

https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image

Signed-off-by: Brady Pratt <bpratt@redhat.com>
