### PR TITLE
add ServiceAccountDir value to config instances

### DIFF
--- a/pkg/e2e/openshift/app_builds.go
+++ b/pkg/e2e/openshift/app_builds.go
@@ -31,6 +31,7 @@ var BuildE2EConfig = E2EConfig{
 		"--include-success",
 		"--junit-dir=" + runner.DefaultRunner.OutputDir,
 	},
+	ServiceAccountDir: "/var/run/secrets/kubernetes.io/serviceaccount",
 }
 
 var testApplications = []string{

--- a/pkg/e2e/openshift/conformance.go
+++ b/pkg/e2e/openshift/conformance.go
@@ -23,6 +23,7 @@ var DefaultE2EConfig = E2EConfig{
 		"--include-success",
 		"--junit-dir=" + runner.DefaultRunner.OutputDir,
 	},
+	ServiceAccountDir: "/var/run/secrets/kubernetes.io/serviceaccount",
 }
 
 var (
@@ -81,7 +82,8 @@ var _ = ginkgo.Describe(conformanceOpenshiftTestName, ginkgo.Ordered, label.OCPN
 
 		// setup runner
 		r := h.RunnerWithNoCommand()
-		r.Name = "openshift-conformance"
+		suffix := util.RandomStr(5)
+		r.Name = "osde2e-main-" + suffix
 		latestImageStream, err := r.GetLatestImageStreamTag()
 		Expect(err).NotTo(HaveOccurred(), "Could not get latest imagestream tag")
 		testcmd := cfg.GenerateOcpTestCmdBlock()
@@ -89,7 +91,7 @@ var _ = ginkgo.Describe(conformanceOpenshiftTestName, ginkgo.Ordered, label.OCPN
 			e2eTimeoutInSeconds,
 			latestImageStream,
 			latestImageStream,
-			util.RandomStr(5),
+			suffix,
 			"openshift-conformance",
 			"/var/run/secrets/kubernetes.io/serviceaccount",
 			testcmd,


### PR DESCRIPTION
add ServiceAccountDir value to config instances

This value will be used to find ca.crt and token values  in command generator https://github.com/openshift/osde2e/blob/3983b960494e52019bed04aa3e9119070c55e26e/pkg/e2e/openshift/config.go#L39

[SDCICD-1275](https://issues.redhat.com//browse/SDCICD-1275)