### PR TITLE
remove cat test command

### DIFF
--- a/assets/tests/ocp-tests-runner.template
+++ b/assets/tests/ocp-tests-runner.template
@@ -70,7 +70,7 @@ PUSH_RESULTS
 
 cat workload.yaml
 cat push-results.sh
-cat test-cmd.sh
+ 
 
 oc create configmap push-results-{{.Suffix}} --from-file=push-results.sh
 oc create configmap test-cmd-{{.Suffix}} --from-file=test-cmd.sh

--- a/pkg/e2e/openshift/conformance.go
+++ b/pkg/e2e/openshift/conformance.go
@@ -102,7 +102,7 @@ var _ = ginkgo.Describe(conformanceOpenshiftTestName, ginkgo.Ordered, label.OCPN
 		Expect(err).NotTo(HaveOccurred())
 
 		// get results
-		results, err := r.RetrieveTestResults()
+		results, err := r.RetrieveResults()
 
 		// write results, including non-xml log files
 		h.WriteResults(results)


### PR DESCRIPTION
remove cat test command - this is being printed in plain text

change result retireval to skip xml format (conformance tests return non xml files) 