### PR TITLE
use "triggered nightly" version selector for all nightly jobs

### DIFF
--- a/pkg/common/versions/installselectors/triggered_nightlies.go
+++ b/pkg/common/versions/installselectors/triggered_nightlies.go
@@ -18,7 +18,7 @@ func init() {
 type triggeredNightlies struct{}
 
 func (t triggeredNightlies) ShouldUse() bool {
-	return strings.Contains(os.Getenv("PROW_JOB_ID"), "nightly")
+	return strings.Contains(os.Getenv("JOB_NAME"), "nightly")
 }
 
 func (t triggeredNightlies) Priority() int {
@@ -28,7 +28,7 @@ func (t triggeredNightlies) Priority() int {
 func (t triggeredNightlies) SelectVersion(versionList *spi.VersionList) (*semver.Version, string, error) {
 	nightlyVersionRegex := regexp.MustCompile(`4.\d+.\d-\d.nightly-\d{4}-\d{2}-\d{2}-\d+`)
 
-	prowJobID := os.Getenv("PROW_JOB_ID")
+	prowJobID := os.Getenv("JOB_NAME")
 	matches := nightlyVersionRegex.FindStringSubmatch(prowJobID)
 	if len(matches) == 0 {
 		return nil, t.String(), fmt.Errorf("failed to find match for %q", prowJobID)

--- a/pkg/e2e/openshift/conformance.go
+++ b/pkg/e2e/openshift/conformance.go
@@ -93,7 +93,7 @@ var _ = ginkgo.Describe(conformanceOpenshiftTestName, ginkgo.Ordered, label.OCPN
 			latestImageStream,
 			suffix,
 			"openshift-conformance",
-			"/var/run/secrets/kubernetes.io/serviceaccount",
+			cfg.ServiceAccountDir,
 			testcmd,
 			"cluster-admin")
 		r = h.SetRunnerCommand(cmd, r)


### PR DESCRIPTION
currently we're using PROW_JOB_ID which doesn't have "nightly" in it for some nightly triggerd jobs, but JOB_NAME does contain nightly.

This will ensure conformance jobs get the release version referred in the nightly pipeline. 

For [sdcicd-1198](https://issues.redhat.com//browse/sdcicd-1198)