### PR TITLE
use "RELEASE_IMAGE_LATEST" env to find version for nightly jobs

### DIFF
--- a/pkg/common/versions/installselectors/triggered_nightlies.go
+++ b/pkg/common/versions/installselectors/triggered_nightlies.go
@@ -18,7 +18,7 @@ func init() {
 type triggeredNightlies struct{}
 
 func (t triggeredNightlies) ShouldUse() bool {
-	return strings.Contains(os.Getenv("PROW_JOB_ID"), "nightly")
+	return strings.Contains(os.Getenv("RELEASE_IMAGE_LATEST"), "nightly")
 }
 
 func (t triggeredNightlies) Priority() int {
@@ -26,12 +26,16 @@ func (t triggeredNightlies) Priority() int {
 }
 
 func (t triggeredNightlies) SelectVersion(versionList *spi.VersionList) (*semver.Version, string, error) {
-	nightlyVersionRegex := regexp.MustCompile(`4.\d+.\d-\d.nightly-\d{4}-\d{2}-\d{2}-\d+`)
+	// RELEASE_IMAGE_LATEST is a tag populated in release controller jobs.
+	// It has the following form.
+	// registry.ci.openshift.org/ocp/release:4.15.0-0.nightly-2024-05-15-103159
+	// Extract the version tag from it.
+	releaseImageLatestRegex := regexp.MustCompile(`\d.\d+.\d-\d.nightly-\d{4}-\d{2}-\d{2}-\d+`)
 
-	prowJobID := os.Getenv("PROW_JOB_ID")
-	matches := nightlyVersionRegex.FindStringSubmatch(prowJobID)
+	releaseImageLatest := os.Getenv("RELEASE_IMAGE_LATEST")
+	matches := releaseImageLatestRegex.FindStringSubmatch(releaseImageLatest)
 	if len(matches) == 0 {
-		return nil, t.String(), fmt.Errorf("failed to find match for %q", prowJobID)
+		return nil, t.String(), fmt.Errorf("failed to match regular expression with RELEASE_IMAGE_LATEST: %q", releaseImageLatest)
 	}
 	payloadName := matches[0] + "-nightly"
 

--- a/pkg/common/versions/versionselector.go
+++ b/pkg/common/versions/versionselector.go
@@ -1,6 +1,7 @@
 package versions
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -38,7 +39,7 @@ func (v *VersionSelector) SelectClusterVersions() error {
 			viper.Set(config.Cluster.Channel, "nightly")
 		}
 
-		err = wait.PollImmediate(1*time.Minute, 30*time.Minute, func() (bool, error) {
+		err = wait.PollUntilContextTimeout(context.Background(), 1*time.Minute, 30*time.Minute, true, func(ctx context.Context) (bool, error) {
 			v.versionList, err = v.Provider.Versions()
 			if err != nil {
 				return false, fmt.Errorf("error getting versions: %v", err)


### PR DESCRIPTION
currently we're using PROW_JOB_ID which may be unreliable if the job ID changes. RELEASE_IMAGE_LATEST is less likely to change.

Discovered during [SDCICD-1198](https://issues.redhat.com//browse/SDCICD-1198)