### PR TITLE
allow origin test to run given suite of skip regex not provided

### DIFF
--- a/pkg/e2e/openshift/config.go
+++ b/pkg/e2e/openshift/config.go
@@ -43,19 +43,27 @@ oc config use-context cluster
 oc config view --raw=true > %s
 export KUBECONFIG=%s
 oc registry login
- 
-openshift-tests run --dry-run --provider "%s" openshift/conformance/parallel suite  | grep -v "%s" > /tmp/tests
-
-%s openshift-tests run --provider "%s" --file=/tmp/tests %s
 `, c.ServiceAccountDir,
 		c.ServiceAccountDir,
 		getKubeconfigPath(),
-		getKubeconfigPath(),
-		getTestProvider(),
-		getTestSkipRegex(),
-		unwrap(c.Env),
-		getTestProvider(),
-		unwrap(c.Flags))
+		getKubeconfigPath())
+	if getTestSkipRegex() != "" {
+		cmd = cmd + fmt.Sprintf(`openshift-tests run --dry-run --provider "%s" %s  | grep -v "%s" > /tmp/tests
+		%s openshift-tests run --provider "%s" --file=/tmp/tests %s
+`,
+			getTestProvider(),
+			c.Suite,
+			getTestSkipRegex(),
+			unwrap(c.Env),
+			getTestProvider(),
+			unwrap(c.Flags))
+	} else {
+		cmd = cmd + fmt.Sprintf(`%s openshift-tests run --provider "%s" %s %s`,
+			unwrap(c.Env),
+			getTestProvider(),
+			c.Suite,
+			unwrap(c.Flags))
+	}
 	return cmd
 }
 

--- a/pkg/e2e/openshift/conformance.go
+++ b/pkg/e2e/openshift/conformance.go
@@ -103,8 +103,9 @@ var _ = ginkgo.Describe(conformanceOpenshiftTestName, ginkgo.Ordered, label.OCPN
 		err = r.Run(e2eTimeoutInSeconds, stopCh)
 		Expect(err).NotTo(HaveOccurred())
 
-		// get results
-		results, err := r.RetrieveResults()
+		// get results - also returns error if no xml file found
+		// keeps tests from showing green if they didn't produce xml output.
+		results, err := r.RetrieveTestResults()
 
 		// write results, including non-xml log files
 		h.WriteResults(results)


### PR DESCRIPTION
Fixes breaking conformance jobs where skip regex is not present

[sdcicd-1198](https://issues.redhat.com//browse/sdcicd-1198)