### PR TITLE
use  "PROW_JOB_ID" only to find version for nightly jobs

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -30,6 +30,10 @@ const (
 	// Env: BUILD_NUMBER
 	JobID = "jobID"
 
+	// ProwJobId is the ID designated by prow for this run
+	// Env: PROW_JOB_ID
+	ProwJobId = "prowJobId"
+
 	// JobType is the type of job according to prow for this run
 	// Env: JOB_TYPE
 	JobType = "jobType"
@@ -772,6 +776,8 @@ func InitOSDe2eViper() {
 	viper.BindEnv(Cluster.InstallTimeout, "CLUSTER_UP_TIMEOUT")
 
 	viper.BindEnv(Cluster.ReleaseImageLatest, "RELEASE_IMAGE_LATEST")
+
+	viper.BindEnv(ProwJobId, "PROW_JOB_ID")
 
 	viper.SetDefault(Cluster.UseProxyForInstall, false)
 	viper.BindEnv(Cluster.UseProxyForInstall, "USE_PROXY_FOR_INSTALL")


### PR DESCRIPTION
"RELEASE_VERSION_LATEST" is only applied to direct job pod, osde2e pod does not have the desired value for this


eg: this is printed in osde2e pod: 

PROW_JOB_ID: "4.15.0-0.nightly-2024-05-23-090107-rosa-classic-sts-conformance"
2024/05/23 09:36:55 
RELEASE_IMAGE_LATEST: "registry.build05.ci.openshift.org/ci-op-mqrdrqz8/release@sha256:459d06cfc1a5b57553381d46279f7e6c43a43465ecf41b68704f9ffe92c0e890"
