### PR TITLE
avoiding abrupt pod exits

### DIFF
--- a/assets/tests/ocp-tests-runner.template
+++ b/assets/tests/ocp-tests-runner.template
@@ -65,7 +65,7 @@ cat <<PUSH_RESULTS > push-results.sh
 JOB_POD=\$(oc get pods -l job-name={{.JobName}} -o=jsonpath='{.items[0].metadata.name}')
 echo "Found Job Pod: \$JOB_POD"
 while ! oc get pod \$JOB_POD -o jsonpath='{.status.containerStatuses[?(@.name=="test-harness")].state}' | grep -q terminated; do sleep 1; done
-for i in {1..5}; do oc rsync {{.OutputDir}}/. $(hostname):{{.OutputDir}} && break; sleep 10; done
+for i in {1..5}; do oc rsync -c push-results {{.OutputDir}}/. $(hostname):{{.OutputDir}} && break; sleep 10; done
 PUSH_RESULTS
 
 cat workload.yaml
@@ -85,5 +85,12 @@ while oc get job/{{.JobName}} -o=jsonpath='{.status}' | grep -q active; do sleep
 
 mkdir -p "{{.OutputDir}}/containerLogs"
 JOB_POD=$(oc get pods -l job-name={{.JobName}} -o=jsonpath='{.items[0].metadata.name}')
-oc logs $JOB_POD -c test-harness > "{{.OutputDir}}/containerLogs/${JOB_POD}-test-harness.log"
-oc logs $JOB_POD -c push-results > "{{.OutputDir}}/containerLogs/${JOB_POD}-push-results.log"
+
+if [[ ! $JOB_POD ]]; then
+  echo "test harness pod not found, may have been terminated. exiting"
+
+else
+  echo "found test harness pod $JOB_POD"
+  oc logs $JOB_POD -c test-harness > "{{.OutputDir}}/containerLogs/${JOB_POD}-test-harness.log"
+  oc logs $JOB_POD -c push-results > "{{.OutputDir}}/containerLogs/${JOB_POD}-push-results.log"
+fi

--- a/pkg/common/runner/service.go
+++ b/pkg/common/runner/service.go
@@ -45,6 +45,7 @@ func (r *Runner) createService(ctx context.Context, pod *kubev1.Pod) (svc *kubev
 }
 
 // waitForCompletion will wait for a runner's pod to have a valid v1.Endpoint available
+// otherwise waits for pod to be running
 func (r *Runner) waitForCompletion(ctx context.Context, podName string, timeoutInSeconds int) error {
 	var endpoints *kubev1.Endpoints
 	pendingCount := 0
@@ -65,7 +66,7 @@ func (r *Runner) waitForCompletion(ctx context.Context, podName string, timeoutI
 			return false, err
 		}
 
-		if pod.Status.Phase == kubev1.PodFailed || pod.Status.Phase == kubev1.PodUnknown {
+		if pod.Status.Phase == kubev1.PodFailed {
 			r.Info(fmt.Sprintf("Pod entered error state while waiting for endpoint: %+v", pod.Status))
 			return false, fmt.Errorf("pod failed while waiting for endpoints")
 		} else if pod.Status.Phase == kubev1.PodSucceeded {
@@ -85,7 +86,7 @@ func (r *Runner) waitForCompletion(ctx context.Context, podName string, timeoutI
 			}
 		}
 
-		r.Info(fmt.Sprintf("Waiting for test results using Endpoint '%s/%s'...", endpoints.Namespace, endpoints.Name))
+		r.Info(fmt.Sprintf("Pod state: %s; polling endpoint '%s'...", pod.Status.Phase, endpoints.Name))
 		return false, nil
 	})
 }


### PR DESCRIPTION
some jobs are adbruptly failing while polling runner pod with no clear root cause.

example https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-osde2e-main-nightly-4.15-conformance-rosa-classic-sts/1793144924145717248/artifacts/conformance-rosa-classic-sts/osde2e-test/build-log.txt 

 implementing following checks
1. provide container name for `oc rsync` in case it is selecting "test-harness" container which should be terminated before collecting results
2. if test pod is completely gone, log it in runner output instead of erroring out
3. log pod status while polling
[sdcicd-1198](https://issues.redhat.com//browse/sdcicd-1198) 