### PR TITLE
revert container name from oc rsync

### DIFF
--- a/assets/tests/ocp-tests-runner.template
+++ b/assets/tests/ocp-tests-runner.template
@@ -65,7 +65,7 @@ cat <<PUSH_RESULTS > push-results.sh
 JOB_POD=\$(oc get pods -l job-name={{.JobName}} -o=jsonpath='{.items[0].metadata.name}')
 echo "Found Job Pod: \$JOB_POD"
 while ! oc get pod \$JOB_POD -o jsonpath='{.status.containerStatuses[?(@.name=="test-harness")].state}' | grep -q terminated; do sleep 1; done
-for i in {1..5}; do oc rsync -c push-results {{.OutputDir}}/. $(hostname):{{.OutputDir}} && break; sleep 10; done
+for i in {1..5}; do oc rsync {{.OutputDir}}/. $(hostname):{{.OutputDir}} && break; sleep 10; done
 PUSH_RESULTS
 
 cat workload.yaml


### PR DESCRIPTION
it is causing issues in the job

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-osde2e-main-nightly-4.16-conformance-osd-aws/1794013530937102336/artifacts/conformance-osd-aws/osde2e-test/artifacts/install/containerLogs/openshift-conformance-nnwbj-push-results.log

[sdcicd-1198](https://issues.redhat.com//browse/sdcicd-1198)