### PR TITLE
if directory is not empty, the path should be joined with child

### DIFF
--- a/pkg/common/runner/results.go
+++ b/pkg/common/runner/results.go
@@ -127,12 +127,7 @@ func (r *Runner) downloadLinks(n *html.Node, results map[string][]byte, director
 		for _, a := range n.Attr {
 			if a.Key == "href" {
 				if strings.HasSuffix(a.Val, "/") {
-					var newDirectory string
-					if directory != "" {
-						newDirectory = a.Val
-					} else {
-						newDirectory = path.Join(directory, a.Val)
-					}
+					newDirectory := path.Join(directory, a.Val)
 
 					log.Println("Downloading directory " + newDirectory)
 					directoryResults, err := r.retrieveResultsForDirectory(newDirectory)


### PR DESCRIPTION
currently, path is joined only when directory is empty, which joins with empty string, which has no effect. To download nested folders, we would need full path to child folder

this is the culprit for nested result file paths erroring out in some jobs [example](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-osde2e-main-nightly-4.15-conformance-osd-aws/1793207161212375040/artifacts/conformance-osd-aws/osde2e-test/build-log.txt)

```
2024/05/22 11:29:22 results.go:137: Downloading directory should_not_pass_FSGroup_to_CSI_driver_if_it_is_set_in_pod_and_driver_supports_VOLUME_MOUNT_GROUP_Suite_openshift_conformance_parallel_Suite_k8s_/
2024/05/22 11:30:23 results.go:140: error while getting results for directory should_not_pass_FSGroup_to_CSI_driver_if_it_is_set_in_pod_and_driver_supports_VOLUME_MOUNT_GROUP_Suite_openshift_conformance_parallel_Suite_k8s_/: could not retrieve result file listing: the server could not find the requested resource (get services http:osde2e-main-2115i-93kda:8000)
``` 

[sdcicd-1198](https://issues.redhat.com//browse/sdcicd-1198)