### PR TITLE
healthchecks: use cluster restconfig

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -133,7 +133,7 @@ func WaitForClusterReadyPostInstall(clusterID string, logger *log.Logger) error 
 		return nil
 	}
 
-	err = healthchecks.CheckHealthcheckJob(context.Background(), nil)
+	err = healthchecks.CheckHealthcheckJob(context.Background(), clusterConfig, logger)
 	if err != nil {
 		return fmt.Errorf("cluster failed health check: %w", err)
 	}

--- a/pkg/common/cluster/healthchecks/healthcheckjob.go
+++ b/pkg/common/cluster/healthchecks/healthcheckjob.go
@@ -11,17 +11,18 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/logging"
+	"k8s.io/client-go/rest"
 )
 
 // CheckHealthcheckJob uses the `osd-cluster-ready` healthcheck job to determine cluster readiness. If the cluster
 // is not ready, it will return an error.
-func CheckHealthcheckJob(ctx context.Context, logger *log.Logger) error {
+func CheckHealthcheckJob(ctx context.Context, restconfig *rest.Config, logger *log.Logger) error {
 	logger = logging.CreateNewStdLoggerOrUseExistingLogger(logger)
 	var k8s *openshift.Client
 
 	name := "osd-cluster-ready"
 
-	k8s, err := openshift.New(ginkgo.GinkgoLogr)
+	k8s, err := openshift.NewFromRestConfig(restconfig, ginkgo.GinkgoLogr)
 	if err != nil {
 		return fmt.Errorf("unable to setup k8s client: %w", err)
 	}


### PR DESCRIPTION
it seems that at some point this broke, the hive cluster is being queried looking for the cluster-ready job. Pass the specific clusterconfig directly to the new openshift client. All of the tests are being executed after this fails, then they subsequently fail.

```
2024/05/30 04:39:51 e2e.go:154: *******************
2024/05/30 04:39:51 e2e.go:155: Cluster failed health check: cluster failed health check: unable to get job logs for openshift-monitoring/osd-cluster-ready: failed to list pods for job osd-cluster-ready in openshift-monitoring namespace: failed to get API group resources: unable to retrieve the complete list of server APIs: v1: Get "https://api.hives02ue1.j5l5.p1.openshiftapps.com:6443/api/v1": dial tcp 10.163.143.192:6443: i/o timeout
2024/05/30 04:39:51 e2e.go:156: *******************
```