### PR TITLE
spin up a osde2e runner job as owner of test pod

### DIFF
--- a/pkg/common/runner/runner.go
+++ b/pkg/common/runner/runner.go
@@ -116,7 +116,7 @@ func (r *Runner) Run(timeoutInSeconds int, stopCh <-chan struct{}) (err error) {
 
 	r.Info(fmt.Sprintf("Creating %s runner Pod...", r.Name))
 	var pod *kubev1.Pod
-	if pod, err = r.createPod(ctx); err != nil {
+	if pod, err = r.createJobPod(ctx); err != nil {
 		return
 	}
 

--- a/pkg/common/runner/service_test.go
+++ b/pkg/common/runner/service_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	kubev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -13,7 +15,18 @@ import (
 
 func TestResultsService(t *testing.T) {
 	// setup mock client
-	client := fake.NewSimpleClientset()
+	client := fake.NewSimpleClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Labels: map[string]string{
+				"job-name": "osde2e-runner",
+			},
+		},
+		Status: corev1.PodStatus{
+			PodIP: "172.1.0.3",
+		},
+	})
 
 	// setup runner
 	def := *DefaultRunner
@@ -22,7 +35,7 @@ func TestResultsService(t *testing.T) {
 	ctx := context.Background()
 
 	// create pod
-	pod, err := r.createPod(ctx)
+	pod, err := r.createJobPod(ctx)
 	if err != nil {
 		t.Fatalf("Failed to create example  pod: %v", err)
 	}


### PR DESCRIPTION
currently test pod doesn't have a specific owner. This causes garbage collector to clean the pod and related objects abruptly during test runs. Instead, create a job to own the pod and namespace objects.

Discovered in conformance job for [sdcicd-1198](https://issues.redhat.com//browse/sdcicd-1198) 