### PR TITLE
e2e/harness_runner: log harnesses in beforeall

### DIFF
--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -39,13 +39,13 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 	} else {
 		timeoutInSeconds = viper.GetInt(config.Tests.PollingTimeout)
 	}
-	fmt.Println("Harnesses to run: ", harnesses)
 	for _, harness := range harnesses {
 		HarnessEntries = append(HarnessEntries, ginkgo.Entry(harness+" should pass", harness))
 	}
 
 	ginkgo.BeforeAll(func(ctx context.Context) {
 		h = helper.New()
+		log.Println("Harnesses to run: ", harnesses)
 	})
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		ginkgo.By("Setting up new namespace")


### PR DESCRIPTION
when focusing specific tests, this shouldn't be printed unless it is being executed