### PR TITLE
e2e: use common prometheus client

### DIFF
--- a/pkg/e2e/state/alerts.go
+++ b/pkg/e2e/state/alerts.go
@@ -8,14 +8,13 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/openshift/osde2e-common/pkg/clients/openshift"
+	"github.com/openshift/osde2e-common/pkg/clients/prometheus"
 	"github.com/openshift/osde2e/pkg/common/alert"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
-	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
-	"github.com/openshift/osde2e/pkg/common/prometheus"
 	"github.com/openshift/osde2e/pkg/common/providers"
-	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -32,25 +31,30 @@ func init() {
 	alert.RegisterGinkgoAlert(clusterStateTestName, "SD-CICD", "Diego Santamaria", "sd-cicd-alerts", "sd-cicd@redhat.com", 4)
 }
 
-var _ = ginkgo.Describe(clusterStateTestName, label.E2E, func() {
-	defer ginkgo.GinkgoRecover()
-	h := helper.New()
+var _ = ginkgo.Describe(clusterStateTestName, ginkgo.Ordered, label.E2E, func() {
+	var (
+		oc   *openshift.Client
+		prom *prometheus.Client
+	)
+
+	ginkgo.BeforeAll(func(ctx context.Context) {
+		var err error
+		oc, err = openshift.New(ginkgo.GinkgoLogr)
+		Expect(err).NotTo(HaveOccurred(), "unable to create openshift client")
+
+		prom, err = prometheus.New(ctx, oc)
+		Expect(err).NotTo(HaveOccurred(), "unable to create prometheus client")
+	})
 
 	ginkgo.It("should have no alerts", func(ctx context.Context) {
-		// Set up prometheus client
-		h.SetServiceAccount(ctx, "system:serviceaccount:%s:cluster-admin")
-		promClient, err := prometheus.CreateClusterClient(h)
-		Expect(err).NotTo(HaveOccurred(), "error creating a prometheus client")
-		promAPI := promv1.NewAPI(promClient)
-
 		var queryresult []byte
 
 		// Query for alerts with a retry count of 40 and timeout of 20 minutes
-		err = wait.PollImmediate(30*time.Second, 20*time.Minute, func() (bool, error) {
+		err := wait.PollImmediate(30*time.Second, 20*time.Minute, func() (bool, error) {
 			query := "ALERTS{alertstate!=\"pending\",alertname!=\"Watchdog\"}"
 			context, cancel := context.WithTimeout(ctx, 1*time.Minute)
 			defer cancel()
-			value, _, err := promAPI.Query(context, query, time.Now())
+			value, err := prom.InstantQuery(context, query)
 			if err != nil {
 				ginkgo.GinkgoLogr.Error(err, "Unable to query prom API")
 				// try again


### PR DESCRIPTION
the code in pkg/common/prometheus doesn't work with 4.16 clusters, use the one from osde2e-common which falls back to openshift/library-go. We should eventually deprecate all of pkg/common/prometheus

```
------------------------------
• [FAILED] [0.150 seconds]
[Suite: e2e] Cluster state [It] should have no alerts [E2E]
/var/home/bpratt/git/openshift/osde2e/pkg/e2e/state/alerts.go:39

  [FAILED] error creating a prometheus client
  Unexpected error:
      <*errors.errorString | 0xc000066520>:
      failed to find token secret for prometheus-k8s SA
      {
          s: "failed to find token secret for prometheus-k8s SA",
      }
  occurred
  In [It] at: /var/home/bpratt/git/openshift/osde2e/pkg/e2e/state/alerts.go:43 @ 05/30/24 09:29:16.55
------------------------------
•••••••••
------------------------------
• [FAILED] [600.664 seconds]
[Suite: operators] AlertmanagerInhibitions [It] inhibits ClusterOperatorDegraded [Operators]
/var/home/bpratt/git/openshift/osde2e/pkg/e2e/osd/inhibitions.go:114

  [FAILED] Expected
      <*errors.errorString | 0xc0011cb530>:
      failed to find token secret for prometheus-k8s SA
      {
          s: "failed to find token secret for prometheus-k8s SA",
      }
  to be nil
  In [It] at: /var/home/bpratt/git/openshift/osde2e/pkg/e2e/osd/inhibitions.go:173 @ 05/30/24 09:39:33.073
------------------------------
```

passing locally after these changes :tada: 