### PR TITLE
e2e/state: use helper client

### DIFF
--- a/pkg/e2e/state/alerts.go
+++ b/pkg/e2e/state/alerts.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/openshift/osde2e-common/pkg/clients/openshift"
 	"github.com/openshift/osde2e-common/pkg/clients/prometheus"
 	"github.com/openshift/osde2e/pkg/common/alert"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/helper"
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/providers"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -32,17 +32,13 @@ func init() {
 }
 
 var _ = ginkgo.Describe(clusterStateTestName, ginkgo.Ordered, label.E2E, func() {
-	var (
-		oc   *openshift.Client
-		prom *prometheus.Client
-	)
+	var prom *prometheus.Client
 
 	ginkgo.BeforeAll(func(ctx context.Context) {
-		var err error
-		oc, err = openshift.New(ginkgo.GinkgoLogr)
-		Expect(err).NotTo(HaveOccurred(), "unable to create openshift client")
+		h := helper.New()
 
-		prom, err = prometheus.New(ctx, oc)
+		var err error
+		prom, err = prometheus.New(ctx, h.GetClient())
 		Expect(err).NotTo(HaveOccurred(), "unable to create prometheus client")
 	})
 


### PR DESCRIPTION
KUBECONFIG is never set in the setup of e2e so `openshift.New` fails trying to find config to use. Just use the helper directly and get the client created from it.

This worked locally because I had `KUBECONFIG` set

```
[Suite: e2e] Cluster state [BeforeAll] should have no alerts [E2E]
  [BeforeAll] /go/src/github.com/openshift/osde2e/pkg/e2e/state/alerts.go:40
  [It] /go/src/github.com/openshift/osde2e/pkg/e2e/state/alerts.go:49

  [FAILED] unable to create openshift client
  Unexpected error:
      <*fmt.wrapError | 0xc000d2a140>:
      failed to get kubernetes config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
      {
          msg: "failed to get kubernetes config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined",
          err: <*errors.errorString | 0x5479350>{
              s: "unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined",
          },
      }
  occurred
  In [BeforeAll] at: /go/src/github.com/openshift/osde2e/pkg/e2e/state/alerts.go:43 @ 06/03/24 11:31:45.855
```

https://ci.int.devshift.net/view/osde2e/job/osde2e-gap-analysis-aws-osd/9/console