### PR TITLE
give cloud provider id env var to harness images

### DIFF
--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -582,6 +582,10 @@ func (h *H) GetRunnerCommandString(templatePath string, timeout int, latestImage
 				Name:  "OCM_CLUSTER_ID",
 				Value: viper.GetString(config.Cluster.ID),
 			},
+			{
+				Name:  "CLOUD_PROVIDER_ID",
+				Value: viper.GetString(config.CloudProvider.CloudProviderID),
+			},
 		},
 
 		EnvironmentVariablesFromSecret: []struct {


### PR DESCRIPTION
this will be useful to write provider specific tests

this came up during question from operator team regarding writing provider specific tests:
- harness test spec [here](https://github.com/openshift/aws-vpce-operator/pull/226/files#diff-497149bdd6d3190416c37b28ff982d6199a7bacd2795d34ea2cc655304858d0fR64) doesn’t have a label, osde2e doesn’t use that to select the spec.
- osde2e uses [this](https://github.com/openshift/osde2e/blob/ff7b6ccb4ebcb03ed8795efde58f8aa676446215/pkg/e2e/harness_runner/harness_runner.go#L35) TestHarness label and HARNESS_IMAGES env var to select harness test image
- adding labels to harness test spec might not take any effect,   because osde2e doesn’t run tests, only runs the image with [this entry poin](https://github.com/openshift/aws-vpce-operator/blob/1bf290f86a82579fdb242d864900f11da44a18cb/osde2e/Dockerfile#L5)t. , so the label filter must be provided in the entrypoint, BUT we’re recommending not to touch the dockerfile. (except for go version )

So what to do?
In the past I’ve done [this](https://github.com/openshift/osde2e/blame/ff7b6ccb4ebcb03ed8795efde58f8aa676446215/pkg/e2e/operators/cloudingress/rhapi_lb.go#L219), but harnesses don’t have access to viper in the test, so harnesses should be able to call os.Getenv("CLOUD_PROVIDER_ID") 