### PR TITLE
sdcicd-1198 improve gcp configs to properly set ccs creds

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -936,6 +936,7 @@ func InitOSDe2eViper() {
 func init() {
 	InitOSDe2eViper()
 	InitAWSViper()
+	InitGCPViper()
 }
 
 // PostProcess is a variety of post-processing commands that is intended to be run after a config is loaded.

--- a/pkg/common/config/gcp_config.go
+++ b/pkg/common/config/gcp_config.go
@@ -1,0 +1,48 @@
+// GCP config provides the gcp configuration for tests run as part of the osde2e suite.
+package config
+
+import viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+
+var (
+	// GCPCredsJSON GCP CCS Credential json
+	// Env: GCP_CREDS_JSON
+	GCPCredsJSON = "gcp.credsJSON"
+	// GCPCredsType GCP creds json internals
+	GCPCredsType               = "gcp.credsType"
+	GCPProjectID               = "gcp.projectID"
+	GCPPrivateKey              = "gcp.privateKey"
+	GCPPrivateKeyID            = "gcp.privateKeyID"
+	GCPClientEmail             = "gcp.clientEmail"
+	GCPClientID                = "gcp.clientID"
+	GCPAuthURI                 = "gcp.authURI"
+	GCPTokenURI                = "gcp.tokenURI"
+	GCPAuthProviderX509CertURL = "gcp.authProviderX509CertURL"
+	GCPClientX509CertURL       = "gcp.clientX509CertURL"
+)
+
+func InitGCPViper() {
+	viper.BindEnv(GCPCredsJSON, "GCP_CREDS_JSON")
+	viper.BindEnv(GCPCredsType, "GCP_CREDS_TYPE")
+	viper.BindEnv(GCPProjectID, "GCP_PROJECT_ID")
+	viper.BindEnv(GCPPrivateKey, "GCP_PRIVATE_KEY")
+	viper.BindEnv(GCPPrivateKeyID, "GCP_PRIVATE_KEY_ID")
+	viper.BindEnv(GCPClientEmail, "GCP_CLIENT_EMAIL")
+	viper.BindEnv(GCPClientID, "GCP_CLIENT_ID")
+	viper.BindEnv(GCPAuthURI, "GCP_AUTH_URI")
+	viper.BindEnv(GCPTokenURI, "GCP_TOKEN_URI")
+	viper.BindEnv(GCPAuthProviderX509CertURL, "GCP_AUTH_PROVIDER_X509_CERT_URL")
+	viper.BindEnv(GCPClientX509CertURL, "GCP_CLIENT_X509_CERT_URL")
+
+	RegisterSecret(GCPCredsJSON, "gcp-creds.json")
+
+	RegisterSecret(GCPCredsType, "gcp-creds-type")
+	RegisterSecret(GCPProjectID, "gcp-project-id")
+	RegisterSecret(GCPPrivateKey, "gcp-private-key")
+	RegisterSecret(GCPPrivateKeyID, "gcp-private-key-id")
+	RegisterSecret(GCPClientEmail, "gcp-client-email")
+	RegisterSecret(GCPClientID, "gcp-client-id")
+	RegisterSecret(GCPAuthURI, "gcp-auth-uri")
+	RegisterSecret(GCPTokenURI, "gcp-token-uri")
+	RegisterSecret(GCPAuthProviderX509CertURL, "gcp-auth-provider-x509-cert-url")
+	RegisterSecret(GCPClientX509CertURL, "gcp-client-x509-cert-url")
+}

--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -430,7 +430,7 @@ func (h *H) GetGCPCreds(ctx context.Context) (*google.Credentials, bool) {
 		Resource: "credentialsrequests",
 	}).Namespace(saCredentialReq.GetNamespace()).Create(ctx, &unstructured.Unstructured{Object: credentialReqObj}, metav1.CreateOptions{})
 
-	_ = wait.PollUntilContextTimeout(ctx, 15*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+	_ = wait.PollUntilContextTimeout(ctx, 15*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
 		unstructCredentialReq, _ := h.Dynamic().Resource(schema.GroupVersionResource{
 			Group:    "cloudcredential.openshift.io",
 			Version:  "v1",

--- a/pkg/common/providers/ocmprovider/config.go
+++ b/pkg/common/providers/ocmprovider/config.go
@@ -38,21 +38,6 @@ const (
 
 	// CCS defines whether the cluster should expect cloud credentials or not
 	CCS = "ocm.ccs"
-
-	// GCP CCS Credential json
-	// Env: GCP_CREDS_JSON, OCM_GCP_CREDS_JSON
-	GCPCredsJSON = "ocm.gcp.credsJSON"
-	// GCP creds json internals
-	GCPCredsType               = "ocm.gcp.credsType"
-	GCPProjectID               = "ocm.gcp.projectID"
-	GCPPrivateKey              = "ocm.gcp.privateKey"
-	GCPPrivateKeyID            = "ocm.gcp.privateKeyID"
-	GCPClientEmail             = "ocm.gcp.clientEmail"
-	GCPClientID                = "ocm.gcp.clientID"
-	GCPAuthURI                 = "ocm.gcp.authURI"
-	GCPTokenURI                = "ocm.gcp.tokenURI"
-	GCPAuthProviderX509CertURL = "ocm.gcp.authProviderX509CertURL"
-	GCPClientX509CertURL       = "ocm.gcp.clientX509CertURL"
 )
 
 func init() {
@@ -87,41 +72,4 @@ func init() {
 
 	viper.SetDefault(CCS, false)
 	viper.BindEnv(CCS, "OCM_CCS", "CCS")
-
-	viper.BindEnv(GCPCredsJSON, "OCM_GCP_CREDS_JSON", "GCP_CREDS_JSON")
-	viper.BindEnv(GCPCredsType, "OCM_GCP_CREDS_TYPE", "GCP_CREDS_TYPE")
-	viper.BindEnv(GCPProjectID, "OCM_GCP_PROJECT_ID", "GCP_PROJECT_ID")
-	viper.BindEnv(GCPPrivateKey, "OCM_GCP_PRIVATE_KEY", "GCP_PRIVATE_KEY")
-	viper.BindEnv(GCPPrivateKeyID, "OCM_GCP_PRIVATE_KEY_ID", "GCP_PRIVATE_KEY_ID")
-	viper.BindEnv(GCPClientEmail, "OCM_GCP_CLIENT_EMAIL", "GCP_CLIENT_EMAIL")
-	viper.BindEnv(GCPClientID, "OCM_GCP_CLIENT_ID", "GCP_CLIENT_ID")
-	viper.BindEnv(GCPAuthURI, "OCM_GCP_AUTH_URI", "GCP_AUTH_URI")
-	viper.BindEnv(GCPTokenURI, "OCM_GCP_TOKEN_URI", "GCP_TOKEN_URI")
-	viper.BindEnv(GCPAuthProviderX509CertURL, "OCM_GCP_AUTH_PROVIDER_X509_CERT_URL", "GCP_AUTH_PROVIDER_X509_CERT_URL")
-	viper.BindEnv(GCPClientX509CertURL, "OCM_GCP_CLIENT_X509_CERT_URL", "GCP_CLIENT_X509_CERT_URL")
-
-	config.RegisterSecret(GCPCredsJSON, "ocm-gcp-creds.json")
-	config.RegisterSecret(GCPCredsJSON, "gcp-creds.json")
-
-	config.RegisterSecret(GCPCredsType, "ocm-gcp-creds-type")
-	config.RegisterSecret(GCPProjectID, "ocm-gcp-project-id")
-	config.RegisterSecret(GCPPrivateKey, "ocm-gcp-private-key")
-	config.RegisterSecret(GCPPrivateKeyID, "ocm-gcp-private-key-id")
-	config.RegisterSecret(GCPClientEmail, "ocm-gcp-client-email")
-	config.RegisterSecret(GCPClientID, "ocm-gcp-client-id")
-	config.RegisterSecret(GCPAuthURI, "ocm-gcp-auth-uri")
-	config.RegisterSecret(GCPTokenURI, "ocm-gcp-token-uri")
-	config.RegisterSecret(GCPAuthProviderX509CertURL, "ocm-gcp-auth-provider-x509-cert-url")
-	config.RegisterSecret(GCPClientX509CertURL, "ocm-gcp-client-x509-cert-url")
-
-	config.RegisterSecret(GCPCredsType, "gcp-creds-type")
-	config.RegisterSecret(GCPProjectID, "gcp-project-id")
-	config.RegisterSecret(GCPPrivateKey, "gcp-private-key")
-	config.RegisterSecret(GCPPrivateKeyID, "ocp-private-key-id")
-	config.RegisterSecret(GCPClientEmail, "gcp-client-email")
-	config.RegisterSecret(GCPClientID, "gcp-client-id")
-	config.RegisterSecret(GCPAuthURI, "gcp-auth-uri")
-	config.RegisterSecret(GCPTokenURI, "gcp-token-uri")
-	config.RegisterSecret(GCPAuthProviderX509CertURL, "gcp-auth-provider-x509-cert-url")
-	config.RegisterSecret(GCPClientX509CertURL, "gcp-client-x509-cert-url")
 }

--- a/pkg/e2e/openshift/config.go
+++ b/pkg/e2e/openshift/config.go
@@ -102,14 +102,21 @@ func getZone() string {
 // Creates testprovider arg string for ocp test command
 func getTestProvider() string {
 	cloud := viper.GetString(config.CloudProvider.CloudProviderID)
-	if viper.GetString(config.CloudProvider.CloudProviderID) == "gcp" {
-		cloud = "gce"
-	}
-	region := viper.GetString(config.CloudProvider.Region)
 	gcpproject := ""
-	if viper.GetString(config.CloudProvider.CloudProviderID) == "gcp" {
+	if cloud == "gcp" {
+		cloud = "gce"
+		provider, err := ocmprovider.New()
+		if err != nil {
+			println("could not get gcp ocm provider")
+		}
+		if err = provider.RetrieveGCPConfigs(); err != nil {
+			println("could not retrieve gcp creds")
+		}
 		gcpproject = fmt.Sprintf(`,\"projectid\":\"%s\"`, viper.GetString(ocmprovider.GCPProjectID))
 	}
+
+	region := viper.GetString(config.CloudProvider.Region)
+
 	c := fmt.Sprintf(`{\"type\":\"%s\",\"region\":\"%s\",\"zone\":\"%s\",\"multizone\":false,\"multimaster\":true %s}`, cloud, region, getZone(), gcpproject)
 	return c
 }

--- a/pkg/e2e/openshift/config.go
+++ b/pkg/e2e/openshift/config.go
@@ -112,7 +112,7 @@ func getTestProvider() string {
 		if err = provider.RetrieveGCPConfigs(); err != nil {
 			println("could not retrieve gcp creds")
 		}
-		gcpproject = fmt.Sprintf(`,\"projectid\":\"%s\"`, viper.GetString(ocmprovider.GCPProjectID))
+		gcpproject = fmt.Sprintf(`,\"projectid\":\"%s\"`, viper.GetString(config.GCPProjectID))
 	}
 
 	region := viper.GetString(config.CloudProvider.Region)


### PR DESCRIPTION
We set gcp CCS account configs in viper (1) during cluster install and (2) in ocp conformance test

 This change
1. moves gcp configs to their own config file
2. sets them in a retrieve function called before cluster create

 