### PR TITLE
skip encrypted cloud storage access test for GCP non-CCS

### DIFF
--- a/pkg/e2e/verify/encrypted_storage.go
+++ b/pkg/e2e/verify/encrypted_storage.go
@@ -53,7 +53,7 @@ func init() {
 
 var _ = ginkgo.Describe(encryptedStorageTestName, label.E2E, func() {
 	ginkgo.Context("in GCP clusters", func() {
-		if viper.GetString(config.CloudProvider.CloudProviderID) != "gcp" {
+		if viper.GetString(config.CloudProvider.CloudProviderID) != "gcp" || !viper.GetBool(ocmprovider.CCS) {
 			return
 		}
 		h := helper.New()


### PR DESCRIPTION
Non ccs cluster tests should not be accessing cloud credentials, as we do not give access to them through osde2e.

relates to [SDCICD-1136](https://issues.redhat.com//browse/SDCICD-1136) 