### PR TITLE
SDCICD-1306: write std konflux TEST_OUTPUT results

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -99,6 +99,8 @@ const (
 	// SharedDir is the location where files to be used by other processes/programs are stored.
 	// This is primarily used when running within Prow and using additional steps after osde2e finishes.
 	SharedDir = "sharedDir"
+
+	KonfluxTestOutputFile = "konfluxResultsPath"
 )
 
 // This is a config key to secret file mapping. We will attempt to read in from secret files before loading anything else.
@@ -656,6 +658,8 @@ func InitOSDe2eViper() {
 	viper.BindEnv(ReportDir, "REPORT_DIR")
 
 	viper.BindEnv(SharedDir, "SHARED_DIR")
+
+	viper.BindEnv(KonfluxTestOutputFile, "KONFLUX_TEST_OUTPUT_FILE")
 
 	viper.BindEnv(Suffix, "SUFFIX")
 


### PR DESCRIPTION
Konflux supports reporting results based on a standard schema that
includes failures, successes, warnings during an integration test
scenario. Write out the results to `KONFLUX_TEST_OUTPUT_FILE` which will be
set to the `TEST_OUTPUT` result path.

This is just an initial attempt at something useable, it can be improved
upon to include things like `notes` and `warnings`.

Using it in a tekton task:

```yaml
...
        results:
          - name: TEST_OUTPUT
        steps:
          - image: $(params.COMPONENT_IMAGE)
            command:
              - /osde2e
            env:
              - name: KONFLUX_TEST_OUTPUT_FILE
                value: $(results.TEST_OUTPUT.path)
```

```
$ KONFLUX_TEST_OUTPUT_FILE=/tmp/konflux-results/TEST_OUTPUT go run ./cmd/osde2e/ test
...
$ cat /tmp/konflux-results/TEST_OUTPUT
{"failures":1,"result":"FAILURE","successes":26,"timestamp":"2024-06-10T02:58:29-05:00","warnings":0}
```

https://github.com/konflux-ci/architecture/blob/cd41772b27bb89cd061e85cdaa7488afc4e29a2e/ADR/0030-tekton-results-naming-convention.md

Signed-off-by: Brady Pratt <bpratt@redhat.com>
