### PR TITLE
e2e: skip setup if cluster-id provided

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -340,7 +340,7 @@ func runGinkgoTests() (int, error) {
 	}
 	metadata.Instance.SetEnvironment(provider.Environment())
 	// setup OSD unless mock provider with given kubeconfig
-	if len(viper.GetString(config.Kubeconfig.Path)) > 0 && providerCfg == "mock" {
+	if (len(viper.GetString(config.Kubeconfig.Path)) > 0 && providerCfg == "mock") || viper.GetString(config.Cluster.ID) != "" {
 		log.Print("Found an existing Kubeconfig for mock provider!")
 	} else {
 		// configure cluster and upgrade versions


### PR DESCRIPTION
when running against an existing cluster, there is no reason to query
the versions endpoint to select cluster versions if we provide an
existing cluster.

```
$ time go run ./cmd/osde2e/ test --configs aws,stage,pr-check --skip-destroy-cluster --skip-health-check --skip-must-gather --cluster-id xxxxxxxxxxxxxxxxxxxxxxxx
```

before:

```
real	3m12.224s
user	0m14.185s
sys	0m1.931s
```

after:

```
real	1m20.389s
user	0m3.436s
sys	0m0.611s
```

Signed-off-by: Brady Pratt <bpratt@redhat.com>
