### PR TITLE
Update date format for cleanup cluster logs

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -128,7 +128,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		for _, cluster := range clusters {
 			creationTime := cluster.CreationTimestamp().UTC()
 			if creationTime.Before(cutoffTime) {
-				fmt.Printf("Cluster will be deleted: %s (created %v)\n", cluster.ID(), creationTime.Format("2006-01-20"))
+				fmt.Printf("Cluster will be deleted: %s (created %v)\n", cluster.ID(), creationTime.Format("2006-01-02"))
 				if !args.dryRun {
 					if err := provider.DeleteCluster(cluster.ID()); err != nil {
 						fmt.Printf("Error deleting cluster: %s\n", err.Error())


### PR DESCRIPTION
The previous log output was:
```
Cluster will be deleted: 26hq23dvcrsueamlet9qmogg26g9cr20 (created 2023-09-280)
Error deleting cluster: cluster already uninstalling, skipped
```
To correct the date format in the log, change from `creationTime.Format("2006-01-20")` to `creationTime.Format("2006-01-02")`