### PR TITLE
SDCICD-1306: add new EC compatible Dockerfile

### DIFF
--- a/.tekton/osde2e-main-pull-request.yaml
+++ b/.tekton/osde2e-main-pull-request.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: Dockerfile.osde2e
+    value: osde2e.Dockerfile
   - name: git-url
     value: '{{source_url}}'
   - name: image-expires-after

--- a/.tekton/osde2e-main-push.yaml
+++ b/.tekton/osde2e-main-push.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   params:
   - name: dockerfile
-    value: Dockerfile.osde2e
+    value: osde2e.Dockerfile
   - name: git-url
     value: '{{source_url}}'
   - name: output-image

--- a/osde2e.Dockerfile
+++ b/osde2e.Dockerfile
@@ -1,0 +1,29 @@
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.22
+
+ENV GOFLAGS=
+ENV PKG=/go/src/github.com/openshift/osde2e/
+WORKDIR ${PKG}
+
+COPY . .
+RUN go env
+RUN make build
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+RUN microdnf install -y git && microdnf clean all
+RUN mkdir /osde2e-bin
+COPY --from=0 /go/src/github.com/openshift/osde2e/out/osde2e /osde2e-bin
+
+# Restore the /osde2e path for backwards compatibility
+RUN ln -s /osde2e-bin/osde2e /osde2e
+ENV PATH "/osde2e-bin:$PATH"
+
+ENTRYPOINT [ "osde2e" ]
+
+LABEL name="osde2e"
+LABEL description="A comprehensive test framework used for Service Delivery to test all aspects of Managed OpenShift Clusters"
+LABEL summary="CLI tool to provision and test Managed OpenShift Clusters"
+LABEL com.redhat.component="osde2e"
+LABEL io.k8s.description="osde2e"
+LABEL io.k8s.display-name="osde2e"
+LABEL io.openshift.tags="data,images"


### PR DESCRIPTION
when trying to build the existing Dockerfile, it fails the enterprise-contract policy due to the base image not being allowed. We should migrate to using an image built from the allowed registries

```
[report]   - metadata:
[report]       code: base_image_registries.base_image_permitted
[report]       collections:
[report]       - minimal
[report]       - redhat
[report]       depends_on:
[report]       - base_image_registries.base_image_info_found
[report]       - base_image_registries.allowed_registries_provided
[report]       description: Verify that the base images used when building a container image
[report]         come from a known set of trusted registries to reduce potential supply chain
[report]         attacks. By default this policy defines trusted registries as registries that
[report]         are fully maintained by Red Hat and only contain content produced by Red Hat.
[report]         The list of permitted registries can be customized by setting the `allowed_registry_prefixes`
[report]         list in the rule data. To exclude this rule add "base_image_registries.base_image_permitted"
[report]         to the `exclude` section of the policy configuration. To exclude this rule
[report]         add "base_image_registries.base_image_permitted" to the `exclude` section
[report]         of the policy configuration.
[report]       solution: Make sure the image used in each task comes from a trusted registry.
[report]         The list of trusted registries is a configurable xref:ec-cli:ROOT:configuration.adoc#_data_sources[data
[report]         source].
[report]       title: Base image comes from permitted registry
[report]     msg: Base image "registry.ci.openshift.org/openshift/release" is from a disallowed
[report]       registry
```