### PR TITLE
move setting cluster properties into util function

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -623,3 +623,23 @@ func clusterName() string {
 
 	return "osde2e-" + suffix
 }
+
+// set cluster infor into viper and metadata
+func SetClusterIntoViperConfig(cluster *spi.Cluster) {
+	viper.Set(config.Cluster.Channel, cluster.ChannelGroup())
+	viper.Set(config.Cluster.Name, cluster.Name())
+	log.Printf("CLUSTER_NAME set to %s from OCM.", viper.GetString(config.Cluster.Name))
+
+	viper.Set(config.Cluster.Version, cluster.Version())
+	log.Printf("CLUSTER_VERSION set to %s from OCM, for channel group %s", viper.GetString(config.Cluster.Version), viper.GetString(config.Cluster.Channel))
+
+	viper.Set(config.CloudProvider.CloudProviderID, cluster.CloudProvider())
+	log.Printf("CLOUD_PROVIDER_ID set to %s from OCM.", viper.GetString(config.CloudProvider.CloudProviderID))
+
+	viper.Set(config.CloudProvider.Region, cluster.Region())
+	log.Printf("CLOUD_PROVIDER_REGION set to %s from OCM.", viper.GetString(config.CloudProvider.Region))
+
+	metadata.Instance.SetClusterName(cluster.Name())
+	metadata.Instance.SetClusterID(cluster.ID())
+	metadata.Instance.SetRegion(cluster.Region())
+}

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -74,9 +74,9 @@ func beforeSuite() bool {
 		log.Printf("Not loading cluster id: %v", err)
 		return false
 	}
-
+	var cluster *spi.Cluster
 	if viper.GetString(config.Kubeconfig.Contents) == "" {
-		cluster, err := clusterutil.ProvisionCluster(nil)
+		cluster, err = clusterutil.ProvisionCluster(nil)
 		events.HandleErrorWithEvents(err, events.InstallSuccessful, events.InstallFailed)
 		if err != nil {
 			log.Printf("Failed to set up or retrieve cluster: %v", err)
@@ -85,8 +85,6 @@ func beforeSuite() bool {
 		}
 
 		viper.Set(config.Cluster.ID, cluster.ID())
-		viper.Set(config.Cluster.Channel, cluster.ChannelGroup())
-
 		log.Printf("CLUSTER_ID set to %s from OCM.", viper.GetString(config.Cluster.ID))
 		_, err = clusterutil.WaitForOCMProvisioning(provider, viper.GetString(config.Cluster.ID), nil, false)
 		if err != nil {
@@ -106,25 +104,9 @@ func beforeSuite() bool {
 			log.Printf("No shared directory provided, skip writing cluster ID")
 		}
 
-		viper.Set(config.Cluster.Name, cluster.Name())
-		log.Printf("CLUSTER_NAME set to %s from OCM.", viper.GetString(config.Cluster.Name))
-
-		viper.Set(config.Cluster.Version, cluster.Version())
-		log.Printf("CLUSTER_VERSION set to %s from OCM, for channel group %s", viper.GetString(config.Cluster.Version), viper.GetString(config.Cluster.Channel))
-
-		viper.Set(config.CloudProvider.CloudProviderID, cluster.CloudProvider())
-		log.Printf("CLOUD_PROVIDER_ID set to %s from OCM.", viper.GetString(config.CloudProvider.CloudProviderID))
-
-		viper.Set(config.CloudProvider.Region, cluster.Region())
-		log.Printf("CLOUD_PROVIDER_REGION set to %s from OCM.", viper.GetString(config.CloudProvider.Region))
-
 		if (!viper.GetBool(config.Addons.SkipAddonList) || viper.GetString(config.Provider) != "mock") && len(cluster.Addons()) > 0 {
 			log.Printf("Found addons: %s", strings.Join(cluster.Addons(), ","))
 		}
-
-		metadata.Instance.SetClusterName(cluster.Name())
-		metadata.Instance.SetClusterID(cluster.ID())
-		metadata.Instance.SetRegion(cluster.Region())
 
 		if err = provider.AddProperty(cluster, "UpgradeVersion", viper.GetString(config.Upgrade.ReleaseName)); err != nil {
 			log.Printf("Error while adding upgrade version property to cluster via OCM: %v", err)
@@ -184,7 +166,9 @@ func beforeSuite() bool {
 
 	} else {
 		log.Println("Using provided kubeconfig")
+		cluster, err = provider.GetCluster(viper.GetString(config.Cluster.ID))
 	}
+	clusterutil.SetClusterIntoViperConfig(cluster)
 
 	if len(viper.GetString(config.Addons.IDs)) > 0 {
 		if viper.GetString(config.Provider) != "mock" {
@@ -351,20 +335,14 @@ func runGinkgoTests() (int, error) {
 
 	// Get the cluster ID now to test against later
 	providerCfg := viper.GetString(config.Provider)
-	// setup OSD unless Kubeconfig is present
+	if provider, err = providers.ClusterProvider(); err != nil {
+		return Failure, fmt.Errorf("could not setup cluster provider: %v", err)
+	}
+	metadata.Instance.SetEnvironment(provider.Environment())
+	// setup OSD unless mock provider with given kubeconfig
 	if len(viper.GetString(config.Kubeconfig.Path)) > 0 && providerCfg == "mock" {
-		log.Print("Found an existing Kubeconfig!")
-		if provider, err = providers.ClusterProvider(); err != nil {
-			return Failure, fmt.Errorf("could not setup cluster provider: %v", err)
-		}
-		metadata.Instance.SetEnvironment(provider.Environment())
+		log.Print("Found an existing Kubeconfig for mock provider!")
 	} else {
-		if provider, err = providers.ClusterProvider(); err != nil {
-			return Failure, fmt.Errorf("could not setup cluster provider: %v", err)
-		}
-
-		metadata.Instance.SetEnvironment(provider.Environment())
-
 		// configure cluster and upgrade versions
 		versionSelector := versions.VersionSelector{Provider: provider}
 		if err = versionSelector.SelectClusterVersions(); err != nil {


### PR DESCRIPTION
currently we only set these viper configs when cluster is provisioned

 this will now also be called when cluster isn't provisioned in osde2e run. Useful for running osde2e on existing cluster.

- also removes a line duplication