### PR TITLE
e2e/webhooks: use dynamic client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/openshift-online/ocm-sdk-go v0.1.422
 	github.com/openshift/client-go v0.0.0-20240510131258-f646d5f29250
 	github.com/openshift/cloud-credential-operator v0.0.0-20230512001141-38e7f96bf730
-	github.com/openshift/custom-domains-operator v0.0.0-20221118201157-bd1052dac818
 	github.com/openshift/managed-upgrade-operator v0.0.0-20230525042514-a9b8c1d2571c
 	github.com/openshift/osde2e-common v0.0.0-20240611060429-ab4359c129ca
 	github.com/openshift/route-monitor-operator v0.0.0-20221118160357-3df1ed1fa1d2
@@ -63,7 +62,6 @@ require (
 require (
 	github.com/openshift/api v0.0.0-20240530151505-37be9ab109d3
 	github.com/openshift/cloud-ingress-operator v0.0.0-20240513131409-8957bf674c69
-	github.com/openshift/must-gather-operator v0.1.2-0.20240528212058-2dab3484f2bd
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -437,14 +437,10 @@ github.com/openshift/cloud-credential-operator v0.0.0-20230512001141-38e7f96bf73
 github.com/openshift/cloud-credential-operator v0.0.0-20230512001141-38e7f96bf730/go.mod h1:H38l/QxcO9xR32fBIOvJgkyPwdKv0snFUdzMwhCeXX0=
 github.com/openshift/cloud-ingress-operator v0.0.0-20240513131409-8957bf674c69 h1:6Iak88503V3Zzz8VEo8ciHt2ccl1kVAcpxASzKnxThU=
 github.com/openshift/cloud-ingress-operator v0.0.0-20240513131409-8957bf674c69/go.mod h1:b+PYtdqSwHjBuVssUuwJdKTapHDExUKCxYlwr7DCoyM=
-github.com/openshift/custom-domains-operator v0.0.0-20221118201157-bd1052dac818 h1:yJFprjRR4TC5QGJIVOuI2GK44QE+3MV1xQnd4Km9t8Y=
-github.com/openshift/custom-domains-operator v0.0.0-20221118201157-bd1052dac818/go.mod h1:doRZPfKZ/dOkq6LGvtkCC4l2V8RJAbpc2cqYn5BYYcs=
 github.com/openshift/library-go v0.0.0-20240517135010-e93e442c2b18 h1:aUFgWf2nsvxzHcyYFpY8OpVncJgZWc4bZsy5vncjgP0=
 github.com/openshift/library-go v0.0.0-20240517135010-e93e442c2b18/go.mod h1:lFwyRj0XjUf25Da3Q00y+KuaxCWTJ6YzYPDX1+96nco=
 github.com/openshift/managed-upgrade-operator v0.0.0-20230525042514-a9b8c1d2571c h1:2Vy855A5z3zQgUumH6PORqbUTNtKZ5SlSgzvq3iQBig=
 github.com/openshift/managed-upgrade-operator v0.0.0-20230525042514-a9b8c1d2571c/go.mod h1:W/ajjexZ/T50ZRpk48HbgbtOXD4rt0/wHlwdXu8arQE=
-github.com/openshift/must-gather-operator v0.1.2-0.20240528212058-2dab3484f2bd h1:FlhwvhVRs2RmfnKZpp+yVLn8iFEdF5DkN6T+LajeEFg=
-github.com/openshift/must-gather-operator v0.1.2-0.20240528212058-2dab3484f2bd/go.mod h1:23q86nyQ0IBWgCskyRbdCNpZo/dEWYb0gjkj2QqRhR0=
 github.com/openshift/osde2e-common v0.0.0-20240611060429-ab4359c129ca h1:DQSFe4AXhvtsEFCJOkUYP6efp7aORAOFtzVMoWkdvUc=
 github.com/openshift/osde2e-common v0.0.0-20240611060429-ab4359c129ca/go.mod h1:oA2+sZPgApVQHbLLWFInDMzheCovGpnWg9ABXppFQpQ=
 github.com/openshift/route-monitor-operator v0.0.0-20221118160357-3df1ed1fa1d2 h1:s97F2fQ5r+XGVfWDy5wgH611iIvIDusQcHtv5jJ36uw=

--- a/pkg/common/helper/impersonate.go
+++ b/pkg/common/helper/impersonate.go
@@ -8,8 +8,6 @@ import (
 	quotav1 "github.com/openshift/api/quota/v1"
 	route "github.com/openshift/api/route/v1"
 	securityv1 "github.com/openshift/api/security/v1"
-	customdomainv1alpha1 "github.com/openshift/custom-domains-operator/api/v1alpha1"
-	mustgatherv1alpha1 "github.com/openshift/must-gather-operator/api/v1alpha1"
 	operatorhubv1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/client-go/rest"
@@ -35,8 +33,6 @@ func (h *H) AsUser(username string, groups ...string) *resources.Resources {
 	quotav1.AddToScheme(client.GetScheme())
 	securityv1.AddToScheme(client.GetScheme())
 	monitoringv1.AddToScheme(client.GetScheme())
-	mustgatherv1alpha1.AddToScheme(client.GetScheme())
-	customdomainv1alpha1.AddToScheme(client.GetScheme())
 	route.AddToScheme(client.GetScheme())
 	operatorhubv1.AddToScheme(client.GetScheme())
 	imagev1.AddToScheme(client.GetScheme())


### PR DESCRIPTION
use the dynamic client to create CustomDomain CRs and MustGather CRs so that we don't pull in the dependency of both operators