### PR TITLE
SDCICD-1306: copy license and set USER

### DIFF
--- a/osde2e.Dockerfile
+++ b/osde2e.Dockerfile
@@ -10,9 +10,12 @@ RUN make build
 
 FROM registry.redhat.io/rhel9-2-els/rhel:9.2
 WORKDIR /
+RUN mkdir /licenses
 COPY --from=builder /go/src/github.com/openshift/osde2e/out/osde2e .
+COPY --from=builder /go/src/github.com/openshift/osde2e/LICENSE /licenses/.
 
 ENTRYPOINT ["/osde2e"]
+USER 65532:65532
 
 LABEL name="osde2e"
 LABEL description="A comprehensive test framework used for Service Delivery to test all aspects of Managed OpenShift Clusters"


### PR DESCRIPTION
Resolve the preflight-checks failures. Brings osde2e image more inline with compliance requirements

```
{
    "name": "HasLicense",
    "elapsed_time": 0,
    "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses",
    "help": "Check HasLicense encountered an error. Please review the preflight.log file for more information.",
    "suggestion": "Create a directory named /licenses and include all relevant licensing and/or terms and conditions as text file(s) in that directory.",
    "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
    "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
},
{
    "name": "RunAsNonRoot",
    "elapsed_time": 0,
    "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication",
    "help": "Check RunAsNonRoot encountered an error. Please review the preflight.log file for more information.",
    "suggestion": "Indicate a specific USER in the dockerfile or containerfile",
    "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
    "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
}
```