### PR TITLE
use CLOUD_PROVIDER_REGION when AWS_REGION is not specified

### DIFF
--- a/pkg/common/config/aws_config.go
+++ b/pkg/common/config/aws_config.go
@@ -38,7 +38,7 @@ func InitAWSViper() {
 	viper.BindEnv(AWSProfile, "AWS_PROFILE")
 	RegisterSecret(AWSProfile, "aws-profile")
 
-	viper.BindEnv(AWSRegion, "AWS_REGION", "ROSA_AWS_REGION")
+	viper.BindEnv(AWSRegion, "AWS_REGION", "ROSA_AWS_REGION", "CLOUD_PROVIDER_REGION")
 	RegisterSecret(AWSRegion, "aws-region")
 
 	viper.BindEnv(AWSVPCSubnetIDs, "AWS_VPC_SUBNET_IDS", "ROSA_SUBNET_IDS", "SUBNET_IDS")


### PR DESCRIPTION
CLOUD_PROVIDER_REGION will be passed to jobs, and should be seen by AWS session as AWS_REGION

Bind it to viper config as a backup for AWS_REGION env var