### PR TITLE
sdcicd-885 add missing cloud provider region var to harness image

### DIFF
--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -586,6 +586,10 @@ func (h *H) GetRunnerCommandString(templatePath string, timeout int, latestImage
 				Value: viper.GetString(config.CloudProvider.CloudProviderID),
 			},
 			{
+				Name:  "CLOUD_PROVIDER_REGION",
+				Value: viper.GetString(config.CloudProvider.Region),
+			},
+			{
 				Name:  "OCM_ENV",
 				Value: viper.GetString(ocmprovider.Env),
 			},


### PR DESCRIPTION
Fixes CIO failing test harness

both gcp and aws jobs need CLOUD_PROVIDER_REGION to work

tekton job and CIO harness are set up to use this, but osde2e was not passing it to the harness. Adding it. 