### PR TITLE
SDCICD-1221 Slack notification functionality

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -225,8 +225,8 @@ func run(cmd *cobra.Command, argv []string) error {
 	if args.sendSummary {
 
 		webhook := viper.GetString(config.Tests.SlackWebhook)
-		buildFile := "Build file: " + viper.GetString(config.BaseJobURL) + "/logs/" + viper.GetString(config.JobName) +
-			"/" + viper.GetString(config.JobID) + "/" + viper.GetString(config.Artifacts) + "/test/build-log.txt"
+		buildFile := "Build file: " + viper.GetString(config.BaseJobURL) + viper.GetString(config.JobName) +
+			"/" + viper.GetString(config.JobID) + "/artifacts/test/build-log.txt"
 
 		summaryMessage := `{"summary":"` + summaryBuilder.String() + `",`
 		errorMessage := `"full":"` + buildFile + "\n" + errorBuilder.String() + `"}`

--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -225,7 +225,7 @@ func run(cmd *cobra.Command, argv []string) error {
 	if args.sendSummary {
 
 		webhook := viper.GetString(config.Tests.SlackWebhook)
-		buildFile := "Build file: " + viper.GetString(config.BaseJobURL) + viper.GetString(config.JobName) +
+		buildFile := "Build file: " + viper.GetString(config.BaseJobURL) + "/" + viper.GetString(config.JobName) +
 			"/" + viper.GetString(config.JobID) + "/artifacts/test/build-log.txt"
 
 		summaryMessage := `{"summary":"` + summaryBuilder.String() + `",`

--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -96,7 +96,7 @@ func init() {
 	flags.StringVar(
 		&args.olderThan,
 		"older-than",
-		"48h",
+		"24h",
 		"Cleanup iam resources older than this duration. Accepts a sequence of decimal numbers with a unit suffix, such as '2h45m'",
 	)
 	flags.BoolVar(

--- a/pkg/common/aws/ec2.go
+++ b/pkg/common/aws/ec2.go
@@ -2,8 +2,9 @@ package aws
 
 import (
 	"fmt"
-	"github.com/openshift/osde2e/pkg/common/config"
 	"strings"
+
+	"github.com/openshift/osde2e/pkg/common/config"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -40,7 +41,8 @@ func (CcsAwsSession *ccsAwsSession) CheckIfEC2ExistBasedOnNodeName(nodeName stri
 // associated with it, we skip its deletion and log tag name. Dryrun returns aws Error
 // from AWS api and is logged.
 func (CcsAwsSession *ccsAwsSession) ReleaseElasticIPs(dryrun bool, sendSummary bool,
-	deletedCounter *int, failedCounter *int, errorBuilder *strings.Builder) error {
+	deletedCounter *int, failedCounter *int, errorBuilder *strings.Builder,
+) error {
 	err := CcsAwsSession.GetAWSSessions()
 	if err != nil {
 		return err

--- a/pkg/common/aws/iam.go
+++ b/pkg/common/aws/iam.go
@@ -217,7 +217,7 @@ func (CcsAwsSession *ccsAwsSession) CleanupPolicies(olderthan time.Duration, dry
 				_, err := CcsAwsSession.iam.DeletePolicy(input)
 				if err != nil {
 					*failedCounter++
-					errorMsg := fmt.Sprintf("Plolicy %s not deleted: %s\n", *policy.PolicyName, err.Error())
+					errorMsg := fmt.Sprintf("Policy %s not deleted: %s\n", *policy.PolicyName, err.Error())
 					if sendSummary && errorBuilder.Len() < config.SlackMessageLength {
 						errorBuilder.WriteString(errorMsg)
 					}

--- a/pkg/common/aws/iam.go
+++ b/pkg/common/aws/iam.go
@@ -2,9 +2,10 @@ package aws
 
 import (
 	"fmt"
-	"github.com/openshift/osde2e/pkg/common/config"
 	"strings"
 	"time"
+
+	"github.com/openshift/osde2e/pkg/common/config"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -16,7 +17,8 @@ var (
 )
 
 func (CcsAwsSession *ccsAwsSession) CleanupOpenIDConnectProviders(olderthan time.Duration, dryrun bool, sendSummary bool,
-	deletedCounter *int, failedCounter *int, errorBuilder *strings.Builder) error {
+	deletedCounter *int, failedCounter *int, errorBuilder *strings.Builder,
+) error {
 	err := CcsAwsSession.GetAWSSessions()
 	if err != nil {
 		return err
@@ -67,7 +69,8 @@ func (CcsAwsSession *ccsAwsSession) CleanupOpenIDConnectProviders(olderthan time
 }
 
 func (CcsAwsSession *ccsAwsSession) CleanupRoles(olderthan time.Duration, dryrun bool, sendSummary bool,
-	deletedCounter *int, failedCounter *int, errorBuilder *strings.Builder) error {
+	deletedCounter *int, failedCounter *int, errorBuilder *strings.Builder,
+) error {
 	err := CcsAwsSession.GetAWSSessions()
 	if err != nil {
 		return err
@@ -188,7 +191,8 @@ func (CcsAwsSession *ccsAwsSession) CleanupRoles(olderthan time.Duration, dryrun
 }
 
 func (CcsAwsSession *ccsAwsSession) CleanupPolicies(olderthan time.Duration, dryrun bool, sendSummary bool,
-	deletedCounter *int, failedCounter *int, errorBuilder *strings.Builder) error {
+	deletedCounter *int, failedCounter *int, errorBuilder *strings.Builder,
+) error {
 	err := CcsAwsSession.GetAWSSessions()
 	if err != nil {
 		return err

--- a/pkg/common/aws/iam.go
+++ b/pkg/common/aws/iam.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"strings"
 	"time"
 
@@ -14,7 +15,8 @@ var (
 	providersubstr = "cloudfront"
 )
 
-func (CcsAwsSession *ccsAwsSession) CleanupOpenIDConnectProviders(olderthan time.Duration, dryrun bool) error {
+func (CcsAwsSession *ccsAwsSession) CleanupOpenIDConnectProviders(olderthan time.Duration, dryrun bool, sendSummary bool,
+	deletedCounter *int, failedCounter *int, errorBuilder *strings.Builder) error {
 	err := CcsAwsSession.GetAWSSessions()
 	if err != nil {
 		return err
@@ -47,8 +49,15 @@ func (CcsAwsSession *ccsAwsSession) CleanupOpenIDConnectProviders(olderthan time
 				}
 				_, err := CcsAwsSession.iam.DeleteOpenIDConnectProvider(input)
 				if err != nil {
+					*failedCounter++
+					errorMsg := fmt.Sprintf("OIDC provider %s not deleted: %s\n", *provider.Arn, err.Error())
+					fmt.Println(errorMsg)
+					if sendSummary && errorBuilder.Len() < config.SlackMessageLength {
+						errorBuilder.WriteString(errorMsg)
+					}
 					return err
 				}
+				*deletedCounter++
 				fmt.Println("Deleted")
 			}
 		}
@@ -57,7 +66,8 @@ func (CcsAwsSession *ccsAwsSession) CleanupOpenIDConnectProviders(olderthan time
 	return nil
 }
 
-func (CcsAwsSession *ccsAwsSession) CleanupRoles(olderthan time.Duration, dryrun bool) error {
+func (CcsAwsSession *ccsAwsSession) CleanupRoles(olderthan time.Duration, dryrun bool, sendSummary bool,
+	deletedCounter *int, failedCounter *int, errorBuilder *strings.Builder) error {
 	err := CcsAwsSession.GetAWSSessions()
 	if err != nil {
 		return err
@@ -95,8 +105,14 @@ func (CcsAwsSession *ccsAwsSession) CleanupRoles(olderthan time.Duration, dryrun
 					}
 					_, errRemoveRoleFromInstanceProfile := CcsAwsSession.iam.RemoveRoleFromInstanceProfile(removeRoleFromInstanceProfileInput)
 					if errRemoveRoleFromInstanceProfile != nil {
-						return fmt.Errorf("error removing role from instance profile: %s", errRemoveRoleFromInstanceProfile)
+						*failedCounter++
+						errorMsg := fmt.Sprintf("error removing role from instance profile: %s", errRemoveRoleFromInstanceProfile)
+						if sendSummary && errorBuilder.Len() < config.SlackMessageLength {
+							errorBuilder.WriteString(errorMsg)
+						}
+						return fmt.Errorf(errorMsg)
 					}
+					*deletedCounter++
 					fmt.Println("Removed")
 				}
 
@@ -171,7 +187,8 @@ func (CcsAwsSession *ccsAwsSession) CleanupRoles(olderthan time.Duration, dryrun
 	return nil
 }
 
-func (CcsAwsSession *ccsAwsSession) CleanupPolicies(olderthan time.Duration, dryrun bool) error {
+func (CcsAwsSession *ccsAwsSession) CleanupPolicies(olderthan time.Duration, dryrun bool, sendSummary bool,
+	deletedCounter *int, failedCounter *int, errorBuilder *strings.Builder) error {
 	err := CcsAwsSession.GetAWSSessions()
 	if err != nil {
 		return err
@@ -195,8 +212,14 @@ func (CcsAwsSession *ccsAwsSession) CleanupPolicies(olderthan time.Duration, dry
 				// Delete the policy
 				_, err := CcsAwsSession.iam.DeletePolicy(input)
 				if err != nil {
+					*failedCounter++
+					errorMsg := fmt.Sprintf("Plolicy %s not deleted: %s\n", *policy.PolicyName, err.Error())
+					if sendSummary && errorBuilder.Len() < config.SlackMessageLength {
+						errorBuilder.WriteString(errorMsg)
+					}
 					return err
 				}
+				*deletedCounter++
 				fmt.Println("Deleted")
 			}
 		}

--- a/pkg/common/aws/s3.go
+++ b/pkg/common/aws/s3.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"bytes"
 	"fmt"
+	"github.com/openshift/osde2e/pkg/common/config"
 	"log"
 	"net/url"
 	"strings"
@@ -92,7 +93,9 @@ func ParseS3URL(s3URL string) (string, string, error) {
 
 // CleanupS3Buckets finds buckets with substring "osde2e-" or "managed-velero",
 // older than given duration, then deletes bucket objects and then buckets
-func (CcsAwsSession *ccsAwsSession) CleanupS3Buckets(olderthan time.Duration, dryrun bool) error {
+func (CcsAwsSession *ccsAwsSession) CleanupS3Buckets(olderthan time.Duration, dryrun bool, sendSummary bool,
+	deletedCounter *int, failedCounter *int, errorBuilder *strings.Builder) error {
+
 	err := CcsAwsSession.GetAWSSessions()
 	if err != nil {
 		return err
@@ -113,17 +116,28 @@ func (CcsAwsSession *ccsAwsSession) CleanupS3Buckets(olderthan time.Duration, dr
 					Bucket: bucket.Name,
 				})
 				if err := batchDeleteClient.Delete(aws.BackgroundContext(), iter); err != nil {
-					fmt.Printf("error deleting objects from bucket %s, skipping: %s", *bucket.Name, err)
+					errorMsg := fmt.Sprintf("error deleting objects from bucket %s, skipping: %s", *bucket.Name, err)
+					fmt.Println(errorMsg)
+					*failedCounter++
+					if sendSummary && errorBuilder.Len() < 10000 {
+						errorBuilder.WriteString(strings.Replace(errorMsg, `""`, "", -1))
+					}
 					continue
 				}
 				fmt.Println("Deleted object(s) from bucket")
 				if _, err := CcsAwsSession.s3.DeleteBucket(&s3.DeleteBucketInput{
 					Bucket: bucket.Name,
 				}); err != nil {
-					fmt.Printf("error deleting bucket: %s: %s", *bucket.Name, err)
+					errorMsg := fmt.Sprintf("error deleting bucket: %s: %s", *bucket.Name, err)
+					fmt.Println(errorMsg)
+					*failedCounter++
+					if sendSummary && errorBuilder.Len() < config.SlackMessageLength {
+						errorBuilder.WriteString(strings.Replace(errorMsg, `""`, "", -1))
+					}
 					continue
 				}
 				fmt.Println("Deleted bucket")
+				*deletedCounter++
 			}
 		}
 	}

--- a/pkg/common/aws/s3.go
+++ b/pkg/common/aws/s3.go
@@ -3,11 +3,12 @@ package aws
 import (
 	"bytes"
 	"fmt"
-	"github.com/openshift/osde2e/pkg/common/config"
 	"log"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/openshift/osde2e/pkg/common/config"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -94,8 +95,8 @@ func ParseS3URL(s3URL string) (string, string, error) {
 // CleanupS3Buckets finds buckets with substring "osde2e-" or "managed-velero",
 // older than given duration, then deletes bucket objects and then buckets
 func (CcsAwsSession *ccsAwsSession) CleanupS3Buckets(olderthan time.Duration, dryrun bool, sendSummary bool,
-	deletedCounter *int, failedCounter *int, errorBuilder *strings.Builder) error {
-
+	deletedCounter *int, failedCounter *int, errorBuilder *strings.Builder,
+) error {
 	err := CcsAwsSession.GetAWSSessions()
 	if err != nil {
 		return err

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -101,6 +101,8 @@ const (
 	SharedDir = "sharedDir"
 
 	KonfluxTestOutputFile = "konfluxResultsPath"
+
+	SlackMessageLength int = 4000
 )
 
 // This is a config key to secret file mapping. We will attempt to read in from secret files before loading anything else.
@@ -236,6 +238,10 @@ var Tests = struct {
 	// Env: SLACK_CHANNEL
 	SlackChannel string
 
+	// Slack Webhook is the URL for Cloud Account Cleanup Report workflow to send notifications.
+	// Env: SLACK_WEBHOOK
+	SlackWebhook string
+
 	// GinkgoSkip is a regex passed to Ginkgo that skips any test suites matching the regex. ex. "Operator"
 	// Env: GINKGO_SKIP
 	GinkgoSkip string
@@ -302,6 +308,7 @@ var Tests = struct {
 	PollingTimeout:             "tests.pollingTimeout",
 	ServiceAccount:             "tests.serviceAccount",
 	SlackChannel:               "tests.slackChannel",
+	SlackWebhook:               "tests.slackWebhook",
 	GinkgoSkip:                 "tests.ginkgoSkip",
 	GinkgoFocus:                "tests.focus",
 	GinkgoLogLevel:             "tests.ginkgoLogLevel",
@@ -637,7 +644,7 @@ func InitOSDe2eViper() {
 	viper.SetDefault(JobID, -1)
 	viper.BindEnv(JobID, "BUILD_NUMBER")
 
-	viper.SetDefault(BaseJobURL, "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs")
+	viper.SetDefault(BaseJobURL, "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs")
 	viper.BindEnv(BaseJobURL, "BASE_JOB_URL")
 
 	viper.SetDefault(BaseProwURL, "https://deck-ci.apps.ci.l2s4.p1.openshiftapps.com")
@@ -749,6 +756,8 @@ func InitOSDe2eViper() {
 
 	viper.SetDefault(Tests.SlackChannel, "sd-cicd-alerts")
 	viper.BindEnv(Tests.SlackChannel, "SLACK_CHANNEL")
+
+	viper.BindEnv(Tests.SlackWebhook, "SLACK_WEBHOOK")
 
 	// ----- Cluster -----
 	viper.SetDefault(Cluster.MultiAZ, false)

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -758,6 +758,7 @@ func InitOSDe2eViper() {
 	viper.BindEnv(Tests.SlackChannel, "SLACK_CHANNEL")
 
 	viper.BindEnv(Tests.SlackWebhook, "SLACK_WEBHOOK")
+	RegisterSecret(Tests.SlackWebhook, "cleanup-job-notification-webhook")
 
 	// ----- Cluster -----
 	viper.SetDefault(Cluster.MultiAZ, false)

--- a/pkg/common/load/load.go
+++ b/pkg/common/load/load.go
@@ -96,10 +96,6 @@ func loadPassthruSecrets(secretLocations []string) {
 				if err != nil {
 					return fmt.Errorf("error loading passthru-secret file %s: %s", path, err.Error())
 				}
-				if info.Name() == "cleanup-job-notification-webhook" {
-					viper.Set(config.Tests.SlackWebhook, strings.TrimSpace(string(data)))
-					return nil
-				}
 				passthruSecrets[info.Name()] = strings.TrimSpace(string(data))
 				return nil
 			})

--- a/pkg/common/load/load.go
+++ b/pkg/common/load/load.go
@@ -96,6 +96,10 @@ func loadPassthruSecrets(secretLocations []string) {
 				if err != nil {
 					return fmt.Errorf("error loading passthru-secret file %s: %s", path, err.Error())
 				}
+				if info.Name() == "cleanup-job-notification-webhook" {
+					viper.Set(config.Tests.SlackWebhook, strings.TrimSpace(string(data)))
+					return nil
+				}
 				passthruSecrets[info.Name()] = strings.TrimSpace(string(data))
 				return nil
 			})


### PR DESCRIPTION
- The `--send-cleanup-summary` option enables the sending of a detailed summary of the cleanup status to [#sd-cicd-notifications](https://redhat.enterprise.slack.com/archives/C06HQR8HN0L)
- This summary includes information about the status of various AWS resources deleted/failed. Some of the errors and the build log link are provided in the same thread.