### PR TITLE
SDCICD-1221 Load osde2e-common secrets to access slack webhook

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -237,6 +237,10 @@ func run(cmd *cobra.Command, argv []string) error {
 
 	if args.sendSummary {
 		webhook := viper.GetString(config.Tests.SlackWebhook)
+		if webhook == "" {
+			fmt.Println("Slack Webhook is not set, skipping notification.")
+			return nil
+		}
 		buildFile := "Build file: " + viper.GetString(config.BaseJobURL) + "/" + viper.GetString(config.JobName) +
 			"/" + viper.GetString(config.JobID) + "/artifacts/test/build-log.txt"
 

--- a/pkg/common/load/load.go
+++ b/pkg/common/load/load.go
@@ -83,7 +83,7 @@ func loadPassthruSecrets(secretLocations []string) {
 
 		for _, folder := range secretLocations {
 			// Omit the osde2e secrets from going to the pass through secrets.
-			if strings.Contains(folder, "osde2e-credentials") || strings.Contains(folder, "osde2e-common") {
+			if strings.Contains(folder, "osde2e-credentials") {
 				continue
 			}
 			err := filepath.Walk(folder, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
- Previously, the `osde2e-common` secrets were not being loaded, which prevented the Slack webhook from being accessed.
- This update ensures that the Slack webhook is now properly loaded into passthruSecrets.