### PR TITLE
SDCICD-1221 Get BUILD_NUMBER from os env

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -242,7 +242,7 @@ func run(cmd *cobra.Command, argv []string) error {
 			return nil
 		}
 		buildFile := "Build file: " + viper.GetString(config.BaseJobURL) + "/" + viper.GetString(config.JobName) +
-			"/" + viper.GetString(config.JobID) + "/artifacts/test/build-log.txt"
+			"/" + os.Getenv("BUILD_NUMBER") + "/artifacts/test/build-log.txt"
 
 		summaryMessage := `{"summary":"` + summaryBuilder.String() + `",`
 		errorMessage := `"full":"` + buildFile + `",`


### PR DESCRIPTION
- The `BUILD_NUMBER` was not properly accessed from the Viper configuration, so it is now retrieved directly from the OS environment.