### PR TITLE
SDCICD-1335 Use BUILD_ID instead of BUILD_NUMBER for prow logs URL

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -249,7 +249,7 @@ func run(cmd *cobra.Command, argv []string) error {
 			buildFile += viper.GetString(config.BaseJobURL)
 		}
 		buildFile += "/" + viper.GetString(config.JobName) +
-			"/" + os.Getenv("BUILD_ID") + "/artifacts/test/build-log.txt"
+			"/" + viper.GetString(config.JobID) + "/artifacts/test/build-log.txt"
 
 		summaryMessage := `{"summary":"` + summaryBuilder.String() + `",`
 		errorMessage := `"full":"` + buildFile + `",`

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -27,7 +27,7 @@ const (
 	JobName = "jobName"
 
 	// JobID is the ID designated by prow for this run
-	// Env: BUILD_NUMBER
+	// Env: BUILD_ID
 	JobID = "jobID"
 
 	// ProwJobId is the ID designated by prow for this run
@@ -642,7 +642,7 @@ func InitOSDe2eViper() {
 	viper.BindEnv(JobType, "JOB_TYPE")
 
 	viper.SetDefault(JobID, -1)
-	viper.BindEnv(JobID, "BUILD_NUMBER")
+	viper.BindEnv(JobID, "BUILD_ID")
 
 	viper.SetDefault(BaseJobURL, "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs")
 	viper.BindEnv(BaseJobURL, "BASE_JOB_URL")


### PR DESCRIPTION
- Set `JobID` Using `BUILD_ID` Instead of `BUILD_NUMBER`
- The `JobID` was previously set using the `BUILD_NUMBER` environment variable, which is not accessible to the osde2e code. Since `BUILD_ID` and `BUILD_NUMBER` are equivalent, we are replacing `BUILD_NUMBER` with `BUILD_ID`