### PR TITLE
SDCICD-1330 EC2 instance cleanup

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -2,6 +2,8 @@ package cleanup
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -38,6 +40,16 @@ var args struct {
 	dryRun          bool
 	clusters        bool
 	sendSummary     bool
+	ec2             bool
+}
+
+type Message struct {
+	Summary   string `json:"summary"`
+	BuildFile string `json:"buildfile"`
+	S3Errors  string `json:"s3"`
+	IAMErrors string `json:"iam"`
+	IPErrors  string `json:"ip"`
+	EC2Errors string `json:"ec2"`
 }
 
 func init() {
@@ -113,6 +125,13 @@ func init() {
 		"Send cleanup summary to webhook",
 	)
 
+	flags.BoolVar(
+		&args.ec2,
+		"ec2",
+		false,
+		"Terminate ec2 instances",
+	)
+
 	Cmd.RegisterFlagCompletionFunc("output-format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json", "prom"}, cobra.ShellCompDirectiveDefault
 	})
@@ -133,9 +152,10 @@ func run(cmd *cobra.Command, argv []string) error {
 	var iamErrorBuilder strings.Builder
 	var s3ErrorBuilder strings.Builder
 	var ipErrorBuilder strings.Builder
+	var ec2ErrorBuilder strings.Builder
 
 	if args.dryRun {
-		summaryBuilder.WriteString("-- Cleanup dry run --\n")
+		summaryBuilder.WriteString("-- Cleanup dry run -- \n")
 	}
 	if os.Getenv("JOB_NAME") != "" {
 		r, _ := regexp.Compile("cleanup-([a-z]+)-aws")
@@ -219,9 +239,24 @@ func run(cmd *cobra.Command, argv []string) error {
 		s3BucketDeletedCounter := 0
 		s3BucketFailedCounter := 0
 		err = aws.CcsAwsSession.CleanupS3Buckets(fmtDuration, args.dryRun, args.sendSummary, &s3BucketDeletedCounter, &s3BucketFailedCounter, &s3ErrorBuilder)
-		summaryBuilder.WriteString("s3 Buckets: " + strconv.Itoa(s3BucketDeletedCounter) + "/" + strconv.Itoa(s3BucketFailedCounter) + "\n")
+		summaryBuilder.WriteString("S3 Buckets: " + strconv.Itoa(s3BucketDeletedCounter) + "/" + strconv.Itoa(s3BucketFailedCounter) + "\n")
 		if err != nil {
 			return fmt.Errorf("could not delete s3 buckets: %s", err.Error())
+		}
+	}
+
+	if args.ec2 {
+		instancesDeleted, instancesFailedToDelete, err := aws.CcsAwsSession.TerminateEC2Instances(fmtDuration, args.dryRun)
+		summaryBuilder.WriteString("EC2 Instances: " + strconv.Itoa(instancesDeleted) + "/" + strconv.Itoa(instancesFailedToDelete) + "\n")
+		if err != nil {
+			if !errors.Is(err, aws.ErrTerminateEC2Instances) {
+				return fmt.Errorf("could not terminate ec2 instances: %s", err.Error())
+			}
+			ec2ErrorMessage := err.Error()
+			if len(ec2ErrorMessage) > config.SlackMessageLength {
+				ec2ErrorMessage = ec2ErrorMessage[:config.SlackMessageLength]
+			}
+			ec2ErrorBuilder.WriteString(ec2ErrorMessage)
 		}
 	}
 
@@ -241,7 +276,7 @@ func run(cmd *cobra.Command, argv []string) error {
 			fmt.Println("Slack Webhook is not set, skipping notification.")
 			return nil
 		}
-		buildFile := "Build file: "
+		buildFile := ""
 		if strings.Contains(viper.GetString(config.JobName), "rehearse") {
 			basePRJobURL := "https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release"
 			buildFile += basePRJobURL + "/" + os.Getenv("PULL_NUMBER")
@@ -251,15 +286,23 @@ func run(cmd *cobra.Command, argv []string) error {
 		buildFile += "/" + viper.GetString(config.JobName) +
 			"/" + viper.GetString(config.JobID) + "/artifacts/test/build-log.txt"
 
-		summaryMessage := `{"summary":"` + summaryBuilder.String() + `",`
-		errorMessage := `"full":"` + buildFile + `",`
-		s3ErrorMessage := `"s3":" S3 Errors: \n ` + s3ErrorBuilder.String() + `",`
-		iamErrorMessage := `"iam":" IAM Errors: \n` + iamErrorBuilder.String() + `",`
-		ipErrorMessage := `"ip":" ElasticIP Errors: \n` + ipErrorBuilder.String() + `"}`
+		message := Message{
+			Summary:   summaryBuilder.String(),
+			BuildFile: "Build Logs: " + buildFile,
+			S3Errors:  "S3 Errors: " + s3ErrorBuilder.String(),
+			IAMErrors: "IAM Errors: " + iamErrorBuilder.String(),
+			IPErrors:  "IP Errors: " + ipErrorBuilder.String(),
+			EC2Errors: "EC2 Errors: " + ec2ErrorBuilder.String(),
+		}
 
-		req, err := http.NewRequest("POST", webhook, bytes.NewBuffer([]byte(summaryMessage+errorMessage+s3ErrorMessage+iamErrorMessage+ipErrorMessage)))
+		jsonDataMessage, err := json.Marshal(message)
 		if err != nil {
-			fmt.Printf("Error creating request: %v\n", err)
+			return fmt.Errorf("Error marshalling summary to JSON: %v\n", err)
+		}
+
+		req, err := http.NewRequest("POST", webhook, bytes.NewBuffer(jsonDataMessage))
+		if err != nil {
+			return fmt.Errorf("Error creating request: %v\n", err)
 		}
 
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
@@ -267,7 +310,7 @@ func run(cmd *cobra.Command, argv []string) error {
 		client := &http.Client{}
 		resp, err := client.Do(req)
 		if err != nil {
-			fmt.Printf("Error making request: %v\n", err)
+			return fmt.Errorf("Error making request: %v\n", err)
 		}
 		defer resp.Body.Close()
 

--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -137,6 +137,7 @@ func init() {
 	})
 }
 
+//nolint:gocyclo
 func run(cmd *cobra.Command, argv []string) error {
 	var err error
 	if err = common.LoadConfigs(args.configString, args.customConfig, args.secretLocations); err != nil {

--- a/pkg/common/aws/ec2.go
+++ b/pkg/common/aws/ec2.go
@@ -3,12 +3,19 @@ package aws
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/openshift/osde2e/pkg/common/config"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
+
+const (
+	tagKeyForExemptEC2Instances = "osde2e-proxy"
+)
+
+var ErrTerminateEC2Instances = fmt.Errorf("unable to terminate EC2 instances")
 
 // Hypershift Test Helper Function:
 // This function is used to validate the worker nodes displayed by the cluster are the same as the worker nodes displayed by the AWS account.
@@ -78,4 +85,57 @@ func (CcsAwsSession *ccsAwsSession) ReleaseElasticIPs(dryrun bool, sendSummary b
 	fmt.Printf("Finished elastic IP cleanup. Deleted %d addresses.", *deletedCounter)
 
 	return nil
+}
+
+// TerminateEC2Instances finds EC2 instances older than given duration, then terminates these EC2 instances.
+// Ignores EC2 instances with tag Name "osde2e-proxy*".
+func (CcsAwsSession *ccsAwsSession) TerminateEC2Instances(olderthan time.Duration, dryrun bool) (int, int, error) {
+	err := CcsAwsSession.GetAWSSessions()
+	if err != nil {
+		return 0, 0, err
+	}
+	result, err := CcsAwsSession.ec2.DescribeInstances(&ec2.DescribeInstancesInput{})
+	if err != nil {
+		return 0, 0, err
+	}
+	var instanceIds []string
+	for _, reservation := range result.Reservations {
+		// Each reservation typically has only 1 instance
+		instance := reservation.Instances[0]
+		if time.Since(*instance.LaunchTime) < olderthan {
+			continue
+		}
+		for _, tag := range instance.Tags {
+			if *tag.Key != "Name" || strings.Contains(*tag.Value, tagKeyForExemptEC2Instances) {
+				continue
+			}
+			instanceIds = append(instanceIds, *instance.InstanceId)
+			break
+		}
+	}
+
+	ec2ErrorBuilder := strings.Builder{}
+	instancesDeleted := 0
+	instancesFailedToDelete := 0
+	if !dryrun {
+		for _, instanceId := range instanceIds {
+			input := &ec2.TerminateInstancesInput{
+				InstanceIds: aws.StringSlice([]string{instanceId}),
+			}
+			_, err := CcsAwsSession.ec2.TerminateInstances(input)
+			if err != nil {
+				errorMessage := fmt.Sprintf("Error terminating instance %s: %s\n", instanceId, err.Error())
+				ec2ErrorBuilder.WriteString(errorMessage)
+				fmt.Printf(errorMessage)
+				instancesFailedToDelete++
+			} else {
+				instancesDeleted++
+			}
+		}
+	}
+	if ec2ErrorBuilder.Len() == 0 {
+		return instancesDeleted, instancesFailedToDelete, nil
+	}
+	ec2Error := fmt.Errorf("%w: %s", ErrTerminateEC2Instances, ec2ErrorBuilder.String())
+	return instancesDeleted, instancesFailedToDelete, ec2Error
 }

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -102,7 +102,11 @@ const (
 
 	KonfluxTestOutputFile = "konfluxResultsPath"
 
-	SlackMessageLength int = 4000
+	// TotalSlackMessageLength is about 10000 characters
+	// Summary: 1500 Characters
+	// Build file comment: 500 Characters
+	// Other comments(s3, ec2, elasticIP, iam): 2000 * 4 = 8000
+	SlackMessageLength int = 2000
 )
 
 // This is a config key to secret file mapping. We will attempt to read in from secret files before loading anything else.


### PR DESCRIPTION
- `--ec2` parameter terminates EC2 instances with tag `Name: osde2e*` and older than 24 hrs.
- Ignores EC2 instances with tag `Name: osde2e-proxy*`
- Notifcation sample: https://redhat-internal.slack.com/archives/C06HQR8HN0L/p1721926378565619