### PR TITLE
change konflux e2e pr check to rosa

### DIFF
--- a/.tekton/osde2e-main-e2e-test.yaml
+++ b/.tekton/osde2e-main-e2e-test.yaml
@@ -12,7 +12,7 @@ spec:
       type: string
     - description: osde2e configs (comma delimited string of configurations)
       name: OSDE2E_CONFIGS
-      default: aws,stage,sts,pr-check
+      default: rosa,stage,pr-check
       type: string
   tasks:
     - name: parse-component-image-spec


### PR DESCRIPTION
We're noticing some aws creds being rotated in the way that an OSD AWS CCS job would do, after this pr check job started running, eg this [run](https://console.redhat.com/application-pipeline/workspaces/osde2e-cicada/applications/osde2e/pipelineruns/osde2e-shbvw-r4vnd/logs).

Changing the type of this cluster to ROSA from OSD AWS to avoid unintentional creds rotation.