### PR TITLE
SDCICD-1382 allow passing subnet IDs in jenkins gap analysis job

### DIFF
--- a/scripts/gap-analysis-jobs.sh
+++ b/scripts/gap-analysis-jobs.sh
@@ -16,6 +16,7 @@ docker create --name "${CONTAINER_NAME}" -e OCM_TOKEN \
 	-e AWS_ACCESS_KEY_ID \
 	-e AWS_SECRET_ACCESS_KEY \
 	-e AWS_REGION \
+	-e AWS_VPC_SUBNET_IDS \
 	-e GCP_CREDS_JSON \
 	-e INSTALL_LATEST_NIGHTLY \
 	-e REPORT_DIR='/tmp/osde2e-report' \


### PR DESCRIPTION
currently code that auto creates vpc is broken. providing subnet IDs will unblock job execution for [OSD-24677](https://issues.redhat.com/browse/OSD-24677)

