### PR TITLE
fix param name for specific nightly in parameterized jenkins job template 

### DIFF
--- a/scripts/parameterized-job.sh
+++ b/scripts/parameterized-job.sh
@@ -21,6 +21,7 @@ docker create --name osde2e-run -e OCM_TOKEN \
 	-e CLUSTER_ID \
 	-e SKIP_MUST_GATHER \
 	-e INSTALL_LATEST_XY \
+	-e INSTALL_LATEST_NIGHTLY \
 	-e TEST_HARNESSES \
 	-e POLLING_TIMEOUT \
 	-e OCM_CCS \


### PR DESCRIPTION
SREs frequently need to spin up specific nighlty clusters for testing. 

To trigger specific nightly, we are now using INSTALL_LATEST_NIGHTLY instead of previous INSTALL_LATEST_XY 


Update parameterized job to accept it  