### PR TITLE
misc: drop CCO dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/onsi/gomega v1.34.1
 	github.com/openshift-online/ocm-sdk-go v0.1.441
 	github.com/openshift/client-go v0.0.0-20240510131258-f646d5f29250
-	github.com/openshift/cloud-credential-operator v0.0.0-20230512001141-38e7f96bf730
 	github.com/openshift/managed-upgrade-operator v0.0.0-20230525042514-a9b8c1d2571c
 	github.com/openshift/osde2e-common v0.0.0-20240913051955-f5206c53c976
 	github.com/operator-framework/api v0.17.7
@@ -43,7 +42,7 @@ require (
 	github.com/tsenart/vegeta v12.7.0+incompatible
 	github.com/vmware-tanzu/velero v1.10.2
 	golang.org/x/net v0.28.0
-	golang.org/x/oauth2 v0.22.0
+	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/sync v0.8.0
 	golang.org/x/tools v0.24.0
 	google.golang.org/api v0.194.0

--- a/go.sum
+++ b/go.sum
@@ -433,8 +433,6 @@ github.com/openshift/api v0.0.0-20240530151505-37be9ab109d3 h1:Irqrkp2eFX9At+OAP
 github.com/openshift/api v0.0.0-20240530151505-37be9ab109d3/go.mod h1:CxgbWAlvu2iQB0UmKTtRu1YfepRg1/vJ64n2DlIEVz4=
 github.com/openshift/client-go v0.0.0-20240510131258-f646d5f29250 h1:WQ0e89xebsNeChdYw8QrxggYkFtEQOaLBEKJDkMmcUk=
 github.com/openshift/client-go v0.0.0-20240510131258-f646d5f29250/go.mod h1:tjGjTE59N1+5W0YE4Wqf0zJpFLIY4d+EpMihDKOn1oA=
-github.com/openshift/cloud-credential-operator v0.0.0-20230512001141-38e7f96bf730 h1:OvlJLL21hWzkey+3nuB3gb/FSU3b6hO/3Hc6dB4SaJg=
-github.com/openshift/cloud-credential-operator v0.0.0-20230512001141-38e7f96bf730/go.mod h1:H38l/QxcO9xR32fBIOvJgkyPwdKv0snFUdzMwhCeXX0=
 github.com/openshift/library-go v0.0.0-20240517135010-e93e442c2b18 h1:aUFgWf2nsvxzHcyYFpY8OpVncJgZWc4bZsy5vncjgP0=
 github.com/openshift/library-go v0.0.0-20240517135010-e93e442c2b18/go.mod h1:lFwyRj0XjUf25Da3Q00y+KuaxCWTJ6YzYPDX1+96nco=
 github.com/openshift/managed-upgrade-operator v0.0.0-20230525042514-a9b8c1d2571c h1:2Vy855A5z3zQgUumH6PORqbUTNtKZ5SlSgzvq3iQBig=

--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -4,7 +4,6 @@ package helper
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"math/rand"
@@ -17,7 +16,6 @@ import (
 	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
 	projectv1 "github.com/openshift/api/project/v1"
-	cloudcredentialv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/osde2e-common/pkg/clients/openshift"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
@@ -25,14 +23,10 @@ import (
 	"github.com/openshift/osde2e/pkg/common/runner"
 	"github.com/openshift/osde2e/pkg/common/templates"
 	"github.com/openshift/osde2e/pkg/common/util"
-	"golang.org/x/oauth2/google"
-	computev1 "google.golang.org/api/compute/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
@@ -382,82 +376,6 @@ func (h *H) GetWorkload(name string) (string, bool) {
 	}
 
 	return "", false
-}
-
-func (h *H) GetGCPCreds(ctx context.Context) (*google.Credentials, bool) {
-	testInstanceName := "test-" + time.Now().Format("20060102-150405-") + fmt.Sprint(time.Now().Nanosecond()/1000000) + "-" + fmt.Sprint(ginkgo.GinkgoParallelProcess())
-	providerBytes := bytes.Buffer{}
-	encoder := json.NewEncoder(&providerBytes)
-	encoder.Encode(cloudcredentialv1.GCPProviderSpec{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "GCPProviderSpec",
-			APIVersion: "cloudcredential.openshift.io/v1",
-		},
-		PredefinedRoles: []string{
-			"roles/owner",
-		},
-		SkipServiceCheck: true,
-	})
-	saCredentialReq := &cloudcredentialv1.CredentialsRequest{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "CredentialsRequest",
-			APIVersion: "cloudcredential.openshift.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      testInstanceName,
-			Namespace: h.CurrentProject(),
-		},
-		Spec: cloudcredentialv1.CredentialsRequestSpec{
-			SecretRef: corev1.ObjectReference{
-				Name:      testInstanceName,
-				Namespace: h.CurrentProject(),
-			},
-			ProviderSpec: &runtime.RawExtension{
-				Raw:    providerBytes.Bytes(),
-				Object: &cloudcredentialv1.GCPProviderSpec{},
-			},
-		},
-	}
-
-	credentialReqObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(saCredentialReq)
-	if err != nil {
-		return nil, false
-	}
-	_, err = h.Dynamic().Resource(schema.GroupVersionResource{
-		Group:    "cloudcredential.openshift.io",
-		Version:  "v1",
-		Resource: "credentialsrequests",
-	}).Namespace(saCredentialReq.GetNamespace()).Create(ctx, &unstructured.Unstructured{Object: credentialReqObj}, metav1.CreateOptions{})
-
-	_ = wait.PollUntilContextTimeout(ctx, 15*time.Second, 5*time.Minute, true, func(ctx context.Context) (bool, error) {
-		unstructCredentialReq, _ := h.Dynamic().Resource(schema.GroupVersionResource{
-			Group:    "cloudcredential.openshift.io",
-			Version:  "v1",
-			Resource: "credentialsrequests",
-		}).Namespace(h.CurrentProject()).Get(ctx, saCredentialReq.GetName(), metav1.GetOptions{})
-
-		err = runtime.DefaultUnstructuredConverter.FromUnstructured(unstructCredentialReq.UnstructuredContent(), saCredentialReq)
-		if err != nil || !saCredentialReq.Status.Provisioned {
-			return false, err
-		}
-		return true, err
-	})
-
-	saSecret, err := h.Kube().CoreV1().Secrets(saCredentialReq.Spec.SecretRef.Namespace).Get(ctx, saCredentialReq.Spec.SecretRef.Name, metav1.GetOptions{})
-	if err != nil {
-		return nil, false
-	}
-	serviceAccountJSON, ok := saSecret.Data["service_account.json"]
-	if !ok {
-		return nil, false
-	}
-	credentials, err := google.CredentialsFromJSON(
-		ctx, serviceAccountJSON,
-		computev1.ComputeScope)
-	if err != nil {
-		return nil, false
-	}
-	return credentials, true
 }
 
 // AddWorkload uniquely appends a workload to the workloads list


### PR DESCRIPTION
the GetGCPCreds function is unused and the createGCPServiceAccount function can be rewritten to use the dynamic client, which it was partially already doing. This drops the dependency completely on CCO

/hold

needs proper testing