### PR TITLE
update validate-sdn-ovn-migration-jobs.sh vars

### DIFF
--- a/test/sdn_migration/README.md
+++ b/test/sdn_migration/README.md
@@ -19,11 +19,9 @@ Below outlines what the test suite is capable of:
     * Perform Pre Upgrade Check
     * Perform upgrade
     * Perform post upgrade health checks
-        * Checks prometheus alerts
         * Runs osd-cluster-ready health check job
     * Perform sdn to ovn migration 
     * Perform post migration health checks
-        * Checks prometheus alerts
         * Runs osd-cluster-ready health check job
 
 The test suite is ordered and has labels which allow you to customize what is
@@ -44,7 +42,7 @@ performed. For example:
 * The proxy needs to be created manually if end-to-end tests are going to be run against a cluster with a cluster-wide proxy
 
 ### Run Ginkgo
-*NOTE:CLUSTER_ID is optional (internal ID), and AWS_HTTP_PROXY, AWS_HTTP_PROXYS, CA_BUNDLE, and 
+*NOTE:CLUSTER_ID is optional (internal ID), and TEST_HTTP_PROXY, TEST_HTTPS_PROXY, USER_CA_BUNDLE, and 
 SUBNETS are also optional unless end-to-end tests need to be run against a cluster with a cluster-wide proxy
 ```shell
 AWS_REGION=<AWS_REGION> \
@@ -54,9 +52,10 @@ OCM_TOKEN=<OCM_TOKEN> \
 CLUSTER_ID=<CLUSTER_ID> \
 CLUSTER_NAME = <CLUSTER_NAME> \
 REPLICAS=<REPLICAS>\
-AWS_HTTP_PROXY=<AWS_HTTP_PROXY>\
-AWS_HTTPs_PROXY=<AWS_HTTP_PROXY> \
-CA_BUNDLE=<CA_BUNDLE> \
-SUBNETS=<SUBNETS> \
+TEST_HTTP_PROXY=<TEST_HTTP_PROXY>\
+TEST_HTTPS_PROXY=<TEST_HTTPS_PROXY> \
+USER_CA_BUNDLE=<USER_CA_BUNDLE> \
+SUBNET_IDS=<SUBNET_IDS> \
+REPORT_DIR='/tmp/osde2e-report' \
 ginkgo run 
 ```

--- a/test/sdn_migration/scripts/validate-sdn-ovn-migration-jobs.sh
+++ b/test/sdn_migration/scripts/validate-sdn-ovn-migration-jobs.sh
@@ -14,10 +14,10 @@ docker create --name "${CONTAINER_NAME}" -e OCM_TOKEN \
 	-e CLUSTER_NAME \
 	-e REPLICAS \
 	-e GINKGO_LABEL_FILTER \
-	-e AWS_HTTPS_PROXY \
-	-e AWS_HTTP_PROXY \
-	-e CA_BUNDLE\
-	-e SUBNETS\
+	-e TEST_HTTPS_PROXY \
+	-e TEST_HTTP_PROXY \
+	-e USER_CA_BUNDLE\
+	-e SUBNET_IDS\
 	-e REPORT_DIR='/tmp/osde2e-report' \
 	quay.io/redhat-services-prod/osde2e-cicada-tenant/osde2e/sdn-migration:latest
 


### PR DESCRIPTION
Update validate-sdn-ovn-migration-jobs.sh env vars to match env vars in https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/resources/jenkins/osde2e/secrets.yaml?ref_type=heads#L29 so the script can run as a Jenkins job