### PR TITLE
Update where the junit is. The tmp osde2e-report is the proper location.

### DIFF
--- a/test/fedramp/Dockerfile
+++ b/test/fedramp/Dockerfile
@@ -31,7 +31,7 @@ ENTRYPOINT ["/usr/local/bin/ginkgo"]
 USER 65532:65532
 
 # Provide default arguments
-CMD ["-v", "--label-filter=Fedramp", "--junit-report=junit.xml", "./osde2e-fedramp.test"]
+CMD ["-v", "--label-filter=Fedramp", "--junit-report=/tmp/osde2e-report/junit.xml", "./osde2e-fedramp.test"]
 
 LABEL name="osde2e-fedramp-tests"
 LABEL description="A test framework for testing ROSA clusters on the FedRAMP environment"


### PR DESCRIPTION
This should fix an error I'm seeing at Jenkins
ginkgo run failed
  could not finalize profiles:
  open junit.xml: permission denied
Running Suite: Fedramp Suite - Picture 