### PR TITLE
SDE-4270 - Update osde2e ocm access to ClientID

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,13 +21,13 @@ require (
 	github.com/joshdk/go-junit v1.0.0
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/onsi/ginkgo/v2 v2.22.1
+	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	github.com/openshift-online/ocm-sdk-go v0.1.458
 	github.com/openshift/client-go v0.0.0-20240510131258-f646d5f29250
 	github.com/openshift/cloud-credential-operator v0.0.0-20230512001141-38e7f96bf730
 	github.com/openshift/managed-upgrade-operator v0.0.0-20230525042514-a9b8c1d2571c
-	github.com/openshift/osde2e-common v0.0.0-20241107205151-751c51bf8518
+	github.com/openshift/osde2e-common v0.0.0-20250204192737-8050d2fe899c
 	github.com/operator-framework/api v0.17.7
 	github.com/operator-framework/operator-lifecycle-manager v0.22.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.64.0

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
-github.com/onsi/ginkgo/v2 v2.22.1 h1:QW7tbJAUDyVDVOM5dFa7qaybo+CRfR7bemlQUN6Z8aM=
-github.com/onsi/ginkgo/v2 v2.22.1/go.mod h1:S6aTpoRsSq2cZOd+pssHAlKW/Q/jZt6cPrPlnj4a1xM=
+github.com/onsi/ginkgo/v2 v2.22.2 h1:/3X8Panh8/WwhU/3Ssa6rCKqPLuAkVY2I0RoyDLySlU=
+github.com/onsi/ginkgo/v2 v2.22.2/go.mod h1:oeMosUL+8LtarXBHu/c0bx2D/K9zyQ6uX3cTyztHwsk=
 github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
 github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
 github.com/openshift-online/ocm-sdk-go v0.1.458 h1:hC/10CxcegR2FTee8fGZx5K7ROaRZ5NHEHlTVP0S0gA=
@@ -436,8 +436,12 @@ github.com/openshift/library-go v0.0.0-20240517135010-e93e442c2b18 h1:aUFgWf2nsv
 github.com/openshift/library-go v0.0.0-20240517135010-e93e442c2b18/go.mod h1:lFwyRj0XjUf25Da3Q00y+KuaxCWTJ6YzYPDX1+96nco=
 github.com/openshift/managed-upgrade-operator v0.0.0-20230525042514-a9b8c1d2571c h1:2Vy855A5z3zQgUumH6PORqbUTNtKZ5SlSgzvq3iQBig=
 github.com/openshift/managed-upgrade-operator v0.0.0-20230525042514-a9b8c1d2571c/go.mod h1:W/ajjexZ/T50ZRpk48HbgbtOXD4rt0/wHlwdXu8arQE=
-github.com/openshift/osde2e-common v0.0.0-20241107205151-751c51bf8518 h1:uM+PkQI/c8+GU12ZymVeZ7YXyzlqS17I0BjRpRfrCog=
-github.com/openshift/osde2e-common v0.0.0-20241107205151-751c51bf8518/go.mod h1:YwPVJMHwsxQYKHtSY4/3Yu6UVeUFXp++grhI+kcmI+4=
+github.com/openshift/osde2e-common v0.0.0-20250203194843-375bf8249ef2 h1:A6jUsIzl48Q0HElJydv6LLUi5YzDweXHwhgCP+j1tUA=
+github.com/openshift/osde2e-common v0.0.0-20250203194843-375bf8249ef2/go.mod h1:x8nTILIaszQ9/lC4smttb6TBRmcAQWwzRDuhBUnP/Qs=
+github.com/openshift/osde2e-common v0.0.0-20250204120456-6d8ffdf1ac4e h1:y/SxudgVN+OkkRquSw9MmXMgPfGOy4pyl7b4cEtnNns=
+github.com/openshift/osde2e-common v0.0.0-20250204120456-6d8ffdf1ac4e/go.mod h1:JKH+EpD9+2NFN05d13AAxtLditjeRBEKaJpQJleOjyc=
+github.com/openshift/osde2e-common v0.0.0-20250204192737-8050d2fe899c h1:lWdM+pleVZTi5rjhd7+c/MDqydvW1yJFhUhVMD4dl0s=
+github.com/openshift/osde2e-common v0.0.0-20250204192737-8050d2fe899c/go.mod h1:JKH+EpD9+2NFN05d13AAxtLditjeRBEKaJpQJleOjyc=
 github.com/operator-framework/api v0.17.7 h1:NLn+Ieg+HaPrw75KbX4efllN21ofFArQzS3q8TDbQY0=
 github.com/operator-framework/api v0.17.7/go.mod h1:lnurXgadLnoZ7pufKMHkErr2BVOIZSpHtvEkHBcKvdk=
 github.com/operator-framework/operator-lifecycle-manager v0.22.0 h1:7DEWOq24HQ0l5xPOXMhn17XaJACgwoipz+JfQ7QCXZw=

--- a/osde2e.Dockerfile
+++ b/osde2e.Dockerfile
@@ -13,8 +13,8 @@ RUN make build
 FROM registry.redhat.io/rhel9-2-els/rhel:9.2
 WORKDIR /
 # Create a writeable directory for licenses used by Tekton.
-# Create a writable directory for configuration used for ocm connection.
-RUN mkdir /licenses && mkdir -p /.config/ocm
+RUN mkdir /licenses 
+
 COPY --from=builder /go/src/github.com/openshift/osde2e/out/osde2e .
 COPY --from=builder /go/src/github.com/openshift/osde2e/LICENSE /licenses/.
 COPY --from=builder /usr/bin/git /usr/bin/git

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -22,6 +22,10 @@ const (
 	// Env: PROVIDER
 	Provider = "provider"
 
+	// OCM_CONFIG is the path for the ocm.json file.
+	// Env: OCM_CONFIG
+	OcmConfig = "ocmConfig"
+
 	// JobName lets you name the current e2e job run
 	// Env: JOB_NAME
 	JobName = "jobName"
@@ -641,6 +645,10 @@ func InitOSDe2eViper() {
 	// ----- Top Level Configs -----
 	viper.SetDefault(Provider, "ocm")
 	_ = viper.BindEnv(Provider, "PROVIDER")
+
+	viper.SetDefault(OcmConfig, fmt.Sprintf("%s/ocm.json", os.TempDir()))
+	_ = viper.BindEnv(OcmConfig, "OCM_CONFIG")
+	os.Setenv("OCM_CONFIG", viper.GetString(OcmConfig))
 
 	_ = viper.BindEnv(JobName, "JOB_NAME")
 	_ = viper.BindEnv(JobType, "JOB_TYPE")

--- a/pkg/common/providers/ocmprovider/config.go
+++ b/pkg/common/providers/ocmprovider/config.go
@@ -9,6 +9,12 @@ const (
 	// Token is used to authenticate with OCM.
 	Token = "ocm.token"
 
+	// ClientID is used to authenticate with OCM.
+	ClientID = "ocm.clientID"
+
+	// ClientSecret is used to authenticate with OCM.
+	ClientSecret = "ocm.clientSecret"
+
 	// Env is the OpenShift Dedicated environment used to provision clusters.
 	Env = "ocm.env"
 
@@ -39,12 +45,6 @@ const (
 	// CCS defines whether the cluster should expect cloud credentials or not
 	CCS = "ocm.ccs"
 
-	// FedRamp Keycloack Client ID
-	FedRampClientID = "fedRamp.clientID"
-
-	// FedRamp Keycloack Client Secret
-	FedRampClientSecret = "fedRamp.clientSecret"
-
 	// HTTPS_PROXY - Currently only used for FedRamp
 	HTTPSProxy = "ocm.https_proxy"
 )
@@ -53,6 +53,12 @@ func init() {
 	// ----- OCM -----
 	_ = viper.BindEnv(Token, "OCM_TOKEN")
 	config.RegisterSecret(Token, "ocm-refresh-token")
+
+	_ = viper.BindEnv(ClientID, "OCM_CLIENT_ID")
+	config.RegisterSecret(ClientID, "ocm-client-id")
+
+	_ = viper.BindEnv(ClientSecret, "OCM_CLIENT_SECRET")
+	config.RegisterSecret(ClientSecret, "ocm-client-secret")
 
 	viper.SetDefault(Env, "prod")
 	_ = viper.BindEnv(Env, "OSD_ENV")
@@ -83,16 +89,8 @@ func init() {
 	_ = viper.BindEnv(CCS, "OCM_CCS", "CCS")
 
 	// ----- FedRamp -----
-	viper.SetDefault(FedRampClientID, "")
-	_ = viper.BindEnv(FedRampClientID, "FEDRAMP_CLIENT_ID")
-
-	viper.SetDefault(FedRampClientSecret, "")
-	_ = viper.BindEnv(FedRampClientSecret, "FEDRAMP_CLIENT_SECRET")
-
 	viper.SetDefault(HTTPSProxy, "")
 	_ = viper.BindEnv(HTTPSProxy, "HTTPS_PROXY")
 
-	config.RegisterSecret(FedRampClientID, "fedramp-client-id")
-	config.RegisterSecret(FedRampClientSecret, "fedramp-client-secret")
 	config.RegisterSecret(HTTPSProxy, "https-proxy")
 }

--- a/pkg/common/providers/ocmprovider/versions.go
+++ b/pkg/common/providers/ocmprovider/versions.go
@@ -101,16 +101,6 @@ func (o *OCMProvider) Versions() (*spi.VersionList, error) {
 
 	var defaultVersionOverride *semver.Version = nil
 
-	if o.env != prod {
-		var versionList *spi.VersionList
-		versionList, err = o.prodProvider.Versions()
-		if err != nil {
-			return nil, fmt.Errorf("error getting production default: %v", err)
-		}
-
-		defaultVersionOverride = versionList.Default()
-	}
-
 	return spi.NewVersionListBuilder().
 		AvailableVersions(versions).
 		DefaultVersionOverride(defaultVersionOverride).

--- a/pkg/common/providers/rosaprovider/rosa.go
+++ b/pkg/common/providers/rosaprovider/rosa.go
@@ -73,8 +73,8 @@ func New() (*ROSAProvider, error) {
 			rosaProvider, err = rosaprovider.New(
 				ctx,
 				viper.GetString("ocm.token"),
-				viper.GetString("fedRamp.clientID"),
-				viper.GetString("fedRamp.clientSecret"),
+				viper.GetString("ocm.clientID"),
+				viper.GetString("ocm.clientSecret"),
 				ocmEnv,
 				textlogger.NewLogger(textlogger.NewConfig()),
 			)

--- a/scripts/gap-analysis-jobs.sh
+++ b/scripts/gap-analysis-jobs.sh
@@ -13,6 +13,7 @@ fi
 
 # Create the container with environment variables and unique name
 docker create --name "${CONTAINER_NAME}" -e OCM_TOKEN \
+	-e OCM_CLIENT_ID -e OCM_CLIENT_SECRET \
 	-e AWS_ACCESS_KEY_ID \
 	-e AWS_SECRET_ACCESS_KEY \
 	-e AWS_ACCOUNT_ID \

--- a/scripts/parameterized-job.sh
+++ b/scripts/parameterized-job.sh
@@ -7,6 +7,7 @@ docker rm osde2e-run
 # bind mounts run into permissions issues, this creates
 # the container and copies the secrets over to ensure it has perms
 docker create --pull=always --name osde2e-run -e OCM_TOKEN \
+	-e OCM_CLIENT_ID -e OCM_CLIENT_SECRET \
 	-e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_ACCOUNT_ID \
 	-e GCP_CREDS_JSON \
 	-e CLOUD_PROVIDER_REGION \


### PR DESCRIPTION
Follow up to https://github.com/openshift/osde2e-common/pull/206
Follow up to https://github.com/openshift/osde2e/pull/2824 and https://github.com/openshift/osde2e-common/commit/0a3a3902b38f64bef745b1ad9a38d03395fb87a3

This PR refactors the logic that we were using for FedRamp's Keycloack to enable ServiceAccount login through OSDe2e. 
This change will be enabled by using the credentials currently stored under /ocm-sd-cicada-sa in vault.
This also bumps the latest osde2e-common dependancies

Added the OCM_CONFIG as part of the viper inits, this also sets the env variable for the container. 

Removed the ProdProvider from the old OCM Provider. The new SA does not support Prod, this is by design.