### PR TITLE
Update the osde2e docker image to hold ocm config

### DIFF
--- a/osde2e.Dockerfile
+++ b/osde2e.Dockerfile
@@ -19,6 +19,9 @@ COPY --from=builder /usr/bin/git /usr/bin/git
 COPY --from=builder /usr/libexec/git-core/* /usr/libexec/git-core/
 COPY --from=builder /usr/share/git-core/* /usr/share/git-core/
 
+# Create a writable directory for configuration used for ocm connection.
+RUN mkdir -p /.config/ocm
+
 ENV PATH="${PATH}:/"
 ENTRYPOINT ["/osde2e"]
 USER 65532:65532


### PR DESCRIPTION
# Create a writable directory for configuration used for ocm connection.