### PR TITLE
Fix permission error by setting writable config directory

### DIFF
--- a/osde2e.Dockerfile
+++ b/osde2e.Dockerfile
@@ -12,7 +12,9 @@ RUN make build
 
 FROM registry.redhat.io/rhel9-2-els/rhel:9.2
 WORKDIR /
-RUN mkdir /licenses
+# Create a writeable directory for licenses used by Tekton.
+# Create a writable directory for configuration used for ocm connection.
+RUN mkdir /licenses && mkdir -p /.config/ocm
 COPY --from=builder /go/src/github.com/openshift/osde2e/out/osde2e .
 COPY --from=builder /go/src/github.com/openshift/osde2e/LICENSE /licenses/.
 COPY --from=builder /usr/bin/git /usr/bin/git


### PR DESCRIPTION
- /.config/ocm dir

This fixes an issue for the CI in https://github.com/openshift/osde2e/pull/2822 to pass. We need to create the /.config/ocm dir in order to sign in using client-id and secret. 
2025/01/22 04:08:39 e2e.go:78: Error getting cluster provider: failed to construct rosa provider: login failed with "ERR: Failed to create OCM connection: error creating connection. Can't persist tokens to config: Failed to create directory /.config/ocm: mkdir /.config: permission denied\n": failed to wait for command to finish: exit status 1

Tested locally: 
```
2025/01/22 16:16:32 configs.go:24: Will load config hypershift
2025/01/22 16:16:32 e2e.go:354: Writing files to report directory: /tmp/osde2e-2boqjqtmbf
2025/01/22 16:16:32 e2e.go:376: Outputting log to build log at /tmp/osde2e-2boqjqtmbf/test_output.log
2025/01/22 16:16:32 e2e.go:400: Running e2e tests...
2025/01/22 16:16:32 rosa.go:132: AWS_PROFILE is not set
2025/01/22 16:16:32 [DEBUG] GET https://mirror.openshift.com/pub/openshift-v4/clients/rosa/latest/rosa-linux.tar.gz
I0122 16:16:35.572391      61 rosa.go:227] "ROSA version" version="INFO: 1.2.49"
I0122 16:16:36.462980      61 versions.go:54] "Getting rosa versions" channel_group="stable" hosted_cp=true ocm_environment="https://api.stage.openshift.com"
I0122 16:16:36.463049      61 rosa.go:54] "Command" rosa_command="rosa list versions --channel-group stable --output json --hosted-cp"
I0122 16:16:37.850605      61 versions.go:79] "ROSA versions retrieved!" channel_group="stable" hosted_cp=true ocm_environment="https://api.stage.openshift.com"
```