### PR TITLE
cmd/osde2e: fix panic in cleanup

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -161,7 +161,9 @@ func run(cmd *cobra.Command, argv []string) error {
 	if os.Getenv("JOB_NAME") != "" {
 		r, _ := regexp.Compile("cleanup-([a-z]+)-aws")
 		act := r.FindStringSubmatch(os.Getenv("JOB_NAME"))
-		summaryBuilder.WriteString("Account: " + act[1] + "\n")
+		if len(act) == 2 {
+			summaryBuilder.WriteString("Account: " + act[1] + "\n")
+		}
 	}
 
 	if args.clusters {


### PR DESCRIPTION
when ran on a periodic, this panicks and fails before actually cleaning up the cluster

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-osde2e-main-nightly-4.19-rosa-classic-sts/1886627949675810816/build-log.txt