### PR TITLE
Fix: load INSTANCE_TYPE variable as machine type for cluster creation

### DIFF
--- a/pkg/common/providers/ocmprovider/config.go
+++ b/pkg/common/providers/ocmprovider/config.go
@@ -70,10 +70,10 @@ func init() {
 	_ = viper.BindEnv(NumRetries, "NUM_RETRIES")
 
 	viper.SetDefault(ComputeMachineType, "")
-	_ = viper.BindEnv(ComputeMachineType, "OCM_COMPUTE_MACHINE_TYPE")
+	_ = viper.BindEnv(ComputeMachineType, "OCM_COMPUTE_MACHINE_TYPE", "INSTANCE_TYPE")
 
 	viper.SetDefault(ComputeMachineTypeRegex, "")
-	_ = viper.BindEnv(ComputeMachineTypeRegex, "OCM_COMPUTE_MACHINE_TYPE_REGEX")
+	_ = viper.BindEnv(ComputeMachineTypeRegex, "OCM_COMPUTE_MACHINE_TYPE_REGEX", "INSTANCE_TYPE")
 
 	_ = viper.BindEnv(UserOverride, "OCM_USER_OVERRIDE")
 

--- a/pkg/common/providers/rosaprovider/config.go
+++ b/pkg/common/providers/rosaprovider/config.go
@@ -56,8 +56,8 @@ func init() {
 
 	_ = viper.BindEnv(PodCIDR, "ROSA_POD_CIDR")
 
-	_ = viper.BindEnv(ComputeMachineType, "ROSA_COMPUTE_MACHINE_TYPE")
-	_ = viper.BindEnv(ComputeMachineTypeRegex, "ROSA_COMPUTE_MACHINE_TYPE")
+	_ = viper.BindEnv(ComputeMachineType, "ROSA_COMPUTE_MACHINE_TYPE", "INSTANCE_TYPE")
+	_ = viper.BindEnv(ComputeMachineTypeRegex, "ROSA_COMPUTE_MACHINE_TYPE", "INSTANCE_TYPE")
 
 	_ = viper.BindEnv(Replicas, "ROSA_REPLICAS")
 	viper.SetDefault(Replicas, 2)


### PR DESCRIPTION
This variable is passed from jenkins parameterized job and should be loaded to take effect

https://github.com/openshift/osde2e/blob/173723722a7da39d78f56c58b3272865429ad0aa/scripts/parameterized-job.sh#L19 