### PR TITLE
fix: bump the golangci-lint timeout

### DIFF
--- a/.golang-ci.yml
+++ b/.golang-ci.yml
@@ -2,7 +2,7 @@
 # Read more at: https://github.com/golangci/golangci-lint#config-file
 
 run:
-  deadline: 30m
+  timeout: 5m
   issues-exit-code: 1
   tests: true
 linters:


### PR DESCRIPTION
it is `timeout`, not `deadline`

https://golangci-lint.run/usage/configuration/#run-configuration