### PR TITLE
Expanding wait time for Degraded Cluster Operator test

### DIFF
--- a/pkg/e2e/osd/inhibitions.go
+++ b/pkg/e2e/osd/inhibitions.go
@@ -159,8 +159,8 @@ var _ = ginkgo.Describe(inhibitionsTestName, label.Operators, func() {
 			cleanup(ctx, h)
 		}()
 
-		// the clusteroperatordown/degraded alerts take 10 minutes to trip
-		time.Sleep(10 * time.Minute)
+		// the clusteroperatordown/degraded alerts take 15 minutes to trip
+		time.Sleep(15 * time.Minute)
 
 		oc, err := openshift.NewFromRestConfig(h.GetConfig(), ginkgo.GinkgoLogr)
 		Expect(err).NotTo(HaveOccurred(), "unable to create openshift client")


### PR DESCRIPTION
Expanding the time to wait for Degraded Cluster check from 10 min to 15 min.