### PR TITLE
Remove cluster hibernate and resume references from osde2e

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -552,9 +552,6 @@ func ProvisionCluster(logger *log.Logger) (*spi.Cluster, error) {
 			return nil, fmt.Errorf("could not retrieve cluster information from OCM: %v", err)
 		}
 
-		if cluster.State() == spi.ClusterStateHibernating && !provider.Resume(cluster.ID()) {
-			return cluster, fmt.Errorf("cluster errored while resuming")
-		}
 	}
 
 	return cluster, nil

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -508,7 +508,6 @@ var Cluster = struct {
 	NetworkProvider:                     "cluster.networkProvider",
 	ImageContentSource:                  "cluster.imageContentSource",
 	InstallConfig:                       "cluster.installConfig",
-	HibernateAfterUse:                   "cluster.hibernateAfterUse",
 	UseExistingCluster:                  "cluster.useExistingCluster",
 	Passing:                             "cluster.passing",
 	Reused:                              "cluster.rused",
@@ -829,9 +828,6 @@ func InitOSDe2eViper() {
 
 	viper.SetDefault(Cluster.NetworkProvider, DefaultNetworkProvider)
 	_ = viper.BindEnv(Cluster.NetworkProvider, "CLUSTER_NETWORK_PROVIDER")
-
-	viper.SetDefault(Cluster.HibernateAfterUse, false)
-	_ = viper.BindEnv(Cluster.HibernateAfterUse, "HIBERNATE_AFTER_USE")
 
 	viper.SetDefault(Cluster.UseExistingCluster, false)
 	_ = viper.BindEnv(Cluster.UseExistingCluster, "USE_EXISTING_CLUSTER")

--- a/pkg/common/providers/mock/mock.go
+++ b/pkg/common/providers/mock/mock.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"os"
 	"time"
 
@@ -295,18 +294,6 @@ func (m *MockProvider) UpdateSchedule(clusterID string, version string, t time.T
 // DetermineMachineType returns a random machine type for a given cluster
 func (m *MockProvider) DetermineMachineType(cloudProvider string) (string, error) {
 	return "mock", fmt.Errorf("not supported by mock clusters")
-}
-
-// Resume resumes a cluster via OCM
-func (o *MockProvider) Resume(id string) bool {
-	log.Println("Hibernation not supported in Mock Provider")
-	return true
-}
-
-// Hibernate resumes a cluster via OCM
-func (o *MockProvider) Hibernate(id string) bool {
-	log.Println("Hibernation not supported in Mock Provider")
-	return true
 }
 
 // AddClusterProxy adds a proxy to a cluster

--- a/pkg/common/providers/rosaprovider/wrapped_calls.go
+++ b/pkg/common/providers/rosaprovider/wrapped_calls.go
@@ -98,16 +98,6 @@ func (m *ROSAProvider) DetermineMachineType(cloudProvider string) (string, error
 	return m.ocmProvider.DetermineMachineType(cloudProvider)
 }
 
-// Resume calls DetermineMachineType from the OCM provider
-func (m *ROSAProvider) Resume(id string) bool {
-	return m.ocmProvider.Resume(id)
-}
-
-// Hibernate calls DetermineMachineType from the OCM provider
-func (m *ROSAProvider) Hibernate(id string) bool {
-	return m.ocmProvider.Hibernate(id)
-}
-
 // AddClusterProxy sets the cluster proxy configuration for the supplied cluster
 func (m *ROSAProvider) AddClusterProxy(clusterId string, httpsProxy string, httpProxy string, userCABundle string) error {
 	return m.ocmProvider.AddClusterProxy(clusterId, httpsProxy, httpProxy, userCABundle)

--- a/pkg/common/spi/provider.go
+++ b/pkg/common/spi/provider.go
@@ -125,16 +125,6 @@ type Provider interface {
 	// DetermineMachineType selects a random machine type for a given cluster.
 	DetermineMachineType(cloudProvider string) (string, error)
 
-	// Hibernate triggers a hibernation of the cluster
-	// If hibernation is unsupported by the provider, it will log that it's unsupported
-	// but still return True.
-	Hibernate(clusterID string) bool
-
-	// Resume triggers a hibernated cluster to wake up
-	// If hibernation is unsupported by the provider, it will log that it's unsupported
-	// but still return True.
-	Resume(clusterID string) bool
-
 	// AddClusterProxy adds a cluster-wide proxy to the cluster.
 	AddClusterProxy(clusterId string, httpsProxy string, httpProxy string, userCABundle string) error
 

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -580,7 +580,6 @@ func cleanupAfterE2E(ctx context.Context, h *helper.H) (errors []error) {
 
 	// If this is a nightly test, we don't want to expire this immediately
 	if viper.GetString(config.Cluster.InstallSpecificNightly) != "" || viper.GetString(config.Cluster.ReleaseImageLatest) != "" {
-		viper.Set(config.Cluster.HibernateAfterUse, false)
 		if viper.GetString(config.Cluster.ID) != "" {
 			if err := provider.Expire(viper.GetString(config.Cluster.ID), 30*time.Minute); err != nil {
 				errors = append(errors, err)
@@ -591,13 +590,7 @@ func cleanupAfterE2E(ctx context.Context, h *helper.H) (errors []error) {
 	// We need a provider to hibernate
 	// We need a cluster to hibernate
 	// We need to check that the test run wants to hibernate after this run
-	if provider != nil && viper.GetString(config.Cluster.ID) != "" && viper.GetBool(config.Cluster.HibernateAfterUse) && viper.GetBool(config.Cluster.SkipDestroyCluster) {
-		msg := "Unable to hibernate %s"
-		if provider.Hibernate(viper.GetString(config.Cluster.ID)) {
-			msg = "Hibernating %s"
-		}
-		log.Printf(msg, viper.GetString(config.Cluster.ID))
-
+	if provider != nil && viper.GetString(config.Cluster.ID) != "" && viper.GetBool(config.Cluster.SkipDestroyCluster) {
 		// Current default expiration is 6 hours.
 		// If this cluster has addons, we don't want to extend the expiration
 


### PR DESCRIPTION
Cluster hibernation is not used operationally in testing logic. In future, if hibernate and resume functionality is to be tested, test suite should be written for it more specifically.