### PR TITLE
Inject CLUSTER_ID into test runner pod for CAD test support

### DIFF
--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -545,3 +545,23 @@ func (h *H) GetRunnerCommandString(templatePath string, timeout int, latestImage
 	Expect(err).NotTo(HaveOccurred(), "Could not convert pod template")
 	return cmd
 }
+
+func (h *H) GetRunnerCommandStringWithEnv(
+	template string,
+	timeout int,
+	image string,
+	harness string,
+	suffix string,
+	jobName string,
+	serviceAccountDir string,
+	envVars map[string]string,
+	serviceAccount string,
+) string {
+	envString := ""
+	for k, v := range envVars {
+		envString += fmt.Sprintf("export %s=%q && ", k, v)
+	}
+	cmd := h.GetRunnerCommandString(template, timeout, image, harness, suffix, jobName, serviceAccountDir, envString, serviceAccount)
+	return cmd
+}
+

--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -71,7 +71,10 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 			h.SetRunnerProject(subProject.Name, r)
 			latestImageStream, err := r.GetLatestImageStreamTag()
 			Expect(err).NotTo(HaveOccurred(), "Could not get latest imagestream tag")
-			cmd := h.GetRunnerCommandString(harnessTestTemplate, timeoutInSeconds, latestImageStream, harness, suffix, jobName, serviceAccountDir, "", serviceAccountNamespacedName)
+			envVars := map[string]string{
+				"CLUSTER_ID": viper.GetString(config.Cluster.ID),
+			}
+			cmd := h.GetRunnerCommandStringWithEnv(harnessTestTemplate, timeoutInSeconds, latestImageStream, harness, suffix, jobName, serviceAccountDir, envVars, serviceAccountNamespacedName)
 			r = h.SetRunnerCommand(cmd, r)
 
 			ginkgo.By("Running harness pod")


### PR DESCRIPTION
This patch ensures that CLUSTER_ID is passed into the environment of the test runner pod. 
This resolves issues where Configuration Anomaly Detection tests failed due to missing cluster context.

- Uses viper to get cluster ID from config
- Passes env var into GetRunnerCommandStringWithEnv
- Fix verified locally using an explicitly exported CLUSTER_ID, and the CAD test completed successfully.