### PR TITLE
pass ocm service account credentials to test harness

### DIFF
--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -507,7 +507,7 @@ func (h *H) GetRunnerCommandString(templatePath string, timeout int, latestImage
 				Value: viper.GetString(ocmprovider.Env),
 			},
 		},
-
+		// loaded as secrets to pod from env vars
 		EnvironmentVariablesFromSecret: []struct {
 			SecretName string
 			SecretKey  string
@@ -515,6 +515,14 @@ func (h *H) GetRunnerCommandString(templatePath string, timeout int, latestImage
 			{
 				SecretName: "ci-secrets",
 				SecretKey:  "OCM_TOKEN",
+			},
+			{
+				SecretName: "ci-secrets",
+				SecretKey:  "OCM_CLIENT_SECRET",
+			},
+			{
+				SecretName: "ci-secrets",
+				SecretKey:  "OCM_CLIENT_ID",
 			},
 			{
 				SecretName: "ci-secrets",


### PR DESCRIPTION
some test suites are using deprecated offline tokens to make ocm connections. pass the service account creds to allow ocm connections instead. eg osd-metrics-exporter