### PR TITLE
SDCICD-1567: enable GINKGO_NO_COLOR

### DIFF
--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -506,6 +506,11 @@ func (h *H) GetRunnerCommandString(templatePath string, timeout int, latestImage
 				Name:  "OCM_ENV",
 				Value: viper.GetString(ocmprovider.Env),
 			},
+			{
+				// https://onsi.github.io/ginkgo/#other-settings
+				Name:  "GINKGO_NO_COLOR",
+				Value: "TRUE",
+			},
 		},
 		// loaded as secrets to pod from env vars
 		EnvironmentVariablesFromSecret: []struct {


### PR DESCRIPTION
turn on the setting to not print color ascii codes to the output - this makes logs unreadable otherwise