### PR TITLE
if SkipDestroyCluster is selected, do not delete e2e harness namespace

### DIFF
--- a/pkg/e2e/harness_runner/harness_runner.go
+++ b/pkg/e2e/harness_runner/harness_runner.go
@@ -104,10 +104,14 @@ var _ = ginkgo.Describe("Test harness", ginkgo.Ordered, ginkgo.ContinueOnFailure
 		HarnessEntries)
 
 	ginkgo.AfterEach(func(ctx context.Context) {
-		ginkgo.By("Deleting harness namespace")
-		err := h.DeleteProject(ctx, subProject.Name)
-		if err != nil {
-			ginkgo.GinkgoLogr.Error(err, fmt.Sprintf("error deleting project %q", subProject.Name))
+		if !viper.GetBool(config.Cluster.SkipDestroyCluster) {
+			ginkgo.By("Deleting harness namespace")
+			err := h.DeleteProject(ctx, subProject.Name)
+			if err != nil {
+				ginkgo.GinkgoLogr.Error(err, fmt.Sprintf("error deleting project %q", subProject.Name))
+			}
+		} else {
+			log.Printf("For debugging, see test harness namespace: %s", subProject.Name)
 		}
 	})
 })


### PR DESCRIPTION
if SkipDestroyCluster is selected, do not delete e2e harness namespace

this should give more trace to debug operator tests