### PR TITLE
remove boolean env var from test suite pod template

### DIFF
--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -194,6 +194,7 @@ func (h *H) Cleanup(ctx context.Context) {
 	if err != nil {
 		ginkgo.GinkgoLogr.Error(err, "error listing existing projects")
 	}
+	// todo use k8s client to get namespace object and delete instead of for looping
 	for _, project := range projects.Items {
 		if h.proj.Name == project.Name {
 			ginkgo.GinkgoLogr.Info(fmt.Sprintf("Deleting project `%s`", project.Name))
@@ -505,11 +506,6 @@ func (h *H) GetRunnerCommandString(templatePath string, timeout int, latestImage
 			{
 				Name:  "OCM_ENV",
 				Value: viper.GetString(ocmprovider.Env),
-			},
-			{
-				// https://onsi.github.io/ginkgo/#other-settings
-				Name:  "GINKGO_NO_COLOR",
-				Value: "TRUE",
 			},
 		},
 		// loaded as secrets to pod from env vars

--- a/pkg/common/load/load.go
+++ b/pkg/common/load/load.go
@@ -107,7 +107,8 @@ func loadPassthruSecrets(secretLocations []string) {
 			}
 		}
 	}
-
+	passthruSecrets["OCM_CLIENT_ID"] = viper.GetString(ocmprovider.ClientID)
+	passthruSecrets["OCM_CLIENT_SECRET"] = viper.GetString(ocmprovider.ClientSecret)
 	passthruSecrets["OCM_TOKEN"] = viper.GetString(ocmprovider.Token)
 	passthruSecrets["CLUSTER_ID"] = viper.GetString(config.Cluster.ID)
 	passthruSecrets["GCP_CREDS_JSON"] = viper.GetString(config.GCPCredsJSON)

--- a/pkg/common/runner/pod.go
+++ b/pkg/common/runner/pod.go
@@ -163,6 +163,7 @@ func (r *Runner) createJobPod(ctx context.Context) (pod *kubev1.Pod, err error) 
 			},
 		},
 	}
+	job.Spec.BackoffLimit = ptr.To[int32](0)
 	// retry until Job can be created or timeout occurs
 	if err = wait.PollUntilContextTimeout(ctx, fastPoll, podCreateTimeout, false, func(ctx context.Context) (done bool, err error) {
 		if job, err = r.Kube.BatchV1().Jobs(r.Namespace).Create(ctx, job, metav1.CreateOptions{}); err != nil {


### PR DESCRIPTION
- removing GINKGO_NO_COLOR since templating does not accept non-string values at the moment and fails to run job
- also add BAckOffLimit of 0 to runner pods. Rerunning this pod fails anyway for test harness jobs, due to duplicate configmap name in the namesace.
- add passthru secrets for SA into harness ns