### PR TITLE
SDCICD-1585 Add "CAD_PAGERDUTY_ROUTING_KEY" env variable and increase Harness Timeout

### DIFF
--- a/configs/ad-hoc-image.yaml
+++ b/configs/ad-hoc-image.yaml
@@ -1,3 +1,3 @@
 tests:
   ginkgoLabelFilter: AdHocTestImages
-  adHocTestContainerTimeout: 900
+  adHocTestContainerTimeout: 1800

--- a/configs/e2e-suite.yaml
+++ b/configs/e2e-suite.yaml
@@ -14,4 +14,4 @@ tests:
     - quay.io/app-sre/route-monitor-operator-e2e
     - quay.io/app-sre/managed-cluster-validating-webhooks-e2e
     - quay.io/app-sre/configuration-anomaly-detection-e2e
-  adHocTestContainerTimeout: 900
+  adHocTestContainerTimeout: 1800

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -593,6 +593,14 @@ var Proxy = struct {
 	UserCABundle: "proxy.user_ca_bundle",
 }
 
+// Configuration Anomaly Detection keys
+var Cad = struct {
+	// Env: CAD_PAGERDUTY_ROUTING_KEY
+	CADPagerDutyRoutingKey string
+}{
+	CADPagerDutyRoutingKey: "cad.pagerDutyRoutingKey",
+}
+
 func InitOSDe2eViper() {
 	// Here's where we bind environment variables to config options and set defaults
 
@@ -876,6 +884,10 @@ func InitOSDe2eViper() {
 
 	_ = viper.BindEnv(Proxy.UserCABundle, "USER_CA_BUNDLE")
 	RegisterSecret(Proxy.UserCABundle, "user-ca-bundle")
+
+	// ------- Configuration Anomaly Detection ------
+	_ = viper.BindEnv(Cad.CADPagerDutyRoutingKey, "CAD_PAGERDUTY_ROUTING_KEY")
+	RegisterSecret(Cad.CADPagerDutyRoutingKey, "pagerduty-routing-key")
 }
 
 func init() {

--- a/pkg/common/helper/helper.go
+++ b/pkg/common/helper/helper.go
@@ -545,6 +545,10 @@ func (h *H) GetRunnerCommandString(templatePath string, timeout int, latestImage
 				SecretName: "ci-secrets",
 				SecretKey:  "GCP_CREDS_JSON",
 			},
+			{
+				SecretName: "ci-secrets",
+				SecretKey:  "CAD_PAGERDUTY_ROUTING_KEY",
+			},
 		},
 		Command: command,
 	}

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -103,7 +103,7 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 			STS:                          viper.GetBool(STS),
 			MintMode:                     viper.GetBool(MintMode),
 			HostedCP:                     viper.GetBool(config.Hypershift),
-			BillingAccountID:             viper.GetString(BillingAccountID),
+			BillingAccountID:             viper.GetString(config.AWSAccountId),
 			FIPS:                         viper.GetBool(config.Cluster.EnableFips),
 			MultiAZ:                      viper.GetBool(config.Cluster.MultiAZ),
 			ExpirationDuration:           viper.GetDuration(config.Cluster.ExpiryInMinutes) * time.Minute,

--- a/pkg/common/providers/rosaprovider/config.go
+++ b/pkg/common/providers/rosaprovider/config.go
@@ -43,9 +43,6 @@ const (
 	// "Managed-*" account roles or create unique roles based on the cluster
 	// name
 	STSUseDefaultAccountRolesPrefix = "rosa.stsUseDefaultAccountRolesPrefix"
-
-	// BillingAccountID is the billing account ID used for Hosted Control Plane clusters.
-	BillingAccountID = "rosa.billingAccountID"
 )
 
 func init() {
@@ -82,7 +79,4 @@ func init() {
 
 	_ = viper.BindEnv(STSUseDefaultAccountRolesPrefix, "ROSA_STS_USE_DEFAULT_ACCOUNT_ROLES_PREFIX")
 	viper.SetDefault(STSUseDefaultAccountRolesPrefix, true)
-
-	_ = viper.BindEnv(BillingAccountID, "ROSA_BILLING_ACCOUNT_ID", "AWS_ACCOUNT_ID")
-	viper.SetDefault(BillingAccountID, "")
 }


### PR DESCRIPTION
- Add support for "CAD_PAGERDUTY_ROUTING_KEY" env variable
- Increase Harness Timeout to 30 minutes
- Jira Ticket: https://issues.redhat.com/browse/SDCICD-1585