### PR TITLE
SDCICD-1592 Provision cluster reserve for testing

### DIFF
--- a/cmd/osde2e/main.go
+++ b/cmd/osde2e/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/openshift/osde2e/cmd/osde2e/provision"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/osde2e/cmd/osde2e/arguments"
@@ -26,6 +27,7 @@ func init() {
 	pfs := root.PersistentFlags()
 	arguments.AddDebugFlag(pfs)
 
+	root.AddCommand(provision.Cmd)
 	root.AddCommand(test.Cmd)
 	root.AddCommand(healthcheck.Cmd)
 	root.AddCommand(completion.Cmd)

--- a/cmd/osde2e/provision/cmd.go
+++ b/cmd/osde2e/provision/cmd.go
@@ -1,0 +1,95 @@
+package provision
+
+import (
+	"fmt"
+
+	"github.com/openshift/osde2e/cmd/osde2e/common"
+	"github.com/openshift/osde2e/cmd/osde2e/helpers"
+	clusterutil "github.com/openshift/osde2e/pkg/common/cluster"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/providers"
+	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "provision",
+	Short: "Provisions cluster",
+	Long:  "Provisions cluster with given configuration",
+	Args:  cobra.OnlyValidArgs,
+	RunE:  run,
+}
+
+var args struct {
+	configString         string
+	secretLocations      string
+	environment          string
+	skipHealthChecks     bool
+	onlyHealthCheckNodes bool
+	reserve              bool
+}
+
+func init() {
+	pfs := Cmd.PersistentFlags()
+	pfs.StringVar(
+		&args.configString,
+		"configs",
+		"",
+		"A comma separated list of built in configs to use",
+	)
+	_ = Cmd.RegisterFlagCompletionFunc("configs", helpers.ConfigComplete)
+
+	pfs.StringVar(
+		&args.secretLocations,
+		"secret-locations",
+		"",
+		"A comma separated list of possible secret directory locations for loading secret configs.",
+	)
+
+	pfs.StringVarP(
+		&args.environment,
+		"environment",
+		"e",
+		"",
+		"Cluster provider environment to use.",
+	)
+
+	pfs.BoolVar(
+		&args.skipHealthChecks,
+		"skip-health-check",
+		false,
+		"Skip cluster health checks.",
+	)
+	pfs.BoolVar(
+		&args.reserve,
+		"reserve",
+		false,
+		"Create test cluster reserve",
+	)
+
+	pfs.BoolVar(
+		&args.onlyHealthCheckNodes,
+		"only-health-check-nodes",
+		false,
+		"Only wait for the cluster nodes to be ready",
+	)
+	_ = viper.BindPFlag(config.Cluster.Reserve, Cmd.PersistentFlags().Lookup("reserve"))
+	_ = viper.BindPFlag(ocmprovider.Env, Cmd.PersistentFlags().Lookup("environment"))
+	_ = viper.BindPFlag(config.Tests.SkipClusterHealthChecks, Cmd.PersistentFlags().Lookup("skip-health-check"))
+	_ = viper.BindPFlag(config.Tests.OnlyHealthCheckNodes, Cmd.PersistentFlags().Lookup("only-health-check-nodes"))
+}
+
+//nolint:gocyclo
+func run(cmd *cobra.Command, argv []string) error {
+	var err error
+	if err = common.LoadConfigs(args.configString, "", args.secretLocations); err != nil {
+		return fmt.Errorf("error loading initial state: %v", err)
+	}
+	provider, err := providers.ClusterProvider()
+	if err != nil {
+		return fmt.Errorf("error getting cluster provider: %s", err.Error())
+	}
+
+	return clusterutil.Provision(provider)
+}

--- a/cmd/osde2e/test/cmd.go
+++ b/cmd/osde2e/test/cmd.go
@@ -41,7 +41,6 @@ var args struct {
 	environment          string
 	kubeConfig           string
 	skipDestroyCluster   bool
-	provisionOnly        bool
 	skipHealthChecks     bool
 	skipMustGather       bool
 	focusTests           string
@@ -101,12 +100,7 @@ func init() {
 		false,
 		"Skip destroy cluster after test completion.",
 	)
-	pfs.BoolVar(
-		&args.provisionOnly,
-		"provision-only",
-		false,
-		"Skip all tests, only provision cluster.",
-	)
+
 	pfs.BoolVar(
 		&args.skipHealthChecks,
 		"skip-health-check",
@@ -160,8 +154,6 @@ func init() {
 	_ = viper.BindPFlag(ocmprovider.Env, Cmd.PersistentFlags().Lookup("environment"))
 	_ = viper.BindPFlag(config.Kubeconfig.Path, Cmd.PersistentFlags().Lookup("kube-config"))
 	_ = viper.BindPFlag(config.Cluster.SkipDestroyCluster, Cmd.PersistentFlags().Lookup("skip-destroy-cluster"))
-	_ = viper.BindPFlag(config.Cluster.ProvisionOnly, Cmd.PersistentFlags().Lookup("provision-only"))
-	_ = viper.BindPFlag(config.Cluster.AddClusterToReserve, Cmd.PersistentFlags().Lookup("add-cluster-to-reserve"))
 	_ = viper.BindPFlag(config.Tests.SkipClusterHealthChecks, Cmd.PersistentFlags().Lookup("skip-health-check"))
 	_ = viper.BindPFlag(config.Tests.OnlyHealthCheckNodes, Cmd.PersistentFlags().Lookup("only-health-check-nodes"))
 	_ = viper.BindPFlag(config.Tests.GinkgoFocus, Cmd.PersistentFlags().Lookup("focus-tests"))

--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/util"
+	"github.com/openshift/osde2e/pkg/common/versions"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -32,6 +33,7 @@ import (
 )
 
 const (
+	RESERVE_COUNT = 2
 	// errorWindow is the number of checks made to determine if a cluster has truly failed.
 	errorWindow = 20
 	// pendingPodThreshold is the maximum number of times a pod is allowed to be in pending state before erroring out in PollClusterHealth.
@@ -442,11 +444,26 @@ func ProvisionCluster(logger *log.Logger) (*spi.Cluster, error) {
 	var cluster *spi.Cluster
 	// get cluster ID from env
 	clusterID := viper.GetString(config.Cluster.ID)
+	ocmProvider, err := ocmprovider.NewWithEnv(viper.GetString(ocmprovider.Env))
+	if err != nil {
+		return nil, fmt.Errorf("could not setup ocm provider: %v", err)
+	}
 	// Only enable cluster reserve claiming for ROSA STS classic for now
 	if viper.GetBool(config.Cluster.UseExistingCluster) && viper.GetString(config.Provider) == "rosa" && !viper.GetBool(config.Hypershift) && viper.GetBool(rosaprovider.STS) {
 		ocmProvider, _ := ocmprovider.New()
 		clusterID = ocmProvider.ClaimClusterFromReserve(viper.GetString(config.Cluster.Version), "aws", "rosa")
 	}
+	if viper.GetBool(config.Cluster.Reserve) {
+		listResponse, err := ocmProvider.QueryReserve(viper.GetString(config.Cluster.Version), viper.GetString(config.CloudProvider.CloudProviderID), viper.GetString(config.Provider))
+		if err != nil {
+			return nil, fmt.Errorf("could not query reserve: %v", err)
+		}
+		if listResponse.Total() >= RESERVE_COUNT {
+			// Provision one cluster per job run. Job should be scheduled every so often to keep adding to reserve so that count is met.
+			return nil, nil
+		}
+	}
+
 	// create a new cluster if no ID is specified
 	if clusterID == "" {
 		log.Printf("no clusterid found, provisioning cluster")
@@ -535,6 +552,85 @@ func clusterName() string {
 	return "osde2e-" + suffix
 }
 
+func Provision(provider spi.Provider) error {
+	status, err := ConfigureVersion(provider)
+	if status != config.Success {
+		return fmt.Errorf("failed configure cluster version: %v", err)
+	}
+
+	cluster, err := ProvisionCluster(nil)
+	if err != nil {
+		return fmt.Errorf("failed to set up or retrieve cluster: %v", err)
+	}
+
+	viper.Set(config.Cluster.ID, cluster.ID())
+	log.Printf("CLUSTER_ID set to %s from OCM.", viper.GetString(config.Cluster.ID))
+	_, err = WaitForOCMProvisioning(provider, viper.GetString(config.Cluster.ID), nil, false)
+	if err != nil {
+		return fmt.Errorf("cluster never became ready: %v", err)
+	}
+	log.Printf("Cluster status is ready")
+
+	if viper.GetString(config.SharedDir) != "" {
+		if err = os.WriteFile(fmt.Sprintf("%s/cluster-id", viper.GetString(config.SharedDir)), []byte(cluster.ID()), 0o644); err != nil {
+			log.Printf("Error writing cluster ID to shared directory: %v", err)
+		} else {
+			log.Printf("Wrote cluster ID to shared dir: %v", cluster.ID())
+		}
+	} else {
+		log.Printf("No shared directory provided, skip writing cluster ID")
+	}
+
+	if (!viper.GetBool(config.Addons.SkipAddonList) || viper.GetString(config.Provider) != "mock") && len(cluster.Addons()) > 0 {
+		log.Printf("Found addons: %s", strings.Join(cluster.Addons(), ","))
+	}
+
+	if err = provider.AddProperty(cluster, "UpgradeVersion", viper.GetString(config.Upgrade.ReleaseName)); err != nil {
+		log.Printf("Error while adding upgrade version property to cluster via OCM: %v", err)
+	}
+
+	if !viper.GetBool(config.Tests.SkipClusterHealthChecks) {
+		// If this is a new cluster, we should check the OSD Ready job unless skipped
+		err = WaitForClusterReadyPostInstall(cluster.ID(), nil)
+		if err != nil {
+			log.Println("*******************")
+			log.Printf("Cluster failed health check: %v", err)
+			log.Println("*******************")
+		} else {
+			log.Println("Cluster is healthy and ready for testing")
+		}
+	} else {
+		log.Println("Skipping health checks as requested")
+	}
+
+	var kubeconfigBytes []byte
+	clusterConfigerr := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
+		kubeconfigBytes, err = provider.ClusterKubeconfig(viper.GetString(config.Cluster.ID))
+		if err != nil {
+			log.Printf("Failed to retrieve kubeconfig: %v\nWaiting two seconds before retrying", err)
+			return false, nil
+		} else {
+			log.Printf("Successfully retrieved kubeconfig from OCM.")
+			viper.Set(config.Kubeconfig.Contents, string(kubeconfigBytes))
+			return true, nil
+		}
+	})
+
+	if clusterConfigerr != nil {
+		return fmt.Errorf("failed retrieving kubeconfig: %v", clusterConfigerr)
+	}
+
+	if viper.GetString(config.SharedDir) != "" {
+		if err = os.WriteFile(fmt.Sprintf("%s/kubeconfig", viper.GetString(config.SharedDir)), kubeconfigBytes, 0o644); err != nil {
+			log.Printf("Error writing cluster kubeconfig to shared directory: %v", err)
+		} else {
+			log.Printf("Passed kubeconfig to prow steps.")
+		}
+	}
+
+	return nil
+}
+
 // set cluster infor into viper and metadata
 func SetClusterIntoViperConfig(cluster *spi.Cluster) {
 	viper.Set(config.Cluster.Channel, cluster.ChannelGroup())
@@ -549,4 +645,32 @@ func SetClusterIntoViperConfig(cluster *spi.Cluster) {
 
 	viper.Set(config.CloudProvider.Region, cluster.Region())
 	log.Printf("CLOUD_PROVIDER_REGION set to %s from OCM.", viper.GetString(config.CloudProvider.Region))
+}
+
+func ConfigureVersion(provider spi.Provider) (int, error) {
+	// configure cluster and upgrade versions
+	versionSelector := versions.VersionSelector{Provider: provider}
+	if err := versionSelector.SelectClusterVersions(); err != nil {
+		// If we can't find a version to use, exit with an error code.
+		return config.Failure, err
+	}
+
+	switch {
+	case !viper.GetBool(config.Cluster.EnoughVersionsForOldestOrMiddleTest):
+		return config.Aborted, fmt.Errorf("there were not enough available cluster image sets to choose and oldest or middle cluster image set to test against -- skipping tests")
+	case !viper.GetBool(config.Cluster.PreviousVersionFromDefaultFound):
+		return config.Aborted, fmt.Errorf("no previous version from default found with the given arguments")
+	case viper.GetBool(config.Upgrade.UpgradeVersionEqualToInstallVersion):
+		return config.Aborted, fmt.Errorf("install version and upgrade version are the same -- skipping tests")
+	case viper.GetString(config.Upgrade.ReleaseName) == util.NoVersionFound:
+		return config.Aborted, fmt.Errorf("no valid upgrade versions were found. Skipping tests")
+	case viper.GetString(config.Cluster.Version) == "":
+		returnState := config.Aborted
+		if viper.GetBool(config.Cluster.LatestYReleaseAfterProdDefault) || viper.GetBool(config.Cluster.LatestZReleaseAfterProdDefault) {
+			log.Println("At the latest available version with no newer targets. Exiting...")
+			returnState = config.Success
+		}
+		return returnState, fmt.Errorf("no valid install version found")
+	}
+	return config.Success, nil
 }

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -18,6 +18,9 @@ type Secret struct {
 }
 
 const (
+	Success = 0
+	Failure = 1
+	Aborted = 130
 	// Provider is what provider to use to create/delete clusters.
 	// Env: PROVIDER
 	Provider = "provider"
@@ -331,13 +334,10 @@ var Tests = struct {
 
 // Cluster config keys.
 var Cluster = struct {
-	// ProvisionOnly only provisions testing-ready cluster and skips all tests.
-	// Env: PROVISION_ONLY
-	ProvisionOnly string
-
-	// AddClusterToReserve only provisions testing-ready cluster and skips all tests.
-	// Env: ADD_CLUSTER_TO_RESERVE
-	AddClusterToReserve string
+	// Reserve  creates a reserve of testing-ready cluster and skips all tests.
+	// Env: RESERVE
+	// Arg --reserve
+	Reserve string
 
 	// MultiAZ deploys a cluster across multiple availability zones.
 	// Env: MULTI_AZ
@@ -476,8 +476,7 @@ var Cluster = struct {
 	MultiAZ:                             "cluster.multiAZ",
 	Channel:                             "cluster.channel",
 	SkipDestroyCluster:                  "cluster.skipDestroyCluster",
-	ProvisionOnly:                       "cluster.provisionOnly",
-	AddClusterToReserve:                 "cluster.addClusterToReserve",
+	Reserve:                             "cluster.reserve",
 	ExpiryInMinutes:                     "cluster.expiryInMinutes",
 	AfterTestWait:                       "cluster.afterTestWait",
 	InstallTimeout:                      "cluster.installTimeout",
@@ -752,12 +751,7 @@ func InitOSDe2eViper() {
 
 	_ = viper.BindEnv(Cluster.SkipDestroyCluster, "SKIP_DESTROY_CLUSTER")
 
-	_ = viper.BindEnv(Cluster.ProvisionOnly, "PROVISION_ONLY")
-
-	_ = viper.BindEnv(Cluster.AddClusterToReserve, "ADD_CLUSTER_TO_RESERVE")
-	if viper.GetBool(Cluster.AddClusterToReserve) && !viper.GetBool(Cluster.ProvisionOnly) {
-		log.Printf("--add-cluster-to-reserve flag has no effect unless --provision-only is provided! Ignoring.")
-	}
+	_ = viper.BindEnv(Cluster.Reserve, "RESERVE")
 
 	viper.SetDefault(Cluster.ExpiryInMinutes, 360)
 	_ = viper.BindEnv(Cluster.ExpiryInMinutes, "CLUSTER_EXPIRY_IN_MINUTES")

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -28,19 +28,13 @@ import (
 	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/upgrade"
 	"github.com/openshift/osde2e/pkg/common/util"
-	"github.com/openshift/osde2e/pkg/common/versions"
 	"github.com/openshift/osde2e/pkg/debug"
-	"k8s.io/apimachinery/pkg/util/wait"
 	ctrlog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const (
 	// buildLog is the name of the build log file.
 	buildLog string = "test_output.log"
-
-	Success = 0
-	Failure = 1
-	Aborted = 130
 )
 
 // provisioner is used to deploy and manage clusters.
@@ -70,90 +64,11 @@ func beforeSuite() bool {
 		return false
 	}
 	if viper.GetString(config.Kubeconfig.Contents) == "" {
-		status, err := configureVersion()
-		if status != Success {
-			log.Printf("Failed configure cluster version: %v", err)
-			return false
-		}
-		cluster, err = clusterutil.ProvisionCluster(nil)
-		if err != nil {
-			log.Printf("Failed to set up or retrieve cluster: %v", err)
-			getLogs()
-			return false
-		}
-
-		viper.Set(config.Cluster.ID, cluster.ID())
-		log.Printf("CLUSTER_ID set to %s from OCM.", viper.GetString(config.Cluster.ID))
-		_, err = clusterutil.WaitForOCMProvisioning(provider, viper.GetString(config.Cluster.ID), nil, false)
-		if err != nil {
-			log.Printf("Cluster never became ready: %v", err)
-			getLogs()
-			return false
-		}
-		log.Printf("Cluster status is ready")
-
-		if viper.GetString(config.SharedDir) != "" {
-			if err = os.WriteFile(fmt.Sprintf("%s/cluster-id", viper.GetString(config.SharedDir)), []byte(cluster.ID()), 0o644); err != nil {
-				log.Printf("Error writing cluster ID to shared directory: %v", err)
-			} else {
-				log.Printf("Wrote cluster ID to shared dir: %v", cluster.ID())
-			}
-		} else {
-			log.Printf("No shared directory provided, skip writing cluster ID")
-		}
-
-		if (!viper.GetBool(config.Addons.SkipAddonList) || viper.GetString(config.Provider) != "mock") && len(cluster.Addons()) > 0 {
-			log.Printf("Found addons: %s", strings.Join(cluster.Addons(), ","))
-		}
-
-		if err = provider.AddProperty(cluster, "UpgradeVersion", viper.GetString(config.Upgrade.ReleaseName)); err != nil {
-			log.Printf("Error while adding upgrade version property to cluster via OCM: %v", err)
-		}
-
-		if !viper.GetBool(config.Tests.SkipClusterHealthChecks) {
-			// If this is a new cluster, we should check the OSD Ready job unless skipped
-			err = clusterutil.WaitForClusterReadyPostInstall(cluster.ID(), nil)
-			if err != nil {
-				log.Println("*******************")
-				log.Printf("Cluster failed health check: %v", err)
-				log.Println("*******************")
-				getLogs()
-			} else {
-				log.Println("Cluster is healthy and ready for testing")
-			}
-		} else {
-			log.Println("Skipping health checks as requested")
-		}
-
-		var kubeconfigBytes []byte
-		clusterConfigerr := wait.PollUntilContextTimeout(context.Background(), 2*time.Second, 5*time.Minute, false, func(ctx context.Context) (bool, error) {
-			kubeconfigBytes, err = provider.ClusterKubeconfig(viper.GetString(config.Cluster.ID))
-			if err != nil {
-				log.Printf("Failed to retrieve kubeconfig: %v\nWaiting two seconds before retrying", err)
-				return false, nil
-			} else {
-				log.Printf("Successfully retrieved kubeconfig from OCM.")
-				viper.Set(config.Kubeconfig.Contents, string(kubeconfigBytes))
-				return true, nil
-			}
-		})
-
-		if clusterConfigerr != nil {
-			log.Printf("Failed retrieving kubeconfig: %v", clusterConfigerr)
-			getLogs()
-			return false
-		}
-
-		if viper.GetString(config.SharedDir) != "" {
-			if err = os.WriteFile(fmt.Sprintf("%s/kubeconfig", viper.GetString(config.SharedDir)), kubeconfigBytes, 0o644); err != nil {
-				log.Printf("Error writing cluster kubeconfig to shared directory: %v", err)
-			} else {
-				log.Printf("Passed kubeconfig to prow steps.")
-			}
-		}
-
+		err = clusterutil.Provision(provider)
 		getLogs()
-
+		if err != nil {
+			return false
+		}
 	} else {
 		log.Println("Using provided kubeconfig")
 		cluster, err = provider.GetCluster(viper.GetString(config.Cluster.ID))
@@ -179,34 +94,6 @@ func beforeSuite() bool {
 	}
 
 	return true
-}
-
-func configureVersion() (int, error) {
-	// configure cluster and upgrade versions
-	versionSelector := versions.VersionSelector{Provider: provider}
-	if err := versionSelector.SelectClusterVersions(); err != nil {
-		// If we can't find a version to use, exit with an error code.
-		return Failure, err
-	}
-
-	switch {
-	case !viper.GetBool(config.Cluster.EnoughVersionsForOldestOrMiddleTest):
-		return Aborted, fmt.Errorf("there were not enough available cluster image sets to choose and oldest or middle cluster image set to test against -- skipping tests")
-	case !viper.GetBool(config.Cluster.PreviousVersionFromDefaultFound):
-		return Aborted, fmt.Errorf("no previous version from default found with the given arguments")
-	case viper.GetBool(config.Upgrade.UpgradeVersionEqualToInstallVersion):
-		return Aborted, fmt.Errorf("install version and upgrade version are the same -- skipping tests")
-	case viper.GetString(config.Upgrade.ReleaseName) == util.NoVersionFound:
-		return Aborted, fmt.Errorf("no valid upgrade versions were found. Skipping tests")
-	case viper.GetString(config.Cluster.Version) == "":
-		returnState := Aborted
-		if viper.GetBool(config.Cluster.LatestYReleaseAfterProdDefault) || viper.GetBool(config.Cluster.LatestZReleaseAfterProdDefault) {
-			log.Println("At the latest available version with no newer targets. Exiting...")
-			returnState = Success
-		}
-		return returnState, fmt.Errorf("no valid install version found")
-	}
-	return Success, nil
 }
 
 func getLogs() {
@@ -343,7 +230,7 @@ func runGinkgoTests() (int, error) {
 	buildLogPath := filepath.Join(reportDir, buildLog)
 	buildLogWriter, err := os.Create(buildLogPath)
 	if err != nil {
-		return Failure, fmt.Errorf("unable to create build log in report directory: %v", err)
+		return config.Failure, fmt.Errorf("unable to create build log in report directory: %v", err)
 	}
 
 	mw := io.MultiWriter(os.Stdout, buildLogWriter)
@@ -362,7 +249,7 @@ func runGinkgoTests() (int, error) {
 		if runInstallTests = viper.GetBool(config.Upgrade.RunPreUpgradeTests); !runInstallTests {
 			if !suiteConfig.DryRun {
 				if !beforeSuite() {
-					return Failure, fmt.Errorf("error occurred during beforeSuite function")
+					return config.Failure, fmt.Errorf("error occurred during beforeSuite function")
 				}
 			}
 		}
@@ -375,21 +262,7 @@ func runGinkgoTests() (int, error) {
 		getLogs()
 		viper.Set(config.Cluster.Passing, testsPassed)
 	}
-	if viper.GetBool(config.Cluster.ProvisionOnly) {
-		if viper.GetBool(config.Cluster.AddClusterToReserve) {
-			cluster, err := provider.GetCluster(viper.GetString(config.Cluster.ID))
-			if err != nil {
-				log.Printf("error initializing cluster object, could not add to cluster reserve: %s", err.Error())
-			} else {
-				err := provider.AddProperty(cluster, clusterproperties.Status, clusterproperties.StatusReserved)
-				if err != nil {
-					log.Printf("could not add cluster to reserve: %s", err.Error())
-				}
-			}
-		}
-		log.Println("Provision only execution finished, exiting.")
-		return Success, nil
-	}
+
 	upgradeTestsPassed := true
 
 	// upgrade cluster if requested
@@ -398,12 +271,12 @@ func runGinkgoTests() (int, error) {
 			// setup helper
 			h, err := helper.NewOutsideGinkgo()
 			if h == nil || err != nil {
-				return Failure, fmt.Errorf("unable to generate helper outside ginkgo: %v", err)
+				return config.Failure, fmt.Errorf("unable to generate helper outside ginkgo: %v", err)
 			}
 
 			// run the upgrade
 			if err = upgrade.RunUpgrade(h); err != nil {
-				return Failure, fmt.Errorf("error performing upgrade: %v", err)
+				return config.Failure, fmt.Errorf("error performing upgrade: %v", err)
 			}
 
 			if viper.GetBool(config.Upgrade.RunPostUpgradeTests) {
@@ -431,22 +304,22 @@ func runGinkgoTests() (int, error) {
 			log.Printf("Failed to generate helper object to perform cleanup operations, deleting cluster: %t", !viper.GetBool(config.Cluster.SkipDestroyCluster))
 			// Ignoring the error to return actual error which caused runtime to abort
 			_ = deleteCluster(provider)
-			return Failure, fmt.Errorf("unable to generate helper object for cleanup: %v", err)
+			return config.Failure, fmt.Errorf("unable to generate helper object for cleanup: %v", err)
 		}
 
 		cleanupAfterE2E(context.TODO(), h)
 
 		if err = deleteCluster(provider); err != nil {
-			return Failure, err
+			return config.Failure, err
 		}
 	}
 
 	if !testsPassed || !upgradeTestsPassed {
 		viper.Set(config.Cluster.Passing, false)
-		return Failure, fmt.Errorf("tests failed, please inspect logs for more details")
+		return config.Failure, fmt.Errorf("tests failed, please inspect logs for more details")
 	}
 
-	return Success, nil
+	return config.Success, nil
 }
 
 // deleteCluster destroys the cluster based on defined settings
@@ -604,9 +477,6 @@ func runTestsInPhase(
 	if !suiteConfig.DryRun {
 		if !beforeSuite() {
 			return false
-		}
-		if viper.GetBool(config.Cluster.ProvisionOnly) {
-			return true
 		}
 	}
 


### PR DESCRIPTION
- new command: `osde2e provision --reserve`
- removed `--provision-only` from test command
- moved provision logic from e2e to clusterutil
- reserve count is a const
- one command run creates one cluster, command must be rerun in periodic job

Test jobs will claim clusters with "reserved" label in ready, pending, installing state.

Provision job will count  clusters with "reserved" label in ready, pending, installing state, and create more if they are less than RESERVE count. 