### PR TITLE
fix missing secret error for jobs without PD key

### DIFF
--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -896,6 +896,7 @@ func InitOSDe2eViper() {
 	RegisterSecret(Proxy.UserCABundle, "user-ca-bundle")
 
 	// ------- Configuration Anomaly Detection ------
+	viper.SetDefault(Cad.CADPagerDutyRoutingKey, "notprovided")
 	_ = viper.BindEnv(Cad.CADPagerDutyRoutingKey, "CAD_PAGERDUTY_ROUTING_KEY")
 	RegisterSecret(Cad.CADPagerDutyRoutingKey, "pagerduty-routing-key")
 }


### PR DESCRIPTION
Unless test pod is passed a PD key, it can't load it from ci-secrets and fails provisioning pod. This way, the pod will always have a key.

This will be fixed in a global way by introducing the key from vault in bp template.