### PR TITLE
pkg/e2e: create executor from kubeconfig if set

### DIFF
--- a/pkg/e2e/adhoctestimages/adhoctestimages.go
+++ b/pkg/e2e/adhoctestimages/adhoctestimages.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/osde2e/pkg/common/label"
 	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
 	"github.com/openshift/osde2e/pkg/e2e/executor"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 var _ = ginkgo.Describe("Ad Hoc Test Images", ginkgo.Ordered, ginkgo.ContinueOnFailure, label.AdHocTestImages, func() {
@@ -39,6 +40,9 @@ var _ = ginkgo.Describe("Ad Hoc Test Images", ginkgo.Ordered, ginkgo.ContinueOnF
 
 	ginkgo.BeforeAll(func(ctx context.Context) {
 		var err error
+		exeConfig.RestConfig, err = clientcmd.RESTConfigFromKubeConfig([]byte(viper.GetString(config.Kubeconfig.Contents)))
+		Expect(err).NotTo(HaveOccurred())
+
 		exe, err = executor.New(logger, exeConfig)
 		Expect(err).NotTo(HaveOccurred())
 		logger.Info("executing test suites", "suites", testImages)

--- a/pkg/e2e/executor/executor.go
+++ b/pkg/e2e/executor/executor.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
@@ -40,6 +41,7 @@ type Config struct {
 	Timeout             time.Duration
 	OutputDir           string
 	SkipCleanup         bool
+	RestConfig          *rest.Config
 }
 
 type Executor struct {
@@ -50,7 +52,13 @@ type Executor struct {
 
 // New sets up a new executor to run a given test suite image
 func New(logger logr.Logger, cfg *Config) (*Executor, error) {
-	oc, err := openshift.New(logger)
+	var oc *openshift.Client
+	var err error
+	if cfg.RestConfig != nil {
+		oc, err = openshift.NewFromRestConfig(cfg.RestConfig, logger)
+	} else {
+		oc, err = openshift.New(logger)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("openshift client creation: %w", err)
 	}


### PR DESCRIPTION
the old runner would create the rest config in the helper from the kubeconfig set by viper - do the same as a short term fix