### PR TITLE
add passthru secrets from env as well as from fileSecrets for compati…

### DIFF
--- a/pkg/common/load/load.go
+++ b/pkg/common/load/load.go
@@ -72,9 +72,24 @@ func Configs(configs []string, customConfig string, secretLocations []string) er
 	return nil
 }
 
+func GetPassthruSecrets(passthruSecrets map[string]string) map[string]string {
+	// set secrets from env into array
+	passthruSecrets["OCM_CLIENT_ID"] = viper.GetString(ocmprovider.ClientID)
+	passthruSecrets["OCM_CLIENT_SECRET"] = viper.GetString(ocmprovider.ClientSecret)
+	passthruSecrets["OCM_TOKEN"] = viper.GetString(ocmprovider.Token)
+	passthruSecrets["CLUSTER_ID"] = viper.GetString(config.Cluster.ID)
+	passthruSecrets["GCP_CREDS_JSON"] = viper.GetString(config.GCPCredsJSON)
+	passthruSecrets["AWS_SECRET_ACCESS_KEY"] = viper.GetString(config.AWSSecretAccessKey)
+	passthruSecrets["AWS_REGION"] = viper.GetString(config.AWSRegion)
+	passthruSecrets["AWS_PROFILE"] = viper.GetString(config.AWSProfile)
+	passthruSecrets["AWS_ACCESS_KEY_ID"] = viper.GetString(config.AWSAccessKey)
+	passthruSecrets["CAD_PAGERDUTY_ROUTING_KEY"] = viper.GetString(config.Cad.CADPagerDutyRoutingKey)
+	return passthruSecrets
+}
+
 func loadPassthruSecrets(secretLocations []string) {
 	passthruSecrets = viper.GetStringMapString(config.NonOSDe2eSecrets)
-	// Load secrets from folders
+	// Load secrets from shared secret files eg on prow
 	if len(secretLocations) > 0 {
 		secrets := config.GetAllSecrets()
 		for _, secret := range secrets {
@@ -107,16 +122,7 @@ func loadPassthruSecrets(secretLocations []string) {
 			}
 		}
 	}
-	passthruSecrets["OCM_CLIENT_ID"] = viper.GetString(ocmprovider.ClientID)
-	passthruSecrets["OCM_CLIENT_SECRET"] = viper.GetString(ocmprovider.ClientSecret)
-	passthruSecrets["OCM_TOKEN"] = viper.GetString(ocmprovider.Token)
-	passthruSecrets["CLUSTER_ID"] = viper.GetString(config.Cluster.ID)
-	passthruSecrets["GCP_CREDS_JSON"] = viper.GetString(config.GCPCredsJSON)
-	passthruSecrets["AWS_SECRET_ACCESS_KEY"] = viper.GetString(config.AWSSecretAccessKey)
-	passthruSecrets["AWS_REGION"] = viper.GetString(config.AWSRegion)
-	passthruSecrets["AWS_PROFILE"] = viper.GetString(config.AWSProfile)
-	passthruSecrets["AWS_ACCESS_KEY_ID"] = viper.GetString(config.AWSAccessKey)
-	passthruSecrets["CAD_PAGERDUTY_ROUTING_KEY"] = viper.GetString(config.Cad.CADPagerDutyRoutingKey)
+	GetPassthruSecrets(passthruSecrets)
 
 	viper.Set(config.NonOSDe2eSecrets, passthruSecrets)
 }

--- a/pkg/e2e/adhoctestimages/adhoctestimages.go
+++ b/pkg/e2e/adhoctestimages/adhoctestimages.go
@@ -12,11 +12,13 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/label"
+	"github.com/openshift/osde2e/pkg/common/load"
 	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
 	"github.com/openshift/osde2e/pkg/e2e/executor"
 )
 
 var _ = ginkgo.Describe("Ad Hoc Test Images", ginkgo.Ordered, ginkgo.ContinueOnFailure, label.AdHocTestImages, func() {
+	passthruSecrets := viper.GetStringMapString(config.NonOSDe2eSecrets)
 	var (
 		logger           = ginkgo.GinkgoLogr
 		testImageEntries = []ginkgo.TableEntry{}
@@ -26,7 +28,7 @@ var _ = ginkgo.Describe("Ad Hoc Test Images", ginkgo.Ordered, ginkgo.ContinueOnF
 			CloudProviderRegion: viper.GetString(config.CloudProvider.Region),
 			ClusterID:           viper.GetString(config.Cluster.ID),
 			Environment:         ocm.Environment(viper.GetString(ocmprovider.Env)),
-			PassthruSecrets:     viper.GetStringMapString(config.NonOSDe2eSecrets),
+			PassthruSecrets:     load.GetPassthruSecrets(passthruSecrets),
 			SkipCleanup:         viper.GetBool(config.Cluster.SkipDestroyCluster),
 			Timeout:             viper.GetDuration(config.Tests.AdHocTestContainerTimeout),
 		}


### PR DESCRIPTION
…bility with tekton env

Prow provides secrets in files which are loaded into viper.GetStringMapString(config.NonOSDe2eSecrets)

whereas tekton provides secrets in env vars which are loaded into individual viper configs. Make sure both are loaded into passthru., 

[SDCICD-1591](https://issues.redhat.com//browse/SDCICD-1591) 