### PR TITLE
pkg/e2e: return cluster to set in viper

### DIFF
--- a/cmd/osde2e/provision/cmd.go
+++ b/cmd/osde2e/provision/cmd.go
@@ -91,5 +91,6 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("error getting cluster provider: %s", err.Error())
 	}
 
-	return clusterutil.Provision(provider)
+	_, err = clusterutil.Provision(provider)
+	return err
 }

--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -552,22 +552,22 @@ func clusterName() string {
 	return "osde2e-" + suffix
 }
 
-func Provision(provider spi.Provider) error {
+func Provision(provider spi.Provider) (*spi.Cluster, error) {
 	status, err := ConfigureVersion(provider)
 	if status != config.Success {
-		return fmt.Errorf("failed configure cluster version: %v", err)
+		return nil, fmt.Errorf("failed configure cluster version: %v", err)
 	}
 
 	cluster, err := ProvisionCluster(nil)
 	if err != nil {
-		return fmt.Errorf("failed to set up or retrieve cluster: %v", err)
+		return nil, fmt.Errorf("failed to set up or retrieve cluster: %v", err)
 	}
 
 	viper.Set(config.Cluster.ID, cluster.ID())
 	log.Printf("CLUSTER_ID set to %s from OCM.", viper.GetString(config.Cluster.ID))
 	_, err = WaitForOCMProvisioning(provider, viper.GetString(config.Cluster.ID), nil, false)
 	if err != nil {
-		return fmt.Errorf("cluster never became ready: %v", err)
+		return nil, fmt.Errorf("cluster never became ready: %v", err)
 	}
 	log.Printf("Cluster status is ready")
 
@@ -617,7 +617,7 @@ func Provision(provider spi.Provider) error {
 	})
 
 	if clusterConfigerr != nil {
-		return fmt.Errorf("failed retrieving kubeconfig: %v", clusterConfigerr)
+		return nil, fmt.Errorf("failed retrieving kubeconfig: %v", clusterConfigerr)
 	}
 
 	if viper.GetString(config.SharedDir) != "" {
@@ -628,7 +628,7 @@ func Provision(provider spi.Provider) error {
 		}
 	}
 
-	return nil
+	return cluster, nil
 }
 
 // set cluster infor into viper and metadata

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -64,7 +64,7 @@ func beforeSuite() bool {
 		return false
 	}
 	if viper.GetString(config.Kubeconfig.Contents) == "" {
-		err = clusterutil.Provision(provider)
+		cluster, err = clusterutil.Provision(provider)
 		getLogs()
 		if err != nil {
 			return false


### PR DESCRIPTION
We aren't returning the cluster from `Provision` so this causes setting it in viper to panic due to nil cluster

```
2025/07/16 07:59:09 clusterutil.go:600: Cluster is healthy and ready for testing
2025/07/16 07:59:11 clusterutil.go:613: Successfully retrieved kubeconfig from OCM.
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x27308c2]

goroutine 1 [running]:
github.com/openshift/osde2e/pkg/common/spi.(*Cluster).ChannelGroup(...)
	/go/src/github.com/openshift/osde2e/pkg/common/spi/cluster.go:73
github.com/openshift/osde2e/pkg/common/cluster.SetClusterIntoViperConfig(0x0)
	/go/src/github.com/openshift/osde2e/pkg/common/cluster/clusterutil.go:636 +0x22
```

https://redhat-internal.slack.com/archives/C01JJKHC0CF/p1752649477587529?thread_ts=1752649409.214929&cid=C01JJKHC0CF

Changed in 7388c9c70427c46ace0e61da5bb51844d44e0b5b