### PR TITLE
Remove CAD from e2e-suite

### DIFF
--- a/configs/e2e-suite.yaml
+++ b/configs/e2e-suite.yaml
@@ -13,5 +13,4 @@ tests:
     - quay.io/app-sre/splunk-forwarder-operator-e2e
     - quay.io/app-sre/route-monitor-operator-e2e
     - quay.io/app-sre/managed-cluster-validating-webhooks-e2e
-    - quay.io/app-sre/configuration-anomaly-detection-e2e
     - quay.io/app-sre/ocm-agent-e2e


### PR DESCRIPTION
This PR removes CAD from the e2e suite as it now runs independently. 