### PR TITLE
Add standalone artifact collector for LLM failure analysis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20250402181141-b3bad3b645f2
 	github.com/openshift/cloud-credential-operator v0.0.0-20250326174647-d66761c09842
 	github.com/openshift/managed-upgrade-operator v0.0.0-20230525042514-a9b8c1d2571c
-	github.com/openshift/osde2e-common v0.0.0-20250804130535-082bd8035ce8
+	github.com/openshift/osde2e-common v0.0.0-20250804220455-7806b74ec777
 	github.com/operator-framework/api v0.30.0
 	github.com/operator-framework/operator-lifecycle-manager v0.22.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.64.0

--- a/go.sum
+++ b/go.sum
@@ -332,6 +332,8 @@ github.com/openshift/managed-upgrade-operator v0.0.0-20230525042514-a9b8c1d2571c
 github.com/openshift/managed-upgrade-operator v0.0.0-20230525042514-a9b8c1d2571c/go.mod h1:W/ajjexZ/T50ZRpk48HbgbtOXD4rt0/wHlwdXu8arQE=
 github.com/openshift/osde2e-common v0.0.0-20250804130535-082bd8035ce8 h1:ZjJP+ZKLYyUxrlV4FSXM+S174R2Y/9eNaJmptFr9VV8=
 github.com/openshift/osde2e-common v0.0.0-20250804130535-082bd8035ce8/go.mod h1:PVd8CEETL2pM+J4f0yLF6B+6PLfaZ2hVKiAOm+ejoFQ=
+github.com/openshift/osde2e-common v0.0.0-20250804220455-7806b74ec777 h1:tAgQfMTlBbfH88Q3pA6DeyifRZ4j0Yj6Wx9eySJDbuk=
+github.com/openshift/osde2e-common v0.0.0-20250804220455-7806b74ec777/go.mod h1:PVd8CEETL2pM+J4f0yLF6B+6PLfaZ2hVKiAOm+ejoFQ=
 github.com/operator-framework/api v0.30.0 h1:44hCmGnEnZk/Miol5o44dhSldNH0EToQUG7vZTl29kk=
 github.com/operator-framework/api v0.30.0/go.mod h1:FYxAPhjtlXSAty/fbn5YJnFagt6SpJZJgFNNbvDe5W0=
 github.com/operator-framework/operator-lifecycle-manager v0.22.0 h1:7DEWOq24HQ0l5xPOXMhn17XaJACgwoipz+JfQ7QCXZw=

--- a/internal/aggregator/collector.go
+++ b/internal/aggregator/collector.go
@@ -1,0 +1,300 @@
+// Package aggregator provides functionality to collect artifacts and metadata
+// from osde2e test runs for LLM analysis.
+package aggregator
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/joshdk/go-junit"
+)
+
+// artifactCollector collects test failure artifacts
+type artifactCollector struct {
+	logger logr.Logger
+}
+
+// AggregatedData contains all collected artifacts and metadata
+type AggregatedData struct {
+	Metadata       ClusterMetadata   `json:"metadata"`
+	TestResults    TestResultSummary `json:"testResults"`
+	FailedTests    []FailedTest      `json:"failedTests"`
+	ClusterLogs    []LogEntry        `json:"clusterLogs"`
+	MustGatherData []LogEntry        `json:"mustGatherData"`
+	BuildLogs      []LogEntry        `json:"buildLogs"`
+	CollectionTime time.Time         `json:"collectionTime"`
+}
+
+// ClusterMetadata contains essential cluster information
+type ClusterMetadata struct {
+	ClusterID      string            `json:"clusterId,omitempty"`
+	ClusterVersion string            `json:"clusterVersion,omitempty"`
+	Provider       string            `json:"provider,omitempty"`
+	CloudProvider  string            `json:"cloudProvider,omitempty"`
+	Region         string            `json:"region,omitempty"`
+	JobName        string            `json:"jobName,omitempty"`
+	JobID          string            `json:"jobId,omitempty"`
+	Phase          string            `json:"phase,omitempty"`
+	Environment    string            `json:"environment,omitempty"`
+	Properties     map[string]string `json:"properties,omitempty"`
+}
+
+// TestResultSummary provides high-level test execution statistics
+type TestResultSummary struct {
+	TotalTests   int           `json:"totalTests"`
+	PassedTests  int           `json:"passedTests"`
+	FailedTests  int           `json:"failedTests"`
+	SkippedTests int           `json:"skippedTests"`
+	ErrorTests   int           `json:"errorTests"`
+	Duration     time.Duration `json:"duration"`
+	SuiteCount   int           `json:"suiteCount"`
+}
+
+// FailedTest contains details about a specific test failure
+type FailedTest struct {
+	Name       string        `json:"name"`
+	ClassName  string        `json:"className,omitempty"`
+	SuiteName  string        `json:"suiteName,omitempty"`
+	Duration   time.Duration `json:"duration"`
+	ErrorMsg   string        `json:"errorMessage,omitempty"`
+	StackTrace string        `json:"stackTrace,omitempty"`
+	SystemOut  string        `json:"systemOut,omitempty"`
+	SystemErr  string        `json:"systemErr,omitempty"`
+}
+
+// LogEntry represents a collected log file
+type LogEntry struct {
+	Source  string `json:"source"`  // File path or source identifier
+	Content string `json:"content"` // Log content
+}
+
+// newArtifactCollector creates a new artifact collector
+func newArtifactCollector(logger logr.Logger) *artifactCollector {
+	return &artifactCollector{
+		logger: logger,
+	}
+}
+
+// collectFromReportDir collects artifacts from the specified report directory
+func (a *artifactCollector) collectFromReportDir(ctx context.Context, reportDir string) (*AggregatedData, error) {
+	a.logger.Info("collecting artifacts", "reportDir", reportDir)
+
+	if _, err := os.Stat(reportDir); os.IsNotExist(err) {
+		return nil, fmt.Errorf("report directory does not exist: %s", reportDir)
+	}
+
+	data := &AggregatedData{
+		CollectionTime: time.Now(),
+	}
+
+	// Collect test results from JUnit files
+	if err := a.collectTestResults(reportDir, data); err != nil {
+		a.logger.Error(err, "failed to collect test results")
+	}
+
+	// Collect build logs
+	if err := a.collectBuildLogs(reportDir, data); err != nil {
+		a.logger.Error(err, "failed to collect build logs")
+	}
+
+	// Collect cluster logs
+	if err := a.collectClusterLogs(reportDir, data); err != nil {
+		a.logger.Error(err, "failed to collect cluster logs")
+	}
+
+	// Collect must-gather data
+	if err := a.collectMustGatherData(reportDir, data); err != nil {
+		a.logger.Error(err, "failed to collect must-gather data")
+	}
+
+	a.logger.Info("completed artifact collection",
+		"failedTests", len(data.FailedTests),
+		"logEntries", len(data.ClusterLogs)+len(data.MustGatherData)+len(data.BuildLogs))
+
+	return data, nil
+}
+
+// collectTestResults processes JUnit XML files to extract test failure information
+func (a *artifactCollector) collectTestResults(reportDir string, data *AggregatedData) error {
+	junitFiles, err := a.findJUnitFiles(reportDir)
+	if err != nil {
+		return fmt.Errorf("finding junit files: %w", err)
+	}
+
+	if len(junitFiles) == 0 {
+		a.logger.Info("no junit files found")
+		return nil
+	}
+
+	var allSuites []junit.Suite
+	for _, file := range junitFiles {
+		suites, err := junit.IngestFile(file)
+		if err != nil {
+			a.logger.Error(err, "failed to parse junit file", "file", file)
+			continue
+		}
+		allSuites = append(allSuites, suites...)
+	}
+
+	// Calculate summary statistics
+	summary := TestResultSummary{SuiteCount: len(allSuites)}
+	var failedTests []FailedTest
+
+	for _, suite := range allSuites {
+		for _, test := range suite.Tests {
+			summary.TotalTests++
+			summary.Duration += test.Duration
+
+			switch test.Status {
+			case junit.StatusPassed:
+				summary.PassedTests++
+			case junit.StatusFailed:
+				summary.FailedTests++
+				failedTests = append(failedTests, a.convertJUnitTest(test, suite.Name))
+			case junit.StatusSkipped:
+				summary.SkippedTests++
+			case junit.StatusError:
+				summary.ErrorTests++
+				failedTests = append(failedTests, a.convertJUnitTest(test, suite.Name))
+			}
+		}
+	}
+
+	data.TestResults = summary
+	data.FailedTests = failedTests
+
+	return nil
+}
+
+// convertJUnitTest converts a junit.Test to our FailedTest structure
+func (a *artifactCollector) convertJUnitTest(test junit.Test, suiteName string) FailedTest {
+	failed := FailedTest{
+		Name:      test.Name,
+		ClassName: test.Classname,
+		SuiteName: suiteName,
+		Duration:  test.Duration,
+		SystemOut: test.SystemOut,
+		SystemErr: test.SystemErr,
+	}
+
+	if test.Error != nil {
+		failed.ErrorMsg = test.Error.Error()
+		failed.StackTrace = test.Error.Error()
+	}
+
+	return failed
+}
+
+// collectBuildLogs collects build logs from the report directory
+func (a *artifactCollector) collectBuildLogs(reportDir string, data *AggregatedData) error {
+	buildLogPath := filepath.Join(reportDir, "build-log.txt")
+	if content, err := a.readLogFile(buildLogPath); err == nil {
+		data.BuildLogs = append(data.BuildLogs, content)
+	}
+	return nil
+}
+
+// collectClusterLogs collects cluster-related logs
+func (a *artifactCollector) collectClusterLogs(reportDir string, data *AggregatedData) error {
+	clusterLogsDir := filepath.Join(reportDir, "cluster-logs")
+	return a.collectLogsFromDir(clusterLogsDir, &data.ClusterLogs)
+}
+
+// collectMustGatherData collects must-gather diagnostic data
+func (a *artifactCollector) collectMustGatherData(reportDir string, data *AggregatedData) error {
+	mustGatherDir := filepath.Join(reportDir, "must-gather")
+	return a.collectLogsFromDir(mustGatherDir, &data.MustGatherData)
+}
+
+// collectLogsFromDir recursively collects log files from a directory
+func (a *artifactCollector) collectLogsFromDir(dir string, logs *[]LogEntry) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return nil // Directory doesn't exist, skip
+	}
+
+	return filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // Skip files with errors
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		// Only collect log files and important text files
+		if a.isLogFile(path) {
+			if content, err := a.readLogFile(path); err == nil {
+				*logs = append(*logs, content)
+			}
+		}
+
+		return nil
+	})
+}
+
+// isLogFile determines if a file should be collected as a log
+func (a *artifactCollector) isLogFile(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	name := strings.ToLower(filepath.Base(path))
+
+	// Include common log file extensions and names
+	logExtensions := []string{".log", ".txt", ".out", ".err"}
+	for _, logExt := range logExtensions {
+		if ext == logExt {
+			return true
+		}
+	}
+
+	// Include files with log-like names
+	logNames := []string{"events", "describe", "status", "pods", "nodes"}
+	for _, logName := range logNames {
+		if strings.Contains(name, logName) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// readLogFile reads a log file
+func (a *artifactCollector) readLogFile(path string) (LogEntry, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return LogEntry{}, err
+	}
+
+	return LogEntry{
+		Source:  path,
+		Content: string(content),
+	}, nil
+}
+
+// findJUnitFiles recursively searches for JUnit XML files
+func (a *artifactCollector) findJUnitFiles(reportDir string) ([]string, error) {
+	var junitFiles []string
+
+	err := filepath.Walk(reportDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		// Look for XML files that might be JUnit reports
+		if strings.HasSuffix(strings.ToLower(info.Name()), ".xml") &&
+			strings.Contains(strings.ToLower(info.Name()), "junit") {
+			junitFiles = append(junitFiles, path)
+		}
+
+		return nil
+	})
+
+	return junitFiles, err
+}

--- a/internal/aggregator/collector_test.go
+++ b/internal/aggregator/collector_test.go
@@ -1,0 +1,181 @@
+package aggregator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArtifactCollector_collectFromReportDir(t *testing.T) {
+	// Create a temporary test directory structure
+	tempDir := t.TempDir()
+
+	// Create test report directory structure
+	reportDir := filepath.Join(tempDir, "report")
+	installDir := filepath.Join(reportDir, "install")
+	upgradeDir := filepath.Join(reportDir, "upgrade")
+	mustGatherDir := filepath.Join(reportDir, "must-gather")
+	clusterLogsDir := filepath.Join(reportDir, "cluster-logs")
+
+	require.NoError(t, os.MkdirAll(installDir, 0o755))
+	require.NoError(t, os.MkdirAll(upgradeDir, 0o755))
+	require.NoError(t, os.MkdirAll(mustGatherDir, 0o755))
+	require.NoError(t, os.MkdirAll(clusterLogsDir, 0o755))
+
+	// Create test files
+	createTestFiles(t, reportDir, installDir, upgradeDir, mustGatherDir, clusterLogsDir)
+
+	// Create collector
+	logger := logr.Discard()
+	collector := newArtifactCollector(logger)
+
+	// Test collection
+	ctx := context.Background()
+	data, err := collector.collectFromReportDir(ctx, reportDir)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	// Verify test results
+	assert.Equal(t, 3, data.TestResults.TotalTests)
+	assert.Equal(t, 1, data.TestResults.PassedTests)
+	assert.Equal(t, 2, data.TestResults.FailedTests)
+	assert.Equal(t, 2, len(data.FailedTests))
+
+	// Verify failed test details
+	failedTest := data.FailedTests[0]
+	assert.Equal(t, "TestOperatorInstallation", failedTest.Name)
+	assert.Equal(t, "operators.test", failedTest.ClassName)
+	assert.Contains(t, failedTest.ErrorMsg, "operator installation timed out")
+
+	// Verify logs were collected
+	assert.Greater(t, len(data.BuildLogs), 0)
+	assert.Greater(t, len(data.ClusterLogs), 0)
+	assert.Greater(t, len(data.MustGatherData), 0)
+
+	// Verify collection time
+	assert.WithinDuration(t, time.Now(), data.CollectionTime, time.Minute)
+}
+
+func TestArtifactCollector_nonExistentDirectory(t *testing.T) {
+	logger := logr.Discard()
+	collector := newArtifactCollector(logger)
+
+	ctx := context.Background()
+	_, err := collector.collectFromReportDir(ctx, "/non/existent/path")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "report directory does not exist")
+}
+
+func TestArtifactCollector_emptyDirectory(t *testing.T) {
+	tempDir := t.TempDir()
+
+	logger := logr.Discard()
+	collector := newArtifactCollector(logger)
+
+	ctx := context.Background()
+	data, err := collector.collectFromReportDir(ctx, tempDir)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	// Should have empty results but valid structure
+	assert.Equal(t, 0, data.TestResults.TotalTests)
+	assert.Equal(t, 0, len(data.FailedTests))
+	assert.Equal(t, 0, len(data.BuildLogs))
+}
+
+func TestIsLogFile(t *testing.T) {
+	logger := logr.Discard()
+	collector := newArtifactCollector(logger)
+
+	tests := []struct {
+		path     string
+		expected bool
+	}{
+		{"/path/to/file.log", true},
+		{"/path/to/file.txt", true},
+		{"/path/to/file.out", true},
+		{"/path/to/file.err", true},
+		{"/path/to/events", true},
+		{"/path/to/describe-pods", true},
+		{"/path/to/file.json", false},
+		{"/path/to/file.yaml", false},
+		{"/path/to/binary", false},
+	}
+
+	for _, test := range tests {
+		result := collector.isLogFile(test.path)
+		assert.Equal(t, test.expected, result, "path: %s", test.path)
+	}
+}
+
+// Helper function to create test files
+func createTestFiles(t *testing.T, reportDir, installDir, upgradeDir, mustGatherDir, clusterLogsDir string) {
+	// Create build log
+	buildLog := `2024-01-15 10:00:00 Starting osde2e test run
+2024-01-15 10:01:00 Provisioning cluster
+2024-01-15 10:05:00 Cluster provisioned successfully
+2024-01-15 10:06:00 Running install tests
+2024-01-15 10:10:00 Test failure detected in operator installation
+2024-01-15 10:15:00 Running must-gather
+2024-01-15 10:20:00 Test run completed with failures`
+
+	require.NoError(t, os.WriteFile(filepath.Join(reportDir, "build-log.txt"), []byte(buildLog), 0o644))
+
+	// Create JUnit XML files
+	junitInstall := `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="install-tests" tests="2" failures="1" errors="0" time="120.5">
+  <testcase name="TestClusterProvisioning" classname="cluster.test" time="60.0">
+  </testcase>
+  <testcase name="TestOperatorInstallation" classname="operators.test" time="60.5">
+    <failure type="InstallationError" message="operator installation timed out after 300 seconds">
+      <![CDATA[
+Error: operator installation timed out after 300 seconds
+Stack trace:
+  at operator_test.go:45
+  at test_runner.go:123
+      ]]>
+    </failure>
+  </testcase>
+</testsuite>`
+
+	junitUpgrade := `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="upgrade-tests" tests="1" failures="1" errors="0" time="180.0">
+  <testcase name="TestUpgradeProcess" classname="upgrade.test" time="180.0">
+    <failure type="UpgradeError" message="cluster upgrade failed">
+      <![CDATA[
+Error: upgrade process failed during node update
+Stack trace:
+  at upgrade_test.go:67
+  at test_runner.go:156
+      ]]>
+    </failure>
+  </testcase>
+</testsuite>`
+
+	require.NoError(t, os.WriteFile(filepath.Join(installDir, "junit_install.xml"), []byte(junitInstall), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(upgradeDir, "junit_upgrade.xml"), []byte(junitUpgrade), 0o644))
+
+	// Create must-gather files
+	mustGatherLog := `2024-01-15T10:15:00Z Collecting cluster information
+2024-01-15T10:15:30Z Gathering node information
+2024-01-15T10:16:00Z Collecting pod logs from all namespaces
+2024-01-15T10:17:00Z Must-gather collection completed`
+
+	require.NoError(t, os.WriteFile(filepath.Join(mustGatherDir, "gather.log"), []byte(mustGatherLog), 0o644))
+
+	// Create cluster logs
+	clusterLog := `2024-01-15T10:00:00Z cluster-version-operator: Starting cluster version reconciliation
+2024-01-15T10:01:00Z cluster-version-operator: Error updating cluster operators
+2024-01-15T10:02:00Z cluster-version-operator: Retrying operator update`
+
+	require.NoError(t, os.WriteFile(filepath.Join(clusterLogsDir, "cluster-version-operator.log"), []byte(clusterLog), 0o644))
+}

--- a/internal/aggregator/service.go
+++ b/internal/aggregator/service.go
@@ -1,0 +1,44 @@
+// Package aggregator provides a unified interface for collecting artifacts
+// and metadata from osde2e test runs for LLM analysis.
+package aggregator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+)
+
+// Service provides a unified interface for collecting artifacts and metadata
+type Service struct {
+	artifactCollector *artifactCollector
+	logger            logr.Logger
+}
+
+// NewService creates a new aggregator service
+func NewService(logger logr.Logger) *Service {
+	return &Service{
+		artifactCollector: newArtifactCollector(logger),
+		logger:            logger,
+	}
+}
+
+// Collect collects all artifacts and metadata from the specified report directory
+func (s *Service) Collect(ctx context.Context, reportDir string, metadata ClusterMetadata) (*AggregatedData, error) {
+	s.logger.Info("collecting data", "reportDir", reportDir)
+
+	// Collect artifacts
+	data, err := s.artifactCollector.collectFromReportDir(ctx, reportDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to collect artifacts: %w", err)
+	}
+
+	// Set provided metadata
+	data.Metadata = metadata
+
+	s.logger.Info("collection completed",
+		"failedTests", len(data.FailedTests),
+		"clusterId", metadata.ClusterID)
+
+	return data, nil
+}

--- a/internal/aggregator/service_test.go
+++ b/internal/aggregator/service_test.go
@@ -1,0 +1,62 @@
+package aggregator
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestService_Collect(t *testing.T) {
+	// Setup test environment
+	tempDir := t.TempDir()
+	reportDir := filepath.Join(tempDir, "report")
+	require.NoError(t, os.MkdirAll(reportDir, 0o755))
+
+	// Create minimal test files
+	buildLog := "Test build log content"
+	require.NoError(t, os.WriteFile(filepath.Join(reportDir, "build-log.txt"), []byte(buildLog), 0o644))
+
+	// Create service
+	logger := logr.Discard()
+	service := NewService(logger)
+
+	// Create test metadata
+	metadata := ClusterMetadata{
+		ClusterID: "test-cluster",
+		Provider:  "rosa",
+	}
+
+	// Test collection
+	ctx := context.Background()
+	data, err := service.Collect(ctx, reportDir, metadata)
+
+	require.NoError(t, err)
+	require.NotNil(t, data)
+
+	// Verify metadata was set
+	assert.Equal(t, "test-cluster", data.Metadata.ClusterID)
+	assert.Equal(t, "rosa", data.Metadata.Provider)
+
+	// Verify build logs were collected
+	assert.Greater(t, len(data.BuildLogs), 0)
+}
+
+func TestService_NonExistentDirectory(t *testing.T) {
+	logger := logr.Discard()
+	service := NewService(logger)
+
+	metadata := ClusterMetadata{
+		ClusterID: "test-cluster",
+	}
+
+	ctx := context.Background()
+	_, err := service.Collect(ctx, "/non/existent/path", metadata)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "report directory does not exist")
+}


### PR DESCRIPTION
Creates a minimal, standalone package to collect test failure artifacts and metadata from osde2e test runs for LLM analysis.

Key features:
- Collects JUnit XML test results, build logs, cluster logs, and must-gather data
- Standalone design with no viper/config dependencies
- Minimal API surface with single entry point
- Comprehensive test coverage
- JSON-serializable data structures for LLM integration

💖 Generated with Crush