### PR TITLE
SDCICD-1566 enable passing a separate billing account for hcp job

### DIFF
--- a/pkg/common/config/aws_config.go
+++ b/pkg/common/config/aws_config.go
@@ -21,6 +21,9 @@ var (
 	// AWSAccountId is the AWS account (Env var: AWS_ACCOUNT_ID)
 	AWSAccountId = "config.aws.account"
 
+	// HCPBillingAccountId is the billing account for HCP (Env var: HCP_BILLING_ACCOUNT_ID)
+	HCPBillingAccountId = "config.aws.hcpBillingAccount"
+
 	// AWSAccessKey is the AWS access key
 	AWSAccessKey = "config.aws.accessKey"
 
@@ -94,6 +97,9 @@ func InitAWSViper() error {
 
 	_ = viper.BindEnv(AWSAccountId, "AWS_ACCOUNT_ID")
 	RegisterSecret(AWSAccountId, "aws-account")
+
+	_ = viper.BindEnv(HCPBillingAccountId, "HCP_BILLING_ACCOUNT_ID")
+	RegisterSecret(HCPBillingAccountId, "hcp-billing-account")
 
 	_ = viper.BindEnv(AWSAccessKey, "AWS_ACCESS_KEY", "OCM_AWS_ACCESS_KEY", "AWS_ACCESS_KEY_ID", "ROSA_AWS_ACCESS_KEY_ID")
 	RegisterSecret(AWSAccessKey, "aws-access-key")

--- a/pkg/common/providers/rosaprovider/cluster.go
+++ b/pkg/common/providers/rosaprovider/cluster.go
@@ -103,7 +103,7 @@ func (m *ROSAProvider) LaunchCluster(clusterName string) (string, error) {
 			STS:                          viper.GetBool(STS),
 			MintMode:                     viper.GetBool(MintMode),
 			HostedCP:                     viper.GetBool(config.Hypershift),
-			BillingAccountID:             viper.GetString(config.AWSAccountId),
+			BillingAccountID:             viper.GetString(config.HCPBillingAccountId),
 			FIPS:                         viper.GetBool(config.Cluster.EnableFips),
 			MultiAZ:                      viper.GetBool(config.Cluster.MultiAZ),
 			ExpirationDuration:           viper.GetDuration(config.Cluster.ExpiryInMinutes) * time.Minute,


### PR DESCRIPTION
 

Hypershift pr check job is failing using base AWS account as the billing account.

The billing account must be an account within the same org, but with HCP contract enabled. It should be the org account on stage.

https://issues.redhat.com/browse/SDCICD-1566

