### PR TITLE
feat(logging): setup logfile early and pass logger around

### DIFF
--- a/cmd/osde2e/main.go
+++ b/cmd/osde2e/main.go
@@ -20,6 +20,9 @@ import (
 	"github.com/openshift/osde2e/cmd/osde2e/test"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
+	"github.com/openshift/osde2e/pkg/common/providers/rosaprovider"
+	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/openshift/osde2e/pkg/common/util"
 )
 
@@ -81,6 +84,11 @@ func main() {
 	log.SetOutput(mw)
 
 	logger.Info("configured logging", "outputFile", buildLogPath, "reportDir", reportDir, "sharedDir", sharedDir)
+
+	// Register providers
+	spi.RegisterProvider("rosa", func() (spi.Provider, error) { return rosaprovider.New(ctx) })
+	spi.RegisterProvider("ocm", func() (spi.Provider, error) { return ocmprovider.New() })
+
 	if err := root.Execute(); err != nil {
 		logger.Error(err, "command execution failed")
 		os.Exit(1)

--- a/cmd/osde2e/main.go
+++ b/cmd/osde2e/main.go
@@ -2,7 +2,11 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
@@ -14,6 +18,9 @@ import (
 	"github.com/openshift/osde2e/cmd/osde2e/healthcheck"
 	"github.com/openshift/osde2e/cmd/osde2e/provision"
 	"github.com/openshift/osde2e/cmd/osde2e/test"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/util"
 )
 
 var root = &cobra.Command{
@@ -36,10 +43,44 @@ func init() {
 }
 
 func main() {
-	logger := textlogger.NewLogger(textlogger.NewConfig())
+	const buildLog = "test_output.log"
+
+	reportDir := viper.GetString(config.ReportDir)
+	sharedDir := viper.GetString(config.SharedDir)
+	runtimeDir := fmt.Sprintf("%s/osde2e-%s", os.TempDir(), util.RandomStr(10))
+
+	if reportDir == "" {
+		reportDir = runtimeDir
+		viper.Set(config.ReportDir, reportDir)
+	}
+
+	if err := os.MkdirAll(reportDir, os.ModePerm); err != nil {
+		log.Printf("Could not create report directory: %s, %v", reportDir, err)
+		os.Exit(1)
+	}
+
+	if sharedDir != "" {
+		if err := os.MkdirAll(sharedDir, os.ModePerm); err != nil {
+			log.Printf("Could not create shared directory: %s, %v", sharedDir, err)
+		}
+	}
+	buildLogPath := filepath.Join(reportDir, buildLog)
+	logFile, err := os.Create(buildLogPath)
+	if err != nil {
+		log.Println("unable to create output file")
+		os.Exit(1)
+	}
+	defer logFile.Close()
+
+	mw := io.MultiWriter(os.Stdout, logFile)
+	config := textlogger.NewConfig(textlogger.Output(mw))
+	logger := textlogger.NewLogger(config)
 	ctx := logr.NewContext(context.Background(), logger)
 	root.SetContext(ctx)
 
+	log.SetOutput(mw)
+
+	logger.Info("configured logging", "outputFile", buildLogPath, "reportDir", reportDir, "sharedDir", sharedDir)
 	if err := root.Execute(); err != nil {
 		logger.Error(err, "command execution failed")
 		os.Exit(1)

--- a/pkg/common/providers/ocmprovider/ocm.go
+++ b/pkg/common/providers/ocmprovider/ocm.go
@@ -42,10 +42,6 @@ type OCMProvider struct {
 	versionGateLabel string
 }
 
-func init() {
-	spi.RegisterProvider("ocm", func() (spi.Provider, error) { return New() })
-}
-
 // OCMConnection returns a raw OCM connection.
 func OCMConnection(token, clientID, clientSecret, env string, debug bool) (*ocm.Connection, error) {
 	cacheKey := ocmConnectionKey{


### PR DESCRIPTION
- **feat(logging): setup log file earlier**
- **feat(logging): register providers in main**

This ensures we now have a wholistic log file that _should_ contain anything we
log with the current loggers. I needed to move the registration of the
providers to somewhere I could pass context in - the init functions get messy.
