### PR TITLE
allow pd jobs to claim clusters even though they may be  in installing or pending state

### DIFF
--- a/pkg/common/clusterproperties/properties.go
+++ b/pkg/common/clusterproperties/properties.go
@@ -20,6 +20,12 @@ const (
 	// JobName is the name of job that is associated with the cluster.
 	JobName = "JobName"
 
+	// AWSAccount is the aws account associated with the cluster, if applicable.
+	AWSAccount = "AWSAccount"
+
+	// AdHocTestImages are the additional test images running on cluster
+	AdHocTestImages = "AdHocTestImages"
+
 	// JobID is the name of the job ID that is associated with the cluster.
 	JobID = "JobID"
 


### PR DESCRIPTION
 

1. [allow pd jobs to claim clusters even though they may be in installing or pending state](https://github.com/openshift/osde2e/pull/3034/commits/f10ee3fe08af0d717032996d32b7d99364085cde) -  if the install has been kicked off, it will still save time rather than starting fresh install. In a rich reserve, there will be more ready clusters, so this should be avoided by creating larger reserve.

Currently pd job will create new cluster if a reserve cluster is still installing 

2. [allow PD jobs to claim a reserved cluster expiring soon by extending it](https://github.com/openshift/osde2e/pull/3034/commits/fefd3865765c02acb40a304eed139e139e739d2a) -current code expires these candidate clusters.  this is a waste of a good cluster that is just expiring too soon. Instead, extend and claim it. 


3. [add cluster properties](https://github.com/openshift/osde2e/pull/3034/commits/fefd3865765c02acb40a304eed139e139e739d2a) - add AWS account and test image in cluster properties to monitor clusters 