### PR TITLE
fix error in extending cluster during claim process

### DIFF
--- a/pkg/common/cluster/clusterutil.go
+++ b/pkg/common/cluster/clusterutil.go
@@ -454,7 +454,6 @@ func ProvisionCluster(logger *log.Logger) (*spi.Cluster, error) {
 	}
 	// Only enable cluster reserve claiming for ROSA STS classic for now
 	if viper.GetBool(config.Cluster.UseExistingCluster) && viper.GetString(config.Provider) == "rosa" && !viper.GetBool(config.Hypershift) && viper.GetBool(rosaprovider.STS) {
-		ocmProvider, _ := ocmprovider.New()
 		clusterID = ocmProvider.ClaimClusterFromReserve(viper.GetString(config.Cluster.Version), "aws", "rosa")
 	}
 	if viper.GetBool(config.Cluster.Reserve) {

--- a/pkg/common/providers/rosaprovider/config.go
+++ b/pkg/common/providers/rosaprovider/config.go
@@ -47,8 +47,8 @@ const (
 
 func init() {
 	// ----- ROSA -----
-	viper.SetDefault(Env, "prod")
-	_ = viper.BindEnv(Env, "ROSA_ENV")
+	viper.SetDefault(Env, "stage")
+	_ = viper.BindEnv(Env, "ROSA_ENV", "OCM_ENV")
 
 	_ = viper.BindEnv(MachineCIDR, "ROSA_MACHINE_CIDR")
 


### PR DESCRIPTION


Before claiming a cluster for testing, the process tries to extend a soon-expiring cluster by 2 hours. 

This is failing with
```
2025/10/02 16:19:42 cloud_provider.id='aws' and  region.id='us-east-1' and properties.MadeByOSDe2e='true' and product.id='rosa' and properties.Availability like 'reserved%' and version.id like 'openshift-v4.19.13%' and state in ('ready','pending','installing')
2025/10/02 16:19:48 Setting expiration on prod clusters is not allowed. Skipping...
2025/10/02 16:19:48 Claiming reserved cluster: 2lm0dnckg5e3jm4md9v18882s8g7pcdq
```

This is due to a prod ocm provider being used during setting expiry. 

This is causing clusters to be deleted during a test. 