### PR TITLE
[SDCICD-1737] Add S3 artifact URLs to Pod termination message

### DIFF
--- a/pkg/common/aws/s3.go
+++ b/pkg/common/aws/s3.go
@@ -187,12 +187,31 @@ func (u *S3Uploader) BuildS3Key() string {
 		jobID = fmt.Sprintf("run-%d", time.Now().Unix())
 	}
 
-	// path.Join handles empty strings correctly and always uses forward slashes
 	return path.Join(u.category, u.component, date, jobID)
 }
 
-// UploadDirectory uploads all files from a directory to S3.
-// Returns a list of upload results with S3 URIs and presigned URLs.
+// allowedExtensions defines file types to upload (prevents binaries, temp files, etc.)
+var allowedExtensions = map[string]bool{
+	".xml": true, ".log": true, ".yaml": true, ".yml": true, ".json": true,
+	".png": true, ".jpg": true, ".jpeg": true, ".gif": true,
+	".csv": true, ".txt": true, ".html": true,
+}
+
+// allowedFilenames are uploaded regardless of extension.
+var allowedFilenames = map[string]bool{
+	"test_output": true, "summary": true, "osde2e-full": true, "cluster-state": true,
+}
+
+func shouldUploadFile(filename string) bool {
+	ext := strings.ToLower(filepath.Ext(filename))
+	if allowedExtensions[ext] {
+		return true
+	}
+	baseName := strings.ToLower(strings.TrimSuffix(filepath.Base(filename), ext))
+	return allowedFilenames[baseName]
+}
+
+// UploadDirectory uploads files matching allowed extensions to S3.
 func (u *S3Uploader) UploadDirectory(srcDir string) ([]S3UploadResult, error) {
 	if u == nil {
 		return nil, nil
@@ -200,6 +219,7 @@ func (u *S3Uploader) UploadDirectory(srcDir string) ([]S3UploadResult, error) {
 
 	baseKey := u.BuildS3Key()
 	var results []S3UploadResult
+	var skippedCount int
 
 	log.Printf("Starting S3 upload from %s to %s", srcDir, CreateS3URL(u.bucket, baseKey))
 
@@ -207,47 +227,45 @@ func (u *S3Uploader) UploadDirectory(srcDir string) ([]S3UploadResult, error) {
 		if err != nil {
 			return err
 		}
-
 		if d.IsDir() {
 			return nil
 		}
 
-		// Get relative path from source directory
 		relPath, err := filepath.Rel(srcDir, filePath)
 		if err != nil {
 			return fmt.Errorf("failed to get relative path: %w", err)
 		}
 
-		// Skip hidden files and marker files
+		// Skip hidden files
 		if strings.HasPrefix(filepath.Base(relPath), ".") {
 			return nil
 		}
 
-		// Construct S3 key using path.Join (always uses forward slashes, correct for S3)
-		s3Key := path.Join(baseKey, relPath)
-
-		// Read file
-		file, err := os.Open(filePath)
-		if err != nil {
-			log.Printf("Warning: failed to open file %s: %v", filePath, err)
-			return nil // Continue with other files
-		}
-		defer file.Close()
-
-		// Get file info for size
-		fileInfo, err := file.Stat()
-		if err != nil {
-			log.Printf("Warning: failed to stat file %s: %v", filePath, err)
+		if !shouldUploadFile(filePath) {
+			skippedCount++
 			return nil
 		}
 
-		// Determine content type using standard mime package
+		s3Key := path.Join(baseKey, relPath)
+
+		file, err := os.Open(filePath)
+		if err != nil {
+			log.Printf("Warning: failed to open %s: %v", filePath, err)
+			return nil
+		}
+		defer file.Close()
+
+		fileInfo, err := file.Stat()
+		if err != nil {
+			log.Printf("Warning: failed to stat %s: %v", filePath, err)
+			return nil
+		}
+
 		contentType := mime.TypeByExtension(filepath.Ext(filePath))
 		if contentType == "" {
 			contentType = "application/octet-stream"
 		}
 
-		// Upload file using cached uploader for better performance
 		_, err = u.uploader.Upload(&s3manager.UploadInput{
 			Bucket:      aws.String(u.bucket),
 			Key:         aws.String(s3Key),
@@ -256,20 +274,17 @@ func (u *S3Uploader) UploadDirectory(srcDir string) ([]S3UploadResult, error) {
 		})
 		if err != nil {
 			log.Printf("Warning: failed to upload %s: %v", filePath, err)
-			return nil // Continue with other files
+			return nil // Continue with other files; partial upload is better than none
 		}
 
-		// Generate presigned URL
 		presignedURL, err := u.generatePresignedURL(s3Key)
 		if err != nil {
 			log.Printf("Warning: failed to generate presigned URL for %s: %v", s3Key, err)
 			presignedURL = ""
 		}
 
-		// Reuse existing CreateS3URL helper
-		s3URI := CreateS3URL(u.bucket, s3Key)
 		results = append(results, S3UploadResult{
-			S3URI:        s3URI,
+			S3URI:        CreateS3URL(u.bucket, s3Key),
 			PresignedURL: presignedURL,
 			Key:          s3Key,
 			Size:         fileInfo.Size(),
@@ -282,10 +297,10 @@ func (u *S3Uploader) UploadDirectory(srcDir string) ([]S3UploadResult, error) {
 		return results, fmt.Errorf("error walking directory: %w", err)
 	}
 
+	log.Printf("S3 upload complete: %d files uploaded, %d files skipped", len(results), skippedCount)
 	return results, nil
 }
 
-// generatePresignedURL creates a presigned URL for accessing an S3 object.
 func (u *S3Uploader) generatePresignedURL(key string) (string, error) {
 	req, _ := u.s3Client.GetObjectRequest(&s3.GetObjectInput{
 		Bucket: aws.String(u.bucket),
@@ -294,7 +309,7 @@ func (u *S3Uploader) generatePresignedURL(key string) (string, error) {
 	return req.Presign(u.urlExpiry)
 }
 
-// LogS3UploadSummary prints a summary of uploaded files with their access URLs.
+// LogS3UploadSummary prints upload summary and writes artifact URLs for downstream systems.
 func LogS3UploadSummary(results []S3UploadResult) {
 	if len(results) == 0 {
 		log.Println("No files were uploaded to S3")
@@ -304,83 +319,64 @@ func LogS3UploadSummary(results []S3UploadResult) {
 	log.Println("=== S3 Upload Summary ===")
 	log.Printf("Uploaded %d files", len(results))
 
-	// Calculate total size
 	var totalSize int64
 	for _, r := range results {
 		totalSize += r.Size
 	}
 	log.Printf("Total size: %d bytes", totalSize)
 
-	// Print presigned URLs for key files (JUnit XML, logs)
 	log.Println("\n=== Presigned URLs (valid for 7 days) ===")
 	for _, r := range results {
-		// .log suffix covers test_output.log, no need for separate check
 		if strings.HasSuffix(r.Key, ".xml") || strings.HasSuffix(r.Key, ".log") {
 			log.Printf("%s:\n  %s", filepath.Base(r.Key), r.PresignedURL)
 		}
 	}
 
-	// Print base S3 URI
 	if len(results) > 0 {
 		baseKey := path.Dir(results[0].Key)
 		log.Printf("\nAll artifacts: %s", CreateS3URL(viper.GetString(config.Tests.LogBucket), baseKey))
 	}
 
-	// Write structured JSON for downstream systems (qontract-reconcile, etc.)
 	writeArtifactsJSON(results)
 }
 
-// ArtifactsJSON is the structured output format for S3 artifact URLs.
-// This JSON is written to stdout and termination message for downstream consumption.
-// Note: Kubernetes termination message is limited to 4KB, so we only include key URLs.
+// ArtifactsJSON is written to stdout and /dev/termination-log for downstream consumption.
+// Only key URLs are included due to k8s termination message 4KB limit.
 type ArtifactsJSON struct {
 	S3URI    string `json:"s3Uri"`
 	JUnitURL string `json:"junitUrl,omitempty"`
 	LogsURL  string `json:"logsUrl,omitempty"`
 }
 
-// writeArtifactsJSON outputs artifact URLs in a well-known JSON format.
-// This enables downstream systems to parse and link to artifacts.
 func writeArtifactsJSON(results []S3UploadResult) {
 	if len(results) == 0 {
 		return
 	}
 
-	artifacts := ArtifactsJSON{}
-
-	// Set base S3 URI (use the common prefix path, not the subdirectory)
-	// Example: if key is "test-results/component/2026-01-30/run-123/install/junit.xml"
-	// we want "test-results/component/2026-01-30/run-123"
-	baseKey := ""
-	if len(results) > 0 {
-		// Extract base path from the first result key
-		// Assume structure: <category>/<component>/<date>/<job-id>/<optional-subdir>/<file>
-		parts := strings.Split(results[0].Key, "/")
-		if len(parts) >= 4 {
-			// Take first 4 parts: category/component/date/job-id
-			baseKey = strings.Join(parts[:4], "/")
-		} else {
-			// Fallback: use directory of first file
-			baseKey = path.Dir(results[0].Key)
-		}
+	// Extract base path: category/component/date/job-id
+	var baseKey string
+	parts := strings.Split(results[0].Key, "/")
+	if len(parts) >= 4 {
+		baseKey = strings.Join(parts[:4], "/")
+	} else {
+		baseKey = path.Dir(results[0].Key)
 	}
-	artifacts.S3URI = CreateS3URL(viper.GetString(config.Tests.LogBucket), baseKey)
 
-	// Find key artifact URLs (prioritize junit XML and main log file)
+	artifacts := ArtifactsJSON{
+		S3URI: CreateS3URL(viper.GetString(config.Tests.LogBucket), baseKey),
+	}
+
 	for _, r := range results {
-		// Match JUnit XML files (junit*.xml pattern)
 		baseName := filepath.Base(r.Key)
 		if strings.HasPrefix(baseName, "junit") && strings.HasSuffix(baseName, ".xml") && artifacts.JUnitURL == "" {
 			artifacts.JUnitURL = r.PresignedURL
 		}
-		// Match main log files
 		if (baseName == "test_output.log" || baseName == "osde2e-full.log") && artifacts.LogsURL == "" {
 			artifacts.LogsURL = r.PresignedURL
 		}
 	}
 
-	// Use encoder with SetEscapeHTML(false) to prevent & from being escaped as \u0026
-	// This ensures presigned URLs remain valid and clickable
+	// SetEscapeHTML(false) keeps presigned URLs valid (prevents & -> \u0026)
 	var buf bytes.Buffer
 	encoder := json.NewEncoder(&buf)
 	encoder.SetEscapeHTML(false)
@@ -390,20 +386,13 @@ func writeArtifactsJSON(results []S3UploadResult) {
 	}
 	data := bytes.TrimSpace(buf.Bytes())
 
-	// Output with marker for easy parsing
 	fmt.Printf("\n###OSDE2E_ARTIFACTS_JSON###\n%s\n###END_ARTIFACTS_JSON###\n", string(data))
-
-	// Write to termination message (standard k8s pattern for job results)
-	// Note: termination message is limited to 4KB, keeping only essential URLs
 	writeTerminationMessage(data)
 }
 
-// writeTerminationMessage writes to /dev/termination-log for Kubernetes job results.
-// This is the standard pattern for making job output available in pod status.
+// writeTerminationMessage writes to /dev/termination-log (k8s job result pattern).
 func writeTerminationMessage(data []byte) {
-	terminationPath := "/dev/termination-log"
-	if err := os.WriteFile(terminationPath, data, 0o644); err != nil {
-		// Not an error - termination-log may not exist outside k8s
+	if err := os.WriteFile("/dev/termination-log", data, 0o644); err != nil {
 		log.Printf("Note: Could not write termination message: %v", err)
 	}
 }

--- a/pkg/common/aws/s3_test.go
+++ b/pkg/common/aws/s3_test.go
@@ -85,3 +85,29 @@ func TestNewS3Uploader_Disabled(t *testing.T) {
 		t.Error("NewS3Uploader() should return nil when LOG_BUCKET is empty")
 	}
 }
+
+func TestBuildBaseKey(t *testing.T) {
+	tests := []struct {
+		key      string
+		expected string
+	}{
+		{"test-results/component/2026-01-30/run-123/install/junit.xml", "test-results/component/2026-01-30/run-123"},
+		{"test-results/component/2026-01-30/run-123/test_output.log", "test-results/component/2026-01-30/run-123"},
+		{"results/file.xml", "results"},
+	}
+
+	for _, tt := range tests {
+		// Simulate the base key extraction logic
+		var baseKey string
+		parts := strings.Split(tt.key, "/")
+		if len(parts) >= 4 {
+			baseKey = strings.Join(parts[:4], "/")
+		} else {
+			baseKey = strings.TrimSuffix(tt.key, "/"+parts[len(parts)-1])
+		}
+
+		if baseKey != tt.expected {
+			t.Errorf("Base key for %s: got %v, want %v", tt.key, baseKey, tt.expected)
+		}
+	}
+}

--- a/pkg/common/aws/s3_test.go
+++ b/pkg/common/aws/s3_test.go
@@ -111,3 +111,46 @@ func TestBuildBaseKey(t *testing.T) {
 		}
 	}
 }
+
+func TestShouldUploadFile(t *testing.T) {
+	tests := []struct {
+		filename string
+		want     bool
+	}{
+		// Allowed extensions
+		{"junit.xml", true},
+		{"test_output.log", true},
+		{"summary.yaml", true},
+		{"config.yml", true},
+		{"report.json", true},
+		{"screenshot.png", true},
+		{"graph.jpg", true},
+		{"photo.jpeg", true},
+		{"animation.gif", true},
+		{"data.csv", true},
+		{"notes.txt", true},
+		{"report.html", true},
+
+		// Allowed filenames (case-insensitive)
+		{"test_output", true},
+		{"TEST_OUTPUT", true},
+		{"summary", true},
+		{"osde2e-full", true},
+		{"cluster-state", true},
+
+		// Not allowed
+		{"binary.exe", false},
+		{"archive.tar.gz", false},
+		{"data.bin", false},
+		{"library.so", false},
+		{"randomfile", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			if got := shouldUploadFile(tt.filename); got != tt.want {
+				t.Errorf("shouldUploadFile(%q) = %v, want %v", tt.filename, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Link S3 artifact URLs to Pod termination message for downstream consumption (qontract-reconcile, Tekton Results, etc.).

Changes:
- Output structured JSON to stdout with `###OSDE2E_ARTIFACTS_JSON###` markers
- Write to `/dev/termination-log` (standard Kubernetes pattern)
- Use `SetEscapeHTML(false)` to keep presigned URLs valid
- S3 uploads only relevant test artifacts: .xml, .log, .yaml, .yml, .json, .png, .jpg, .jpeg, .gif, .csv, .txt, .html

**Usage**
From Pod status
`kubectl get pod <pod> -o jsonpath='{.status.containerStatuses[0].state.terminated.message}'
`

From logs
`kubectl logs <pod> | grep -A1 "###OSDE2E_ARTIFACTS_JSON###"
`

**Output**
{
 "s3Uri": "s3://osde2e-loki-logs/test-results/...",
 "junitUrl": "https://...?X-Amz-Algorithm=...&X-Amz-Credential=...",
 "logsUrl": "https://...?X-Amz-Algorithm=...&X-Amz-Credential=..."
}

[SDCICD-1737](https://issues.redhat.com//browse/SDCICD-1737)