### PR TITLE
[SDCICD-1754] Add S3 artifact presigned URLs to Slack failure notifications

### DIFF
--- a/pkg/common/orchestrator/orchestrator.go
+++ b/pkg/common/orchestrator/orchestrator.go
@@ -14,6 +14,13 @@ type Orchestrator interface {
 	// optional upgrade tests with their respective phases.
 	Execute(ctx context.Context) error
 
+	// UploadArtifacts persists test artifacts (logs, JUnit XML) to durable
+	// storage and generates shareable URLs. Called after Execute so that
+	// downstream phases (AnalyzeLogs) can include artifact links in
+	// notifications. Implementations that don't need artifact persistence
+	// should return nil.
+	UploadArtifacts(ctx context.Context) error
+
 	// AnalyzeLogs performs AI-powered log analysis when tests fail,
 	// providing insights into failure root causes.
 	AnalyzeLogs(ctx context.Context, testErr error) error

--- a/pkg/krknai/krknai.go
+++ b/pkg/krknai/krknai.go
@@ -299,6 +299,12 @@ func detectContainerRuntime() (string, error) {
 	return "", fmt.Errorf("no container runtime found: install podman or docker")
 }
 
+// UploadArtifacts persists test artifacts to durable storage.
+func (k *KrknAI) UploadArtifacts(ctx context.Context) error {
+	// TODO: Upload chaos test artifacts when persistent storage is configured
+	return nil
+}
+
 // AnalyzeLogs performs AI-powered log analysis when tests fail,
 // providing insights into failure root causes.
 func (k *KrknAI) AnalyzeLogs(ctx context.Context, testErr error) error {


### PR DESCRIPTION
### Changes

| File | Change |
|---|---|
| `pkg/common/orchestrator/orchestrator.go` | Add `UploadArtifacts` to `Orchestrator` interface |
| `pkg/e2e/e2e.go` | Implement `UploadArtifacts`, `cleanStaleJunitFiles`, `sendDeferredNotifications`, `s3ResultsToArtifactLinks`; inject artifact links into `AnalyzeLogs` notification config; fix `ClusterInfo` type conversion |
| `pkg/e2e/adhoctestimages/adhoctestimages.go` | Replace immediate Slack send with deferred notification queue (`PendingNotification`, `DrainPendingNotifications`) |
| `pkg/krknai/krknai.go` | No-op `UploadArtifacts` implementation |
| `internal/reporter/slack.go` | Add `ArtifactLink` type, `buildArtifactLinksSection`; prefer artifact links over embedded logs in `extended_logs` payload field |
| `internal/reporter/slack_workflow_test.go` | Tests for artifact link priority, fallback to embedded logs, formatting (bare URLs, no file sizes, no mrkdwn syntax) |

### Orchestrator Lifecycle
Provision → Execute → UploadArtifacts → AnalyzeLogs → Report → PostProcessCluster → Cleanup
