### PR TITLE
SDCICD-1768 Decouple analysis engines from notification logic

### DIFF
--- a/internal/analysisengine/engine.go
+++ b/internal/analysisengine/engine.go
@@ -12,7 +12,6 @@ import (
 	"github.com/openshift/osde2e/internal/llm/tools"
 	"github.com/openshift/osde2e/internal/prompts"
 	"github.com/openshift/osde2e/internal/sanitizer"
-	"github.com/openshift/osde2e/pkg/common/slack"
 	"gopkg.in/yaml.v3"
 )
 
@@ -48,7 +47,6 @@ type Engine struct {
 	aggregatorService *aggregator.Aggregator
 	promptStore       *prompts.PromptStore
 	llmClient         llm.LLMClient
-	reporterRegistry  *slack.ReporterRegistry
 }
 
 // New creates a new analysis engine
@@ -80,16 +78,11 @@ func New(ctx context.Context, config *Config) (*Engine, error) {
 		return nil, fmt.Errorf("failed to initialize LLM client: %w", err)
 	}
 
-	// Initialize reporter registry
-	reporterRegistry := slack.NewReporterRegistry()
-	reporterRegistry.Register(slack.NewSlackReporter())
-
 	return &Engine{
 		config:            config,
 		aggregatorService: aggregatorService,
 		promptStore:       promptStore,
 		llmClient:         client,
-		reporterRegistry:  reporterRegistry,
 	}, nil
 }
 
@@ -159,25 +152,6 @@ func (e *Engine) Run(ctx context.Context) (*Result, error) {
 
 	if err := analysisResult.WriteSummary(e.config.ArtifactsDir, e.config.ClusterInfo, e.config.FailureContext); err != nil {
 		return nil, fmt.Errorf("failed to write analysis files: %w", err)
-	}
-
-	// Send notifications if configured
-	if e.config.NotificationConfig != nil && e.config.NotificationConfig.Enabled {
-		reporterResult := &slack.AnalysisResult{
-			Status:   analysisResult.Status,
-			Content:  analysisResult.Content,
-			Metadata: analysisResult.Metadata,
-			Error:    analysisResult.Error,
-			Prompt:   analysisResult.Prompt,
-		}
-
-		// Send to all configured reporters
-		for _, reporterConfig := range e.config.NotificationConfig.Reporters {
-			if err := e.reporterRegistry.SendNotification(ctx, reporterResult, &reporterConfig); err != nil {
-				// Log error but don't fail the analysis
-				fmt.Fprintf(os.Stderr, "Warning: Failed to send notification via %s: %v\n", reporterConfig.Type, err)
-			}
-		}
 	}
 
 	return analysisResult, nil

--- a/internal/analysisengine/types.go
+++ b/internal/analysisengine/types.go
@@ -2,16 +2,14 @@ package analysisengine
 
 import (
 	"github.com/openshift/osde2e/internal/llm"
-	"github.com/openshift/osde2e/pkg/common/slack"
 	"google.golang.org/genai"
 )
 
 // BaseConfig holds common configuration shared by all analysis engines.
 type BaseConfig struct {
-	ArtifactsDir       string                    // Directory containing artifacts or results
-	APIKey             string                    // LLM API key
-	LLMConfig          *llm.AnalysisConfig       // Optional LLM configuration overrides
-	NotificationConfig *slack.NotificationConfig // Optional notification configuration
+	ArtifactsDir string              // Directory containing artifacts or results
+	APIKey       string              // LLM API key
+	LLMConfig    *llm.AnalysisConfig // Optional LLM configuration overrides
 }
 
 // Result represents the analysis output shared across all engines.

--- a/pkg/common/orchestrator/orchestrator.go
+++ b/pkg/common/orchestrator/orchestrator.go
@@ -19,9 +19,7 @@ type Orchestrator interface {
 	// internally for use by Report.
 	AnalyzeLogs(ctx context.Context, testErr error) error
 
-	// Report uploads artifacts, sends notifications, and generates reports.
-	// It consolidates S3 uploads, Slack notifications (both built-in analysis
-	// and deferred ad-hoc test suite results), and diagnostic data collection.
+	// Report saves artifacts and/or sends notifications for generated results.
 	Report(ctx context.Context) error
 
 	// Cleanup performs post-test cleanup including resource cleanup and

--- a/pkg/common/orchestrator/orchestrator.go
+++ b/pkg/common/orchestrator/orchestrator.go
@@ -14,19 +14,14 @@ type Orchestrator interface {
 	// optional upgrade tests with their respective phases.
 	Execute(ctx context.Context) error
 
-	// UploadArtifacts persists test artifacts (logs, JUnit XML) to durable
-	// storage and generates shareable URLs. Called after Execute so that
-	// downstream phases (AnalyzeLogs) can include artifact links in
-	// notifications. Implementations that don't need artifact persistence
-	// should return nil.
-	UploadArtifacts(ctx context.Context) error
-
 	// AnalyzeLogs performs AI-powered log analysis when tests fail,
-	// providing insights into failure root causes.
+	// providing insights into failure root causes. Results are cached
+	// internally for use by Report.
 	AnalyzeLogs(ctx context.Context, testErr error) error
 
-	// Report generates test reports (JUnit, Konflux) and collects diagnostic data
-	// (must-gather, logs).
+	// Report uploads artifacts, sends notifications, and generates reports.
+	// It consolidates S3 uploads, Slack notifications (both built-in analysis
+	// and deferred ad-hoc test suite results), and diagnostic data collection.
 	Report(ctx context.Context) error
 
 	// Cleanup performs post-test cleanup including resource cleanup and

--- a/pkg/common/slack/types.go
+++ b/pkg/common/slack/types.go
@@ -1,10 +1,5 @@
 package slack
 
-import (
-	"context"
-	"fmt"
-)
-
 // AnalysisResult represents the analysis output passed to reporters.
 type AnalysisResult struct {
 	Status   string         `json:"status"`
@@ -14,63 +9,11 @@ type AnalysisResult struct {
 	Prompt   string         `json:"prompt,omitempty"`
 }
 
-// Reporter interface defines the contract for sending analysis results to external systems
-type Reporter interface {
-	Report(ctx context.Context, result *AnalysisResult, config *ReporterConfig) error
-	Name() string
-}
-
 // ReporterConfig holds configuration for different reporter implementations
 type ReporterConfig struct {
 	Type     string                 `json:"type" yaml:"type"`
 	Enabled  bool                   `json:"enabled" yaml:"enabled"`
 	Settings map[string]interface{} `json:"settings" yaml:"settings"`
-}
-
-// ReporterRegistry manages available reporters
-type ReporterRegistry struct {
-	reporters map[string]Reporter
-}
-
-// NewReporterRegistry creates a new reporter registry
-func NewReporterRegistry() *ReporterRegistry {
-	return &ReporterRegistry{
-		reporters: make(map[string]Reporter),
-	}
-}
-
-// Register adds a reporter to the registry
-func (r *ReporterRegistry) Register(reporter Reporter) {
-	r.reporters[reporter.Name()] = reporter
-}
-
-// Get retrieves a reporter by name
-func (r *ReporterRegistry) Get(name string) (Reporter, bool) {
-	reporter, exists := r.reporters[name]
-	return reporter, exists
-}
-
-// List returns all registered reporter names
-func (r *ReporterRegistry) List() []string {
-	names := make([]string, 0, len(r.reporters))
-	for name := range r.reporters {
-		names = append(names, name)
-	}
-	return names
-}
-
-// SendNotification sends analysis result to a specific reporter
-func (r *ReporterRegistry) SendNotification(ctx context.Context, result *AnalysisResult, config *ReporterConfig) error {
-	if !config.Enabled {
-		return nil
-	}
-
-	reporter, exists := r.Get(config.Type)
-	if !exists {
-		return fmt.Errorf("reporter type %s not found", config.Type)
-	}
-
-	return reporter.Report(ctx, result, config)
 }
 
 // NotificationConfig holds configuration for notification settings

--- a/pkg/e2e/adhoctestimages/adhoctestimages.go
+++ b/pkg/e2e/adhoctestimages/adhoctestimages.go
@@ -138,9 +138,9 @@ var _ = ginkgo.Describe("Ad Hoc Test Images", ginkgo.Ordered, ginkgo.ContinueOnF
 })
 
 // runLogAnalysisForAdHocTestImage runs AI analysis and queues the result for
-// deferred Slack delivery. The engine runs WITHOUT notification config because
+// deferred Slack delivery. The engine runs without sending notifications because
 // S3 artifacts have not been uploaded yet at this point. The queued result is
-// later sent by e2e.RunTests after UploadArtifacts populates presigned URLs.
+// later sent by Report after S3 upload populates presigned URLs.
 func runLogAnalysisForAdHocTestImage(ctx context.Context, logger logr.Logger, testSuite config.TestSuite, err error, artifactsDir string) {
 	logger.Info("Running Log analysis for test image", "image", testSuite.Image, "slackChannel", testSuite.SlackChannel)
 

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -129,6 +129,7 @@ func (o *E2EOrchestrator) Provision(ctx context.Context) error {
 
 	// Load cluster context (kubeconfig and cluster ID)
 	if err := cluster.LoadClusterContext(); err != nil {
+		o.result.ExitCode = config.Failure
 		return err
 	}
 
@@ -136,6 +137,7 @@ func (o *E2EOrchestrator) Provision(ctx context.Context) error {
 	cl, err := cluster.ProvisionOrReuseCluster(o.provider)
 	runner.ReportClusterInstallLogs(o.provider)
 	if err != nil {
+		o.result.ExitCode = config.Failure
 		return err
 	}
 
@@ -144,6 +146,7 @@ func (o *E2EOrchestrator) Provision(ctx context.Context) error {
 	// Install addons if configured
 	if _, err := cluster.InstallAddonsIfConfigured(o.provider, cl.ID()); err != nil {
 		runner.ReportClusterInstallLogs(o.provider)
+		o.result.ExitCode = config.Failure
 		return fmt.Errorf("addon installation failed: %w", err)
 	}
 
@@ -273,9 +276,9 @@ func (o *E2EOrchestrator) Report(ctx context.Context) error {
 		}
 	}
 
-	// Send built-in analysis notification (if analysis ran and Slack is enabled)
-	if o.analysisResult != nil && viper.GetBool(config.Tests.EnableSlackNotify) {
-		o.sendAnalysisNotification(ctx)
+	// Send failure notification (with or without LLM analysis)
+	if o.result.ExitCode != config.Success && viper.GetBool(config.Tests.EnableSlackNotify) {
+		o.sendFailureNotification(ctx)
 	}
 
 	// Send deferred ad-hoc test suite notifications (with S3 URLs)
@@ -285,9 +288,11 @@ func (o *E2EOrchestrator) Report(ctx context.Context) error {
 	return nil
 }
 
-// sendAnalysisNotification sends the built-in log analysis result via Slack.
-// Called by Report after S3 upload so that presigned URLs are available.
-func (o *E2EOrchestrator) sendAnalysisNotification(ctx context.Context) {
+// sendFailureNotification sends a test failure notification via Slack.
+// If LLM analysis results are available they are included; otherwise a
+// basic failure notice is sent. Called by Report after S3 upload so that
+// presigned URLs are available.
+func (o *E2EOrchestrator) sendFailureNotification(ctx context.Context) {
 	reportDir := viper.GetString(config.ReportDir)
 	notificationConfig := slack.BuildNotificationConfig(
 		viper.GetString(config.LogAnalysis.SlackWebhook),
@@ -313,18 +318,26 @@ func (o *E2EOrchestrator) sendAnalysisNotification(ctx context.Context) {
 		}
 	}
 
-	slackReporter := slack.NewSlackReporter()
-	result := &slack.AnalysisResult{
-		Status:   o.analysisResult.Status,
-		Content:  o.analysisResult.Content,
-		Metadata: o.analysisResult.Metadata,
-		Error:    o.analysisResult.Error,
-		Prompt:   o.analysisResult.Prompt,
+	var result *slack.AnalysisResult
+	if o.analysisResult != nil {
+		result = &slack.AnalysisResult{
+			Status:   o.analysisResult.Status,
+			Content:  o.analysisResult.Content,
+			Metadata: o.analysisResult.Metadata,
+			Error:    o.analysisResult.Error,
+			Prompt:   o.analysisResult.Prompt,
+		}
+	} else {
+		result = &slack.AnalysisResult{
+			Status:  "skipped",
+			Content: "Log analysis was not enabled for this run.",
+		}
 	}
 
+	slackReporter := slack.NewSlackReporter()
 	for _, cfg := range notificationConfig.Reporters {
 		if err := slackReporter.Report(ctx, result, &cfg); err != nil {
-			log.Printf("Failed to send analysis notification via %s: %v", cfg.Type, err)
+			log.Printf("Failed to send failure notification via %s: %v", cfg.Type, err)
 		}
 	}
 }

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -52,21 +52,19 @@ func RunTests(ctx context.Context) int {
 				log.Printf("Log analysis failed: %v", err)
 			}
 		}
+		if err := orch.Report(ctx); err != nil {
+			log.Printf("Report errors: %v", err)
+		}
 		return config.Failure
 	}
 
 	// Execute tests
 	testErr := orch.Execute(ctx)
 
-	// On failure: upload artifacts, send notifications, and analyze logs
+	// On failure: analyze logs (results are cached for Report)
 	if testErr != nil {
 		log.Printf("Tests failed: %v", testErr)
 
-		if err := orch.UploadArtifacts(ctx); err != nil {
-			log.Printf("Artifact upload failed: %v", err)
-		}
-
-		// Built-in test analysis (skipped when TestSuites/AdHoc handle their own)
 		if viper.GetBool(config.LogAnalysis.EnableAnalysis) && viper.GetString(config.Tests.TestSuites) == "" && viper.GetString(config.Tests.AdHocTestImages) == "" {
 			if err := orch.AnalyzeLogs(ctx, testErr); err != nil {
 				log.Printf("Log analysis failed: %v", err)
@@ -74,7 +72,7 @@ func RunTests(ctx context.Context) int {
 		}
 	}
 
-	// Generate reports
+	// Report: upload artifacts, send notifications, generate reports
 	if err := orch.Report(ctx); err != nil {
 		log.Printf("Report errors: %v", err)
 	}
@@ -100,6 +98,7 @@ type E2EOrchestrator struct {
 	suiteConfig    types.SuiteConfig
 	reporterConfig types.ReporterConfig
 	s3Results      []aws.S3UploadResult
+	analysisResult *analysisengine.Result
 }
 
 // NewOrchestrator creates a new E2E orchestrator instance.
@@ -194,20 +193,6 @@ func (o *E2EOrchestrator) Execute(ctx context.Context) error {
 	return nil
 }
 
-// UploadArtifacts persists test artifacts to S3 and delivers any deferred
-// Slack notifications that were queued during test execution.
-func (o *E2EOrchestrator) UploadArtifacts(ctx context.Context) error {
-	if viper.GetString(config.Tests.LogBucket) == "" {
-		return nil
-	}
-	cleanStaleJunitFiles()
-	if err := o.uploadToS3(); err != nil {
-		return err
-	}
-	o.sendDeferredNotifications(ctx)
-	return nil
-}
-
 // cleanStaleJunitFiles removes junit XML files from previous runs in the report directory,
 // keeping only the file matching the current run suffix.
 func cleanStaleJunitFiles() {
@@ -232,53 +217,29 @@ func cleanStaleJunitFiles() {
 }
 
 // AnalyzeLogs performs AI-powered log analysis on test failures.
+// Results are cached on the orchestrator for use by Report.
 func (o *E2EOrchestrator) AnalyzeLogs(ctx context.Context, testErr error) error {
 	log.Println("Running log analysis...")
-	var notificationConfig *slack.NotificationConfig
 	reportDir := viper.GetString(config.ReportDir)
 	if reportDir == "" {
 		return fmt.Errorf("no report directory available for log analysis")
 	}
 
-	clusterInfo := &analysisengine.ClusterInfo{
-		ID:            viper.GetString(config.Cluster.ID),
-		Name:          viper.GetString(config.Cluster.Name),
-		Provider:      viper.GetString(config.Provider),
-		Region:        viper.GetString(config.CloudProvider.Region),
-		CloudProvider: viper.GetString(config.CloudProvider.CloudProviderID),
-		Version:       viper.GetString(config.Cluster.Version),
-	}
-	if viper.GetBool(config.Tests.EnableSlackNotify) {
-		notificationConfig = slack.BuildNotificationConfig(
-			viper.GetString(config.LogAnalysis.SlackWebhook),
-			viper.GetString(config.LogAnalysis.SlackChannel),
-			&slack.ClusterInfo{
-				ID:            clusterInfo.ID,
-				Name:          clusterInfo.Name,
-				Provider:      clusterInfo.Provider,
-				Region:        clusterInfo.Region,
-				CloudProvider: clusterInfo.CloudProvider,
-				Version:       clusterInfo.Version,
-			},
-			reportDir,
-		)
-		if notificationConfig != nil && len(o.s3Results) > 0 {
-			artifactLinks := s3ResultsToArtifactLinks(o.s3Results)
-			for i := range notificationConfig.Reporters {
-				notificationConfig.Reporters[i].Settings["artifact_links"] = artifactLinks
-			}
-		}
-	}
-
 	engineConfig := &analysisengine.Config{
 		BaseConfig: analysisengine.BaseConfig{
-			ArtifactsDir:       reportDir,
-			APIKey:             viper.GetString(config.LogAnalysis.APIKey),
-			NotificationConfig: notificationConfig,
+			ArtifactsDir: reportDir,
+			APIKey:       viper.GetString(config.LogAnalysis.APIKey),
 		},
 		PromptTemplate: "default",
 		FailureContext: testErr.Error(),
-		ClusterInfo:    clusterInfo,
+		ClusterInfo: &analysisengine.ClusterInfo{
+			ID:            viper.GetString(config.Cluster.ID),
+			Name:          viper.GetString(config.Cluster.Name),
+			Provider:      viper.GetString(config.Provider),
+			Region:        viper.GetString(config.CloudProvider.Region),
+			CloudProvider: viper.GetString(config.CloudProvider.CloudProviderID),
+			Version:       viper.GetString(config.Cluster.Version),
+		},
 	}
 
 	engine, err := analysisengine.New(ctx, engineConfig)
@@ -291,25 +252,86 @@ func (o *E2EOrchestrator) AnalyzeLogs(ctx context.Context, testErr error) error 
 		return fmt.Errorf("log analysis failed: %w", err)
 	}
 
+	o.analysisResult = result
 	log.Printf("Log analysis completed. Results: %s/%s/", reportDir, analysisengine.AnalysisDirName)
 	log.Printf("=== Log Analysis Result ===\n%s", result.Content)
 
 	return nil
 }
 
-// Report generates reports and collects diagnostic data.
+// Report uploads artifacts, sends notifications, and generates diagnostic reports.
 func (o *E2EOrchestrator) Report(ctx context.Context) error {
 	if o.suiteConfig.DryRun {
 		return nil
 	}
 
+	// Upload artifacts to S3
+	if viper.GetString(config.Tests.LogBucket) != "" {
+		cleanStaleJunitFiles()
+		if err := o.uploadToS3(); err != nil {
+			log.Printf("S3 upload failed: %v", err)
+		}
+	}
+
+	// Send built-in analysis notification (if analysis ran and Slack is enabled)
+	if o.analysisResult != nil && viper.GetBool(config.Tests.EnableSlackNotify) {
+		o.sendAnalysisNotification(ctx)
+	}
+
+	// Send deferred ad-hoc test suite notifications (with S3 URLs)
+	o.sendDeferredNotifications(ctx)
+
 	runner.ReportClusterInstallLogs(o.provider)
 	return nil
 }
 
+// sendAnalysisNotification sends the built-in log analysis result via Slack.
+// Called by Report after S3 upload so that presigned URLs are available.
+func (o *E2EOrchestrator) sendAnalysisNotification(ctx context.Context) {
+	reportDir := viper.GetString(config.ReportDir)
+	notificationConfig := slack.BuildNotificationConfig(
+		viper.GetString(config.LogAnalysis.SlackWebhook),
+		viper.GetString(config.LogAnalysis.SlackChannel),
+		&slack.ClusterInfo{
+			ID:            viper.GetString(config.Cluster.ID),
+			Name:          viper.GetString(config.Cluster.Name),
+			Provider:      viper.GetString(config.Provider),
+			Region:        viper.GetString(config.CloudProvider.Region),
+			CloudProvider: viper.GetString(config.CloudProvider.CloudProviderID),
+			Version:       viper.GetString(config.Cluster.Version),
+		},
+		reportDir,
+	)
+	if notificationConfig == nil {
+		return
+	}
+
+	if len(o.s3Results) > 0 {
+		artifactLinks := s3ResultsToArtifactLinks(o.s3Results)
+		for i := range notificationConfig.Reporters {
+			notificationConfig.Reporters[i].Settings["artifact_links"] = artifactLinks
+		}
+	}
+
+	slackReporter := slack.NewSlackReporter()
+	result := &slack.AnalysisResult{
+		Status:   o.analysisResult.Status,
+		Content:  o.analysisResult.Content,
+		Metadata: o.analysisResult.Metadata,
+		Error:    o.analysisResult.Error,
+		Prompt:   o.analysisResult.Prompt,
+	}
+
+	for _, cfg := range notificationConfig.Reporters {
+		if err := slackReporter.Report(ctx, result, &cfg); err != nil {
+			log.Printf("Failed to send analysis notification via %s: %v", cfg.Type, err)
+		}
+	}
+}
+
 // sendDeferredNotifications delivers Slack notifications that were queued by
-// adhoctestimages during test execution. Called after UploadArtifacts so that
-// presigned S3 URLs are available for inclusion in the message.
+// adhoctestimages during test execution. Called by Report after S3 upload so
+// that presigned URLs are available for inclusion in the message.
 func (o *E2EOrchestrator) sendDeferredNotifications(ctx context.Context) {
 	pending := adhoctestimages.DrainPendingNotifications()
 	if len(pending) == 0 {

--- a/pkg/krknai/analysisengine/engine.go
+++ b/pkg/krknai/analysisengine/engine.go
@@ -19,7 +19,6 @@ import (
 	"github.com/openshift/osde2e/internal/llm"
 	"github.com/openshift/osde2e/internal/llm/tools"
 	"github.com/openshift/osde2e/internal/prompts"
-	"github.com/openshift/osde2e/pkg/common/slack"
 	krknAggregator "github.com/openshift/osde2e/pkg/krknai/aggregator"
 	"gopkg.in/yaml.v3"
 )
@@ -44,11 +43,10 @@ type Config struct {
 
 // Engine analyzes krkn-ai chaos test results using LLM.
 type Engine struct {
-	config           *Config
-	aggregator       *krknAggregator.KrknAIAggregator
-	promptStore      *prompts.PromptStore
-	llmClient        llm.LLMClient
-	reporterRegistry *slack.ReporterRegistry
+	config      *Config
+	aggregator  *krknAggregator.KrknAIAggregator
+	promptStore *prompts.PromptStore
+	llmClient   llm.LLMClient
 }
 
 // New creates a new krkn-ai analysis engine.
@@ -85,16 +83,11 @@ func New(ctx context.Context, config *Config) (*Engine, error) {
 		return nil, fmt.Errorf("failed to initialize LLM client: %w", err)
 	}
 
-	// Initialize reporter registry
-	reporterRegistry := slack.NewReporterRegistry()
-	reporterRegistry.Register(slack.NewSlackReporter())
-
 	return &Engine{
-		config:           config,
-		aggregator:       agg,
-		promptStore:      promptStore,
-		llmClient:        client,
-		reporterRegistry: reporterRegistry,
+		config:      config,
+		aggregator:  agg,
+		promptStore: promptStore,
+		llmClient:   client,
 	}, nil
 }
 
@@ -191,11 +184,6 @@ func (e *Engine) Run(ctx context.Context) (*analysisengine.Result, error) {
 		return nil, fmt.Errorf("failed to write analysis summary: %w", err)
 	}
 
-	// Send notifications if configured
-	if e.config.NotificationConfig != nil && e.config.NotificationConfig.Enabled {
-		e.sendNotifications(ctx, analysisResult)
-	}
-
 	return analysisResult, nil
 }
 
@@ -263,21 +251,4 @@ func markdownToHTML(content string) (string, error) {
 	}
 
 	return buf.String(), nil
-}
-
-// sendNotifications sends analysis results to configured reporters.
-func (e *Engine) sendNotifications(ctx context.Context, result *analysisengine.Result) {
-	reporterResult := &slack.AnalysisResult{
-		Status:   result.Status,
-		Content:  result.Content,
-		Metadata: result.Metadata,
-		Error:    result.Error,
-		Prompt:   result.Prompt,
-	}
-
-	for _, reporterConfig := range e.config.NotificationConfig.Reporters {
-		if err := e.reporterRegistry.SendNotification(ctx, reporterResult, &reporterConfig); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: Failed to send notification via %s: %v\n", reporterConfig.Type, err)
-		}
-	}
 }

--- a/pkg/krknai/analysisengine/engine_test.go
+++ b/pkg/krknai/analysisengine/engine_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openshift/osde2e/internal/llm"
 	"github.com/openshift/osde2e/internal/llm/tools"
 	"github.com/openshift/osde2e/internal/prompts"
-	"github.com/openshift/osde2e/pkg/common/slack"
 	krknAgg "github.com/openshift/osde2e/pkg/krknai/aggregator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -170,10 +169,9 @@ func TestRun_MarkdownReportFormat(t *testing.T) {
 			BaseConfig:   analysisengine.BaseConfig{ArtifactsDir: tempDir, APIKey: "fake-key"},
 			ReportFormat: "markdown",
 		},
-		aggregator:       agg,
-		promptStore:      promptStore,
-		llmClient:        mockClient,
-		reporterRegistry: newTestReporterRegistry(),
+		aggregator:  agg,
+		promptStore: promptStore,
+		llmClient:   mockClient,
 	}
 
 	result, err := engine.Run(ctx)
@@ -204,10 +202,9 @@ func TestRun_HTMLReportFormat(t *testing.T) {
 			BaseConfig:   analysisengine.BaseConfig{ArtifactsDir: tempDir, APIKey: "fake-key"},
 			ReportFormat: "html",
 		},
-		aggregator:       agg,
-		promptStore:      promptStore,
-		llmClient:        mockClient,
-		reporterRegistry: newTestReporterRegistry(),
+		aggregator:  agg,
+		promptStore: promptStore,
+		llmClient:   mockClient,
 	}
 
 	result, err := engine.Run(ctx)
@@ -309,10 +306,9 @@ func TestRun_WithMockLLM(t *testing.T) {
 		config: &Config{
 			BaseConfig: analysisengine.BaseConfig{ArtifactsDir: tempDir, APIKey: "fake-key"},
 		},
-		aggregator:       agg,
-		promptStore:      promptStore,
-		llmClient:        mockClient,
-		reporterRegistry: newTestReporterRegistry(),
+		aggregator:  agg,
+		promptStore: promptStore,
+		llmClient:   mockClient,
 	}
 
 	result, err := engine.Run(ctx)
@@ -355,10 +351,9 @@ func TestRun_LLMFailure(t *testing.T) {
 		config: &Config{
 			BaseConfig: analysisengine.BaseConfig{ArtifactsDir: tempDir, APIKey: "fake-key"},
 		},
-		aggregator:       agg,
-		promptStore:      promptStore,
-		llmClient:        mockClient,
-		reporterRegistry: newTestReporterRegistry(),
+		aggregator:  agg,
+		promptStore: promptStore,
+		llmClient:   mockClient,
 	}
 
 	_, err := engine.Run(ctx)
@@ -375,10 +370,9 @@ func TestRun_MissingResults(t *testing.T) {
 		config: &Config{
 			BaseConfig: analysisengine.BaseConfig{ArtifactsDir: "/nonexistent/path", APIKey: "fake-key"},
 		},
-		aggregator:       agg,
-		promptStore:      promptStore,
-		llmClient:        &mockLLMClient{},
-		reporterRegistry: newTestReporterRegistry(),
+		aggregator:  agg,
+		promptStore: promptStore,
+		llmClient:   &mockLLMClient{},
 	}
 
 	_, err := engine.Run(ctx)
@@ -397,11 +391,6 @@ func newTestPromptStore(t *testing.T) *prompts.PromptStore {
 	require.NoError(t, store.RegisterTemplates(localFS))
 
 	return store
-}
-
-// newTestReporterRegistry creates an empty reporter registry for testing.
-func newTestReporterRegistry() *slack.ReporterRegistry {
-	return slack.NewReporterRegistry()
 }
 
 func createTestResultFiles(t *testing.T, resultsDir, reportsDir string) {

--- a/pkg/krknai/krknai.go
+++ b/pkg/krknai/krknai.go
@@ -14,15 +14,12 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/openshift/osde2e-common/pkg/clients/openshift"
 	"github.com/openshift/osde2e-common/pkg/clients/prometheus"
-	"github.com/openshift/osde2e/internal/analysisengine"
 	"github.com/openshift/osde2e/pkg/common/cluster"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/orchestrator"
 	"github.com/openshift/osde2e/pkg/common/providers"
-	"github.com/openshift/osde2e/pkg/common/slack"
 	"github.com/openshift/osde2e/pkg/common/spi"
-	krknengine "github.com/openshift/osde2e/pkg/krknai/analysisengine"
 	"gopkg.in/yaml.v3"
 )
 
@@ -42,9 +39,8 @@ const (
 
 // KrknAI implements the orchestrator.Orchestrator interface for Kraken AI chaos testing.
 type KrknAI struct {
-	provider       spi.Provider
-	result         *orchestrator.Result
-	analysisResult *analysisengine.Result
+	provider spi.Provider
+	result   *orchestrator.Result
 }
 
 // New creates a new KrknAI orchestrator instance.
@@ -338,86 +334,33 @@ func detectContainerRuntime() (string, error) {
 	return "", fmt.Errorf("no container runtime found: install podman or docker")
 }
 
-// AnalyzeLogs performs AI-powered log analysis on krkn-ai chaos test results.
-// Results are cached on the orchestrator for use by Report.
+// AnalyzeLogs performs AI-powered log analysis when tests fail,
+// providing insights into failure root causes.
 func (k *KrknAI) AnalyzeLogs(ctx context.Context, testErr error) error {
-	log.Println("Running krkn-ai log analysis...")
-	reportDir := viper.GetString(config.ReportDir)
-	if reportDir == "" {
-		return fmt.Errorf("no report directory available for log analysis")
-	}
+	log.Println("Analyzing logs for failure insights")
 
-	apiKey := viper.GetString(config.LogAnalysis.APIKey)
-	if apiKey == "" {
-		log.Println("Skipping log analysis: GEMINI_API_KEY not configured")
-		return nil
-	}
+	// TODO: Implement Kraken AI-specific log analysis
+	// This could include:
+	// - Correlating chaos events with failures
+	// - AI-powered root cause analysis
+	// - Generating remediation suggestions
 
-	engineConfig := &krknengine.Config{
-		BaseConfig: analysisengine.BaseConfig{
-			ArtifactsDir: reportDir,
-			APIKey:       apiKey,
-		},
-	}
-
-	engine, err := krknengine.New(ctx, engineConfig)
-	if err != nil {
-		return fmt.Errorf("failed to create krkn-ai analysis engine: %w", err)
-	}
-
-	result, err := engine.Run(ctx)
-	if err != nil {
-		return fmt.Errorf("krkn-ai log analysis failed: %w", err)
-	}
-
-	k.analysisResult = result
-	log.Printf("Krkn-ai log analysis completed. Results: %s/llm-analysis/", reportDir)
-	log.Printf("=== Krkn-ai Analysis Result ===\n%s", result.Content)
-
+	log.Printf("Log analysis completed for error: %v", testErr)
 	return nil
 }
 
-// Report sends notifications and generates diagnostic reports.
+// Report generates test reports and collects diagnostic data.
 func (k *KrknAI) Report(ctx context.Context) error {
-	if k.analysisResult != nil && viper.GetBool(config.Tests.EnableSlackNotify) {
-		k.sendAnalysisNotification(ctx)
-	}
+	log.Println("Generating test reports")
+
+	// TODO: Implement chaos test reporting
+	// This should include:
+	// - Chaos experiment results
+	// - Cluster resilience metrics
+	// - Recovery time statistics
+
+	log.Println("Report generation completed")
 	return nil
-}
-
-// sendAnalysisNotification sends the krkn-ai analysis result via Slack.
-func (k *KrknAI) sendAnalysisNotification(ctx context.Context) {
-	notificationConfig := slack.BuildNotificationConfig(
-		viper.GetString(config.LogAnalysis.SlackWebhook),
-		viper.GetString(config.LogAnalysis.SlackChannel),
-		&slack.ClusterInfo{
-			ID:            viper.GetString(config.Cluster.ID),
-			Name:          viper.GetString(config.Cluster.Name),
-			Provider:      viper.GetString(config.Provider),
-			Region:        viper.GetString(config.CloudProvider.Region),
-			CloudProvider: viper.GetString(config.CloudProvider.CloudProviderID),
-			Version:       viper.GetString(config.Cluster.Version),
-		},
-		viper.GetString(config.ReportDir),
-	)
-	if notificationConfig == nil {
-		return
-	}
-
-	slackReporter := slack.NewSlackReporter()
-	result := &slack.AnalysisResult{
-		Status:   k.analysisResult.Status,
-		Content:  k.analysisResult.Content,
-		Metadata: k.analysisResult.Metadata,
-		Error:    k.analysisResult.Error,
-		Prompt:   k.analysisResult.Prompt,
-	}
-
-	for _, cfg := range notificationConfig.Reporters {
-		if err := slackReporter.Report(ctx, result, &cfg); err != nil {
-			log.Printf("Failed to send krkn-ai notification via %s: %v", cfg.Type, err)
-		}
-	}
 }
 
 // Cleanup performs post-test cleanup including resource cleanup and

--- a/pkg/krknai/krknai.go
+++ b/pkg/krknai/krknai.go
@@ -14,12 +14,15 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/openshift/osde2e-common/pkg/clients/openshift"
 	"github.com/openshift/osde2e-common/pkg/clients/prometheus"
+	"github.com/openshift/osde2e/internal/analysisengine"
 	"github.com/openshift/osde2e/pkg/common/cluster"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/orchestrator"
 	"github.com/openshift/osde2e/pkg/common/providers"
+	"github.com/openshift/osde2e/pkg/common/slack"
 	"github.com/openshift/osde2e/pkg/common/spi"
+	krknengine "github.com/openshift/osde2e/pkg/krknai/analysisengine"
 	"gopkg.in/yaml.v3"
 )
 
@@ -39,8 +42,9 @@ const (
 
 // KrknAI implements the orchestrator.Orchestrator interface for Kraken AI chaos testing.
 type KrknAI struct {
-	provider spi.Provider
-	result   *orchestrator.Result
+	provider       spi.Provider
+	result         *orchestrator.Result
+	analysisResult *analysisengine.Result
 }
 
 // New creates a new KrknAI orchestrator instance.
@@ -334,39 +338,86 @@ func detectContainerRuntime() (string, error) {
 	return "", fmt.Errorf("no container runtime found: install podman or docker")
 }
 
-// UploadArtifacts persists test artifacts to durable storage.
-func (k *KrknAI) UploadArtifacts(ctx context.Context) error {
-	// TODO: Upload chaos test artifacts when persistent storage is configured
-	return nil
-}
-
-// AnalyzeLogs performs AI-powered log analysis when tests fail,
-// providing insights into failure root causes.
+// AnalyzeLogs performs AI-powered log analysis on krkn-ai chaos test results.
+// Results are cached on the orchestrator for use by Report.
 func (k *KrknAI) AnalyzeLogs(ctx context.Context, testErr error) error {
-	log.Println("Analyzing logs for failure insights")
+	log.Println("Running krkn-ai log analysis...")
+	reportDir := viper.GetString(config.ReportDir)
+	if reportDir == "" {
+		return fmt.Errorf("no report directory available for log analysis")
+	}
 
-	// TODO: Implement Kraken AI-specific log analysis
-	// This could include:
-	// - Correlating chaos events with failures
-	// - AI-powered root cause analysis
-	// - Generating remediation suggestions
+	apiKey := viper.GetString(config.LogAnalysis.APIKey)
+	if apiKey == "" {
+		log.Println("Skipping log analysis: GEMINI_API_KEY not configured")
+		return nil
+	}
 
-	log.Printf("Log analysis completed for error: %v", testErr)
+	engineConfig := &krknengine.Config{
+		BaseConfig: analysisengine.BaseConfig{
+			ArtifactsDir: reportDir,
+			APIKey:       apiKey,
+		},
+	}
+
+	engine, err := krknengine.New(ctx, engineConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create krkn-ai analysis engine: %w", err)
+	}
+
+	result, err := engine.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("krkn-ai log analysis failed: %w", err)
+	}
+
+	k.analysisResult = result
+	log.Printf("Krkn-ai log analysis completed. Results: %s/llm-analysis/", reportDir)
+	log.Printf("=== Krkn-ai Analysis Result ===\n%s", result.Content)
+
 	return nil
 }
 
-// Report generates test reports and collects diagnostic data.
+// Report sends notifications and generates diagnostic reports.
 func (k *KrknAI) Report(ctx context.Context) error {
-	log.Println("Generating test reports")
-
-	// TODO: Implement chaos test reporting
-	// This should include:
-	// - Chaos experiment results
-	// - Cluster resilience metrics
-	// - Recovery time statistics
-
-	log.Println("Report generation completed")
+	if k.analysisResult != nil && viper.GetBool(config.Tests.EnableSlackNotify) {
+		k.sendAnalysisNotification(ctx)
+	}
 	return nil
+}
+
+// sendAnalysisNotification sends the krkn-ai analysis result via Slack.
+func (k *KrknAI) sendAnalysisNotification(ctx context.Context) {
+	notificationConfig := slack.BuildNotificationConfig(
+		viper.GetString(config.LogAnalysis.SlackWebhook),
+		viper.GetString(config.LogAnalysis.SlackChannel),
+		&slack.ClusterInfo{
+			ID:            viper.GetString(config.Cluster.ID),
+			Name:          viper.GetString(config.Cluster.Name),
+			Provider:      viper.GetString(config.Provider),
+			Region:        viper.GetString(config.CloudProvider.Region),
+			CloudProvider: viper.GetString(config.CloudProvider.CloudProviderID),
+			Version:       viper.GetString(config.Cluster.Version),
+		},
+		viper.GetString(config.ReportDir),
+	)
+	if notificationConfig == nil {
+		return
+	}
+
+	slackReporter := slack.NewSlackReporter()
+	result := &slack.AnalysisResult{
+		Status:   k.analysisResult.Status,
+		Content:  k.analysisResult.Content,
+		Metadata: k.analysisResult.Metadata,
+		Error:    k.analysisResult.Error,
+		Prompt:   k.analysisResult.Prompt,
+	}
+
+	for _, cfg := range notificationConfig.Reporters {
+		if err := slackReporter.Report(ctx, result, &cfg); err != nil {
+			log.Printf("Failed to send krkn-ai notification via %s: %v", cfg.Type, err)
+		}
+	}
 }
 
 // Cleanup performs post-test cleanup including resource cleanup and


### PR DESCRIPTION

- Analysis engines now only perform LLM analysis and return results; notification delivery moved to orchestrators
- `UploadArtifacts` removed from `Orchestrator` interface; S3 upload and all notifications consolidated into `Report`
- KrknAI orchestrator wired to use `pkg/krknai/analysisengine` (previously dead code)
- Unused `Reporter` interface and `ReporterRegistry` removed

**Architecture**
```
BEFORE                                    AFTER
══════════════════════════════            ══════════════════════════════

UploadArtifacts                           AnalyzeLogs  (on failure only)
├── S3 upload                             └── engine.Run()
└── send deferred notifications               └── pure LLM analysis
                                                  → cache result
AnalyzeLogs
└── engine.Run()                          Report  (always called)
    ├── LLM analysis                      ├── S3 upload
    └── send notifications ←── coupled    ├── built-in analysis notification
                                          ├── deferred ad-hoc notifications
Report                                    └── cluster install logs
└── cluster install logs
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured artifact upload and notification handling flow.
  * Simplified notification configuration structure.
  * Implemented analysis result caching for reuse.

* **Bug Fixes**
  * Removed `UploadArtifacts()` method from Orchestrator interface; artifact operations now integrated into Report workflow.

* **Chores**
  * Updated internal comments to reflect revised notification and artifact-handling semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->