### PR TITLE
[WIP] SDCICD-1767 dedupe slack configs and separate them from llm config

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -150,7 +150,7 @@ func init() {
 		return []string{"json", "prom"}, cobra.ShellCompDirectiveDefault
 	})
 
-	_ = viper.BindPFlag(config.Tests.EnableSlackNotify, Cmd.Flags().Lookup("send-cleanup-summary"))
+	_ = viper.BindPFlag(config.Slack.Enable, Cmd.Flags().Lookup("send-cleanup-summary"))
 }
 
 // collectActiveClusters collects active cluster names from multiple OCM environments
@@ -189,7 +189,7 @@ func sendSlackNotification(msg Message, runErr error) {
 	if !args.sendSummary {
 		return
 	}
-	webhook := viper.GetString(config.Tests.SlackWebhook)
+	webhook := viper.GetString(config.Slack.Webhook)
 	if webhook == "" {
 		fmt.Println("Slack Webhook is not set, skipping notification.")
 		return

--- a/internal/reporter/README.md
+++ b/internal/reporter/README.md
@@ -143,8 +143,8 @@ go test -v -run TestSlackReporter_extractFailureBlocks
 #### Integration Test (with real Slack)
 ```bash
 # Set environment variables
-export LOG_ANALYSIS_SLACK_WEBHOOK="https://hooks.slack.com/workflows/..."
-export LOG_ANALYSIS_SLACK_CHANNEL="C06HQR8HN0L"
+export SLACK_WEBHOOK="https://hooks.slack.com/workflows/..."
+export SLACK_CHANNEL="C06HQR8HN0L"
 
 # Run integration test
 go test -v -run TestSlackReporter_Integration github.com/openshift/osde2e/pkg/e2e

--- a/pkg/common/config/config.go
+++ b/pkg/common/config/config.go
@@ -255,19 +255,6 @@ var Tests = struct {
 	// Env: TEST_USER
 	TestUser string
 
-	// SlackChannel is the name of a slack channel in the Internal Red hat slack workspace that will
-	// receive an alert if the tests fail.
-	// Env: SLACK_CHANNEL
-	SlackChannel string
-
-	// Slack Webhook is the URL to osde2e owner channel for Cloud Account Cleanup Report workflow to send notifications.
-	// Env: SLACK_WEBHOOK
-	SlackWebhook string
-
-	// SlackNotify is a boolean that determines if Slack notifications should be sent.
-	// Env: SLACK_NOTIFY
-	EnableSlackNotify string
-
 	// GinkgoSkip is a regex passed to Ginkgo that skips any test suites matching the regex. ex. "Operator"
 	// Env: GINKGO_SKIP
 	GinkgoSkip string
@@ -322,15 +309,13 @@ var Tests = struct {
 	// Env: ONLY_HEALTH_CHECK_NODES
 	OnlyHealthCheckNodes string
 }{
-	AdHocTestImages:            "tests.adHocTestImages",
-	TestSuites:                 "tests.testSuites",
-	SuiteTimeout:               "tests.suiteTimeout",
-	AdHocTestContainerTimeout:  "tests.adHocTestContainerTimeout",
-	PollingTimeout:             "tests.pollingTimeout",
-	ServiceAccount:             "tests.serviceAccount",
-	SlackChannel:               "tests.slackChannel",
-	SlackWebhook:               "tests.slackWebhook",
-	EnableSlackNotify:          "tests.enableSlackNotify",
+	AdHocTestImages:           "tests.adHocTestImages",
+	TestSuites:                "tests.testSuites",
+	SuiteTimeout:              "tests.suiteTimeout",
+	AdHocTestContainerTimeout: "tests.adHocTestContainerTimeout",
+	PollingTimeout:            "tests.pollingTimeout",
+	ServiceAccount:            "tests.serviceAccount",
+
 	GinkgoSkip:                 "tests.ginkgoSkip",
 	GinkgoFocus:                "tests.focus",
 	GinkgoLogLevel:             "tests.ginkgoLogLevel",
@@ -602,20 +587,28 @@ var LogAnalysis = struct {
 	// Model specifies which LLM model to use
 	// Env: LLM_MODEL
 	Model string
-
-	// SlackWebhook is the Slack webhook URL for log analysis notifications
-	// Env: LOG_ANALYSIS_SLACK_WEBHOOK
-	SlackWebhook string
-
-	// SlackChannel is the default Slack channel for OSDE2E notifications
-	// Env: LOG_ANALYSIS_SLACK_CHANNEL
-	SlackChannel string
 }{
 	EnableAnalysis: "logAnalysis.enableAnalysis",
 	APIKey:         "logAnalysis.apiKey",
 	Model:          "logAnalysis.model",
-	SlackWebhook:   "logAnalysis.slackWebhook",
-	SlackChannel:   "logAnalysis.slackChannel",
+}
+
+var Slack = struct {
+	// SlackNotify is a boolean that determines if Slack notifications should be sent.
+	// Env: SLACK_NOTIFY
+	Enable string
+
+	// Webhook is the Slack webhook URL for log analysis notifications
+	// Env: SLACK_WEBHOOK
+	Webhook string
+
+	// Channel is the default Slack channel for OSDE2E notifications
+	// Env: SLACK_CHANNEL
+	Channel string
+}{
+	Enable:  "slack.enable",
+	Webhook: "slack.webhook",
+	Channel: "slack.channel",
 }
 
 // KrknAI config keys for Kraken AI chaos testing.
@@ -802,14 +795,14 @@ func InitOSDe2eViper() {
 
 	_ = viper.BindEnv(Tests.OnlyHealthCheckNodes, "ONLY_HEALTH_CHECK_NODES")
 
-	viper.SetDefault(Tests.SlackChannel, "hcm-cicd-alerts")
-	_ = viper.BindEnv(Tests.SlackChannel, "SLACK_CHANNEL")
+	viper.SetDefault(Slack.Channel, "hcm-cicd-alerts")
+	_ = viper.BindEnv(Slack.Channel, "SLACK_CHANNEL")
 
-	_ = viper.BindEnv(Tests.SlackWebhook, "SLACK_WEBHOOK")
-	RegisterSecret(Tests.SlackWebhook, "cleanup-job-notification-webhook")
+	_ = viper.BindEnv(Slack.Webhook, "SLACK_WEBHOOK")
+	RegisterSecret(Slack.Webhook, "notifier_slack_webhook")
 
-	viper.SetDefault(Tests.EnableSlackNotify, false)
-	_ = viper.BindEnv(Tests.EnableSlackNotify, "SLACK_NOTIFY")
+	viper.SetDefault(Slack.Enable, false)
+	_ = viper.BindEnv(Slack.Enable, "SLACK_NOTIFY")
 
 	// ----- Cluster -----
 	viper.SetDefault(Cluster.MultiAZ, false)
@@ -958,13 +951,6 @@ func InitOSDe2eViper() {
 
 	viper.SetDefault(LogAnalysis.Model, "gemini-2.5-pro")
 	_ = viper.BindEnv(LogAnalysis.Model, "LLM_MODEL")
-
-	viper.SetDefault(LogAnalysis.SlackWebhook, "")
-	_ = viper.BindEnv(LogAnalysis.SlackWebhook, "LOG_ANALYSIS_SLACK_WEBHOOK")
-	RegisterSecret(LogAnalysis.SlackWebhook, "notifier_slack_webhook")
-
-	viper.SetDefault(LogAnalysis.SlackChannel, defaultNotificationsChannel)
-	_ = viper.BindEnv(LogAnalysis.SlackChannel, "LOG_ANALYSIS_SLACK_CHANNEL")
 
 	// ----- KrknAI Configuration -----
 	viper.SetDefault(KrknAI.Namespace, "default")

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -277,7 +277,7 @@ func (o *E2EOrchestrator) Report(ctx context.Context) error {
 	}
 
 	// Send failure notification (with or without LLM analysis)
-	if o.result.ExitCode != config.Success && viper.GetBool(config.Tests.EnableSlackNotify) {
+	if o.result.ExitCode != config.Success && viper.GetBool(config.Slack.Enable) {
 		o.sendFailureNotification(ctx)
 	}
 
@@ -295,8 +295,8 @@ func (o *E2EOrchestrator) Report(ctx context.Context) error {
 func (o *E2EOrchestrator) sendFailureNotification(ctx context.Context) {
 	reportDir := viper.GetString(config.ReportDir)
 	notificationConfig := slack.BuildNotificationConfig(
-		viper.GetString(config.LogAnalysis.SlackWebhook),
-		viper.GetString(config.LogAnalysis.SlackChannel),
+		viper.GetString(config.Slack.Webhook),
+		viper.GetString(config.Slack.Channel),
 		&slack.ClusterInfo{
 			ID:            viper.GetString(config.Cluster.ID),
 			Name:          viper.GetString(config.Cluster.Name),
@@ -351,8 +351,8 @@ func (o *E2EOrchestrator) sendDeferredNotifications(ctx context.Context) {
 		return
 	}
 
-	webhook := viper.GetString(config.LogAnalysis.SlackWebhook)
-	if webhook == "" || !viper.GetBool(config.Tests.EnableSlackNotify) {
+	webhook := viper.GetString(config.Slack.Webhook)
+	if webhook == "" || !viper.GetBool(config.Slack.Enable) {
 		return
 	}
 

--- a/pkg/e2e/slack_integration_test.go
+++ b/pkg/e2e/slack_integration_test.go
@@ -26,8 +26,8 @@ import (
 //    - Scroll to bottom and copy the channel ID (starts with C, e.g., C06HQR8HN0L)
 //
 // 3. Set environment variables:
-//    export LOG_ANALYSIS_SLACK_WEBHOOK="https://hooks.slack.com/workflows/..."
-//    export LOG_ANALYSIS_SLACK_CHANNEL="C06HQR8HN0L"
+//    export SLACK_WEBHOOK="https://hooks.slack.com/workflows/..."
+//    export SLACK_CHANNEL="C06HQR8HN0L"
 //
 // RUNNING THE TESTS:
 //
@@ -75,20 +75,20 @@ import (
 //
 // Required environment variables:
 //
-//	LOG_ANALYSIS_SLACK_WEBHOOK - Workflow webhook URL
-//	LOG_ANALYSIS_SLACK_CHANNEL - Channel ID (e.g., C06HQR8HN0L)
+//	SLACK_WEBHOOK - Workflow webhook URL
+//	SLACK_CHANNEL - Channel ID (e.g., C06HQR8HN0L)
 //
 // To run:
 //
-//	export LOG_ANALYSIS_SLACK_WEBHOOK="https://hooks.slack.com/workflows/..."
-//	export LOG_ANALYSIS_SLACK_CHANNEL="C06HQR8HN0L"
+//	export SLACK_WEBHOOK="https://hooks.slack.com/workflows/..."
+//	export SLACK_CHANNEL="C06HQR8HN0L"
 //	go test -v -run TestSlackReporter_Integration github.com/openshift/osde2e/pkg/e2e
 func TestSlackReporter_Integration(t *testing.T) {
-	webhookURL := os.Getenv("LOG_ANALYSIS_SLACK_WEBHOOK")
-	channelID := os.Getenv("LOG_ANALYSIS_SLACK_CHANNEL")
+	webhookURL := os.Getenv("SLACK_WEBHOOK")
+	channelID := os.Getenv("SLACK_CHANNEL")
 
 	if webhookURL == "" || channelID == "" {
-		t.Skip("Skipping integration test: LOG_ANALYSIS_SLACK_WEBHOOK or LOG_ANALYSIS_SLACK_CHANNEL not set")
+		t.Skip("Skipping integration test: SLACK_WEBHOOK or SLACK_CHANNEL not set")
 	}
 
 	// Create test cluster info
@@ -159,11 +159,11 @@ func TestSlackReporter_Integration(t *testing.T) {
 
 // TestSlackReporter_Integration_MinimalPayload tests with minimal required fields.
 func TestSlackReporter_Integration_MinimalPayload(t *testing.T) {
-	webhookURL := os.Getenv("LOG_ANALYSIS_SLACK_WEBHOOK")
-	channelID := os.Getenv("LOG_ANALYSIS_SLACK_CHANNEL")
+	webhookURL := os.Getenv("SLACK_WEBHOOK")
+	channelID := os.Getenv("SLACK_CHANNEL")
 
 	if webhookURL == "" || channelID == "" {
-		t.Skip("Skipping integration test: LOG_ANALYSIS_SLACK_WEBHOOK or LOG_ANALYSIS_SLACK_CHANNEL not set")
+		t.Skip("Skipping integration test: SLACK_WEBHOOK or SLACK_CHANNEL not set")
 	}
 
 	// Minimal cluster info
@@ -202,11 +202,11 @@ func TestSlackReporter_Integration_MinimalPayload(t *testing.T) {
 
 // TestSlackReporter_Integration_WithError tests error handling and display.
 func TestSlackReporter_Integration_WithError(t *testing.T) {
-	webhookURL := os.Getenv("LOG_ANALYSIS_SLACK_WEBHOOK")
-	channelID := os.Getenv("LOG_ANALYSIS_SLACK_CHANNEL")
+	webhookURL := os.Getenv("SLACK_WEBHOOK")
+	channelID := os.Getenv("SLACK_CHANNEL")
 
 	if webhookURL == "" || channelID == "" {
-		t.Skip("Skipping integration test: LOG_ANALYSIS_SLACK_WEBHOOK or LOG_ANALYSIS_SLACK_CHANNEL not set")
+		t.Skip("Skipping integration test: SLACK_WEBHOOK or SLACK_CHANNEL not set")
 	}
 
 	clusterInfo := &slack.ClusterInfo{

--- a/pkg/krknai/krknai_integration_test.go
+++ b/pkg/krknai/krknai_integration_test.go
@@ -49,7 +49,7 @@ func TestAnalyzeLogs_MissingAPIKey(t *testing.T) {
 	viper.Set(config.ReportDir, reportDir)
 	viper.Set(config.Cluster.ID, "test-cluster-123")
 	viper.Set(config.LogAnalysis.APIKey, "") // No API key
-	viper.Set(config.Tests.EnableSlackNotify, false)
+	viper.Set(config.Slack.Enable, false)
 
 	k := &KrknAI{
 		result: &orchestrator.Result{},
@@ -201,7 +201,7 @@ func TestAnalyzeLogs_WithRealLLM(t *testing.T) {
 	viper.Set(config.CloudProvider.CloudProviderID, "aws")
 	viper.Set(config.Cluster.Version, "4.17.3")
 	viper.Set(config.LogAnalysis.APIKey, apiKey)
-	viper.Set(config.Tests.EnableSlackNotify, false)
+	viper.Set(config.Slack.Enable, false)
 
 	// Test the full AnalyzeLogs workflow
 	k := &KrknAI{
@@ -248,9 +248,9 @@ func captureViperConfig() viperConfig {
 		cloudProvider:     viper.GetString(config.CloudProvider.CloudProviderID),
 		version:           viper.GetString(config.Cluster.Version),
 		apiKey:            viper.GetString(config.LogAnalysis.APIKey),
-		enableSlackNotify: viper.GetBool(config.Tests.EnableSlackNotify),
-		slackWebhook:      viper.GetString(config.LogAnalysis.SlackWebhook),
-		slackChannel:      viper.GetString(config.LogAnalysis.SlackChannel),
+		enableSlackNotify: viper.GetBool(config.Slack.Enable),
+		slackWebhook:      viper.GetString(config.Slack.Webhook),
+		slackChannel:      viper.GetString(config.Slack.Channel),
 	}
 }
 
@@ -263,7 +263,7 @@ func restoreViperConfig(cfg viperConfig) {
 	viper.Set(config.CloudProvider.CloudProviderID, cfg.cloudProvider)
 	viper.Set(config.Cluster.Version, cfg.version)
 	viper.Set(config.LogAnalysis.APIKey, cfg.apiKey)
-	viper.Set(config.Tests.EnableSlackNotify, cfg.enableSlackNotify)
-	viper.Set(config.LogAnalysis.SlackWebhook, cfg.slackWebhook)
-	viper.Set(config.LogAnalysis.SlackChannel, cfg.slackChannel)
+	viper.Set(config.Slack.Enable, cfg.enableSlackNotify)
+	viper.Set(config.Slack.Webhook, cfg.slackWebhook)
+	viper.Set(config.Slack.Channel, cfg.slackChannel)
 }


### PR DESCRIPTION
 Consolidates and deduplicates Slack configuration by creating a dedicated config.Slack section, eliminating scattered Slack settings across config.Tests and config.LogAnalysis.


 - Created new config.Slack section with three unified configuration keys:
    - slack.enable (previously tests.enableSlackNotify)
    - slack.webhook (previously duplicated in tests.slackWebhook and logAnalysis.slackWebhook)
    - slack.channel (previously duplicated in tests.slackChannel and logAnalysis.slackChannel)



