### PR TITLE
SDCICD-1783 Capture stderr in test_output.log

### DIFF
--- a/cmd/osde2e/main.go
+++ b/cmd/osde2e/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
@@ -78,8 +79,25 @@ func main() {
 	defer logFile.Close()
 
 	mw := io.MultiWriter(os.Stdout, logFile)
-	config := textlogger.NewConfig(textlogger.Output(mw))
-	logger := textlogger.NewLogger(config)
+
+	// Tee stderr into the log file so that panics and subprocess
+	// error output are captured in the uploaded artifact.
+	var stderrW *os.File
+	stderrDone := make(chan struct{})
+	origStderr := os.Stderr
+	if stderrR, sw, err := os.Pipe(); err == nil {
+		stderrW = sw
+		os.Stderr = stderrW
+		go func() {
+			defer close(stderrDone)
+			_, _ = io.Copy(io.MultiWriter(origStderr, logFile), stderrR)
+		}()
+	} else {
+		close(stderrDone)
+	}
+
+	cfg := textlogger.NewConfig(textlogger.Output(mw))
+	logger := textlogger.NewLogger(cfg)
 	ctx := logr.NewContext(context.Background(), logger)
 	root.SetContext(ctx)
 
@@ -91,10 +109,20 @@ func main() {
 	spi.RegisterProvider("rosa", func() (spi.Provider, error) { return rosaprovider.New(ctx) })
 	spi.RegisterProvider("ocm", func() (spi.Provider, error) { return ocmprovider.New() })
 
+	exitCode := 0
 	if err := root.Execute(); err != nil {
 		logger.Error(err, "command execution failed")
-		os.Exit(1)
+		exitCode = 1
 	}
 
-	os.Exit(0)
+	// Flush stderr pipe before exit so all output reaches the log file.
+	if stderrW != nil {
+		_ = stderrW.Close()
+	}
+	select {
+	case <-stderrDone:
+	case <-time.After(5 * time.Second):
+		logger.Error(fmt.Errorf("timeout waiting for stderr drain"), "forcing exit")
+	}
+	os.Exit(exitCode)
 }

--- a/pkg/e2e/adhoctestimages/adhoctestimages.go
+++ b/pkg/e2e/adhoctestimages/adhoctestimages.go
@@ -94,37 +94,32 @@ var _ = ginkgo.Describe("Ad Hoc Test Images", ginkgo.Ordered, ginkgo.ContinueOnF
 
 			logger.Info("running test suite", "suite", testImage, "timeout", exeConfig.Timeout)
 			results, err := exe.Execute(ctx, testImage)
+			if err != nil {
+				logger.Error(err, "execution failed", "suite", testImage)
+			}
 
-			// Defer the Expect calls to ensure they always run and get logged
-			defer func() {
-				Expect(err).NotTo(HaveOccurred(), "failed to run test suite")
-				if results != nil {
-					for _, suite := range results.Suites {
-						for _, test := range suite.Tests {
-							Expect(test.Error).To(BeNil(), fmt.Sprintf("failed test case: %q", test.Name))
-						}
-					}
-				}
-			}()
-
-			// Collect failures in single loop
 			var allFailures []string
-
-			// Check for execution failure
 			if err != nil {
 				allFailures = append(allFailures, fmt.Sprintf("execution failure: %v", err))
 			}
-
-			// Collect test case failures in single loop
 			if results != nil {
 				for _, suite := range results.Suites {
+					var failed int
 					for _, test := range suite.Tests {
 						if test.Error != nil {
+							failed++
 							allFailures = append(allFailures, fmt.Sprintf("test case failure: %q - %v", test.Name, test.Error))
 						}
 					}
+					logger.Info("suite results", "suite", suite.Name, "total", len(suite.Tests), "failed", failed)
 				}
 			}
+
+			defer func() {
+				if len(allFailures) > 0 {
+					ginkgo.Fail(strings.Join(allFailures, "\n"))
+				}
+			}()
 
 			if len(allFailures) > 0 {
 				combinedErr := fmt.Errorf("failures in %s: %s", testImage, strings.Join(allFailures, "; "))

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -271,6 +271,15 @@ func (o *E2EOrchestrator) Report(ctx context.Context) error {
 		return nil
 	}
 
+	// Log analysis results before S3 upload so they are included in
+	// the uploaded test_output.log artifact.
+	pending := adhoctestimages.DrainPendingNotifications()
+	for _, p := range pending {
+		if p.AnalysisContent != "" {
+			log.Printf("=== Log Analysis Result for %s ===\n%s", p.TestSuite.Image, p.AnalysisContent)
+		}
+	}
+
 	// Upload artifacts to S3
 	if viper.GetString(config.Tests.LogBucket) != "" {
 		cleanStaleJunitFiles()
@@ -279,9 +288,7 @@ func (o *E2EOrchestrator) Report(ctx context.Context) error {
 		}
 	}
 
-	// Drain per-suite pending notifications. If any were queued (suites ran),
-	// send them; otherwise fall back to global failure notification.
-	pending := adhoctestimages.DrainPendingNotifications()
+	// Send notifications after S3 upload so presigned URLs are available.
 	if len(pending) > 0 {
 		o.sendDeferredNotifications(ctx, pending)
 	} else if o.result.ExitCode != config.Success && viper.GetBool(config.Tests.EnableSlackNotify) {
@@ -584,6 +591,27 @@ func (o *E2EOrchestrator) runTestsInPhase(phaseName, description string) bool {
 		)
 		if err != nil {
 			log.Printf("Error creating junit report: %v", err)
+		}
+
+		// Log failure details so they appear in test_output.log.
+		// Ginkgo's output interceptor is inactive during ReportAfterSuite,
+		// so log.Printf writes directly to the log file via the MultiWriter.
+		for _, spec := range report.SpecReports {
+			if !spec.State.Is(types.SpecStateFailed) && !spec.State.Is(types.SpecStatePanicked) {
+				continue
+			}
+			log.Printf("  FAIL: %s", spec.FullText())
+			if spec.Failure.Message != "" {
+				log.Printf("        %s", spec.Failure.Message)
+			}
+			log.Printf("        %s:%d", spec.Failure.Location.FileName, spec.Failure.Location.LineNumber)
+			if captured := spec.CapturedGinkgoWriterOutput; captured != "" {
+				const maxCaptured = 2000
+				if len(captured) > maxCaptured {
+					captured = captured[:maxCaptured] + "\n... (truncated)"
+				}
+				log.Printf("        --- Captured Output ---\n%s", captured)
+			}
 		}
 	})
 


### PR DESCRIPTION
test_output.log previously captured only stdout, so critical stderr diagnostics were missing from the S3 artifact and Slack notifications. 

- This fix tees stderr into test_output.log with a safe fallback and drains all buffered output before exiting.
- Captures Ginkgo failure messages per spec.