### PR TITLE
SDCICD-1763 Remove duplicate Log Analysis Result

### DIFF
--- a/pkg/e2e/adhoctestimages/adhoctestimages.go
+++ b/pkg/e2e/adhoctestimages/adhoctestimages.go
@@ -3,7 +3,6 @@ package adhoctestimages
 import (
 	"context"
 	"fmt"
-	"log"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -186,7 +185,6 @@ func runLogAnalysisForAdHocTestImage(ctx context.Context, logger logr.Logger, te
 	}
 
 	logger.Info("Log analysis completed successfully", "image", testSuite.Image, "resultsDir", fmt.Sprintf("%s/%s/", artifactsDir, analysisengine.AnalysisDirName))
-	log.Printf("=== Log Analysis Result for %s ===\n%s", testSuite.Image, result.Content)
 
 	return result.Content
 }


### PR DESCRIPTION
The LLM log analysis result was printed twice in test_output.log:
once from `adhoctestimages.go` (per-image) and again from the global `e2e.go` ReportAfterSuite summary. 

Remove the `log.Printf` call in `runLogAnalysisForAdHocTestImage`