### PR TITLE
SDCICD-1804 Fix S3 upload failure on GCP clusters

### DIFF
--- a/pkg/common/aws/s3.go
+++ b/pkg/common/aws/s3.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	velerosubstr = "managed-velero"
-	logsBucket   = "osde2e-logs"
+	velerosubstr     = "managed-velero"
+	logsBucket       = "osde2e-logs"
+	logsBucketRegion = "us-east-1"
 )
 
 // Pre-compiled regex for extracting cluster name from bucket name
@@ -145,24 +146,24 @@ type S3UploadResult struct {
 func NewS3Uploader(component string) (*S3Uploader, error) {
 	bucket := viper.GetString(config.Tests.LogBucket)
 
-	// Ensure region is set (default to us-east-1)
-	if viper.GetString(config.AWSRegion) == "" {
-		viper.Set(config.AWSRegion, "us-east-1")
-	}
-
-	// Use the global AWS session infrastructure
+	// Use the global AWS session for credentials, but override the region
+	// for the S3 client. The log bucket lives in a fixed AWS region that is
+	// independent of the cluster's cloud provider region (which may be a GCP
+	// region like "us-east1" that is invalid for AWS).
 	sess, err := CcsAwsSession.GetSession()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get AWS session: %w", err)
 	}
+
+	s3Sess := sess.Copy(aws.NewConfig().WithRegion(logsBucketRegion))
 
 	if component == "" {
 		component = "unknown"
 	}
 
 	return &S3Uploader{
-		s3Client:  s3.New(sess),
-		uploader:  s3manager.NewUploader(sess),
+		s3Client:  s3.New(s3Sess),
+		uploader:  s3manager.NewUploader(s3Sess),
 		bucket:    bucket,
 		component: component,
 		category:  "test-results",  // fixed category for S3 path organization

--- a/pkg/common/aws/s3.go
+++ b/pkg/common/aws/s3.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"log"
@@ -17,6 +18,10 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 )
+
+// ErrNoAWSCredentials is returned when S3 upload is requested but no AWS
+// credentials are configured. Callers should treat this as a non-fatal skip.
+var ErrNoAWSCredentials = errors.New("S3 upload skipped: AWS credentials not configured (set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY)")
 
 const (
 	velerosubstr     = "managed-velero"
@@ -145,6 +150,12 @@ type S3UploadResult struct {
 // and reusability. Caller should check config and decide whether to upload.
 func NewS3Uploader(component string) (*S3Uploader, error) {
 	bucket := viper.GetString(config.Tests.LogBucket)
+
+	if viper.GetString(config.AWSProfile) == "" &&
+		viper.GetString(config.AWSAccessKey) == "" &&
+		viper.GetString(config.AWSSecretAccessKey) == "" {
+		return nil, ErrNoAWSCredentials
+	}
 
 	// Use the global AWS session for credentials, but override the region
 	// for the S3 client. The log bucket lives in a fixed AWS region that is

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -418,11 +419,12 @@ func (o *E2EOrchestrator) uploadToS3() error {
 
 	component := deriveComponentFromFirstImage()
 	uploader, err := aws.NewS3Uploader(component)
+	if errors.Is(err, aws.ErrNoAWSCredentials) {
+		log.Printf("%v", err)
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("failed to create S3 uploader: %w", err)
-	}
-	if uploader == nil {
-		return nil
 	}
 
 	reportDir := viper.GetString(config.ReportDir)


### PR DESCRIPTION
- S3 artifact uploads fail on GCP clusters because the cluster's cloud provider region (us-east1, GCP format) is used as the AWS S3 region, producing an invalid endpoint s3.us-east1.amazonaws.com.

- Add a `logsBucketRegion` constant (`us-east-1`) in `s3.go`, co-located with the existing `logsBucket` constant.
- Use `sess.Copy()` to create a region-overridden S3 session that keeps the shared AWS credentials but always targets the correct bucket region, independent of the cluster's cloud provider.

Co-authored-by: Cursor [cursor@cursor.com](mailto:cursor@cursor.com)