### PR TITLE
[SREP-4255] Add --security-group flag to cleanup command

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -280,6 +280,7 @@ func run(_ context.Context) (msg Message, err error) {
 	}
 	log.Printf("Found %d active clusters for cleanup operations\n", len(activeClusters))
 
+	// Security groups exist inside VPCs so we want to make sure they are cleaned up before we try to clean up the VPCs
 	if args.securityGroup {
 		sgDeletedCounter := 0
 		sgFailedCounter := 0

--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -48,6 +48,7 @@ var args struct {
 	sendSummary     bool
 	ec2             bool
 	vpc             bool
+	securityGroup   bool
 }
 
 type Message struct {
@@ -58,6 +59,7 @@ type Message struct {
 	IPErrors  string `json:"ip"`
 	EC2Errors string `json:"ec2"`
 	VPCErrors string `json:"vpc"`
+	SGErrors  string `json:"sg"`
 }
 
 func init() {
@@ -147,6 +149,13 @@ func init() {
 		"Cleanup vpc resources",
 	)
 
+	flags.BoolVar(
+		&args.securityGroup,
+		"security-group",
+		false,
+		"Cleanup leftover security groups in orphaned VPCs (workaround for OCPBUGS-74960)",
+	)
+
 	_ = Cmd.RegisterFlagCompletionFunc("output-format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return []string{"json", "prom"}, cobra.ShellCompDirectiveDefault
 	})
@@ -221,6 +230,7 @@ func run(_ context.Context) (msg Message, err error) {
 	var ipErrorBuilder strings.Builder
 	var ec2ErrorBuilder strings.Builder
 	var vpcErrorBuilder strings.Builder
+	var sgErrorBuilder strings.Builder
 
 	defer func() {
 		buildFile := ""
@@ -240,6 +250,7 @@ func run(_ context.Context) (msg Message, err error) {
 			IPErrors:  "IP Errors: " + ipErrorBuilder.String(),
 			EC2Errors: "EC2 Errors: " + ec2ErrorBuilder.String(),
 			VPCErrors: "VPC Errors: " + vpcErrorBuilder.String(),
+			SGErrors:  "SG Errors: " + sgErrorBuilder.String(),
 		}
 	}()
 
@@ -268,6 +279,16 @@ func run(_ context.Context) (msg Message, err error) {
 		return msg, fmt.Errorf("could not collect active clusters: %v", err)
 	}
 	log.Printf("Found %d active clusters for cleanup operations\n", len(activeClusters))
+
+	if args.securityGroup {
+		sgDeletedCounter := 0
+		sgFailedCounter := 0
+		err = aws.CcsAwsSession.CleanupSecurityGroups(activeClusters, args.dryRun, args.sendSummary, &sgDeletedCounter, &sgFailedCounter, &sgErrorBuilder)
+		summaryBuilder.WriteString("Security Groups: " + strconv.Itoa(sgDeletedCounter) + "/" + strconv.Itoa(sgFailedCounter) + "\n")
+		if err != nil {
+			return msg, fmt.Errorf("could not cleanup security groups: %s", err.Error())
+		}
+	}
 
 	if args.vpc {
 		vpcCounters, err := aws.CcsAwsSession.CleanupVPCs(activeClusters, args.dryRun, args.sendSummary, &vpcErrorBuilder)

--- a/pkg/common/aws/securitygroups.go
+++ b/pkg/common/aws/securitygroups.go
@@ -1,0 +1,168 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/openshift/osde2e/pkg/common/config"
+)
+
+// CleanupSecurityGroups deletes all non-default security groups in orphaned osde2e VPCs
+// whose CloudFormation stacks are in DELETE_FAILED state. Leftover security groups
+// (e.g. from OCPBUGS-74960) block CloudFormation stack deletion, so removing them
+// allows the subsequent --vpc cleanup to succeed.
+func (CcsAwsSession *ccsAwsSession) CleanupSecurityGroups(activeClusters map[string]bool, dryrun bool, sendSummary bool,
+	deletedCounter *int, failedCounter *int, errorBuilder *strings.Builder,
+) error {
+	err := CcsAwsSession.GetAWSSessions()
+	if err != nil {
+		return err
+	}
+
+	// Find all osde2e VPCs
+	results, err := CcsAwsSession.ec2.DescribeVpcs(&ec2.DescribeVpcsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("tag:Name"),
+				Values: []*string{aws.String("osde2e-*")},
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	if len(results.Vpcs) == 0 {
+		log.Println("No osde2e VPCs found for security group cleanup")
+		return nil
+	}
+
+	log.Printf("Found %d osde2e VPCs to check for leftover security groups\n", len(results.Vpcs))
+
+	// Build active VPC stack names
+	activeVpcStacks := make(map[string]bool)
+	for clusterName := range activeClusters {
+		activeVpcStacks[clusterName+"-vpc"] = true
+	}
+
+	cfnClient := cloudformation.New(CcsAwsSession.session)
+
+	for _, vpc := range results.Vpcs {
+		vpcID := aws.StringValue(vpc.VpcId)
+
+		var vpcName string
+		for _, tag := range vpc.Tags {
+			if aws.StringValue(tag.Key) == "Name" {
+				vpcName = aws.StringValue(tag.Value)
+				break
+			}
+		}
+
+		if vpcName == "" {
+			continue
+		}
+
+		vpcStackName := getClusterNameFromVPCName(vpcName)
+
+		// Skip VPCs belonging to active clusters
+		if activeVpcStacks[vpcStackName] {
+			log.Printf("Skipping security group cleanup for active cluster VPC: %s\n", vpcName)
+			continue
+		}
+
+		// Verify the stack exists and is in a failed state before cleaning up
+		stackResp, err := cfnClient.DescribeStacks(&cloudformation.DescribeStacksInput{
+			StackName: aws.String(vpcStackName),
+		})
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ValidationError" {
+				// Stack does not exist — nothing to clean up
+				continue
+			}
+			log.Printf("Warning: failed to describe stack %s: %v\n", vpcStackName, err)
+			continue
+		}
+
+		if len(stackResp.Stacks) == 0 {
+			continue
+		}
+		stackStatus := aws.StringValue(stackResp.Stacks[0].StackStatus)
+		if stackStatus != "DELETE_FAILED" {
+			log.Printf("Stack %s is in %s state, skipping security group cleanup\n", vpcStackName, stackStatus)
+			continue
+		}
+
+		// Find all non-default security groups in this VPC
+		sgResult, err := CcsAwsSession.ec2.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+			Filters: []*ec2.Filter{
+				{
+					Name:   aws.String("vpc-id"),
+					Values: []*string{aws.String(vpcID)},
+				},
+			},
+		})
+		if err != nil {
+			log.Printf("Warning: failed to describe security groups for VPC %s: %v\n", vpcID, err)
+			continue
+		}
+
+		for _, sg := range sgResult.SecurityGroups {
+			sgID := aws.StringValue(sg.GroupId)
+			sgName := aws.StringValue(sg.GroupName)
+
+			if sgName == "default" {
+				continue
+			}
+
+			if dryrun {
+				log.Printf("Would delete security group %s (%s) in VPC %s\n", sgID, sgName, vpcID)
+				continue
+			}
+
+			// Revoke all ingress/egress rules before deleting, to avoid DependencyViolation errors
+			if len(sg.IpPermissions) > 0 {
+				_, err := CcsAwsSession.ec2.RevokeSecurityGroupIngress(&ec2.RevokeSecurityGroupIngressInput{
+					GroupId:       aws.String(sgID),
+					IpPermissions: sg.IpPermissions,
+				})
+				if err != nil {
+					log.Printf("Warning: failed to revoke ingress rules for SG %s: %v\n", sgID, err)
+				}
+			}
+
+			if len(sg.IpPermissionsEgress) > 0 {
+				_, err := CcsAwsSession.ec2.RevokeSecurityGroupEgress(&ec2.RevokeSecurityGroupEgressInput{
+					GroupId:       aws.String(sgID),
+					IpPermissions: sg.IpPermissionsEgress,
+				})
+				if err != nil {
+					log.Printf("Warning: failed to revoke egress rules for SG %s: %v\n", sgID, err)
+				}
+			}
+
+			log.Printf("Deleting security group %s (%s) in VPC %s\n", sgID, sgName, vpcID)
+			_, err := CcsAwsSession.ec2.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
+				GroupId: aws.String(sgID),
+			})
+			if err != nil {
+				*failedCounter++
+				errorMsg := fmt.Sprintf("Failed to delete security group %s (%s): %v\n", sgID, sgName, err)
+				log.Print(errorMsg)
+				if sendSummary && errorBuilder.Len() < config.SlackMessageLength {
+					errorBuilder.WriteString(errorMsg)
+				}
+				continue
+			}
+
+			*deletedCounter++
+			log.Printf("Deleted security group %s (%s)\n", sgID, sgName)
+		}
+	}
+
+	return nil
+}

--- a/pkg/common/aws/securitygroups.go
+++ b/pkg/common/aws/securitygroups.go
@@ -12,6 +12,18 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 )
 
+type securityGroupEC2 interface {
+	DescribeVpcs(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
+	DescribeSecurityGroups(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error)
+	RevokeSecurityGroupIngress(*ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error)
+	RevokeSecurityGroupEgress(*ec2.RevokeSecurityGroupEgressInput) (*ec2.RevokeSecurityGroupEgressOutput, error)
+	DeleteSecurityGroup(*ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error)
+}
+
+type securityGroupCFN interface {
+	DescribeStacks(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error)
+}
+
 // CleanupSecurityGroups deletes all non-default security groups in orphaned osde2e VPCs
 // whose CloudFormation stacks are in DELETE_FAILED state. Leftover security groups
 // (e.g. from OCPBUGS-74960) block CloudFormation stack deletion, so removing them
@@ -24,8 +36,16 @@ func (CcsAwsSession *ccsAwsSession) CleanupSecurityGroups(activeClusters map[str
 		return err
 	}
 
+	cfnClient := cloudformation.New(CcsAwsSession.session)
+	return cleanupSecurityGroups(CcsAwsSession.ec2, cfnClient, activeClusters, dryrun, sendSummary, deletedCounter, failedCounter, errorBuilder)
+}
+
+func cleanupSecurityGroups(ec2Client securityGroupEC2, cfnClient securityGroupCFN,
+	activeClusters map[string]bool, dryrun bool, sendSummary bool,
+	deletedCounter *int, failedCounter *int, errorBuilder *strings.Builder,
+) error {
 	// Find all osde2e VPCs
-	results, err := CcsAwsSession.ec2.DescribeVpcs(&ec2.DescribeVpcsInput{
+	results, err := ec2Client.DescribeVpcs(&ec2.DescribeVpcsInput{
 		Filters: []*ec2.Filter{
 			{
 				Name:   aws.String("tag:Name"),
@@ -49,8 +69,6 @@ func (CcsAwsSession *ccsAwsSession) CleanupSecurityGroups(activeClusters map[str
 	for clusterName := range activeClusters {
 		activeVpcStacks[clusterName+"-vpc"] = true
 	}
-
-	cfnClient := cloudformation.New(CcsAwsSession.session)
 
 	for _, vpc := range results.Vpcs {
 		vpcID := aws.StringValue(vpc.VpcId)
@@ -98,7 +116,7 @@ func (CcsAwsSession *ccsAwsSession) CleanupSecurityGroups(activeClusters map[str
 		}
 
 		// Find all non-default security groups in this VPC
-		sgResult, err := CcsAwsSession.ec2.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
+		sgResult, err := ec2Client.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
 			Filters: []*ec2.Filter{
 				{
 					Name:   aws.String("vpc-id"),
@@ -126,7 +144,7 @@ func (CcsAwsSession *ccsAwsSession) CleanupSecurityGroups(activeClusters map[str
 
 			// Revoke all ingress/egress rules before deleting, to avoid DependencyViolation errors
 			if len(sg.IpPermissions) > 0 {
-				_, err := CcsAwsSession.ec2.RevokeSecurityGroupIngress(&ec2.RevokeSecurityGroupIngressInput{
+				_, err := ec2Client.RevokeSecurityGroupIngress(&ec2.RevokeSecurityGroupIngressInput{
 					GroupId:       aws.String(sgID),
 					IpPermissions: sg.IpPermissions,
 				})
@@ -136,7 +154,7 @@ func (CcsAwsSession *ccsAwsSession) CleanupSecurityGroups(activeClusters map[str
 			}
 
 			if len(sg.IpPermissionsEgress) > 0 {
-				_, err := CcsAwsSession.ec2.RevokeSecurityGroupEgress(&ec2.RevokeSecurityGroupEgressInput{
+				_, err := ec2Client.RevokeSecurityGroupEgress(&ec2.RevokeSecurityGroupEgressInput{
 					GroupId:       aws.String(sgID),
 					IpPermissions: sg.IpPermissionsEgress,
 				})
@@ -146,7 +164,7 @@ func (CcsAwsSession *ccsAwsSession) CleanupSecurityGroups(activeClusters map[str
 			}
 
 			log.Printf("Deleting security group %s (%s) in VPC %s\n", sgID, sgName, vpcID)
-			_, err := CcsAwsSession.ec2.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
+			_, err := ec2Client.DeleteSecurityGroup(&ec2.DeleteSecurityGroupInput{
 				GroupId: aws.String(sgID),
 			})
 			if err != nil {

--- a/pkg/common/aws/securitygroups_test.go
+++ b/pkg/common/aws/securitygroups_test.go
@@ -1,0 +1,734 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+type mockSGEC2 struct {
+	describeVpcsFn        func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error)
+	describeSGFn          func(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error)
+	revokeIngressFn       func(*ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error)
+	revokeEgressFn        func(*ec2.RevokeSecurityGroupEgressInput) (*ec2.RevokeSecurityGroupEgressOutput, error)
+	deleteSecurityGroupFn func(*ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error)
+}
+
+func (m *mockSGEC2) DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+	return m.describeVpcsFn(input)
+}
+
+func (m *mockSGEC2) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+	return m.describeSGFn(input)
+}
+
+func (m *mockSGEC2) RevokeSecurityGroupIngress(input *ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+	if m.revokeIngressFn != nil {
+		return m.revokeIngressFn(input)
+	}
+	return &ec2.RevokeSecurityGroupIngressOutput{}, nil
+}
+
+func (m *mockSGEC2) RevokeSecurityGroupEgress(input *ec2.RevokeSecurityGroupEgressInput) (*ec2.RevokeSecurityGroupEgressOutput, error) {
+	if m.revokeEgressFn != nil {
+		return m.revokeEgressFn(input)
+	}
+	return &ec2.RevokeSecurityGroupEgressOutput{}, nil
+}
+
+func (m *mockSGEC2) DeleteSecurityGroup(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+	return m.deleteSecurityGroupFn(input)
+}
+
+type mockSGCFN struct {
+	describeStacksFn func(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error)
+}
+
+func (m *mockSGCFN) DescribeStacks(input *cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+	return m.describeStacksFn(input)
+}
+
+func makeVPC(id, name string) *ec2.Vpc {
+	vpc := &ec2.Vpc{
+		VpcId: aws.String(id),
+	}
+	if name != "" {
+		vpc.Tags = []*ec2.Tag{
+			{Key: aws.String("Name"), Value: aws.String(name)},
+		}
+	}
+	return vpc
+}
+
+func makeSG(id, name string, ingress, egress []*ec2.IpPermission) *ec2.SecurityGroup {
+	return &ec2.SecurityGroup{
+		GroupId:             aws.String(id),
+		GroupName:           aws.String(name),
+		IpPermissions:       ingress,
+		IpPermissionsEgress: egress,
+	}
+}
+
+func deleteFailedStack(name string) *cloudformation.DescribeStacksOutput {
+	return &cloudformation.DescribeStacksOutput{
+		Stacks: []*cloudformation.Stack{
+			{StackName: aws.String(name), StackStatus: aws.String("DELETE_FAILED")},
+		},
+	}
+}
+
+func TestCleanupSecurityGroups_NoVPCs(t *testing.T) {
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return &ec2.DescribeVpcsOutput{Vpcs: []*ec2.Vpc{}}, nil
+		},
+	}
+
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, &mockSGCFN{}, nil, false, false, &deleted, &failed, &errBuilder)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deleted != 0 || failed != 0 {
+		t.Errorf("expected 0 deleted/failed, got %d/%d", deleted, failed)
+	}
+}
+
+func TestCleanupSecurityGroups_DescribeVpcsError(t *testing.T) {
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return nil, fmt.Errorf("ec2 api error")
+		},
+	}
+
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, &mockSGCFN{}, nil, false, false, &deleted, &failed, &errBuilder)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestCleanupSecurityGroups_SkipsVPCWithNoNameTag(t *testing.T) {
+	cfnCalled := false
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return &ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{makeVPC("vpc-1", "")},
+			}, nil
+		},
+	}
+	cfnMock := &mockSGCFN{
+		describeStacksFn: func(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+			cfnCalled = true
+			return nil, fmt.Errorf("should not be called")
+		},
+	}
+
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, cfnMock, nil, false, false, &deleted, &failed, &errBuilder)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfnCalled {
+		t.Error("DescribeStacks should not be called for VPCs with no Name tag")
+	}
+}
+
+func TestCleanupSecurityGroups_SkipsActiveClusterVPC(t *testing.T) {
+	cfnCalled := false
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return &ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{makeVPC("vpc-1", "osde2e-abcde-fghij-vpc")},
+			}, nil
+		},
+	}
+	cfnMock := &mockSGCFN{
+		describeStacksFn: func(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+			cfnCalled = true
+			return nil, fmt.Errorf("should not be called")
+		},
+	}
+
+	activeClusters := map[string]bool{"osde2e-abcde": true}
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, cfnMock, activeClusters, false, false, &deleted, &failed, &errBuilder)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfnCalled {
+		t.Error("DescribeStacks should not be called for VPCs belonging to active clusters")
+	}
+}
+
+func TestCleanupSecurityGroups_SkipsWhenStackNotFound(t *testing.T) {
+	sgCalled := false
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return &ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{makeVPC("vpc-1", "osde2e-abcde-fghij-vpc")},
+			}, nil
+		},
+		describeSGFn: func(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+			sgCalled = true
+			return nil, fmt.Errorf("should not be called")
+		},
+	}
+	cfnMock := &mockSGCFN{
+		describeStacksFn: func(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+			return nil, awserr.New("ValidationError", "Stack does not exist", nil)
+		},
+	}
+
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, cfnMock, nil, false, false, &deleted, &failed, &errBuilder)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sgCalled {
+		t.Error("DescribeSecurityGroups should not be called when stack does not exist")
+	}
+}
+
+func TestCleanupSecurityGroups_SkipsNonValidationErrorFromDescribeStacks(t *testing.T) {
+	sgCalled := false
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return &ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{makeVPC("vpc-1", "osde2e-abcde-fghij-vpc")},
+			}, nil
+		},
+		describeSGFn: func(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+			sgCalled = true
+			return nil, fmt.Errorf("should not be called")
+		},
+	}
+	cfnMock := &mockSGCFN{
+		describeStacksFn: func(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+			return nil, awserr.New("InternalError", "something broke", nil)
+		},
+	}
+
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, cfnMock, nil, false, false, &deleted, &failed, &errBuilder)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sgCalled {
+		t.Error("DescribeSecurityGroups should not be called when DescribeStacks fails")
+	}
+}
+
+func TestCleanupSecurityGroups_SkipsStackNotInDeleteFailed(t *testing.T) {
+	sgCalled := false
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return &ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{makeVPC("vpc-1", "osde2e-abcde-fghij-vpc")},
+			}, nil
+		},
+		describeSGFn: func(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+			sgCalled = true
+			return nil, fmt.Errorf("should not be called")
+		},
+	}
+	cfnMock := &mockSGCFN{
+		describeStacksFn: func(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+			return &cloudformation.DescribeStacksOutput{
+				Stacks: []*cloudformation.Stack{
+					{StackName: aws.String("osde2e-abcde-vpc"), StackStatus: aws.String("CREATE_COMPLETE")},
+				},
+			}, nil
+		},
+	}
+
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, cfnMock, nil, false, false, &deleted, &failed, &errBuilder)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sgCalled {
+		t.Error("DescribeSecurityGroups should not be called when stack is not in DELETE_FAILED state")
+	}
+}
+
+func TestCleanupSecurityGroups_SkipsEmptyStacksResponse(t *testing.T) {
+	sgCalled := false
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return &ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{makeVPC("vpc-1", "osde2e-abcde-fghij-vpc")},
+			}, nil
+		},
+		describeSGFn: func(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+			sgCalled = true
+			return nil, fmt.Errorf("should not be called")
+		},
+	}
+	cfnMock := &mockSGCFN{
+		describeStacksFn: func(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+			return &cloudformation.DescribeStacksOutput{Stacks: []*cloudformation.Stack{}}, nil
+		},
+	}
+
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, cfnMock, nil, false, false, &deleted, &failed, &errBuilder)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sgCalled {
+		t.Error("DescribeSecurityGroups should not be called when DescribeStacks returns no stacks")
+	}
+}
+
+func TestCleanupSecurityGroups_SkipsDefaultSecurityGroup(t *testing.T) {
+	var deletedIDs []string
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return &ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{makeVPC("vpc-1", "osde2e-abcde-fghij-vpc")},
+			}, nil
+		},
+		describeSGFn: func(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+			return &ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{
+					makeSG("sg-default", "default", nil, nil),
+					makeSG("sg-custom", "my-sg", nil, nil),
+				},
+			}, nil
+		},
+		deleteSecurityGroupFn: func(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+			deletedIDs = append(deletedIDs, aws.StringValue(input.GroupId))
+			return &ec2.DeleteSecurityGroupOutput{}, nil
+		},
+	}
+	cfnMock := &mockSGCFN{
+		describeStacksFn: func(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+			return deleteFailedStack("osde2e-abcde-vpc"), nil
+		},
+	}
+
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, cfnMock, nil, false, false, &deleted, &failed, &errBuilder)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("expected 1 deleted, got %d", deleted)
+	}
+	if len(deletedIDs) != 1 || deletedIDs[0] != "sg-custom" {
+		t.Errorf("expected only sg-custom to be deleted, got %v", deletedIDs)
+	}
+}
+
+func TestCleanupSecurityGroups_DeletesWithRuleRevocation(t *testing.T) {
+	var revokedIngressIDs, revokedEgressIDs, deletedIDs []string
+
+	ingress := []*ec2.IpPermission{{IpProtocol: aws.String("tcp")}}
+	egress := []*ec2.IpPermission{{IpProtocol: aws.String("-1")}}
+
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return &ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{makeVPC("vpc-1", "osde2e-abcde-fghij-vpc")},
+			}, nil
+		},
+		describeSGFn: func(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+			return &ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{
+					makeSG("sg-1", "custom-sg", ingress, egress),
+				},
+			}, nil
+		},
+		revokeIngressFn: func(input *ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+			revokedIngressIDs = append(revokedIngressIDs, aws.StringValue(input.GroupId))
+			return &ec2.RevokeSecurityGroupIngressOutput{}, nil
+		},
+		revokeEgressFn: func(input *ec2.RevokeSecurityGroupEgressInput) (*ec2.RevokeSecurityGroupEgressOutput, error) {
+			revokedEgressIDs = append(revokedEgressIDs, aws.StringValue(input.GroupId))
+			return &ec2.RevokeSecurityGroupEgressOutput{}, nil
+		},
+		deleteSecurityGroupFn: func(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+			deletedIDs = append(deletedIDs, aws.StringValue(input.GroupId))
+			return &ec2.DeleteSecurityGroupOutput{}, nil
+		},
+	}
+	cfnMock := &mockSGCFN{
+		describeStacksFn: func(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+			return deleteFailedStack("osde2e-abcde-vpc"), nil
+		},
+	}
+
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, cfnMock, nil, false, false, &deleted, &failed, &errBuilder)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deleted != 1 || failed != 0 {
+		t.Errorf("expected 1 deleted / 0 failed, got %d / %d", deleted, failed)
+	}
+	if len(revokedIngressIDs) != 1 || revokedIngressIDs[0] != "sg-1" {
+		t.Errorf("expected ingress revoked for sg-1, got %v", revokedIngressIDs)
+	}
+	if len(revokedEgressIDs) != 1 || revokedEgressIDs[0] != "sg-1" {
+		t.Errorf("expected egress revoked for sg-1, got %v", revokedEgressIDs)
+	}
+	if len(deletedIDs) != 1 || deletedIDs[0] != "sg-1" {
+		t.Errorf("expected sg-1 deleted, got %v", deletedIDs)
+	}
+}
+
+func TestCleanupSecurityGroups_DryRunSkipsDeletion(t *testing.T) {
+	deleteCalled := false
+	revokeCalled := false
+
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return &ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{makeVPC("vpc-1", "osde2e-abcde-fghij-vpc")},
+			}, nil
+		},
+		describeSGFn: func(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+			return &ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{
+					makeSG("sg-1", "custom-sg",
+						[]*ec2.IpPermission{{IpProtocol: aws.String("tcp")}},
+						[]*ec2.IpPermission{{IpProtocol: aws.String("-1")}},
+					),
+				},
+			}, nil
+		},
+		revokeIngressFn: func(*ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+			revokeCalled = true
+			return &ec2.RevokeSecurityGroupIngressOutput{}, nil
+		},
+		revokeEgressFn: func(*ec2.RevokeSecurityGroupEgressInput) (*ec2.RevokeSecurityGroupEgressOutput, error) {
+			revokeCalled = true
+			return &ec2.RevokeSecurityGroupEgressOutput{}, nil
+		},
+		deleteSecurityGroupFn: func(*ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+			deleteCalled = true
+			return &ec2.DeleteSecurityGroupOutput{}, nil
+		},
+	}
+	cfnMock := &mockSGCFN{
+		describeStacksFn: func(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+			return deleteFailedStack("osde2e-abcde-vpc"), nil
+		},
+	}
+
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, cfnMock, nil, true, false, &deleted, &failed, &errBuilder)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deleteCalled {
+		t.Error("DeleteSecurityGroup should not be called in dry-run mode")
+	}
+	if revokeCalled {
+		t.Error("Revoke calls should not be made in dry-run mode")
+	}
+	if deleted != 0 || failed != 0 {
+		t.Errorf("expected 0 deleted/failed in dry-run, got %d/%d", deleted, failed)
+	}
+}
+
+func TestCleanupSecurityGroups_DeleteFailureIncrementsCounter(t *testing.T) {
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return &ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{makeVPC("vpc-1", "osde2e-abcde-fghij-vpc")},
+			}, nil
+		},
+		describeSGFn: func(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+			return &ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{
+					makeSG("sg-1", "custom-sg", nil, nil),
+				},
+			}, nil
+		},
+		deleteSecurityGroupFn: func(*ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+			return nil, fmt.Errorf("DependencyViolation: sg has dependencies")
+		},
+	}
+	cfnMock := &mockSGCFN{
+		describeStacksFn: func(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+			return deleteFailedStack("osde2e-abcde-vpc"), nil
+		},
+	}
+
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, cfnMock, nil, false, true, &deleted, &failed, &errBuilder)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("expected 0 deleted, got %d", deleted)
+	}
+	if failed != 1 {
+		t.Errorf("expected 1 failed, got %d", failed)
+	}
+	if !strings.Contains(errBuilder.String(), "sg-1") {
+		t.Errorf("expected error builder to contain sg-1, got: %s", errBuilder.String())
+	}
+}
+
+func TestCleanupSecurityGroups_SendSummaryFalseDoesNotWriteErrors(t *testing.T) {
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return &ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{makeVPC("vpc-1", "osde2e-abcde-fghij-vpc")},
+			}, nil
+		},
+		describeSGFn: func(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+			return &ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{
+					makeSG("sg-1", "custom-sg", nil, nil),
+				},
+			}, nil
+		},
+		deleteSecurityGroupFn: func(*ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+			return nil, fmt.Errorf("delete failed")
+		},
+	}
+	cfnMock := &mockSGCFN{
+		describeStacksFn: func(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+			return deleteFailedStack("osde2e-abcde-vpc"), nil
+		},
+	}
+
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, cfnMock, nil, false, false, &deleted, &failed, &errBuilder)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if failed != 1 {
+		t.Errorf("expected 1 failed, got %d", failed)
+	}
+	if errBuilder.Len() != 0 {
+		t.Errorf("expected empty error builder when sendSummary=false, got: %s", errBuilder.String())
+	}
+}
+
+func TestCleanupSecurityGroups_DescribeSGErrorContinues(t *testing.T) {
+	describeSGCalls := 0
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return &ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{
+					makeVPC("vpc-1", "osde2e-aaaaa-bbbbb-vpc"),
+					makeVPC("vpc-2", "osde2e-ccccc-ddddd-vpc"),
+				},
+			}, nil
+		},
+		describeSGFn: func(input *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+			describeSGCalls++
+			vpcID := aws.StringValue(input.Filters[0].Values[0])
+			if vpcID == "vpc-1" {
+				return nil, fmt.Errorf("access denied")
+			}
+			return &ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{
+					makeSG("sg-2", "custom-sg-2", nil, nil),
+				},
+			}, nil
+		},
+		deleteSecurityGroupFn: func(*ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+			return &ec2.DeleteSecurityGroupOutput{}, nil
+		},
+	}
+	cfnMock := &mockSGCFN{
+		describeStacksFn: func(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+			return deleteFailedStack("any-stack"), nil
+		},
+	}
+
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, cfnMock, nil, false, false, &deleted, &failed, &errBuilder)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if describeSGCalls != 2 {
+		t.Errorf("expected DescribeSecurityGroups called twice, got %d", describeSGCalls)
+	}
+	if deleted != 1 {
+		t.Errorf("expected 1 deleted (from second VPC), got %d", deleted)
+	}
+}
+
+func TestCleanupSecurityGroups_RevokeErrorsDoNotBlockDeletion(t *testing.T) {
+	var deletedIDs []string
+
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return &ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{makeVPC("vpc-1", "osde2e-abcde-fghij-vpc")},
+			}, nil
+		},
+		describeSGFn: func(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+			return &ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{
+					makeSG("sg-1", "custom-sg",
+						[]*ec2.IpPermission{{IpProtocol: aws.String("tcp")}},
+						[]*ec2.IpPermission{{IpProtocol: aws.String("-1")}},
+					),
+				},
+			}, nil
+		},
+		revokeIngressFn: func(*ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+			return nil, fmt.Errorf("revoke ingress failed")
+		},
+		revokeEgressFn: func(*ec2.RevokeSecurityGroupEgressInput) (*ec2.RevokeSecurityGroupEgressOutput, error) {
+			return nil, fmt.Errorf("revoke egress failed")
+		},
+		deleteSecurityGroupFn: func(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+			deletedIDs = append(deletedIDs, aws.StringValue(input.GroupId))
+			return &ec2.DeleteSecurityGroupOutput{}, nil
+		},
+	}
+	cfnMock := &mockSGCFN{
+		describeStacksFn: func(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+			return deleteFailedStack("osde2e-abcde-vpc"), nil
+		},
+	}
+
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, cfnMock, nil, false, false, &deleted, &failed, &errBuilder)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("expected 1 deleted despite revoke errors, got %d", deleted)
+	}
+	if len(deletedIDs) != 1 || deletedIDs[0] != "sg-1" {
+		t.Errorf("expected sg-1 deleted, got %v", deletedIDs)
+	}
+}
+
+func TestCleanupSecurityGroups_MultipleSGsInOneVPC(t *testing.T) {
+	var deletedIDs []string
+
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return &ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{makeVPC("vpc-1", "osde2e-abcde-fghij-vpc")},
+			}, nil
+		},
+		describeSGFn: func(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+			return &ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{
+					makeSG("sg-default", "default", nil, nil),
+					makeSG("sg-1", "worker-sg", nil, nil),
+					makeSG("sg-2", "master-sg", nil, nil),
+					makeSG("sg-3", "lb-sg", nil, nil),
+				},
+			}, nil
+		},
+		deleteSecurityGroupFn: func(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+			deletedIDs = append(deletedIDs, aws.StringValue(input.GroupId))
+			return &ec2.DeleteSecurityGroupOutput{}, nil
+		},
+	}
+	cfnMock := &mockSGCFN{
+		describeStacksFn: func(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+			return deleteFailedStack("osde2e-abcde-vpc"), nil
+		},
+	}
+
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, cfnMock, nil, false, false, &deleted, &failed, &errBuilder)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deleted != 3 {
+		t.Errorf("expected 3 deleted (all non-default), got %d", deleted)
+	}
+	if failed != 0 {
+		t.Errorf("expected 0 failed, got %d", failed)
+	}
+
+	expected := map[string]bool{"sg-1": true, "sg-2": true, "sg-3": true}
+	for _, id := range deletedIDs {
+		if !expected[id] {
+			t.Errorf("unexpected deletion of %s", id)
+		}
+		delete(expected, id)
+	}
+	if len(expected) > 0 {
+		t.Errorf("expected deletions not seen: %v", expected)
+	}
+}
+
+func TestCleanupSecurityGroups_SkipsNoRulesRevocation(t *testing.T) {
+	revokeIngressCalled := false
+	revokeEgressCalled := false
+
+	ec2Mock := &mockSGEC2{
+		describeVpcsFn: func(*ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+			return &ec2.DescribeVpcsOutput{
+				Vpcs: []*ec2.Vpc{makeVPC("vpc-1", "osde2e-abcde-fghij-vpc")},
+			}, nil
+		},
+		describeSGFn: func(*ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error) {
+			return &ec2.DescribeSecurityGroupsOutput{
+				SecurityGroups: []*ec2.SecurityGroup{
+					makeSG("sg-1", "empty-sg", nil, nil),
+				},
+			}, nil
+		},
+		revokeIngressFn: func(*ec2.RevokeSecurityGroupIngressInput) (*ec2.RevokeSecurityGroupIngressOutput, error) {
+			revokeIngressCalled = true
+			return &ec2.RevokeSecurityGroupIngressOutput{}, nil
+		},
+		revokeEgressFn: func(*ec2.RevokeSecurityGroupEgressInput) (*ec2.RevokeSecurityGroupEgressOutput, error) {
+			revokeEgressCalled = true
+			return &ec2.RevokeSecurityGroupEgressOutput{}, nil
+		},
+		deleteSecurityGroupFn: func(*ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
+			return &ec2.DeleteSecurityGroupOutput{}, nil
+		},
+	}
+	cfnMock := &mockSGCFN{
+		describeStacksFn: func(*cloudformation.DescribeStacksInput) (*cloudformation.DescribeStacksOutput, error) {
+			return deleteFailedStack("osde2e-abcde-vpc"), nil
+		},
+	}
+
+	deleted, failed := 0, 0
+	var errBuilder strings.Builder
+	err := cleanupSecurityGroups(ec2Mock, cfnMock, nil, false, false, &deleted, &failed, &errBuilder)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if revokeIngressCalled {
+		t.Error("RevokeSecurityGroupIngress should not be called when there are no ingress rules")
+	}
+	if revokeEgressCalled {
+		t.Error("RevokeSecurityGroupEgress should not be called when there are no egress rules")
+	}
+	if deleted != 1 {
+		t.Errorf("expected 1 deleted, got %d", deleted)
+	}
+}

--- a/pkg/common/aws/vpc.go
+++ b/pkg/common/aws/vpc.go
@@ -137,11 +137,11 @@ func (CcsAwsSession *ccsAwsSession) CleanupVPCs(activeClusters map[string]bool, 
 	return counters, nil
 }
 
+var vpcNameRegexp = regexp.MustCompile(`^(osde2e-[^-]+)-[^-]+-vpc$`)
+
 // removes the -yyyyy suffix from VPC names that follow the osde2e-xxxxx-yyyyy-vpc format
 func getClusterNameFromVPCName(vpcName string) string {
-	// Match osde2e-xxxxx-yyyyy-vpc pattern and extract osde2e-xxxxx-vpc part
-	re := regexp.MustCompile(`^(osde2e-[^-]+)-[^-]+-vpc$`)
-	matches := re.FindStringSubmatch(vpcName)
+	matches := vpcNameRegexp.FindStringSubmatch(vpcName)
 	if len(matches) == 2 {
 		return matches[1] + "-vpc"
 	}


### PR DESCRIPTION
Add a --security-group flag to the osde2e cleanup command that removes leftover security groups from orphaned VPCs whose CloudFormation stacks are in DELETE_FAILED state.

Leftover security groups (e.g. from OCPBUGS-74960) block CloudFormation stack deletion, causing all VPC cleanup to fail silently. This flag is designed to run before --vpc so that the subsequent stack deletion can succeed.

The implementation:
- Finds osde2e VPCs with DELETE_FAILED CloudFormation stacks
- Skips VPCs belonging to active clusters
- Revokes all ingress/egress rules to clear cross-SG dependencies
- Deletes all non-default security groups in those VPCs
- Reports results to Slack summary