### PR TITLE
[SREP-3734] Use internal registry image for executor artifact sidecar

### DIFF
--- a/pkg/common/executor/executor.go
+++ b/pkg/common/executor/executor.go
@@ -242,7 +242,7 @@ func (e *Executor) buildJobSpec(namespace string, image string) *batchv1.Job {
 						},
 						{
 							Name:    "pause-for-artifacts",
-							Image:   "busybox:latest",
+							Image:   "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest",
 							Command: []string{"tail", "-f", "/dev/null"},
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/pkg/common/executor/executor.go
+++ b/pkg/common/executor/executor.go
@@ -242,7 +242,7 @@ func (e *Executor) buildJobSpec(namespace string, image string) *batchv1.Job {
 						},
 						{
 							Name:    "pause-for-artifacts",
-							Image:   "image-registry.openshift-image-registry.svc:5000/openshift/cli:latest",
+							Image:   "registry.access.redhat.com/ubi10/ubi:10",
 							Command: []string{"tail", "-f", "/dev/null"},
 							VolumeMounts: []corev1.VolumeMount{
 								{


### PR DESCRIPTION
## Summary
- Replace `busybox:latest` with the internal OpenShift CLI image (`image-registry.openshift-image-registry.svc:5000/openshift/cli:latest`) for the `pause-for-artifacts` sidecar container in the ad-hoc test executor
- The `busybox:latest` pull from Docker Hub is subject to rate limits and transient 503 errors, which caused a race condition where the sidecar hadn't started by the time artifact collection was attempted after a fast-completing test
- The internal CLI image is already used elsewhere in the codebase (`pkg/e2e/osd/rebalance_infra_nodes.go`) and is pre-cached on cluster nodes

## Test plan
- [ ] Verify the `pause-for-artifacts` container starts reliably in ad-hoc test executor jobs
- [ ] Confirm artifact collection succeeds for fast-completing test suites
- [ ] Run `periodic-ci-openshift-osde2e-main-nightly-4.21-osd-aws` and verify no `container not found` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)