### PR TITLE
[SREP-3734] Fix retryer exponential backoff using XOR instead of exponentiation

### DIFF
--- a/pkg/common/providers/ocmprovider/retryer.go
+++ b/pkg/common/providers/ocmprovider/retryer.go
@@ -18,7 +18,7 @@ var (
 func retryer() *retry.Retryer {
 	ocmOnce.Do(func() {
 		ocmRetryer = retry.New(retry.SleepFn(func(attempts int) {
-			time.Sleep(time.Duration(2^attempts) * time.Second)
+			time.Sleep(time.Duration(1<<attempts) * time.Second)
 		}))
 		ocmRetryer.Tries = viper.GetInt(NumRetries)
 		ocmRetryer.AfterEachFailFn = func(err error) {


### PR DESCRIPTION
## Summary
- In Go, `^` is the bitwise XOR operator, not exponentiation. The expression `2^attempts` produced incorrect sleep durations (2s, 3s, 0s, 1s) instead of the intended exponential backoff (1s, 2s, 4s, 8s).
- Replaced `2^attempts` with `1<<attempts` (bit shift) to produce correct powers of 2.

## Test plan
- [x] Verify the retryer sleep durations follow exponential backoff: 1s, 2s, 4s, 8s, etc.
- [ ] Confirm OCM retry behavior works correctly in integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)