### PR TITLE
[SREP-3734] fix: include kubelet error in image pull failure message

### DIFF
--- a/pkg/common/executor/executor.go
+++ b/pkg/common/executor/executor.go
@@ -282,7 +282,11 @@ func (e *Executor) waitForSuite(ctx context.Context, name, namespace, image stri
 				if containerStatus.State.Waiting != nil {
 					reason := containerStatus.State.Waiting.Reason
 					if reason == "ImagePullBackOff" || reason == "ErrImagePull" {
-						return false, fmt.Errorf("failed to pull image: %s", image)
+						msg := containerStatus.State.Waiting.Message
+						if msg == "" {
+							msg = "no details available"
+						}
+						return false, fmt.Errorf("failed to pull image %s: %s: %s", image, reason, msg)
 					}
 				}
 				// Return true if container has terminated (succeeded or failed)


### PR DESCRIPTION
## Summary

- Include `Waiting.Reason` and `Waiting.Message` from the container status in the image pull failure error, so auth failures, network issues, and missing tags are distinguishable from the job logs alone.
- Falls back to `"no details available"` when the kubelet hasn't populated the message yet.

## Context

Observed in `periodic-ci-openshift-osde2e-main-nightly-4.21-osd-aws` ([build 2046394451827363840](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-osde2e-main-nightly-4.21-osd-aws/2046394451827363840), 2026-04-21):

```
FAIL: Ad Hoc Test Images execution
  quay.io/redhat-services-prod/openshift/cloud-ingress-operator-e2e should pass
  execution failure: waiting for suite to finish:
    failed to pull image: quay.io/redhat-services-prod/openshift/cloud-ingress-operator-e2e
```

The image was public and available, but the root cause could not be determined. The must-gather was also unhelpful — the executor deletes its temporary namespace before the CI gather chain runs, so pod events are already gone by collection time. The executor's poll loop is the only point where the kubelet error is still available.

## Test plan

- [x] `go build ./pkg/common/executor/` passes
- [ ] Verify error output includes reason and message when an image pull fails (e.g. use a non-existent image tag)
- [ ] Verify fallback text appears when `Waiting.Message` is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for container image pull failures to include detailed diagnostic information from pod status, providing clearer troubleshooting details for image retrieval issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->