### PR TITLE
Update the UBI10 image to 10.1

### DIFF
--- a/pkg/common/executor/executor.go
+++ b/pkg/common/executor/executor.go
@@ -242,7 +242,7 @@ func (e *Executor) buildJobSpec(namespace string, image string) *batchv1.Job {
 						},
 						{
 							Name:    "pause-for-artifacts",
-							Image:   "registry.access.redhat.com/ubi10/ubi:10",
+							Image:   "registry.access.redhat.com/ubi10/ubi:10.1",
 							Command: []string{"tail", "-f", "/dev/null"},
 							VolumeMounts: []corev1.VolumeMount{
 								{


### PR DESCRIPTION
Ubi does not seem to provide a :10 tag.

```
❯ podman pull registry.access.redhat.com/ubi10/ubi:10
Trying to pull registry.access.redhat.com/ubi10/ubi:10...
Pulling image //registry.access.redhat.com/ubi10/ubi:10 inside systemd: setting pull timeout to 5m0s
Error: unable to copy from source docker://registry.access.redhat.com/ubi10/ubi:10: initializing source docker://registry.access.redhat.com
/ubi10/ubi:10: reading manifest 10 in registry.access.redhat.com/ubi10/ubi: manifest unknown
```

But using 10.1:

```
❯ podman pull registry.access.redhat.com/ubi10/ubi:10.1
Trying to pull registry.access.redhat.com/ubi10/ubi:10.1...
Pulling image //registry.access.redhat.com/ubi10/ubi:10.1 inside systemd: setting pull timeout to 5m0s
Getting image source signatures
Checking if image destination supports signatures
Copying blob 5403baf246a9 [>-------------------------------------] 1.1MiB / 76.7MiB | 5.2 MiB/s
```