### PR TITLE
Revert "[SREP-3734] Use internal registry image for executor artifact sidecar"

### DIFF
--- a/pkg/common/executor/executor.go
+++ b/pkg/common/executor/executor.go
@@ -242,7 +242,7 @@ func (e *Executor) buildJobSpec(namespace string, image string) *batchv1.Job {
 						},
 						{
 							Name:    "pause-for-artifacts",
-							Image:   "registry.access.redhat.com/ubi10/ubi:10",
+							Image:   "busybox:latest",
 							Command: []string{"tail", "-f", "/dev/null"},
 							VolumeMounts: []corev1.VolumeMount{
 								{


### PR DESCRIPTION
Reverts openshift/osde2e#3205