### PR TITLE
[SREP-3734] Fix AlertmanagerInhibitions test race condition

### DIFF
--- a/pkg/e2e/osd/inhibitions.go
+++ b/pkg/e2e/osd/inhibitions.go
@@ -153,32 +153,33 @@ var _ = ginkgo.Describe("[Suite: operators] AlertmanagerInhibitions", label.Oper
 			cleanup(ctx, h)
 		}()
 
-		// the clusteroperatordown/degraded alerts take several minutes to trip
-		time.Sleep(3 * time.Minute)
-
 		oc, err := openshift.NewFromRestConfig(h.GetConfig(), ginkgo.GinkgoLogr)
 		Expect(err).NotTo(HaveOccurred(), "unable to create openshift client")
 		prom, err := prometheus.New(ctx, oc)
 		Expect(err).NotTo(HaveOccurred(), "unable to create prometheus client")
 		prometheusApiClient := prom.GetClient()
 
-		timeout, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		alerts, err := prometheusApiClient.Alerts(timeout)
-		Expect(err).To(BeNil())
-
-		// confirm the source is firing and the target isn't by cycling through all
-		// the returned alerts
-		operatorDownAlertPresent := false
-		for _, alert := range alerts.Alerts {
-			if alert.Labels["alertname"] == "ClusterOperatorDown" && alert.Labels["name"] == "authentication" {
-				operatorDownAlertPresent = true
+		// Poll for the alert to appear. The alert enters "pending" state once the
+		// operator reports degraded and Prometheus scrapes + evaluates the rule
+		// (typically 2-3 min). We check for existence, not firing state, so we
+		// don't need to wait for the full for: duration (10m/30m).
+		Eventually(ctx, func() bool {
+			timeout, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+			alerts, err := prometheusApiClient.Alerts(timeout)
+			if err != nil {
+				ginkgo.GinkgoLogr.Error(err, "Unable to query prom API")
+				return false
 			}
-			if alert.Labels["alertname"] == "ClusterOperatorDegraded" && alert.Labels["name"] == "authentication" {
-				operatorDownAlertPresent = true
+			for _, alert := range alerts.Alerts {
+				if (alert.Labels["alertname"] == "ClusterOperatorDown" ||
+					alert.Labels["alertname"] == "ClusterOperatorDegraded") &&
+					alert.Labels["name"] == "authentication" {
+					return true
+				}
 			}
-		}
-		Expect(operatorDownAlertPresent).To(BeTrue())
+			return false
+		}, 5*time.Minute, 30*time.Second).Should(BeTrue())
 	})
 })
 


### PR DESCRIPTION
## Summary

- The `inhibits ClusterOperatorDegraded` test was using a fixed 3-minute sleep before querying Prometheus for alerts, which was occasionally too short
- Replace the fixed sleep with an `Eventually` poll (5m timeout, 30s interval) that returns as soon as the alert appears

## Details

The test injects a bogus OIDC identity provider to degrade the `authentication` ClusterOperator, then checks Prometheus for `ClusterOperatorDown` or `ClusterOperatorDegraded` alerts. The alert enters "pending" state once the operator reports degraded and Prometheus scrapes + evaluates the rule (typically 2-3 min). The previous fixed 3-minute sleep was tight enough that slight timing variation caused failures.

The sleep was reduced from 10m to 3m in #2952 ([OSD-29225](https://redhat.atlassian.net/browse/OSD-29225)), which was primarily fixing an unrelated deep-equality bug.

## Example failures

- [4.21 Apr 25](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-osde2e-main-nightly-4.21-osd-aws/2048177745950674944) — `Expected <bool>: false to be true` at `inhibitions.go:181`
- [4.21 Apr 24](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-osde2e-main-nightly-4.21-osd-aws/2047815355216171008) — same failure
- [4.21 Apr 23](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-osde2e-main-nightly-4.21-osd-aws/2047452965253419008) — same failure

## Test plan

- [ ] Verify `periodic-ci-openshift-osde2e-main-nightly-4.21-osd-aws` passes with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[OSD-29225]: https://redhat.atlassian.net/browse/OSD-29225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ