### PR TITLE
SDCICD-1814 scope cleanup cluster listing to current OCM account

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -19,7 +19,6 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
 	commonslack "github.com/openshift/osde2e/pkg/common/slack"
-	"github.com/openshift/osde2e/pkg/common/spi"
 )
 
 var Cmd = &cobra.Command{
@@ -167,7 +166,7 @@ func init() {
 func collectActiveClusters() (map[string]bool, error) {
 	// Create OCM provider map for different environments
 	envs := []string{"int", "stage", "prod"}
-	providers := make(map[string]spi.Provider)
+	providers := make(map[string]*ocmprovider.OCMProvider)
 
 	for _, env := range envs {
 		provider, err := ocmprovider.NewWithEnv(env)
@@ -185,7 +184,7 @@ func collectActiveClusters() (map[string]bool, error) {
 
 	activeClusters := make(map[string]bool)
 	for env, provider := range providers {
-		clusters, err := provider.ListClusters("properties.MadeByOSDe2e='true'")
+		clusters, err := provider.ListOwnedClusters("properties.MadeByOSDe2e='true'")
 		if err != nil {
 			log.Printf("Warning: error listing clusters for environment %s: %v (skipping)\n", env, err)
 			continue
@@ -305,7 +304,7 @@ func run(_ context.Context) (msg Message, err error) {
 			return msg, fmt.Errorf("could not setup cluster provider: %v", err)
 		}
 
-		clusters, err := provider.ListClusters("properties.MadeByOSDe2e='true'")
+		clusters, err := provider.ListOwnedClusters("properties.MadeByOSDe2e='true'")
 		if err != nil {
 			return msg, err
 		}

--- a/pkg/common/providers/ocmprovider/cluster.go
+++ b/pkg/common/providers/ocmprovider/cluster.go
@@ -681,6 +681,64 @@ func (o *OCMProvider) ListClusters(query string) ([]*spi.Cluster, error) {
 	return clusters, nil
 }
 
+// ListOwnedClusters returns clusters matching the query that belong to the
+// currently authenticated OCM account. It queries accounts_mgmt subscriptions
+// to identify clusters created by the current service account, then filters
+// the clusters_mgmt results to exclude clusters owned by other accounts.
+func (o *OCMProvider) ListOwnedClusters(query string) ([]*spi.Cluster, error) {
+	acctResp, err := o.conn.AccountsMgmt().V1().CurrentAccount().Get().Send()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get current account: %v", err)
+	}
+	accountID := acctResp.Body().ID()
+	log.Printf("Current OCM account ID: %s\n", accountID)
+
+	ownedClusterIDs := make(map[string]bool)
+	subsSearch := fmt.Sprintf("creator.id='%s' and status in ('Active','Reserved')", accountID)
+	collected := 0
+	page := 1
+	for {
+		subsResp, err := o.conn.AccountsMgmt().V1().Subscriptions().List().
+			Search(subsSearch).
+			Page(page).
+			Size(100).
+			Send()
+		if err != nil {
+			return nil, fmt.Errorf("couldn't list subscriptions for account %s: %v", accountID, err)
+		}
+
+		for _, sub := range subsResp.Items().Slice() {
+			if cid := sub.ClusterID(); cid != "" {
+				ownedClusterIDs[cid] = true
+			}
+		}
+
+		collected += subsResp.Size()
+		if collected >= subsResp.Total() || subsResp.Size() == 0 {
+			break
+		}
+		page++
+	}
+	log.Printf("Found %d cluster IDs owned by current account\n", len(ownedClusterIDs))
+
+	allClusters, err := o.ListClusters(query)
+	if err != nil {
+		return nil, err
+	}
+
+	var ownedClusters []*spi.Cluster
+	for _, cluster := range allClusters {
+		if ownedClusterIDs[cluster.ID()] {
+			ownedClusters = append(ownedClusters, cluster)
+		} else {
+			log.Printf("Skipping cluster %s (%s): not owned by current account\n", cluster.ID(), cluster.Name())
+		}
+	}
+
+	log.Printf("Filtered to %d owned clusters (from %d total matching query)\n", len(ownedClusters), len(allClusters))
+	return ownedClusters, nil
+}
+
 // GetClusterRegion returns the cloud region for the cluster from OCM.
 func (o *OCMProvider) GetClusterRegion(clusterID string) (string, error) {
 	c, err := o.GetCluster(clusterID)

--- a/pkg/common/providers/ocmprovider/list_owned_clusters_test.go
+++ b/pkg/common/providers/ocmprovider/list_owned_clusters_test.go
@@ -1,0 +1,337 @@
+package ocmprovider
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	ocm "github.com/openshift-online/ocm-sdk-go"
+	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
+	"github.com/openshift/osde2e/pkg/common/config"
+	"github.com/openshift/osde2e/pkg/common/spi"
+)
+
+var testJWTKey *rsa.PrivateKey
+
+func init() {
+	var err error
+	testJWTKey, err = rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func makeTestToken() string {
+	claims := jwt.MapClaims{
+		"typ": "Bearer",
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(15 * time.Minute).Unix(),
+		"iss": "https://sso.redhat.com/auth/realms/redhat-external",
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = "test-key"
+	signed, err := token.SignedString(testJWTKey)
+	if err != nil {
+		panic(err)
+	}
+	return signed
+}
+
+func tokenHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(w, `{"access_token":"%s","token_type":"Bearer","expires_in":900}`, makeTestToken())
+}
+
+func newTestProvider(t *testing.T, handler http.Handler) *OCMProvider {
+	t.Helper()
+	viper.Set(config.Addons.SkipAddonList, true)
+	t.Cleanup(func() { viper.Set(config.Addons.SkipAddonList, false) })
+
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+
+	conn, err := ocm.NewConnectionBuilder().
+		URL(server.URL).
+		TokenURL(server.URL+"/token").
+		Client("test", "test").
+		TransportWrapper(func(_ http.RoundTripper) http.RoundTripper {
+			return server.Client().Transport
+		}).
+		Insecure(true).
+		Build()
+	if err != nil {
+		t.Fatalf("failed to build OCM connection: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	return &OCMProvider{
+		env:              "test",
+		conn:             conn,
+		clusterCache:     make(map[string]*spi.Cluster),
+		credentialCache:  make(map[string]string),
+		versionGateLabel: "api.openshift.com/gate-ocp",
+	}
+}
+
+func accountHandler(id string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"kind":"Account","id":"%s","username":"cicd-sa"}`, id)
+	}
+}
+
+func clusterJSON(id, name string) string {
+	return fmt.Sprintf(`{
+		"kind": "Cluster",
+		"id": "%s",
+		"href": "/api/clusters_mgmt/v1/clusters/%s",
+		"name": "%s",
+		"state": "ready",
+		"region": {"id": "us-east-1"},
+		"cloud_provider": {"id": "aws"},
+		"properties": {"MadeByOSDe2e": "true"},
+		"version": {"id": "openshift-v4.14.0", "channel_group": "stable"}
+	}`, id, id, name)
+}
+
+// clusterListHandler returns items on page=1 and an empty list on subsequent pages,
+// matching what ListClusters' pagination loop expects.
+func clusterListHandler(total int, itemsJSON string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		page := r.URL.Query().Get("page")
+		if page != "" && page != "1" {
+			fmt.Fprintf(w, `{"kind":"ClusterList","page":%s,"size":0,"total":%d,"items":[]}`, page, total)
+			return
+		}
+		fmt.Fprintf(w, `{"kind":"ClusterList","page":1,"size":%d,"total":%d,"items":[%s]}`, total, total, itemsJSON)
+	}
+}
+
+func TestListOwnedClusters_FiltersOutUnownedClusters(t *testing.T) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/accounts_mgmt/v1/current_account", accountHandler("acct-123"))
+
+	mux.HandleFunc("/api/accounts_mgmt/v1/subscriptions", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		search := r.URL.Query().Get("search")
+		if !strings.Contains(search, "acct-123") {
+			t.Errorf("unexpected subscription search query: %s", search)
+		}
+		fmt.Fprint(w, `{
+			"kind": "SubscriptionList",
+			"page": 1, "size": 2, "total": 2,
+			"items": [
+				{"kind":"Subscription","id":"sub-1","cluster_id":"cluster-aaa"},
+				{"kind":"Subscription","id":"sub-2","cluster_id":"cluster-bbb"}
+			]
+		}`)
+	})
+
+	items := strings.Join([]string{
+		clusterJSON("cluster-aaa", "osde2e-ours1"),
+		clusterJSON("cluster-bbb", "osde2e-ours2"),
+		clusterJSON("cluster-ccc", "osde2e-rosa-theirs"),
+	}, ",")
+	mux.HandleFunc("/api/clusters_mgmt/v1/clusters", clusterListHandler(3, items))
+	mux.HandleFunc("/token", tokenHandler)
+
+	provider := newTestProvider(t, mux)
+
+	clusters, err := provider.ListOwnedClusters("properties.MadeByOSDe2e='true'")
+	if err != nil {
+		t.Fatalf("ListOwnedClusters returned error: %v", err)
+	}
+
+	if len(clusters) != 2 {
+		t.Fatalf("expected 2 owned clusters, got %d", len(clusters))
+	}
+
+	ids := map[string]bool{}
+	for _, c := range clusters {
+		ids[c.ID()] = true
+	}
+
+	if !ids["cluster-aaa"] {
+		t.Error("expected cluster-aaa to be included")
+	}
+	if !ids["cluster-bbb"] {
+		t.Error("expected cluster-bbb to be included")
+	}
+	if ids["cluster-ccc"] {
+		t.Error("expected cluster-ccc (not owned) to be filtered out")
+	}
+}
+
+func TestListOwnedClusters_NoneOwned(t *testing.T) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/accounts_mgmt/v1/current_account", accountHandler("acct-empty"))
+
+	mux.HandleFunc("/api/accounts_mgmt/v1/subscriptions", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"kind": "SubscriptionList",
+			"page": 1, "size": 0, "total": 0,
+			"items": []
+		}`)
+	})
+
+	items := strings.Join([]string{
+		clusterJSON("cluster-x", "osde2e-rosa1"),
+		clusterJSON("cluster-y", "osde2e-rosa2"),
+	}, ",")
+	mux.HandleFunc("/api/clusters_mgmt/v1/clusters", clusterListHandler(2, items))
+	mux.HandleFunc("/token", tokenHandler)
+
+	provider := newTestProvider(t, mux)
+
+	clusters, err := provider.ListOwnedClusters("properties.MadeByOSDe2e='true'")
+	if err != nil {
+		t.Fatalf("ListOwnedClusters returned error: %v", err)
+	}
+
+	if len(clusters) != 0 {
+		t.Fatalf("expected 0 clusters, got %d", len(clusters))
+	}
+}
+
+func TestListOwnedClusters_PaginatedSubscriptions(t *testing.T) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/accounts_mgmt/v1/current_account", accountHandler("acct-paged"))
+
+	subsCallCount := 0
+	mux.HandleFunc("/api/accounts_mgmt/v1/subscriptions", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		subsCallCount++
+		if subsCallCount == 1 {
+			fmt.Fprint(w, `{
+				"kind": "SubscriptionList",
+				"page": 1, "size": 1, "total": 2,
+				"items": [
+					{"kind":"Subscription","id":"sub-1","cluster_id":"cluster-page1"}
+				]
+			}`)
+		} else {
+			fmt.Fprint(w, `{
+				"kind": "SubscriptionList",
+				"page": 2, "size": 1, "total": 2,
+				"items": [
+					{"kind":"Subscription","id":"sub-2","cluster_id":"cluster-page2"}
+				]
+			}`)
+		}
+	})
+
+	items := strings.Join([]string{
+		clusterJSON("cluster-page1", "osde2e-p1"),
+		clusterJSON("cluster-page2", "osde2e-p2"),
+		clusterJSON("cluster-other", "osde2e-other"),
+	}, ",")
+	mux.HandleFunc("/api/clusters_mgmt/v1/clusters", clusterListHandler(3, items))
+	mux.HandleFunc("/token", tokenHandler)
+
+	provider := newTestProvider(t, mux)
+
+	clusters, err := provider.ListOwnedClusters("properties.MadeByOSDe2e='true'")
+	if err != nil {
+		t.Fatalf("ListOwnedClusters returned error: %v", err)
+	}
+
+	if len(clusters) != 2 {
+		t.Fatalf("expected 2 clusters from paginated subscriptions, got %d", len(clusters))
+	}
+
+	ids := map[string]bool{}
+	for _, c := range clusters {
+		ids[c.ID()] = true
+	}
+
+	if !ids["cluster-page1"] || !ids["cluster-page2"] {
+		t.Error("expected both paginated cluster IDs to be included")
+	}
+	if ids["cluster-other"] {
+		t.Error("expected cluster-other to be filtered out")
+	}
+
+	if subsCallCount != 2 {
+		t.Errorf("expected 2 subscription API calls for pagination, got %d", subsCallCount)
+	}
+}
+
+func TestListOwnedClusters_SubscriptionError(t *testing.T) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/accounts_mgmt/v1/current_account", accountHandler("acct-err"))
+
+	mux.HandleFunc("/api/accounts_mgmt/v1/subscriptions", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"kind":"Error","reason":"subscription service down"}`)
+	})
+
+	mux.HandleFunc("/token", tokenHandler)
+
+	provider := newTestProvider(t, mux)
+
+	_, err := provider.ListOwnedClusters("properties.MadeByOSDe2e='true'")
+	if err == nil {
+		t.Fatal("expected error when subscription listing fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "couldn't list subscriptions") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestListOwnedClusters_ClusterListError(t *testing.T) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/accounts_mgmt/v1/current_account", accountHandler("acct-ok"))
+
+	mux.HandleFunc("/api/accounts_mgmt/v1/subscriptions", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"kind":"SubscriptionList","page":1,"size":1,"total":1,"items":[{"kind":"Subscription","id":"sub-1","cluster_id":"c1"}]}`)
+	})
+
+	mux.HandleFunc("/api/clusters_mgmt/v1/clusters", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"kind":"Error","reason":"clusters service down"}`)
+	})
+
+	mux.HandleFunc("/token", tokenHandler)
+
+	provider := newTestProvider(t, mux)
+
+	_, err := provider.ListOwnedClusters("properties.MadeByOSDe2e='true'")
+	if err == nil {
+		t.Fatal("expected error when cluster listing fails, got nil")
+	}
+}
+
+func TestListOwnedClusters_AccountError(t *testing.T) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/accounts_mgmt/v1/current_account", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"kind":"Error","reason":"internal error"}`)
+	})
+
+	mux.HandleFunc("/token", tokenHandler)
+
+	provider := newTestProvider(t, mux)
+
+	_, err := provider.ListOwnedClusters("properties.MadeByOSDe2e='true'")
+	if err == nil {
+		t.Fatal("expected error when CurrentAccount fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "couldn't get current account") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}


### PR DESCRIPTION
Add `ListOwnedClusters` to `OCMProvider` that scopes cluster listing to the currently authenticated OCM account by cross-referencing `accounts_mgmt/v1/subscriptions` with `creator.id`

Two-step query:
1. `GET /api/accounts_mgmt/v1/current_account` → get account ID
2. `GET /api/accounts_mgmt/v1/subscriptions?search=creator.id='<id>'` → collect owned cluster IDs
3. Filter `ListClusters` results to only include owned clusters


Test with CLI
```
go build ./cmd/osde2e/

OCM_CLIENT_ID=ocm-sd-cicada \
OCM_CLIENT_SECRET=<OCM_CLIENT_SECRET> \
OSD_ENV=stage \
./osde2e cleanup --clusters --dry-run --older-than 24h
```


Example output
```
I0506 10:12:10.927319   69976 main.go:106] "configured logging" outputFile="/var/folders/q0/z_647xgs4xjg6ndxdh0g6d_80000gn/T/osde2e-68mzh2wwe1/test_output.log" reportDir="/var/folders/q0/z_647xgs4xjg6ndxdh0g6d_80000gn/T//osde2e-68mzh2wwe1" sharedDir=""
2026/05/06 10:12:11 Current OCM account ID: 2wBT3Hclp0EyOp6RFqmkstmvt4n
2026/05/06 10:12:11 Found 0 cluster IDs owned by current account
2026/05/06 10:12:12 Filtered to 0 owned clusters (from 0 total matching query)
2026/05/06 10:12:12 Current OCM account ID: 2jyrgE3ldAv2g6vU0s3qAclIXMR
2026/05/06 10:12:12 Found 6 cluster IDs owned by current account
2026/05/06 10:12:18 Filtered to 6 owned clusters (from 6 total matching query)
2026/05/06 10:12:18 Found active cluster: osde2e-kai0f (state: error)
2026/05/06 10:12:18 Found active cluster: osde2e-433xk (state: ready)
2026/05/06 10:12:18 Found active cluster: osde2e-lvheo (state: ready)
2026/05/06 10:12:18 Found active cluster: osde2e-snsyg (state: ready)
2026/05/06 10:12:18 Found active cluster: osde2e-fwqk8 (state: ready)
2026/05/06 10:12:18 Found active cluster: osde2e-acf6r (state: pending)
2026/05/06 10:12:19 Current OCM account ID: 2jyomJMFrqUSf3irKatbgRbjK2N
2026/05/06 10:12:19 Found 8 cluster IDs owned by current account
2026/05/06 10:12:20 Skipping cluster 27m20jfd6gtitlpqcedoru4l0nior9al (osde2e-lsnpa): not owned by current account
2026/05/06 10:12:20 Filtered to 7 owned clusters (from 8 total matching query)
2026/05/06 10:12:20 Found active cluster: osde2e-k0nx5 (state: ready)
2026/05/06 10:12:20 Found active cluster: osde2e-d2q66 (state: ready)
2026/05/06 10:12:20 Found active cluster: osde2e-xq29m (state: ready)
2026/05/06 10:12:20 Found active cluster: osde2e-d3p38 (state: ready)
2026/05/06 10:12:20 Found active cluster: osde2e-b4c58 (state: ready)
2026/05/06 10:12:20 Found active cluster: osde2e-oehrq (state: ready)
2026/05/06 10:12:20 Found active cluster: osde2e-gprj6 (state: installing)
2026/05/06 10:12:20 Found 13 active clusters for cleanup operations
2026/05/06 10:12:20 Current OCM account ID: 2jyomJMFrqUSf3irKatbgRbjK2N
2026/05/06 10:12:20 Found 8 cluster IDs owned by current account
2026/05/06 10:12:22 Skipping cluster 27m20jfd6gtitlpqcedoru4l0nior9al (osde2e-lsnpa): not owned by current account
2026/05/06 10:12:22 Filtered to 7 owned clusters (from 8 total matching query)
```


 Co-authored-by: Cursor [cursor@cursor.com](mailto:cursor@cursor.com)