### PR TITLE
Fix prometheus data collection exit code guard killing HTTP server

### DIFF
--- a/pkg/e2e/state/prometheus.go
+++ b/pkg/e2e/state/prometheus.go
@@ -38,7 +38,7 @@ var _ = ginkgo.Describe(clusterStateInformingName, label.E2E, func() {
 		// common for a running prometheus instance
 		cmd := "oc cp -c prometheus openshift-monitoring/prometheus-k8s-0:/prometheus /tmp/prometheus || exit $?; " +
 			"tar -cvzf " + runner.DefaultRunner.OutputDir + "/prometheus.tar.gz -C /tmp/prometheus .; " +
-			"err=$?; if (( err != 1 )); then exit $err; fi"
+			"err=$?; if (( err > 1 )); then exit $err; fi"
 
 		// ensure prometheus pods are up before trying to extract data
 		poderr := wait.PollUntilContextTimeout(ctx, 2*time.Second, prometheusPodStartedDuration, true, func(ctx context.Context) (bool, error) {


### PR DESCRIPTION
## Summary
- The tar exit code guard `!= 1` in the prometheus data collection command caused `exit 0` when tar succeeded, killing the shell before the runner's HTTP server could start
- This made `RetrieveResults()` fail with context deadline exceeded on every nightly run where tar succeeded
- Changed the condition to `> 1` so both exit code 0 (success) and 1 (files changed during archive) fall through to the HTTP server, while real tar errors (exit 2+) still propagate as failures
- This regression was introduced in #3221, which changed the guard from `!= 0` to `!= 1` — inadvertently causing tar's success exit code to kill the shell

## Failed builds

- 4.21 osd-aws nightly: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-osde2e-main-nightly-4.21-osd-aws-e2e-default/2051439278570868736
- 4.22 osd-aws nightly: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-osde2e-main-nightly-4.22-osd-aws-e2e-default/2051185159343968256

## Test plan
- [ ] Verify 4.21 and 4.22 osd-aws nightly runs pass the "should include Prometheus data" test
- [ ] Confirm runner pod logs show "Starting server" after tar completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of Prometheus data collection in end-to-end tests by refining exit code handling for tar operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->