### PR TITLE
add test coverage for provision error handling [SDCICD-1752]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ custom-*
 .crush
 
 .env
+*.log
+.tool-versions

--- a/cmd/osde2e/provision/cmd.go
+++ b/cmd/osde2e/provision/cmd.go
@@ -11,8 +11,22 @@ import (
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/providers"
 	"github.com/openshift/osde2e/pkg/common/providers/ocmprovider"
+	"github.com/openshift/osde2e/pkg/common/spi"
 	"github.com/spf13/cobra"
 )
+
+// Provisioner is an interface that abstracts cluster provisioning for testing.
+type Provisioner interface {
+	Provision(provider spi.Provider) (*spi.Cluster, error)
+}
+
+// RealProvisioner wraps the actual clusterutil.Provision function.
+type RealProvisioner struct{}
+
+// Provision calls the real clusterutil.Provision function.
+func (r *RealProvisioner) Provision(provider spi.Provider) (*spi.Cluster, error) {
+	return clusterutil.Provision(provider)
+}
 
 var Cmd = &cobra.Command{
 	Use:   "provision",
@@ -81,9 +95,20 @@ func init() {
 	_ = viper.BindPFlag(config.Tests.OnlyHealthCheckNodes, Cmd.PersistentFlags().Lookup("only-health-check-nodes"))
 }
 
-func run(cmd *cobra.Command, argv []string) error {
+// handleProvisionError determines whether a provision error should cause the command to fail.
+// Returns nil if the error should be treated as success (e.g., ErrReserveFull).
+// Returns the error if it should cause command failure.
+func handleProvisionError(err error) error {
+	if err != nil && !errors.Is(err, clusterutil.ErrReserveFull) {
+		return err
+	}
+	return nil
+}
+
+// runWithProvisioner allows dependency injection for testing.
+func runWithProvisioner(provisioner Provisioner, configString, secretLocations string) error {
 	var err error
-	if err = common.LoadConfigs(args.configString, "", args.secretLocations); err != nil {
+	if err = common.LoadConfigs(configString, "", secretLocations); err != nil {
 		return fmt.Errorf("error loading initial state: %v", err)
 	}
 	provider, err := providers.ClusterProvider()
@@ -91,9 +116,10 @@ func run(cmd *cobra.Command, argv []string) error {
 		return fmt.Errorf("error getting cluster provider: %s", err.Error())
 	}
 
-	_, err = clusterutil.Provision(provider)
-	if err != nil && !errors.Is(err, clusterutil.ErrReserveFull) {
-		return err
-	}
-	return nil
+	_, err = provisioner.Provision(provider)
+	return handleProvisionError(err)
+}
+
+func run(cmd *cobra.Command, argv []string) error {
+	return runWithProvisioner(&RealProvisioner{}, args.configString, args.secretLocations)
 }

--- a/cmd/osde2e/provision/cmd_test.go
+++ b/cmd/osde2e/provision/cmd_test.go
@@ -1,0 +1,67 @@
+package provision
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	clusterutil "github.com/openshift/osde2e/pkg/common/cluster"
+)
+
+func TestHandleProvisionError(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputError  error
+		expectError bool
+	}{
+		{
+			name:        "success returns nil",
+			inputError:  nil,
+			expectError: false,
+		},
+		{
+			name:        "ErrReserveFull returns nil (treated as success)",
+			inputError:  clusterutil.ErrReserveFull,
+			expectError: false,
+		},
+		{
+			name:        "wrapped ErrReserveFull returns nil",
+			inputError:  fmt.Errorf("failed to set up or retrieve cluster: %w", clusterutil.ErrReserveFull),
+			expectError: false,
+		},
+		{
+			name:        "OIDC error returns error (SDCICD-1752)",
+			inputError:  errors.New("failed to set up or retrieve cluster: could not launch cluster: create oidc config failed"),
+			expectError: true,
+		},
+		{
+			name:        "IAM permission error returns error (SDCICD-1752)",
+			inputError:  errors.New("failed to set up or retrieve cluster: AccessDenied"),
+			expectError: true,
+		},
+		{
+			name:        "cluster never ready returns error",
+			inputError:  errors.New("cluster never became ready: timeout"),
+			expectError: true,
+		},
+		{
+			name:        "health check failure returns error",
+			inputError:  errors.New("cluster failed health check: nodes not ready"),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := handleProvisionError(tt.inputError)
+
+			if tt.expectError && result == nil {
+				t.Errorf("expected error but got nil for input: %v", tt.inputError)
+			}
+			if !tt.expectError && result != nil {
+				t.Errorf("expected nil but got error: %v", result)
+			}
+		})
+	}
+}
+

--- a/cmd/osde2e/provision/cmd_test.go
+++ b/cmd/osde2e/provision/cmd_test.go
@@ -64,4 +64,3 @@ func TestHandleProvisionError(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
 ## Summary                                                
                                                                                                                                                                                                                    
  Adds test coverage for provision command error handling to prevent regression of the fix from PR #3122.
                                                                                                                                                                                                                    
  Relates to: [SDCICD-1752](https://redhat.atlassian.net/browse/SDCICD-1752)                                                                                                                                                                                           
   
  ## Changes                                                                                                                                                                                                        
                                                            
  - Refactored provision command to be testable (no logic changes)                                                                                                                                                  
  - Added `handleProvisionError()` function with test coverage
  - Added `Provisioner` interface for dependency injection                                                                                                                                                          
  - Tests verify correct exit codes for all error scenarios 
                                                                                                                                                                                                                    
  ## Test Coverage                                                                                                                                                                                                  
   
  ✓ Success → exit 0                                                                                                                                                                                                
  ✓ Reserve full → exit 0 (treated as success)              
  ✓ OIDC failures → exit 1 ([SDCICD-1752](https://redhat.atlassian.net/browse/SDCICD-1752))
  ✓ IAM errors → exit 1 ([SDCICD-1752](https://redhat.atlassian.net/browse/SDCICD-1752))                                                                                                                                                                               
  ✓ Cluster timeouts → exit 1
  ✓ Health check failures → exit 1                                                                                                                                                                                  
                                                                                                                                                                                                                    
  All tests pass in 0.016s (7 test cases)

[SDCICD-1752]: https://redhat.atlassian.net/browse/SDCICD-1752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDCICD-1752]: https://redhat.atlassian.net/browse/SDCICD-1752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `.gitignore` to exclude log files and `.tool-versions`.

* **Bug Fixes**
  * Improved error handling during cluster provisioning with consistent treatment of reservation-full scenarios.

* **Tests**
  * Added comprehensive test coverage for provisioning error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->