### PR TITLE
Fix provision-cluster-reserve.sh to propagate osde2e exit codes [SDCICD-1752]

### DIFF
--- a/scripts/provision-cluster-reserve.sh
+++ b/scripts/provision-cluster-reserve.sh
@@ -21,13 +21,17 @@ docker create --name "${CONTAINER_NAME}" -e OCM_TOKEN \
 	-e ROSA_STS="${STS}" \
 	-e CHANNEL \
 	-e REPORT_DIR='/tmp/osde2e-report' \
-	quay.io/redhat-services-prod/osde2e-cicada-tenant/osde2e:latest provision --reserve --configs "${CONFIGS}" 
+	quay.io/redhat-services-prod/osde2e-cicada-tenant/osde2e:latest provision --reserve --configs "${CONFIGS}"
 
-# Start the container
+# Start the container and capture exit code
 docker start -a "${CONTAINER_NAME}"
+EXIT_CODE=$?
 
-# Copy the junit results xml for publishing
-docker cp "${CONTAINER_NAME}":/tmp/osde2e-report .
+# Copy the junit results xml for publishing (even on failure, for debugging)
+docker cp "${CONTAINER_NAME}":/tmp/osde2e-report . || true
 
-# Optionally, clean up by removing the container after use
+# Clean up by removing the container
 docker rm "${CONTAINER_NAME}"
+
+# Exit with the osde2e exit code
+exit ${EXIT_CODE}


### PR DESCRIPTION
## Summary

Fixes [SDCICD-1752](https://redhat.atlassian.net/browse/SDCICD-1752) - Jenkins jobs currently report SUCCESS even when osde2e fails during cluster provisioning.

## Problem

The `provision-cluster-reserve.sh` script doesn't capture or propagate the exit code from the osde2e container. When osde2e fails (e.g., OIDC config creation error), the script continues and exits with the code from `docker rm` (which is 0), causing Jenkins to report SUCCESS.

Example from ticket:
```
E0210 14:24:29.891401       1 main.go:95] "command execution failed" err=<
    failed to set up or retrieve cluster: could not launch cluster...
Finished: SUCCESS  # ❌ Should be FAILURE
```

## Solution

This PR modifies the script to:
1. Capture the exit code from `docker start -a` (the osde2e command)
2. Continue cleanup operations (`docker cp`, `docker rm`)
3. Exit with the captured osde2e exit code

## Testing

Works in combination with PR https://github.com/openshift/osde2e-common/pull/538 which makes osde2e fail fast on terminal cluster states.

After both PRs:
- ✅ osde2e detects cluster errors and exits with code 1
- ✅ Shell script propagates that code to Jenkins
- ✅ Jenkins correctly reports FAILURE

## Affects

- `osde2e-provision-pd-reserve-int` Jenkins job
- `osde2e-provision-pd-reserve` Jenkins job

[SDCICD-1752]: https://redhat.atlassian.net/browse/SDCICD-1752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ