### PR TITLE
SDCICD-1798 per-suite S3 upload and artifact links for multi-suite ad-hoc runs

### DIFF
--- a/pkg/e2e/adhoctestimages/adhoctestimages.go
+++ b/pkg/e2e/adhoctestimages/adhoctestimages.go
@@ -26,6 +26,7 @@ import (
 type PendingNotification struct {
 	AnalysisContent string
 	TestSuite       config.TestSuite
+	OutputDir       string // per-suite artifact directory for suite-specific S3 upload
 }
 
 var (
@@ -90,8 +91,10 @@ var _ = ginkgo.Describe("Ad Hoc Test Images", ginkgo.Ordered, ginkgo.ContinueOnF
 	ginkgo.DescribeTable("execution",
 		func(ctx context.Context, testSuite config.TestSuite) {
 			testImage := testSuite.Image
-			baseImageName := strings.Split(testImage[strings.LastIndex(testImage, "/")+1:], ":")[0]
-			exeConfig.OutputDir = filepath.Join(viper.GetString(config.ReportDir), viper.GetString(config.Phase), baseImageName)
+			// Use image name + tag as dir name so suites from the same repo
+			// but different tags get separate artifact directories.
+			dirName := strings.ReplaceAll(testImage[strings.LastIndex(testImage, "/")+1:], ":", "-")
+			exeConfig.OutputDir = filepath.Join(viper.GetString(config.ReportDir), viper.GetString(config.Phase), dirName)
 
 			logger.Info("running test suite", "suite", testImage, "timeout", exeConfig.Timeout)
 			results, err := exe.Execute(ctx, testImage)
@@ -128,7 +131,7 @@ var _ = ginkgo.Describe("Ad Hoc Test Images", ginkgo.Ordered, ginkgo.ContinueOnF
 				if viper.GetBool(config.LogAnalysis.EnableAnalysis) {
 					analysisContent = runLogAnalysisForAdHocTestImage(ctx, logger, testSuite, combinedErr, exeConfig.OutputDir)
 				}
-				queueNotification(testSuite, analysisContent)
+				queueNotification(testSuite, analysisContent, exeConfig.OutputDir)
 			}
 		},
 		testImageEntries)
@@ -136,11 +139,12 @@ var _ = ginkgo.Describe("Ad Hoc Test Images", ginkgo.Ordered, ginkgo.ContinueOnF
 
 // queueNotification adds a PendingNotification for deferred Slack delivery.
 // Called directly when log analysis is disabled so notifications are still sent.
-func queueNotification(testSuite config.TestSuite, analysisContent string) {
+func queueNotification(testSuite config.TestSuite, analysisContent, outputDir string) {
 	pendingMu.Lock()
 	pendingNotifications = append(pendingNotifications, PendingNotification{
 		AnalysisContent: analysisContent,
 		TestSuite:       testSuite,
+		OutputDir:       outputDir,
 	})
 	pendingMu.Unlock()
 }

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -99,12 +99,13 @@ func RunTests(ctx context.Context) int {
 
 // E2EOrchestrator implements the orchestrator.Orchestrator interface for OSD e2e tests.
 type E2EOrchestrator struct {
-	provider       spi.Provider
-	result         *orchestrator.Result
-	suiteConfig    types.SuiteConfig
-	reporterConfig types.ReporterConfig
-	s3Results      []aws.S3UploadResult
-	analysisResult *analysisengine.Result
+	provider          spi.Provider
+	result            *orchestrator.Result
+	suiteConfig       types.SuiteConfig
+	reporterConfig    types.ReporterConfig
+	s3Results         []aws.S3UploadResult
+	perSuiteS3Results map[string][]aws.S3UploadResult // keyed by test image
+	analysisResult    *analysisengine.Result
 }
 
 // NewOrchestrator creates a new E2E orchestrator instance.
@@ -120,9 +121,10 @@ func NewOrchestrator(ctx context.Context) (orchestrator.Orchestrator, error) {
 	configureGinkgo(&suiteConfig, &reporterConfig)
 
 	return &E2EOrchestrator{
-		provider:       provider,
-		suiteConfig:    suiteConfig,
-		reporterConfig: reporterConfig,
+		provider:          provider,
+		suiteConfig:       suiteConfig,
+		reporterConfig:    reporterConfig,
+		perSuiteS3Results: make(map[string][]aws.S3UploadResult),
 		result: &orchestrator.Result{
 			ExitCode: config.Success,
 		},
@@ -295,6 +297,9 @@ func (o *E2EOrchestrator) Report(ctx context.Context) error {
 		if err := o.uploadToS3(); err != nil {
 			log.Printf("S3 upload failed: %v", err)
 		}
+		if len(pending) > 0 {
+			o.uploadSuiteArtifacts(pending)
+		}
 	}
 
 	// Send notifications after S3 upload so presigned URLs are available.
@@ -364,11 +369,17 @@ func (o *E2EOrchestrator) sendFailureNotification(ctx context.Context) {
 // upload so that presigned URLs are available for inclusion in the message.
 func (o *E2EOrchestrator) sendDeferredNotifications(ctx context.Context, pending []adhoctestimages.PendingNotification) {
 	webhook := viper.GetString(config.Slack.WebhookURL)
-	if webhook == "" || !viper.GetBool(config.Tests.EnableSlackNotify) {
+	if webhook == "" {
+		log.Println("Skipping deferred notifications: no Slack webhook configured")
+		return
+	}
+	if !viper.GetBool(config.Tests.EnableSlackNotify) {
+		log.Println("Skipping deferred notifications: Slack notifications disabled")
 		return
 	}
 
-	artifactLinks := s3ResultsToArtifactLinks(o.s3Results)
+	globalLink := globalTestOutputLink(o.s3Results)
+	fallbackLinks := s3ResultsToArtifactLinks(o.s3Results)
 	slackReporter := slack.NewSlackReporter()
 	var expiration string
 	if o.provider != nil {
@@ -397,7 +408,7 @@ func (o *E2EOrchestrator) sendDeferredNotifications(ctx context.Context, pending
 			Version:    viper.GetString(config.Cluster.Version),
 			Expiration: expiration,
 		}
-		cfg.Settings["artifact_links"] = artifactLinks
+		cfg.Settings["artifact_links"] = o.artifactLinksForSuite(p.TestSuite.Image, globalLink, fallbackLinks)
 
 		result := &slack.AnalysisResult{
 			Status:  "completed",
@@ -406,8 +417,24 @@ func (o *E2EOrchestrator) sendDeferredNotifications(ctx context.Context, pending
 
 		if err := slackReporter.Report(ctx, result, &cfg); err != nil {
 			log.Printf("Failed to send deferred notification for %s: %v", p.TestSuite.Image, err)
+		} else {
+			log.Printf("Sent notification for %s to %s", p.TestSuite.Image, p.TestSuite.SlackChannel)
 		}
 	}
+}
+
+// artifactLinksForSuite returns per-suite artifact links if available,
+// prepending the global test_output.log link. Falls back to global links.
+func (o *E2EOrchestrator) artifactLinksForSuite(image string, globalLink *slack.ArtifactLink, fallback []slack.ArtifactLink) []slack.ArtifactLink {
+	results, ok := o.perSuiteS3Results[image]
+	if !ok {
+		return fallback
+	}
+	var links []slack.ArtifactLink
+	if globalLink != nil {
+		links = append(links, *globalLink)
+	}
+	return append(links, suiteArtifactLinks(results)...)
 }
 
 // uploadToS3 uploads the report directory contents to S3 and caches results.
@@ -417,7 +444,7 @@ func (o *E2EOrchestrator) uploadToS3() error {
 		return nil
 	}
 
-	component := deriveComponentFromFirstImage()
+	component := deriveGlobalComponent()
 	uploader, err := aws.NewS3Uploader(component)
 	if errors.Is(err, aws.ErrNoAWSCredentials) {
 		log.Printf("%v", err)
@@ -441,47 +468,111 @@ func (o *E2EOrchestrator) uploadToS3() error {
 	return nil
 }
 
+func toArtifactLink(r aws.S3UploadResult) slack.ArtifactLink {
+	return slack.ArtifactLink{
+		Name: filepath.Base(r.Key),
+		URL:  r.PresignedURL,
+		Size: r.Size,
+	}
+}
+
 // s3ResultsToArtifactLinks converts S3 upload results to artifact links for Slack.
 // Returns links in a fixed order: test_output.log, junit_<suffix>.xml.
 func s3ResultsToArtifactLinks(results []aws.S3UploadResult) []slack.ArtifactLink {
 	suffix := viper.GetString(config.Suffix)
 	currentJunit := "junit_" + suffix + ".xml"
-
 	orderedNames := []string{"test_output.log", currentJunit}
 
 	byName := make(map[string]aws.S3UploadResult, len(orderedNames))
 	for _, r := range results {
-		if r.PresignedURL == "" {
-			continue
+		if r.PresignedURL != "" {
+			byName[filepath.Base(r.Key)] = r
 		}
-		byName[filepath.Base(r.Key)] = r
 	}
 
 	links := make([]slack.ArtifactLink, 0, len(orderedNames))
 	for _, name := range orderedNames {
 		if r, ok := byName[name]; ok {
-			links = append(links, slack.ArtifactLink{
-				Name: name,
-				URL:  r.PresignedURL,
-				Size: r.Size,
-			})
+			links = append(links, toArtifactLink(r))
 		}
 	}
 	return links
 }
 
-// deriveComponentFromFirstImage determines the component name from the test image.
-// It extracts a meaningful name from the test image path to organize S3 artifacts.
-// Examples:
-//
-//	quay.io/org/osd-example-operator-e2e:tag -> osd-example-operator
-//	quay.io/org/my-service-test:latest -> my-service
-func deriveComponentFromFirstImage() string {
-	testSuites, err := config.GetTestSuites()
-	if err == nil && len(testSuites) > 0 {
-		imageName := testSuites[0].Image
-		if component, _ := extractDetailsFromImage(imageName); component != "" {
-			return component
+// uploadSuiteArtifacts uploads each failed suite's artifact directory to S3
+// under a suite-specific component key. Results are stored in perSuiteS3Results
+// keyed by the test image name for use in per-suite Slack notifications.
+func (o *E2EOrchestrator) uploadSuiteArtifacts(pending []adhoctestimages.PendingNotification) {
+	for _, p := range pending {
+		if p.OutputDir == "" {
+			continue
+		}
+		component, tag := extractDetailsFromImage(p.TestSuite.Image)
+		if tag != "" {
+			component = component + "-" + tag
+		}
+		uploader, err := aws.NewS3Uploader(component)
+		if errors.Is(err, aws.ErrNoAWSCredentials) {
+			return
+		}
+		if err != nil {
+			log.Printf("Failed to create S3 uploader for suite %s: %v", p.TestSuite.Image, err)
+			continue
+		}
+
+		results, err := uploader.UploadDirectory(p.OutputDir)
+		if err != nil {
+			log.Printf("Failed to upload artifacts for suite %s: %v", p.TestSuite.Image, err)
+			continue
+		}
+
+		o.perSuiteS3Results[p.TestSuite.Image] = results
+	}
+}
+
+// globalTestOutputLink extracts the test_output.log presigned URL from global
+// S3 upload results. Returns nil if not found.
+func globalTestOutputLink(results []aws.S3UploadResult) *slack.ArtifactLink {
+	for _, r := range results {
+		if r.PresignedURL != "" && filepath.Base(r.Key) == "test_output.log" {
+			link := toArtifactLink(r)
+			return &link
+		}
+	}
+	return nil
+}
+
+// suiteArtifactLinks converts all S3 upload results for a single suite into
+// artifact links suitable for Slack notifications.
+func suiteArtifactLinks(results []aws.S3UploadResult) []slack.ArtifactLink {
+	links := make([]slack.ArtifactLink, 0, len(results))
+	for _, r := range results {
+		if r.PresignedURL != "" {
+			links = append(links, toArtifactLink(r))
+		}
+	}
+	return links
+}
+
+// deriveGlobalComponent determines the component name for the global S3 upload.
+// For single-suite runs, it extracts from the image name (backward compatible).
+// For multi-suite runs, it uses the job name to avoid misleading attribution.
+func deriveGlobalComponent() string {
+	testSuites, _ := config.GetTestSuites()
+
+	if len(testSuites) == 1 {
+		if c, _ := extractDetailsFromImage(testSuites[0].Image); c != "" {
+			return c
+		}
+	}
+
+	if jn := viper.GetString(config.JobName); jn != "" {
+		return jn
+	}
+
+	if len(testSuites) > 0 {
+		if c, _ := extractDetailsFromImage(testSuites[0].Image); c != "" {
+			return c
 		}
 	}
 

--- a/pkg/e2e/e2e_test.go
+++ b/pkg/e2e/e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/onsi/ginkgo/v2/types"
+	"github.com/openshift/osde2e/pkg/common/aws"
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/orchestrator"
@@ -276,5 +277,333 @@ func TestCleanup_DryRun(t *testing.T) {
 	err := orch.Cleanup(context.TODO())
 	if err != nil {
 		t.Errorf("Expected no error in dry run mode, got: %v", err)
+	}
+}
+
+func TestExtractDetailsFromImage(t *testing.T) {
+	tests := []struct {
+		name          string
+		image         string
+		wantComponent string
+		wantTag       string
+	}{
+		{
+			name:          "standard image with e2e suffix",
+			image:         "quay.io/org/osd-example-operator-e2e:v1.2.3",
+			wantComponent: "osd-example-operator",
+			wantTag:       "v1.2.3",
+		},
+		{
+			name:          "image with test suffix",
+			image:         "quay.io/org/my-service-test:latest",
+			wantComponent: "my-service",
+			wantTag:       "latest",
+		},
+		{
+			name:          "image with tests suffix",
+			image:         "quay.io/org/my-service-tests:abc123",
+			wantComponent: "my-service",
+			wantTag:       "abc123",
+		},
+		{
+			name:          "image with harness suffix",
+			image:         "quay.io/org/platform-harness:v1",
+			wantComponent: "platform",
+			wantTag:       "v1",
+		},
+		{
+			name:          "image without test suffix",
+			image:         "quay.io/org/simple:v1",
+			wantComponent: "simple",
+			wantTag:       "v1",
+		},
+		{
+			name:          "image without tag",
+			image:         "quay.io/org/my-operator-e2e",
+			wantComponent: "my-operator",
+			wantTag:       "",
+		},
+		{
+			name:          "image without registry or org",
+			image:         "my-image-test:latest",
+			wantComponent: "my-image",
+			wantTag:       "latest",
+		},
+		{
+			name:          "empty string",
+			image:         "",
+			wantComponent: "",
+			wantTag:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotComponent, gotTag := extractDetailsFromImage(tt.image)
+			if gotComponent != tt.wantComponent {
+				t.Errorf("extractDetailsFromImage(%q) component = %q, want %q", tt.image, gotComponent, tt.wantComponent)
+			}
+			if gotTag != tt.wantTag {
+				t.Errorf("extractDetailsFromImage(%q) tag = %q, want %q", tt.image, gotTag, tt.wantTag)
+			}
+		})
+	}
+}
+
+func TestS3ResultsToArtifactLinks(t *testing.T) {
+	setupTestConfig(t)
+	viper.Set(config.Suffix, "abc123")
+
+	results := []aws.S3UploadResult{
+		{Key: "test-results/comp/2026-01-30/123/test_output.log", PresignedURL: "https://s3/log", Size: 5000},
+		{Key: "test-results/comp/2026-01-30/123/install/junit_abc123.xml", PresignedURL: "https://s3/junit", Size: 200},
+		{Key: "test-results/comp/2026-01-30/123/install/operator-a-e2e/results.xml", PresignedURL: "https://s3/other", Size: 100},
+	}
+
+	links := s3ResultsToArtifactLinks(results)
+	if len(links) != 2 {
+		t.Fatalf("Expected 2 links (test_output.log + junit), got %d", len(links))
+	}
+	if links[0].Name != "test_output.log" {
+		t.Errorf("links[0].Name = %q, want %q", links[0].Name, "test_output.log")
+	}
+	if links[1].Name != "junit_abc123.xml" {
+		t.Errorf("links[1].Name = %q, want %q", links[1].Name, "junit_abc123.xml")
+	}
+}
+
+func TestS3ResultsToArtifactLinks_EmptyPresignedURL(t *testing.T) {
+	setupTestConfig(t)
+	viper.Set(config.Suffix, "test")
+
+	results := []aws.S3UploadResult{
+		{Key: "test-results/comp/2026-01-30/123/test_output.log", PresignedURL: "", Size: 5000},
+	}
+
+	links := s3ResultsToArtifactLinks(results)
+	if len(links) != 0 {
+		t.Errorf("Expected 0 links when presigned URLs are empty, got %d", len(links))
+	}
+}
+
+func TestS3ResultsToArtifactLinks_Empty(t *testing.T) {
+	setupTestConfig(t)
+
+	links := s3ResultsToArtifactLinks(nil)
+	if len(links) != 0 {
+		t.Errorf("Expected 0 links for nil input, got %d", len(links))
+	}
+}
+
+func TestGlobalTestOutputLink_EmptyPresignedURL(t *testing.T) {
+	results := []aws.S3UploadResult{
+		{Key: "test-results/comp/2026-01-30/123/test_output.log", PresignedURL: "", Size: 5000},
+	}
+
+	link := globalTestOutputLink(results)
+	if link != nil {
+		t.Errorf("Expected nil link when presigned URL is empty, got %+v", link)
+	}
+}
+
+func TestGlobalTestOutputLink_PreservesSize(t *testing.T) {
+	results := []aws.S3UploadResult{
+		{Key: "test-results/comp/2026-01-30/123/test_output.log", PresignedURL: "https://s3/log", Size: 12345},
+	}
+
+	link := globalTestOutputLink(results)
+	if link == nil {
+		t.Fatal("Expected non-nil link")
+	}
+	if link.Size != 12345 {
+		t.Errorf("link.Size = %d, want %d", link.Size, 12345)
+	}
+}
+
+func TestSuiteArtifactLinks_PreservesOrder(t *testing.T) {
+	results := []aws.S3UploadResult{
+		{Key: "test-results/op-a/2026-01-30/123/alpha.xml", PresignedURL: "https://s3/a", Size: 10},
+		{Key: "test-results/op-a/2026-01-30/123/beta.log", PresignedURL: "https://s3/b", Size: 20},
+		{Key: "test-results/op-a/2026-01-30/123/gamma.json", PresignedURL: "https://s3/c", Size: 30},
+	}
+
+	links := suiteArtifactLinks(results)
+	if len(links) != 3 {
+		t.Fatalf("Expected 3 links, got %d", len(links))
+	}
+	expected := []string{"alpha.xml", "beta.log", "gamma.json"}
+	for i, want := range expected {
+		if links[i].Name != want {
+			t.Errorf("links[%d].Name = %q, want %q", i, links[i].Name, want)
+		}
+	}
+}
+
+func TestDeriveGlobalComponent_LegacyAdHocTestImages(t *testing.T) {
+	setupTestConfig(t)
+	viper.Set(config.Tests.AdHocTestImages, "quay.io/org/legacy-operator-e2e:v1")
+	viper.Set(config.JobName, "")
+
+	got := deriveGlobalComponent()
+	if got != "legacy-operator" {
+		t.Errorf("deriveGlobalComponent() with legacy format = %q, want %q", got, "legacy-operator")
+	}
+}
+
+func TestDeriveGlobalComponent_SingleSuite(t *testing.T) {
+	setupTestConfig(t)
+	viper.Set(config.Tests.TestSuites, []config.TestSuite{
+		{Image: "quay.io/org/osd-example-operator-e2e:latest"},
+	})
+
+	got := deriveGlobalComponent()
+	if got != "osd-example-operator" {
+		t.Errorf("deriveGlobalComponent() = %q, want %q", got, "osd-example-operator")
+	}
+}
+
+func TestDeriveGlobalComponent_MultiSuiteWithJobName(t *testing.T) {
+	setupTestConfig(t)
+	viper.Set(config.Tests.TestSuites, []config.TestSuite{
+		{Image: "quay.io/org/operator-a-e2e:v1"},
+		{Image: "quay.io/org/operator-b-e2e:v2"},
+	})
+	viper.Set(config.JobName, "osde2e-prod-gcp-nightly")
+
+	got := deriveGlobalComponent()
+	if got != "osde2e-prod-gcp-nightly" {
+		t.Errorf("deriveGlobalComponent() = %q, want %q", got, "osde2e-prod-gcp-nightly")
+	}
+}
+
+func TestDeriveGlobalComponent_MultiSuiteNoJobName(t *testing.T) {
+	setupTestConfig(t)
+	viper.Set(config.Tests.TestSuites, []config.TestSuite{
+		{Image: "quay.io/org/operator-a-e2e:v1"},
+		{Image: "quay.io/org/operator-b-e2e:v2"},
+	})
+	viper.Set(config.JobName, "")
+
+	got := deriveGlobalComponent()
+	if got != "operator-a" {
+		t.Errorf("deriveGlobalComponent() = %q, want %q (fallback to first image)", got, "operator-a")
+	}
+}
+
+func TestDeriveGlobalComponent_NoSuites(t *testing.T) {
+	setupTestConfig(t)
+
+	got := deriveGlobalComponent()
+	if got != "unknown" {
+		t.Errorf("deriveGlobalComponent() = %q, want %q", got, "unknown")
+	}
+}
+
+func TestGlobalTestOutputLink(t *testing.T) {
+	results := []aws.S3UploadResult{
+		{Key: "test-results/comp/2026-01-30/123/install/junit_abc.xml", PresignedURL: "https://s3/junit", Size: 100},
+		{Key: "test-results/comp/2026-01-30/123/test_output.log", PresignedURL: "https://s3/log", Size: 5000},
+	}
+
+	link := globalTestOutputLink(results)
+	if link == nil {
+		t.Fatal("Expected non-nil link for test_output.log")
+	}
+	if link.Name != "test_output.log" {
+		t.Errorf("link.Name = %q, want %q", link.Name, "test_output.log")
+	}
+	if link.URL != "https://s3/log" {
+		t.Errorf("link.URL = %q, want %q", link.URL, "https://s3/log")
+	}
+}
+
+func TestGlobalTestOutputLink_NotFound(t *testing.T) {
+	results := []aws.S3UploadResult{
+		{Key: "test-results/comp/2026-01-30/123/install/junit_abc.xml", PresignedURL: "https://s3/junit", Size: 100},
+	}
+
+	link := globalTestOutputLink(results)
+	if link != nil {
+		t.Errorf("Expected nil link when test_output.log not present, got %+v", link)
+	}
+}
+
+func TestSuiteArtifactLinks(t *testing.T) {
+	results := []aws.S3UploadResult{
+		{Key: "test-results/operator-a/2026-01-30/123/junit.xml", PresignedURL: "https://s3/junit", Size: 100},
+		{Key: "test-results/operator-a/2026-01-30/123/executor.log", PresignedURL: "https://s3/exec", Size: 2000},
+		{Key: "test-results/operator-a/2026-01-30/123/no-url.log", PresignedURL: "", Size: 500},
+	}
+
+	links := suiteArtifactLinks(results)
+	if len(links) != 2 {
+		t.Fatalf("Expected 2 links (skipping empty presigned URL), got %d", len(links))
+	}
+	if links[0].Name != "junit.xml" {
+		t.Errorf("links[0].Name = %q, want %q", links[0].Name, "junit.xml")
+	}
+	if links[1].Name != "executor.log" {
+		t.Errorf("links[1].Name = %q, want %q", links[1].Name, "executor.log")
+	}
+}
+
+func TestSuiteArtifactLinks_Empty(t *testing.T) {
+	links := suiteArtifactLinks(nil)
+	if len(links) != 0 {
+		t.Errorf("Expected 0 links for nil input, got %d", len(links))
+	}
+}
+
+func TestArtifactLinksForSuite_PerSuite(t *testing.T) {
+	orch := &E2EOrchestrator{
+		perSuiteS3Results: map[string][]aws.S3UploadResult{
+			"quay.io/org/op-e2e:abc": {
+				{Key: "test-results/op-abc/junit.xml", PresignedURL: "https://s3/junit", Size: 100},
+				{Key: "test-results/op-abc/exec.log", PresignedURL: "https://s3/exec", Size: 200},
+			},
+		},
+		result: &orchestrator.Result{ExitCode: config.Success},
+	}
+	globalLink := &slack.ArtifactLink{Name: "test_output.log", URL: "https://s3/log", Size: 5000}
+	fallback := []slack.ArtifactLink{{Name: "fallback.log", URL: "https://s3/fb"}}
+
+	links := orch.artifactLinksForSuite("quay.io/org/op-e2e:abc", globalLink, fallback)
+	if len(links) != 3 {
+		t.Fatalf("Expected 3 links (1 global + 2 per-suite), got %d", len(links))
+	}
+	if links[0].Name != "test_output.log" {
+		t.Errorf("links[0] = %q, want global test_output.log", links[0].Name)
+	}
+	if links[1].Name != "junit.xml" {
+		t.Errorf("links[1] = %q, want junit.xml", links[1].Name)
+	}
+}
+
+func TestArtifactLinksForSuite_Fallback(t *testing.T) {
+	orch := &E2EOrchestrator{
+		perSuiteS3Results: map[string][]aws.S3UploadResult{},
+		result:            &orchestrator.Result{ExitCode: config.Success},
+	}
+	fallback := []slack.ArtifactLink{{Name: "test_output.log", URL: "https://s3/log"}}
+
+	links := orch.artifactLinksForSuite("quay.io/org/unknown:xyz", nil, fallback)
+	if len(links) != 1 || links[0].Name != "test_output.log" {
+		t.Errorf("Expected fallback links, got %v", links)
+	}
+}
+
+func TestArtifactLinksForSuite_NoGlobalLink(t *testing.T) {
+	orch := &E2EOrchestrator{
+		perSuiteS3Results: map[string][]aws.S3UploadResult{
+			"img:v1": {
+				{Key: "k/junit.xml", PresignedURL: "https://s3/j", Size: 50},
+			},
+		},
+		result: &orchestrator.Result{ExitCode: config.Success},
+	}
+
+	links := orch.artifactLinksForSuite("img:v1", nil, nil)
+	if len(links) != 1 || links[0].Name != "junit.xml" {
+		t.Errorf("Expected 1 per-suite link without global, got %v", links)
 	}
 }


### PR DESCRIPTION
For multi-suite ad-hoc runs, each failing suite now uploads its artifacts to a tag-disambiguated S3 path and receives its own Slack notification with suite-specific artifact links. Previously all suites shared a single S3 component path, making artifacts ambiguous and Slack links incorrect.

- Each failing suite uploads to `test-results/ <component>-<tag>/ ... `
- Deferred Slack notifications include the global test_output.log + per-suite JUnit/log links
- PendingNotification carries OutputDir so Report() knows where to find each suite's artifacts
- Unit tests added for all new helpers (extractDetailsFromImage, s3ResultsToArtifactLinks, globalTestOutputLink, suiteArtifactLinks, deriveGlobalComponent, artifactLinksForSuite)

**Data flow**
```
adhoctestimages.DescribeTable (executes suite, queues PendingNotification + OutputDir)
  → Report() drains pending notifications
    → uploadToS3()
      — global upload for all artifacts
    → uploadSuiteArtifacts()
      — per-suite upload with tag-disambiguated S3 keys
    → sendDeferredNotifications()
      → artifactLinksForSuite()
        — combines global test_output.log link + per-suite artifact links
      → slackReporter.Report()
        — sends notification to each suite's Slack channel
```

**Test**

- [ ]  Single-suite run: behavior unchanged, global component key used, one Slack message with artifact links
- [ ]  Multi-suite run with failures: each failing suite sends its own Slack message with suite-specific links, test_output.log from global upload included in each
- [ ]  Multi-suite run with a mix of pass/fail: only failing suites trigger notification and per-suite upload
- [ ]  Unit tests: go test ./pkg/e2e/ passes

Eaxmple:
https://redhat-internal.slack.com/archives/C095XQANCBD/p1779916339954319
https://redhat-internal.slack.com/archives/C095XQANCBD/p1779916340213409

Co-authored-by: Cursor [cursor@cursor.com](mailto:cursor@cursor.com)