### PR TITLE
SDCICD-1840 Add mcsimulation package with CRD installation logic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.2
 	k8s.io/api v0.35.2
+	k8s.io/apiextensions-apiserver v0.35.1
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2
 	k8s.io/klog/v2 v2.130.1
@@ -171,7 +172,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	k8s.io/apiextensions-apiserver v0.35.1 // indirect
 	k8s.io/component-base v0.35.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/pkg/common/mcsimulation/crds.go
+++ b/pkg/common/mcsimulation/crds.go
@@ -1,0 +1,177 @@
+// Package mcsimulation provides Management Cluster simulation for HCP operator
+// testing. It installs minimal CRDs onto a ROSA Classic cluster so that
+// operators that watch HyperShift resources can be tested without a real
+// Management Cluster.
+package mcsimulation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+)
+
+// Minimal CRD definitions with x-kubernetes-preserve-unknown-fields: true
+// so that any spec/status content is accepted without full schema validation.
+// Sourced from route-monitor-operator e2e tests.
+const (
+	HostedControlPlaneCRDYAML = `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hostedcontrolplanes.hypershift.openshift.io
+spec:
+  group: hypershift.openshift.io
+  names:
+    kind: HostedControlPlane
+    listKind: HostedControlPlaneList
+    plural: hostedcontrolplanes
+    shortNames:
+    - hcp
+    singular: hostedcontrolplane
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
+`
+
+	VpcEndpointCRDYAML = `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: vpcendpoints.avo.openshift.io
+spec:
+  group: avo.openshift.io
+  names:
+    kind: VpcEndpoint
+    listKind: VpcEndpointList
+    plural: vpcendpoints
+    singular: vpcendpoint
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
+`
+)
+
+// BuiltinCRDs maps short aliases (used in config) to embedded CRD YAML.
+// Keys: "hcp" (HostedControlPlane), "vpce" (VpcEndpoint).
+var BuiltinCRDs = map[string]string{
+	"hcp":  HostedControlPlaneCRDYAML,
+	"vpce": VpcEndpointCRDYAML,
+}
+
+var crdGVR = schema.GroupVersionResource{
+	Group:    "apiextensions.k8s.io",
+	Version:  "v1",
+	Resource: "customresourcedefinitions",
+}
+
+// EnsureCRDsInstalled resolves a list of CRD aliases and installs any that are
+// not already present on the cluster. Forbidden errors are collected and returned
+// together so callers get a single actionable message with all missing CRDs.
+func EnsureCRDsInstalled(ctx context.Context, dynClient dynamic.Interface, crdAliases []string) error {
+	var forbidden []string
+
+	for _, alias := range crdAliases {
+		alias = strings.TrimSpace(alias)
+		if alias == "" {
+			continue
+		}
+
+		crdYAML, ok := BuiltinCRDs[alias]
+		if !ok {
+			return fmt.Errorf("unknown CRD alias %q (available: hcp, vpce)", alias)
+		}
+
+		// Decode the embedded YAML into an unstructured object to get the CRD name.
+		obj := &unstructured.Unstructured{}
+		if err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(crdYAML), 4096).Decode(obj); err != nil {
+			return fmt.Errorf("decoding CRD YAML for %q: %w", alias, err)
+		}
+		name := obj.GetName()
+
+		// Check existence first to avoid unnecessary write attempts.
+		if _, err := dynClient.Resource(crdGVR).Get(ctx, name, metav1.GetOptions{}); err == nil {
+			klog.V(2).InfoS("CRD already exists, skipping", "name", name)
+			continue
+		} else if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("checking CRD %s: %w", name, err)
+		}
+
+		// Install the CRD.
+		klog.V(2).InfoS("Installing CRD", "name", name)
+		if _, err := dynClient.Resource(crdGVR).Create(ctx, obj, metav1.CreateOptions{}); err != nil {
+			switch {
+			case apierrors.IsAlreadyExists(err):
+				// Another process created it concurrently; still wait for Established below.
+				klog.V(2).InfoS("CRD appeared concurrently, waiting for Established", "name", name)
+			case apierrors.IsForbidden(err):
+				klog.InfoS("Warning: permission denied installing CRD", "name", name)
+				forbidden = append(forbidden, name)
+				continue
+			default:
+				return fmt.Errorf("creating CRD %s: %w", name, err)
+			}
+		}
+
+		// Wait for the API server to mark the CRD as Established before returning.
+		// Operators that detect CRD presence at startup will fail if it isn't ready.
+		if err := waitForCRDEstablished(ctx, dynClient, name, 30*time.Second); err != nil {
+			return fmt.Errorf("CRD %s not Established after install: %w", name, err)
+		}
+		klog.V(2).InfoS("CRD installed and Established", "name", name)
+	}
+
+	if len(forbidden) > 0 {
+		return fmt.Errorf(
+			"insufficient permissions to install CRDs: [%s] — grant cluster-admin or pre-install them",
+			strings.Join(forbidden, ", "),
+		)
+	}
+	return nil
+}
+
+// waitForCRDEstablished polls until the CRD's Established condition is True.
+func waitForCRDEstablished(ctx context.Context, dynClient dynamic.Interface, name string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		obj, err := dynClient.Resource(crdGVR).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+		if !found {
+			return false, nil
+		}
+		for _, c := range conditions {
+			cond, ok := c.(map[string]interface{})
+			if ok && cond["type"] == "Established" && cond["status"] == "True" {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}

--- a/pkg/common/mcsimulation/crds.go
+++ b/pkg/common/mcsimulation/crds.go
@@ -10,90 +10,94 @@ import (
 	"strings"
 	"time"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
 
-// Minimal CRD definitions with x-kubernetes-preserve-unknown-fields: true
-// so that any spec/status content is accepted without full schema validation.
-// Sourced from route-monitor-operator e2e tests.
-const (
-	HostedControlPlaneCRDYAML = `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: hostedcontrolplanes.hypershift.openshift.io
-spec:
-  group: hypershift.openshift.io
-  names:
-    kind: HostedControlPlane
-    listKind: HostedControlPlaneList
-    plural: hostedcontrolplanes
-    shortNames:
-    - hcp
-    singular: hostedcontrolplane
-  scope: Namespaced
-  versions:
-  - name: v1beta1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    subresources:
-      status: {}
-`
-
-	VpcEndpointCRDYAML = `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: vpcendpoints.avo.openshift.io
-spec:
-  group: avo.openshift.io
-  names:
-    kind: VpcEndpoint
-    listKind: VpcEndpointList
-    plural: vpcendpoints
-    singular: vpcendpoint
-  scope: Namespaced
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    subresources:
-      status: {}
-`
-)
-
-// BuiltinCRDs maps short aliases (used in config) to embedded CRD YAML.
-// Keys: "hcp" (HostedControlPlane), "vpce" (VpcEndpoint).
-var BuiltinCRDs = map[string]string{
-	"hcp":  HostedControlPlaneCRDYAML,
-	"vpce": VpcEndpointCRDYAML,
+// Minimal stub CRDs with x-kubernetes-preserve-unknown-fields: true.
+// These accept any spec/status content without full schema validation,
+// keeping test fixtures lightweight.
+var builtinCRDs = map[string]*apiextensionsv1.CustomResourceDefinition{
+	"hcp": {
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hostedcontrolplanes.hypershift.openshift.io",
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "hypershift.openshift.io",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:       "HostedControlPlane",
+				ListKind:   "HostedControlPlaneList",
+				Plural:     "hostedcontrolplanes",
+				Singular:   "hostedcontrolplane",
+				ShortNames: []string{"hcp"},
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name:    "v1beta1",
+				Served:  true,
+				Storage: true,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type:                   "object",
+						XPreserveUnknownFields: ptr.To(true),
+					},
+				},
+				Subresources: &apiextensionsv1.CustomResourceSubresources{
+					Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+				},
+			}},
+		},
+	},
+	"vpce": {
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "vpcendpoints.avo.openshift.io",
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "avo.openshift.io",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     "VpcEndpoint",
+				ListKind: "VpcEndpointList",
+				Plural:   "vpcendpoints",
+				Singular: "vpcendpoint",
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name:    "v1alpha2",
+				Served:  true,
+				Storage: true,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type:                   "object",
+						XPreserveUnknownFields: ptr.To(true),
+					},
+				},
+				Subresources: &apiextensionsv1.CustomResourceSubresources{
+					Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+				},
+			}},
+		},
+	},
 }
 
-var crdGVR = schema.GroupVersionResource{
-	Group:    "apiextensions.k8s.io",
-	Version:  "v1",
-	Resource: "customresourcedefinitions",
+// BuiltinCRDAliases returns the known alias names for documentation/validation.
+func BuiltinCRDAliases() []string {
+	aliases := make([]string, 0, len(builtinCRDs))
+	for k := range builtinCRDs {
+		aliases = append(aliases, k)
+	}
+	return aliases
 }
 
 // EnsureCRDsInstalled resolves a list of CRD aliases and installs any that are
 // not already present on the cluster. Forbidden errors are collected and returned
 // together so callers get a single actionable message with all missing CRDs.
-func EnsureCRDsInstalled(ctx context.Context, dynClient dynamic.Interface, crdAliases []string) error {
+func EnsureCRDsInstalled(ctx context.Context, extClient apiextensionsclient.Interface, crdAliases []string) error {
+	crdClient := extClient.ApiextensionsV1().CustomResourceDefinitions()
 	var forbidden []string
 
 	for _, alias := range crdAliases {
@@ -102,32 +106,23 @@ func EnsureCRDsInstalled(ctx context.Context, dynClient dynamic.Interface, crdAl
 			continue
 		}
 
-		crdYAML, ok := BuiltinCRDs[alias]
+		crd, ok := builtinCRDs[alias]
 		if !ok {
-			return fmt.Errorf("unknown CRD alias %q (available: hcp, vpce)", alias)
+			return fmt.Errorf("unknown CRD alias %q (available: %s)", alias, strings.Join(BuiltinCRDAliases(), ", "))
 		}
+		name := crd.Name
 
-		// Decode the embedded YAML into an unstructured object to get the CRD name.
-		obj := &unstructured.Unstructured{}
-		if err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(crdYAML), 4096).Decode(obj); err != nil {
-			return fmt.Errorf("decoding CRD YAML for %q: %w", alias, err)
-		}
-		name := obj.GetName()
-
-		// Check existence first to avoid unnecessary write attempts.
-		if _, err := dynClient.Resource(crdGVR).Get(ctx, name, metav1.GetOptions{}); err == nil {
+		if _, err := crdClient.Get(ctx, name, metav1.GetOptions{}); err == nil {
 			klog.V(2).InfoS("CRD already exists, skipping", "name", name)
 			continue
 		} else if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("checking CRD %s: %w", name, err)
 		}
 
-		// Install the CRD.
 		klog.V(2).InfoS("Installing CRD", "name", name)
-		if _, err := dynClient.Resource(crdGVR).Create(ctx, obj, metav1.CreateOptions{}); err != nil {
+		if _, err := crdClient.Create(ctx, crd, metav1.CreateOptions{}); err != nil {
 			switch {
 			case apierrors.IsAlreadyExists(err):
-				// Another process created it concurrently; still wait for Established below.
 				klog.V(2).InfoS("CRD appeared concurrently, waiting for Established", "name", name)
 			case apierrors.IsForbidden(err):
 				klog.InfoS("Warning: permission denied installing CRD", "name", name)
@@ -138,9 +133,7 @@ func EnsureCRDsInstalled(ctx context.Context, dynClient dynamic.Interface, crdAl
 			}
 		}
 
-		// Wait for the API server to mark the CRD as Established before returning.
-		// Operators that detect CRD presence at startup will fail if it isn't ready.
-		if err := waitForCRDEstablished(ctx, dynClient, name, 30*time.Second); err != nil {
+		if err := waitForCRDEstablished(ctx, extClient, name, 30*time.Second); err != nil {
 			return fmt.Errorf("CRD %s not Established after install: %w", name, err)
 		}
 		klog.V(2).InfoS("CRD installed and Established", "name", name)
@@ -156,19 +149,15 @@ func EnsureCRDsInstalled(ctx context.Context, dynClient dynamic.Interface, crdAl
 }
 
 // waitForCRDEstablished polls until the CRD's Established condition is True.
-func waitForCRDEstablished(ctx context.Context, dynClient dynamic.Interface, name string, timeout time.Duration) error {
+func waitForCRDEstablished(ctx context.Context, extClient apiextensionsclient.Interface, name string, timeout time.Duration) error {
+	crdClient := extClient.ApiextensionsV1().CustomResourceDefinitions()
 	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		obj, err := dynClient.Resource(crdGVR).Get(ctx, name, metav1.GetOptions{})
+		crd, err := crdClient.Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
-		conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
-		if !found {
-			return false, nil
-		}
-		for _, c := range conditions {
-			cond, ok := c.(map[string]interface{})
-			if ok && cond["type"] == "Established" && cond["status"] == "True" {
+		for _, c := range crd.Status.Conditions {
+			if c.Type == apiextensionsv1.Established && c.Status == apiextensionsv1.ConditionTrue {
 				return true, nil
 			}
 		}

--- a/pkg/common/mcsimulation/crds_test.go
+++ b/pkg/common/mcsimulation/crds_test.go
@@ -1,0 +1,181 @@
+package mcsimulation
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// parseCRDForFake decodes a CRD YAML constant into an unstructured object
+// suitable for pre-populating a dynamicfake client.
+func parseCRDForFake(t *testing.T) *unstructured.Unstructured {
+	t.Helper()
+	obj := &unstructured.Unstructured{}
+	if err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(HostedControlPlaneCRDYAML), 4096).Decode(obj); err != nil {
+		t.Fatalf("parseCRDForFake: %v", err)
+	}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1",
+		Kind:    "CustomResourceDefinition",
+	})
+	obj.SetResourceVersion("1")
+	return obj
+}
+
+func notFoundReactor(action k8stesting.Action) (bool, runtime.Object, error) {
+	return true, nil, apierrors.NewNotFound(
+		schema.GroupResource{Resource: "customresourcedefinitions"},
+		action.(k8stesting.GetAction).GetName(),
+	)
+}
+
+func TestBuiltinCRDs_YAMLDecodes(t *testing.T) {
+	for alias, crdYAML := range BuiltinCRDs {
+		t.Run(alias, func(t *testing.T) {
+			obj := &unstructured.Unstructured{}
+			err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(crdYAML), 4096).Decode(obj)
+			if err != nil {
+				t.Fatalf("alias %q: decode error: %v", alias, err)
+			}
+			if obj.GetKind() != "CustomResourceDefinition" {
+				t.Errorf("alias %q: expected kind CustomResourceDefinition, got %q", alias, obj.GetKind())
+			}
+			if obj.GetName() == "" {
+				t.Errorf("alias %q: CRD has no name", alias)
+			}
+		})
+	}
+}
+
+func TestEnsureCRDsInstalled_UnknownAlias(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	err := EnsureCRDsInstalled(context.Background(), client, []string{"nonexistent"})
+	if err == nil || !strings.Contains(err.Error(), "unknown CRD alias") {
+		t.Fatalf("expected 'unknown CRD alias' error, got: %v", err)
+	}
+}
+
+func TestEnsureCRDsInstalled_EmptyAliases(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	if err := EnsureCRDsInstalled(context.Background(), client, []string{"", "  "}); err != nil {
+		t.Fatalf("expected no error for empty aliases, got: %v", err)
+	}
+}
+
+func TestEnsureCRDsInstalled_AlreadyExists(t *testing.T) {
+	existing := parseCRDForFake(t)
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), existing)
+	if err := EnsureCRDsInstalled(context.Background(), client, []string{"hcp"}); err != nil {
+		t.Fatalf("expected no error when CRD already exists, got: %v", err)
+	}
+}
+
+func TestEnsureCRDsInstalled_Forbidden(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	client.PrependReactor("get", "customresourcedefinitions", notFoundReactor)
+	client.PrependReactor("create", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "customresourcedefinitions"}, "test", nil)
+	})
+
+	err := EnsureCRDsInstalled(context.Background(), client, []string{"hcp"})
+	if err == nil || !strings.Contains(err.Error(), "insufficient permissions") {
+		t.Fatalf("expected 'insufficient permissions' error, got: %v", err)
+	}
+}
+
+func TestEnsureCRDsInstalled_RaceConditionAlreadyExists(t *testing.T) {
+	// First Get → not found; Create → AlreadyExists (concurrent creator won the race);
+	// subsequent Gets → established CRD so waitForCRDEstablished returns quickly.
+	established := parseCRDForFake(t)
+	if err := unstructured.SetNestedSlice(established.Object, []interface{}{
+		map[string]interface{}{"type": "Established", "status": "True"},
+	}, "status", "conditions"); err != nil {
+		t.Fatalf("SetNestedSlice: %v", err)
+	}
+
+	getCallCount := 0
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	client.PrependReactor("get", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		getCallCount++
+		if getCallCount == 1 {
+			return notFoundReactor(action)
+		}
+		return true, established, nil
+	})
+	client.PrependReactor("create", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewAlreadyExists(schema.GroupResource{Resource: "customresourcedefinitions"}, "test")
+	})
+
+	if err := EnsureCRDsInstalled(context.Background(), client, []string{"hcp"}); err != nil {
+		t.Fatalf("expected no error for concurrent race, got: %v", err)
+	}
+	if getCallCount < 2 {
+		t.Errorf("expected waitForCRDEstablished to poll after race, got %d get calls", getCallCount)
+	}
+}
+
+func TestWaitForCRDEstablished_AlreadyEstablished(t *testing.T) {
+	crdObj := parseCRDForFake(t)
+	if err := unstructured.SetNestedSlice(crdObj.Object, []interface{}{
+		map[string]interface{}{"type": "Established", "status": "True"},
+	}, "status", "conditions"); err != nil {
+		t.Fatalf("SetNestedSlice: %v", err)
+	}
+
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), crdObj)
+	if err := waitForCRDEstablished(context.Background(), client, crdObj.GetName(), 5*time.Second); err != nil {
+		t.Fatalf("expected no error for already-established CRD, got: %v", err)
+	}
+}
+
+func TestWaitForCRDEstablished_TimesOut(t *testing.T) {
+	crdObj := parseCRDForFake(t)
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), crdObj)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	if err := waitForCRDEstablished(ctx, client, crdObj.GetName(), 2*time.Second); err == nil {
+		t.Fatal("expected timeout error for non-established CRD")
+	}
+}
+
+func TestEnsureCRDsInstalled_EstablishmentTimeout(t *testing.T) {
+	// Create succeeds but CRD never reaches Established state — exercises the
+	// "not Established after install" error path in EnsureCRDsInstalled.
+	// First Get → NotFound (triggers install); subsequent Gets → CRD with no
+	// conditions (waitForCRDEstablished keeps polling until context deadline).
+	crdObj := parseCRDForFake(t)
+
+	getCallCount := 0
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	client.PrependReactor("get", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		getCallCount++
+		if getCallCount == 1 {
+			return notFoundReactor(action)
+		}
+		// Return CRD with no status conditions — never Established.
+		return true, crdObj, nil
+	})
+	client.PrependReactor("create", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, crdObj, nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := EnsureCRDsInstalled(ctx, client, []string{"hcp"})
+	if err == nil || !strings.Contains(err.Error(), "not Established after install") {
+		t.Fatalf("expected 'not Established after install' error, got: %v", err)
+	}
+}

--- a/pkg/common/mcsimulation/crds_test.go
+++ b/pkg/common/mcsimulation/crds_test.go
@@ -6,30 +6,27 @@ import (
 	"testing"
 	"time"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	fakeapiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/yaml"
-	dynamicfake "k8s.io/client-go/dynamic/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
 
-// parseCRDForFake decodes a CRD YAML constant into an unstructured object
-// suitable for pre-populating a dynamicfake client.
-func parseCRDForFake(t *testing.T) *unstructured.Unstructured {
-	t.Helper()
-	obj := &unstructured.Unstructured{}
-	if err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(HostedControlPlaneCRDYAML), 4096).Decode(obj); err != nil {
-		t.Fatalf("parseCRDForFake: %v", err)
-	}
-	obj.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "apiextensions.k8s.io",
-		Version: "v1",
-		Kind:    "CustomResourceDefinition",
-	})
-	obj.SetResourceVersion("1")
-	return obj
+func hcpCRD() *apiextensionsv1.CustomResourceDefinition {
+	crd := builtinCRDs["hcp"].DeepCopy()
+	crd.ResourceVersion = "1"
+	return crd
+}
+
+func establishedCRD() *apiextensionsv1.CustomResourceDefinition {
+	crd := hcpCRD()
+	crd.Status.Conditions = []apiextensionsv1.CustomResourceDefinitionCondition{{
+		Type:   apiextensionsv1.Established,
+		Status: apiextensionsv1.ConditionTrue,
+	}}
+	return crd
 }
 
 func notFoundReactor(action k8stesting.Action) (bool, runtime.Object, error) {
@@ -39,26 +36,28 @@ func notFoundReactor(action k8stesting.Action) (bool, runtime.Object, error) {
 	)
 }
 
-func TestBuiltinCRDs_YAMLDecodes(t *testing.T) {
-	for alias, crdYAML := range BuiltinCRDs {
+func TestBuiltinCRDs_Defined(t *testing.T) {
+	for _, alias := range []string{"hcp", "vpce"} {
 		t.Run(alias, func(t *testing.T) {
-			obj := &unstructured.Unstructured{}
-			err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(crdYAML), 4096).Decode(obj)
-			if err != nil {
-				t.Fatalf("alias %q: decode error: %v", alias, err)
+			crd, ok := builtinCRDs[alias]
+			if !ok {
+				t.Fatalf("alias %q not found in builtinCRDs", alias)
 			}
-			if obj.GetKind() != "CustomResourceDefinition" {
-				t.Errorf("alias %q: expected kind CustomResourceDefinition, got %q", alias, obj.GetKind())
+			if crd.Name == "" {
+				t.Error("CRD has no name")
 			}
-			if obj.GetName() == "" {
-				t.Errorf("alias %q: CRD has no name", alias)
+			if crd.Spec.Group == "" {
+				t.Error("CRD has no group")
+			}
+			if len(crd.Spec.Versions) == 0 {
+				t.Error("CRD has no versions")
 			}
 		})
 	}
 }
 
 func TestEnsureCRDsInstalled_UnknownAlias(t *testing.T) {
-	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	client := fakeapiextensions.NewClientset()
 	err := EnsureCRDsInstalled(context.Background(), client, []string{"nonexistent"})
 	if err == nil || !strings.Contains(err.Error(), "unknown CRD alias") {
 		t.Fatalf("expected 'unknown CRD alias' error, got: %v", err)
@@ -66,23 +65,22 @@ func TestEnsureCRDsInstalled_UnknownAlias(t *testing.T) {
 }
 
 func TestEnsureCRDsInstalled_EmptyAliases(t *testing.T) {
-	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	client := fakeapiextensions.NewClientset()
 	if err := EnsureCRDsInstalled(context.Background(), client, []string{"", "  "}); err != nil {
 		t.Fatalf("expected no error for empty aliases, got: %v", err)
 	}
 }
 
 func TestEnsureCRDsInstalled_AlreadyExists(t *testing.T) {
-	existing := parseCRDForFake(t)
-	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), existing)
+	existing := hcpCRD()
+	client := fakeapiextensions.NewClientset(existing)
 	if err := EnsureCRDsInstalled(context.Background(), client, []string{"hcp"}); err != nil {
 		t.Fatalf("expected no error when CRD already exists, got: %v", err)
 	}
 }
 
 func TestEnsureCRDsInstalled_Forbidden(t *testing.T) {
-	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
-	client.PrependReactor("get", "customresourcedefinitions", notFoundReactor)
+	client := fakeapiextensions.NewClientset()
 	client.PrependReactor("create", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "customresourcedefinitions"}, "test", nil)
 	})
@@ -94,17 +92,10 @@ func TestEnsureCRDsInstalled_Forbidden(t *testing.T) {
 }
 
 func TestEnsureCRDsInstalled_RaceConditionAlreadyExists(t *testing.T) {
-	// First Get → not found; Create → AlreadyExists (concurrent creator won the race);
-	// subsequent Gets → established CRD so waitForCRDEstablished returns quickly.
-	established := parseCRDForFake(t)
-	if err := unstructured.SetNestedSlice(established.Object, []interface{}{
-		map[string]interface{}{"type": "Established", "status": "True"},
-	}, "status", "conditions"); err != nil {
-		t.Fatalf("SetNestedSlice: %v", err)
-	}
+	established := establishedCRD()
 
 	getCallCount := 0
-	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	client := fakeapiextensions.NewClientset()
 	client.PrependReactor("get", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		getCallCount++
 		if getCallCount == 1 {
@@ -125,50 +116,39 @@ func TestEnsureCRDsInstalled_RaceConditionAlreadyExists(t *testing.T) {
 }
 
 func TestWaitForCRDEstablished_AlreadyEstablished(t *testing.T) {
-	crdObj := parseCRDForFake(t)
-	if err := unstructured.SetNestedSlice(crdObj.Object, []interface{}{
-		map[string]interface{}{"type": "Established", "status": "True"},
-	}, "status", "conditions"); err != nil {
-		t.Fatalf("SetNestedSlice: %v", err)
-	}
-
-	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), crdObj)
-	if err := waitForCRDEstablished(context.Background(), client, crdObj.GetName(), 5*time.Second); err != nil {
+	established := establishedCRD()
+	client := fakeapiextensions.NewClientset(established)
+	if err := waitForCRDEstablished(context.Background(), client, established.Name, 5*time.Second); err != nil {
 		t.Fatalf("expected no error for already-established CRD, got: %v", err)
 	}
 }
 
 func TestWaitForCRDEstablished_TimesOut(t *testing.T) {
-	crdObj := parseCRDForFake(t)
-	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), crdObj)
+	crd := hcpCRD()
+	client := fakeapiextensions.NewClientset(crd)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	if err := waitForCRDEstablished(ctx, client, crdObj.GetName(), 2*time.Second); err == nil {
+	if err := waitForCRDEstablished(ctx, client, crd.Name, 2*time.Second); err == nil {
 		t.Fatal("expected timeout error for non-established CRD")
 	}
 }
 
 func TestEnsureCRDsInstalled_EstablishmentTimeout(t *testing.T) {
-	// Create succeeds but CRD never reaches Established state — exercises the
-	// "not Established after install" error path in EnsureCRDsInstalled.
-	// First Get → NotFound (triggers install); subsequent Gets → CRD with no
-	// conditions (waitForCRDEstablished keeps polling until context deadline).
-	crdObj := parseCRDForFake(t)
+	crd := hcpCRD()
 
 	getCallCount := 0
-	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	client := fakeapiextensions.NewClientset()
 	client.PrependReactor("get", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		getCallCount++
 		if getCallCount == 1 {
 			return notFoundReactor(action)
 		}
-		// Return CRD with no status conditions — never Established.
-		return true, crdObj, nil
+		return true, crd, nil
 	})
 	client.PrependReactor("create", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
-		return true, crdObj, nil
+		return true, crd, nil
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
Introduces pkg/common/mcsimulation to support Management Cluster simulation for HCP operator testing. Operators that watch HyperShift resources (e.g. HostedControlPlane) can be tested on ROSA Classic clusters without a real Management Cluster, by installing minimal CRDs that accept arbitrary spec/status fields via `x-kubernetes-preserve-unknown-fields: true`.

Co-authored-by: Cursor [cursor@cursor.com](mailto:cursor@cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated setup/install of Custom Resource Definitions to support Management Cluster simulation and HyperShift operator workflows.
* **Tests**
  * Added unit tests covering CRD installation, idempotency, permission errors, establishment polling, and timeout scenarios.
* **Chores**
  * Updated module dependency declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->