### PR TITLE
SDCICD-1840 Add MCSimulation operator restart logic

### DIFF
--- a/pkg/common/mcsimulation/restart.go
+++ b/pkg/common/mcsimulation/restart.go
@@ -1,0 +1,75 @@
+package mcsimulation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// RestartOperator deletes pods matching labelSelector in the given namespace,
+// then waits for the owning Deployment to reach ready state. This is used
+// after CRD installation so the operator detects the newly registered CRDs.
+//
+// The Deployment's own replica controller recreates deleted pods automatically,
+// making this equivalent to "kubectl rollout restart" without mutating the
+// Deployment spec.
+func RestartOperator(ctx context.Context, clientset kubernetes.Interface, namespace, labelSelector string) error {
+	// Find the Deployment that owns these pods so we can wait on its readiness.
+	deployments, err := clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return fmt.Errorf("listing deployments in %s: %w", namespace, err)
+	}
+	if len(deployments.Items) == 0 {
+		return fmt.Errorf("no deployment found in %s matching %q", namespace, labelSelector)
+	}
+	deploy := &deployments.Items[0]
+
+	// Resolve the Deployment's pod selector to find matching pods.
+	podSelector := labels.SelectorFromSet(deploy.Spec.Selector.MatchLabels).String()
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: podSelector,
+	})
+	if err != nil {
+		return fmt.Errorf("listing pods in %s: %w", namespace, err)
+	}
+	if len(pods.Items) == 0 {
+		klog.InfoS("No pods found to restart", "namespace", namespace, "selector", podSelector)
+		return nil
+	}
+
+	for i := range pods.Items {
+		name := pods.Items[i].Name
+		klog.V(2).InfoS("Deleting pod to trigger restart", "pod", name, "namespace", namespace)
+		if err := clientset.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+			return fmt.Errorf("deleting pod %s: %w", name, err)
+		}
+	}
+
+	// Wait for the Deployment to have at least one ready replica.
+	klog.V(2).InfoS("Waiting for deployment readiness after restart", "deployment", deploy.Name, "namespace", namespace)
+	if err := waitForDeploymentReady(ctx, clientset, namespace, deploy.Name, 2*time.Minute); err != nil {
+		return fmt.Errorf("deployment %s did not become ready: %w", deploy.Name, err)
+	}
+	klog.V(2).InfoS("Deployment restarted successfully", "deployment", deploy.Name)
+	return nil
+}
+
+// waitForDeploymentReady polls until the named Deployment has at least one
+// ready replica or the timeout expires.
+func waitForDeploymentReady(ctx context.Context, clientset kubernetes.Interface, namespace, name string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		deploy, err := clientset.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return deploy.Status.ReadyReplicas > 0, nil
+	})
+}

--- a/pkg/common/mcsimulation/restart.go
+++ b/pkg/common/mcsimulation/restart.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -30,10 +30,22 @@ func RestartOperator(ctx context.Context, clientset kubernetes.Interface, namesp
 	if len(deployments.Items) == 0 {
 		return fmt.Errorf("no deployment found in %s matching %q", namespace, labelSelector)
 	}
+	if len(deployments.Items) > 1 {
+		names := make([]string, len(deployments.Items))
+		for i := range deployments.Items {
+			names[i] = deployments.Items[i].Name
+		}
+		return fmt.Errorf("multiple deployments found in %s matching %q, expected exactly one: %v", namespace, labelSelector, names)
+	}
 	deploy := &deployments.Items[0]
 
 	// Resolve the Deployment's pod selector to find matching pods.
-	podSelector := labels.SelectorFromSet(deploy.Spec.Selector.MatchLabels).String()
+	// Use LabelSelectorAsSelector to honour both matchLabels and matchExpressions.
+	selector, err := metav1.LabelSelectorAsSelector(deploy.Spec.Selector)
+	if err != nil {
+		return fmt.Errorf("converting deployment selector: %w", err)
+	}
+	podSelector := selector.String()
 	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: podSelector,
 	})
@@ -49,6 +61,10 @@ func RestartOperator(ctx context.Context, clientset kubernetes.Interface, namesp
 		name := pods.Items[i].Name
 		klog.V(2).InfoS("Deleting pod to trigger restart", "pod", name, "namespace", namespace)
 		if err := clientset.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.V(2).InfoS("Pod already deleted", "pod", name, "namespace", namespace)
+				continue
+			}
 			return fmt.Errorf("deleting pod %s: %w", name, err)
 		}
 	}

--- a/pkg/common/mcsimulation/restart_test.go
+++ b/pkg/common/mcsimulation/restart_test.go
@@ -1,0 +1,107 @@
+package mcsimulation
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const testNS = "openshift-test-operator"
+
+const testDeploymentName = "controller-manager"
+
+func newDeployment(ready int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testDeploymentName,
+			Namespace: testNS,
+			Labels:    map[string]string{"app": "test-operator"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test-operator"},
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			ReadyReplicas: ready,
+		},
+	}
+}
+
+func newPod(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNS,
+			Labels:    map[string]string{"app": "test-operator"},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+}
+
+func TestRestartOperator_DeletesPodsAndWaitsReady(t *testing.T) {
+	deploy := newDeployment(1)
+	pod := newPod("controller-manager-abc12")
+	client := fake.NewSimpleClientset(deploy, pod)
+
+	err := RestartOperator(context.Background(), client, testNS, "app=test-operator")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Pod should have been deleted.
+	pods, _ := client.CoreV1().Pods(testNS).List(context.Background(), metav1.ListOptions{})
+	if len(pods.Items) != 0 {
+		t.Errorf("expected pod to be deleted, got %d pods", len(pods.Items))
+	}
+}
+
+func TestRestartOperator_NoDeployment(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	err := RestartOperator(context.Background(), client, testNS, "app=nonexistent")
+	if err == nil || !strings.Contains(err.Error(), "no deployment found") {
+		t.Fatalf("expected 'no deployment found' error, got: %v", err)
+	}
+}
+
+func TestRestartOperator_NoPods(t *testing.T) {
+	deploy := newDeployment(1)
+	client := fake.NewSimpleClientset(deploy)
+
+	// No pods exist — should succeed without error (nothing to restart).
+	err := RestartOperator(context.Background(), client, testNS, "app=test-operator")
+	if err != nil {
+		t.Fatalf("unexpected error when no pods: %v", err)
+	}
+}
+
+func TestRestartOperator_ReadinessTimeout(t *testing.T) {
+	deploy := newDeployment(0) // never ready
+	pod := newPod("controller-manager-abc12")
+	client := fake.NewSimpleClientset(deploy, pod)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := RestartOperator(ctx, client, testNS, "app=test-operator")
+	if err == nil || !strings.Contains(err.Error(), "did not become ready") {
+		t.Fatalf("expected 'did not become ready' error, got: %v", err)
+	}
+}
+
+func TestWaitForDeploymentReady_AlreadyReady(t *testing.T) {
+	deploy := newDeployment(1)
+	client := fake.NewSimpleClientset(deploy)
+
+	err := waitForDeploymentReady(context.Background(), client, testNS, deploy.Name, 5*time.Second)
+	if err != nil {
+		t.Fatalf("expected no error for already-ready deployment, got: %v", err)
+	}
+}

--- a/pkg/common/mcsimulation/restart_test.go
+++ b/pkg/common/mcsimulation/restart_test.go
@@ -71,6 +71,18 @@ func TestRestartOperator_NoDeployment(t *testing.T) {
 	}
 }
 
+func TestRestartOperator_MultipleDeployments(t *testing.T) {
+	deploy1 := newDeployment(1)
+	deploy2 := newDeployment(1)
+	deploy2.Name = "controller-manager-2"
+	client := fake.NewSimpleClientset(deploy1, deploy2)
+
+	err := RestartOperator(context.Background(), client, testNS, "app=test-operator")
+	if err == nil || !strings.Contains(err.Error(), "multiple deployments") {
+		t.Fatalf("expected 'multiple deployments' error, got: %v", err)
+	}
+}
+
 func TestRestartOperator_NoPods(t *testing.T) {
 	deploy := newDeployment(1)
 	client := fake.NewSimpleClientset(deploy)


### PR DESCRIPTION
Adds RestartOperator to the mcsimulation package. After CRD installation, operators that detect CRD presence at startup (like RMO's HostedControlPlane controller) need to be restarted to pick up the newly registered CRDs. This function handles that restart safely.

Approach mirrors [RMO's restartRMODeployment](https://github.com/openshift/route-monitor-operator/blob/2af1624d2370accadd2aa81c88e42d6747f71ece/test/e2e/route_monitor_operator_tests.go#L1110) pattern: delete matching pods (Deployment controller recreates them automatically) then poll until ReadyReplicas > 0. No Deployment spec mutation — equivalent to kubectl rollout restart without the annotation.

Co-authored-by: Cursor [cursor@cursor.com](mailto:cursor@cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added restart capability for McSimulation workloads in Kubernetes environments, enabling automatic pod restart through Deployment management with ready replica verification.

* **Tests**
  * Added comprehensive test coverage for restart functionality, including deployment verification, timeout handling, and pod lifecycle management scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->