### PR TITLE
SDCICD-1840 MC simulation orchestrator integration + executor env propagation

### DIFF
--- a/configs/mc-simulation.yaml
+++ b/configs/mc-simulation.yaml
@@ -1,0 +1,4 @@
+mcSimulation:
+  enable: true
+  crds: "hcp,vpce"
+  skipInfraCheck: true

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.2
 	k8s.io/api v0.35.2
+	k8s.io/apiextensions-apiserver v0.35.1
 	k8s.io/apimachinery v0.35.2
 	k8s.io/client-go v0.35.2
 	k8s.io/klog/v2 v2.130.1
@@ -171,7 +172,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	k8s.io/apiextensions-apiserver v0.35.1 // indirect
 	k8s.io/component-base v0.35.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect

--- a/pkg/common/executor/executor.go
+++ b/pkg/common/executor/executor.go
@@ -33,16 +33,18 @@ import (
 )
 
 type Config struct {
-	Environment         ocm.Environment
-	ClusterID           string
-	CloudProviderID     string
-	CloudProviderRegion string
-	PassthruSecrets     map[string]string
-	Timeout             time.Duration
-	OutputDir           string
-	CCS                 bool
-	SkipCleanup         bool
-	RestConfig          *rest.Config
+	Environment           ocm.Environment
+	ClusterID             string
+	CloudProviderID       string
+	CloudProviderRegion   string
+	PassthruSecrets       map[string]string
+	Timeout               time.Duration
+	OutputDir             string
+	CCS                   bool
+	SkipCleanup           bool
+	RestConfig            *rest.Config
+	MCSimulationEnabled   bool
+	MCSimulationSkipInfra bool
 }
 
 type Executor struct {
@@ -174,6 +176,13 @@ func (e *Executor) createJob(ctx context.Context, namespace string, image string
 					LocalObjectReference: corev1.LocalObjectReference{Name: "ci-secrets"},
 				},
 			})
+	}
+
+	if e.cfg.MCSimulationEnabled {
+		job.Spec.Template.Spec.Containers[0].Env = append(job.Spec.Template.Spec.Containers[0].Env,
+			corev1.EnvVar{Name: "MC_SIMULATION_ENABLED", Value: "true"},
+			corev1.EnvVar{Name: "MC_SIMULATION_SKIP_INFRA_CHECK", Value: fmt.Sprintf("%t", e.cfg.MCSimulationSkipInfra)},
+		)
 	}
 
 	if err := e.oc.Create(ctx, job); err != nil {

--- a/pkg/common/mcsimulation/crds.go
+++ b/pkg/common/mcsimulation/crds.go
@@ -1,0 +1,177 @@
+// Package mcsimulation provides Management Cluster simulation for HCP operator
+// testing. It installs minimal CRDs onto a ROSA Classic cluster so that
+// operators that watch HyperShift resources can be tested without a real
+// Management Cluster.
+package mcsimulation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+)
+
+// Minimal CRD definitions with x-kubernetes-preserve-unknown-fields: true
+// so that any spec/status content is accepted without full schema validation.
+// Sourced from route-monitor-operator e2e tests.
+const (
+	HostedControlPlaneCRDYAML = `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: hostedcontrolplanes.hypershift.openshift.io
+spec:
+  group: hypershift.openshift.io
+  names:
+    kind: HostedControlPlane
+    listKind: HostedControlPlaneList
+    plural: hostedcontrolplanes
+    shortNames:
+    - hcp
+    singular: hostedcontrolplane
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
+`
+
+	VpcEndpointCRDYAML = `
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: vpcendpoints.avo.openshift.io
+spec:
+  group: avo.openshift.io
+  names:
+    kind: VpcEndpoint
+    listKind: VpcEndpointList
+    plural: vpcendpoints
+    singular: vpcendpoint
+  scope: Namespaced
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    subresources:
+      status: {}
+`
+)
+
+// BuiltinCRDs maps short aliases (used in config) to embedded CRD YAML.
+// Keys: "hcp" (HostedControlPlane), "vpce" (VpcEndpoint).
+var BuiltinCRDs = map[string]string{
+	"hcp":  HostedControlPlaneCRDYAML,
+	"vpce": VpcEndpointCRDYAML,
+}
+
+var crdGVR = schema.GroupVersionResource{
+	Group:    "apiextensions.k8s.io",
+	Version:  "v1",
+	Resource: "customresourcedefinitions",
+}
+
+// EnsureCRDsInstalled resolves a list of CRD aliases and installs any that are
+// not already present on the cluster. Forbidden errors are collected and returned
+// together so callers get a single actionable message with all missing CRDs.
+func EnsureCRDsInstalled(ctx context.Context, dynClient dynamic.Interface, crdAliases []string) error {
+	var forbidden []string
+
+	for _, alias := range crdAliases {
+		alias = strings.TrimSpace(alias)
+		if alias == "" {
+			continue
+		}
+
+		crdYAML, ok := BuiltinCRDs[alias]
+		if !ok {
+			return fmt.Errorf("unknown CRD alias %q (available: hcp, vpce)", alias)
+		}
+
+		// Decode the embedded YAML into an unstructured object to get the CRD name.
+		obj := &unstructured.Unstructured{}
+		if err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(crdYAML), 4096).Decode(obj); err != nil {
+			return fmt.Errorf("decoding CRD YAML for %q: %w", alias, err)
+		}
+		name := obj.GetName()
+
+		// Check existence first to avoid unnecessary write attempts.
+		if _, err := dynClient.Resource(crdGVR).Get(ctx, name, metav1.GetOptions{}); err == nil {
+			klog.V(2).InfoS("CRD already exists, skipping", "name", name)
+			continue
+		} else if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("checking CRD %s: %w", name, err)
+		}
+
+		// Install the CRD.
+		klog.V(2).InfoS("Installing CRD", "name", name)
+		if _, err := dynClient.Resource(crdGVR).Create(ctx, obj, metav1.CreateOptions{}); err != nil {
+			switch {
+			case apierrors.IsAlreadyExists(err):
+				// Another process created it concurrently; still wait for Established below.
+				klog.V(2).InfoS("CRD appeared concurrently, waiting for Established", "name", name)
+			case apierrors.IsForbidden(err):
+				klog.InfoS("Warning: permission denied installing CRD", "name", name)
+				forbidden = append(forbidden, name)
+				continue
+			default:
+				return fmt.Errorf("creating CRD %s: %w", name, err)
+			}
+		}
+
+		// Wait for the API server to mark the CRD as Established before returning.
+		// Operators that detect CRD presence at startup will fail if it isn't ready.
+		if err := waitForCRDEstablished(ctx, dynClient, name, 30*time.Second); err != nil {
+			return fmt.Errorf("CRD %s not Established after install: %w", name, err)
+		}
+		klog.V(2).InfoS("CRD installed and Established", "name", name)
+	}
+
+	if len(forbidden) > 0 {
+		return fmt.Errorf(
+			"insufficient permissions to install CRDs: [%s] — grant cluster-admin or pre-install them",
+			strings.Join(forbidden, ", "),
+		)
+	}
+	return nil
+}
+
+// waitForCRDEstablished polls until the CRD's Established condition is True.
+func waitForCRDEstablished(ctx context.Context, dynClient dynamic.Interface, name string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		obj, err := dynClient.Resource(crdGVR).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
+		if !found {
+			return false, nil
+		}
+		for _, c := range conditions {
+			cond, ok := c.(map[string]interface{})
+			if ok && cond["type"] == "Established" && cond["status"] == "True" {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}

--- a/pkg/common/mcsimulation/crds.go
+++ b/pkg/common/mcsimulation/crds.go
@@ -10,90 +10,94 @@ import (
 	"strings"
 	"time"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 )
 
-// Minimal CRD definitions with x-kubernetes-preserve-unknown-fields: true
-// so that any spec/status content is accepted without full schema validation.
-// Sourced from route-monitor-operator e2e tests.
-const (
-	HostedControlPlaneCRDYAML = `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: hostedcontrolplanes.hypershift.openshift.io
-spec:
-  group: hypershift.openshift.io
-  names:
-    kind: HostedControlPlane
-    listKind: HostedControlPlaneList
-    plural: hostedcontrolplanes
-    shortNames:
-    - hcp
-    singular: hostedcontrolplane
-  scope: Namespaced
-  versions:
-  - name: v1beta1
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    subresources:
-      status: {}
-`
-
-	VpcEndpointCRDYAML = `
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: vpcendpoints.avo.openshift.io
-spec:
-  group: avo.openshift.io
-  names:
-    kind: VpcEndpoint
-    listKind: VpcEndpointList
-    plural: vpcendpoints
-    singular: vpcendpoint
-  scope: Namespaced
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
-    schema:
-      openAPIV3Schema:
-        type: object
-        x-kubernetes-preserve-unknown-fields: true
-    subresources:
-      status: {}
-`
-)
-
-// BuiltinCRDs maps short aliases (used in config) to embedded CRD YAML.
-// Keys: "hcp" (HostedControlPlane), "vpce" (VpcEndpoint).
-var BuiltinCRDs = map[string]string{
-	"hcp":  HostedControlPlaneCRDYAML,
-	"vpce": VpcEndpointCRDYAML,
+// Minimal stub CRDs with x-kubernetes-preserve-unknown-fields: true.
+// These accept any spec/status content without full schema validation,
+// keeping test fixtures lightweight.
+var builtinCRDs = map[string]*apiextensionsv1.CustomResourceDefinition{
+	"hcp": {
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hostedcontrolplanes.hypershift.openshift.io",
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "hypershift.openshift.io",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:       "HostedControlPlane",
+				ListKind:   "HostedControlPlaneList",
+				Plural:     "hostedcontrolplanes",
+				Singular:   "hostedcontrolplane",
+				ShortNames: []string{"hcp"},
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name:    "v1beta1",
+				Served:  true,
+				Storage: true,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type:                   "object",
+						XPreserveUnknownFields: ptr.To(true),
+					},
+				},
+				Subresources: &apiextensionsv1.CustomResourceSubresources{
+					Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+				},
+			}},
+		},
+	},
+	"vpce": {
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "vpcendpoints.avo.openshift.io",
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "avo.openshift.io",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Kind:     "VpcEndpoint",
+				ListKind: "VpcEndpointList",
+				Plural:   "vpcendpoints",
+				Singular: "vpcendpoint",
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+				Name:    "v1alpha2",
+				Served:  true,
+				Storage: true,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type:                   "object",
+						XPreserveUnknownFields: ptr.To(true),
+					},
+				},
+				Subresources: &apiextensionsv1.CustomResourceSubresources{
+					Status: &apiextensionsv1.CustomResourceSubresourceStatus{},
+				},
+			}},
+		},
+	},
 }
 
-var crdGVR = schema.GroupVersionResource{
-	Group:    "apiextensions.k8s.io",
-	Version:  "v1",
-	Resource: "customresourcedefinitions",
+// BuiltinCRDAliases returns the known alias names for documentation/validation.
+func BuiltinCRDAliases() []string {
+	aliases := make([]string, 0, len(builtinCRDs))
+	for k := range builtinCRDs {
+		aliases = append(aliases, k)
+	}
+	return aliases
 }
 
 // EnsureCRDsInstalled resolves a list of CRD aliases and installs any that are
 // not already present on the cluster. Forbidden errors are collected and returned
 // together so callers get a single actionable message with all missing CRDs.
-func EnsureCRDsInstalled(ctx context.Context, dynClient dynamic.Interface, crdAliases []string) error {
+func EnsureCRDsInstalled(ctx context.Context, extClient apiextensionsclient.Interface, crdAliases []string) error {
+	crdClient := extClient.ApiextensionsV1().CustomResourceDefinitions()
 	var forbidden []string
 
 	for _, alias := range crdAliases {
@@ -102,32 +106,23 @@ func EnsureCRDsInstalled(ctx context.Context, dynClient dynamic.Interface, crdAl
 			continue
 		}
 
-		crdYAML, ok := BuiltinCRDs[alias]
+		crd, ok := builtinCRDs[alias]
 		if !ok {
-			return fmt.Errorf("unknown CRD alias %q (available: hcp, vpce)", alias)
+			return fmt.Errorf("unknown CRD alias %q (available: %s)", alias, strings.Join(BuiltinCRDAliases(), ", "))
 		}
+		name := crd.Name
 
-		// Decode the embedded YAML into an unstructured object to get the CRD name.
-		obj := &unstructured.Unstructured{}
-		if err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(crdYAML), 4096).Decode(obj); err != nil {
-			return fmt.Errorf("decoding CRD YAML for %q: %w", alias, err)
-		}
-		name := obj.GetName()
-
-		// Check existence first to avoid unnecessary write attempts.
-		if _, err := dynClient.Resource(crdGVR).Get(ctx, name, metav1.GetOptions{}); err == nil {
+		if _, err := crdClient.Get(ctx, name, metav1.GetOptions{}); err == nil {
 			klog.V(2).InfoS("CRD already exists, skipping", "name", name)
 			continue
 		} else if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("checking CRD %s: %w", name, err)
 		}
 
-		// Install the CRD.
 		klog.V(2).InfoS("Installing CRD", "name", name)
-		if _, err := dynClient.Resource(crdGVR).Create(ctx, obj, metav1.CreateOptions{}); err != nil {
+		if _, err := crdClient.Create(ctx, crd, metav1.CreateOptions{}); err != nil {
 			switch {
 			case apierrors.IsAlreadyExists(err):
-				// Another process created it concurrently; still wait for Established below.
 				klog.V(2).InfoS("CRD appeared concurrently, waiting for Established", "name", name)
 			case apierrors.IsForbidden(err):
 				klog.InfoS("Warning: permission denied installing CRD", "name", name)
@@ -138,9 +133,7 @@ func EnsureCRDsInstalled(ctx context.Context, dynClient dynamic.Interface, crdAl
 			}
 		}
 
-		// Wait for the API server to mark the CRD as Established before returning.
-		// Operators that detect CRD presence at startup will fail if it isn't ready.
-		if err := waitForCRDEstablished(ctx, dynClient, name, 30*time.Second); err != nil {
+		if err := waitForCRDEstablished(ctx, extClient, name, 30*time.Second); err != nil {
 			return fmt.Errorf("CRD %s not Established after install: %w", name, err)
 		}
 		klog.V(2).InfoS("CRD installed and Established", "name", name)
@@ -156,19 +149,15 @@ func EnsureCRDsInstalled(ctx context.Context, dynClient dynamic.Interface, crdAl
 }
 
 // waitForCRDEstablished polls until the CRD's Established condition is True.
-func waitForCRDEstablished(ctx context.Context, dynClient dynamic.Interface, name string, timeout time.Duration) error {
+func waitForCRDEstablished(ctx context.Context, extClient apiextensionsclient.Interface, name string, timeout time.Duration) error {
+	crdClient := extClient.ApiextensionsV1().CustomResourceDefinitions()
 	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		obj, err := dynClient.Resource(crdGVR).Get(ctx, name, metav1.GetOptions{})
+		crd, err := crdClient.Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
-		conditions, found, _ := unstructured.NestedSlice(obj.Object, "status", "conditions")
-		if !found {
-			return false, nil
-		}
-		for _, c := range conditions {
-			cond, ok := c.(map[string]interface{})
-			if ok && cond["type"] == "Established" && cond["status"] == "True" {
+		for _, c := range crd.Status.Conditions {
+			if c.Type == apiextensionsv1.Established && c.Status == apiextensionsv1.ConditionTrue {
 				return true, nil
 			}
 		}

--- a/pkg/common/mcsimulation/crds_test.go
+++ b/pkg/common/mcsimulation/crds_test.go
@@ -1,0 +1,181 @@
+package mcsimulation
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// parseCRDForFake decodes a CRD YAML constant into an unstructured object
+// suitable for pre-populating a dynamicfake client.
+func parseCRDForFake(t *testing.T) *unstructured.Unstructured {
+	t.Helper()
+	obj := &unstructured.Unstructured{}
+	if err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(HostedControlPlaneCRDYAML), 4096).Decode(obj); err != nil {
+		t.Fatalf("parseCRDForFake: %v", err)
+	}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1",
+		Kind:    "CustomResourceDefinition",
+	})
+	obj.SetResourceVersion("1")
+	return obj
+}
+
+func notFoundReactor(action k8stesting.Action) (bool, runtime.Object, error) {
+	return true, nil, apierrors.NewNotFound(
+		schema.GroupResource{Resource: "customresourcedefinitions"},
+		action.(k8stesting.GetAction).GetName(),
+	)
+}
+
+func TestBuiltinCRDs_YAMLDecodes(t *testing.T) {
+	for alias, crdYAML := range BuiltinCRDs {
+		t.Run(alias, func(t *testing.T) {
+			obj := &unstructured.Unstructured{}
+			err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(crdYAML), 4096).Decode(obj)
+			if err != nil {
+				t.Fatalf("alias %q: decode error: %v", alias, err)
+			}
+			if obj.GetKind() != "CustomResourceDefinition" {
+				t.Errorf("alias %q: expected kind CustomResourceDefinition, got %q", alias, obj.GetKind())
+			}
+			if obj.GetName() == "" {
+				t.Errorf("alias %q: CRD has no name", alias)
+			}
+		})
+	}
+}
+
+func TestEnsureCRDsInstalled_UnknownAlias(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	err := EnsureCRDsInstalled(context.Background(), client, []string{"nonexistent"})
+	if err == nil || !strings.Contains(err.Error(), "unknown CRD alias") {
+		t.Fatalf("expected 'unknown CRD alias' error, got: %v", err)
+	}
+}
+
+func TestEnsureCRDsInstalled_EmptyAliases(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	if err := EnsureCRDsInstalled(context.Background(), client, []string{"", "  "}); err != nil {
+		t.Fatalf("expected no error for empty aliases, got: %v", err)
+	}
+}
+
+func TestEnsureCRDsInstalled_AlreadyExists(t *testing.T) {
+	existing := parseCRDForFake(t)
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), existing)
+	if err := EnsureCRDsInstalled(context.Background(), client, []string{"hcp"}); err != nil {
+		t.Fatalf("expected no error when CRD already exists, got: %v", err)
+	}
+}
+
+func TestEnsureCRDsInstalled_Forbidden(t *testing.T) {
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	client.PrependReactor("get", "customresourcedefinitions", notFoundReactor)
+	client.PrependReactor("create", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "customresourcedefinitions"}, "test", nil)
+	})
+
+	err := EnsureCRDsInstalled(context.Background(), client, []string{"hcp"})
+	if err == nil || !strings.Contains(err.Error(), "insufficient permissions") {
+		t.Fatalf("expected 'insufficient permissions' error, got: %v", err)
+	}
+}
+
+func TestEnsureCRDsInstalled_RaceConditionAlreadyExists(t *testing.T) {
+	// First Get → not found; Create → AlreadyExists (concurrent creator won the race);
+	// subsequent Gets → established CRD so waitForCRDEstablished returns quickly.
+	established := parseCRDForFake(t)
+	if err := unstructured.SetNestedSlice(established.Object, []interface{}{
+		map[string]interface{}{"type": "Established", "status": "True"},
+	}, "status", "conditions"); err != nil {
+		t.Fatalf("SetNestedSlice: %v", err)
+	}
+
+	getCallCount := 0
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	client.PrependReactor("get", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		getCallCount++
+		if getCallCount == 1 {
+			return notFoundReactor(action)
+		}
+		return true, established, nil
+	})
+	client.PrependReactor("create", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewAlreadyExists(schema.GroupResource{Resource: "customresourcedefinitions"}, "test")
+	})
+
+	if err := EnsureCRDsInstalled(context.Background(), client, []string{"hcp"}); err != nil {
+		t.Fatalf("expected no error for concurrent race, got: %v", err)
+	}
+	if getCallCount < 2 {
+		t.Errorf("expected waitForCRDEstablished to poll after race, got %d get calls", getCallCount)
+	}
+}
+
+func TestWaitForCRDEstablished_AlreadyEstablished(t *testing.T) {
+	crdObj := parseCRDForFake(t)
+	if err := unstructured.SetNestedSlice(crdObj.Object, []interface{}{
+		map[string]interface{}{"type": "Established", "status": "True"},
+	}, "status", "conditions"); err != nil {
+		t.Fatalf("SetNestedSlice: %v", err)
+	}
+
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), crdObj)
+	if err := waitForCRDEstablished(context.Background(), client, crdObj.GetName(), 5*time.Second); err != nil {
+		t.Fatalf("expected no error for already-established CRD, got: %v", err)
+	}
+}
+
+func TestWaitForCRDEstablished_TimesOut(t *testing.T) {
+	crdObj := parseCRDForFake(t)
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), crdObj)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	if err := waitForCRDEstablished(ctx, client, crdObj.GetName(), 2*time.Second); err == nil {
+		t.Fatal("expected timeout error for non-established CRD")
+	}
+}
+
+func TestEnsureCRDsInstalled_EstablishmentTimeout(t *testing.T) {
+	// Create succeeds but CRD never reaches Established state — exercises the
+	// "not Established after install" error path in EnsureCRDsInstalled.
+	// First Get → NotFound (triggers install); subsequent Gets → CRD with no
+	// conditions (waitForCRDEstablished keeps polling until context deadline).
+	crdObj := parseCRDForFake(t)
+
+	getCallCount := 0
+	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	client.PrependReactor("get", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		getCallCount++
+		if getCallCount == 1 {
+			return notFoundReactor(action)
+		}
+		// Return CRD with no status conditions — never Established.
+		return true, crdObj, nil
+	})
+	client.PrependReactor("create", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, crdObj, nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := EnsureCRDsInstalled(ctx, client, []string{"hcp"})
+	if err == nil || !strings.Contains(err.Error(), "not Established after install") {
+		t.Fatalf("expected 'not Established after install' error, got: %v", err)
+	}
+}

--- a/pkg/common/mcsimulation/crds_test.go
+++ b/pkg/common/mcsimulation/crds_test.go
@@ -6,30 +6,27 @@ import (
 	"testing"
 	"time"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	fakeapiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/yaml"
-	dynamicfake "k8s.io/client-go/dynamic/fake"
 	k8stesting "k8s.io/client-go/testing"
 )
 
-// parseCRDForFake decodes a CRD YAML constant into an unstructured object
-// suitable for pre-populating a dynamicfake client.
-func parseCRDForFake(t *testing.T) *unstructured.Unstructured {
-	t.Helper()
-	obj := &unstructured.Unstructured{}
-	if err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(HostedControlPlaneCRDYAML), 4096).Decode(obj); err != nil {
-		t.Fatalf("parseCRDForFake: %v", err)
-	}
-	obj.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "apiextensions.k8s.io",
-		Version: "v1",
-		Kind:    "CustomResourceDefinition",
-	})
-	obj.SetResourceVersion("1")
-	return obj
+func hcpCRD() *apiextensionsv1.CustomResourceDefinition {
+	crd := builtinCRDs["hcp"].DeepCopy()
+	crd.ResourceVersion = "1"
+	return crd
+}
+
+func establishedCRD() *apiextensionsv1.CustomResourceDefinition {
+	crd := hcpCRD()
+	crd.Status.Conditions = []apiextensionsv1.CustomResourceDefinitionCondition{{
+		Type:   apiextensionsv1.Established,
+		Status: apiextensionsv1.ConditionTrue,
+	}}
+	return crd
 }
 
 func notFoundReactor(action k8stesting.Action) (bool, runtime.Object, error) {
@@ -39,26 +36,28 @@ func notFoundReactor(action k8stesting.Action) (bool, runtime.Object, error) {
 	)
 }
 
-func TestBuiltinCRDs_YAMLDecodes(t *testing.T) {
-	for alias, crdYAML := range BuiltinCRDs {
+func TestBuiltinCRDs_Defined(t *testing.T) {
+	for _, alias := range []string{"hcp", "vpce"} {
 		t.Run(alias, func(t *testing.T) {
-			obj := &unstructured.Unstructured{}
-			err := yaml.NewYAMLOrJSONDecoder(strings.NewReader(crdYAML), 4096).Decode(obj)
-			if err != nil {
-				t.Fatalf("alias %q: decode error: %v", alias, err)
+			crd, ok := builtinCRDs[alias]
+			if !ok {
+				t.Fatalf("alias %q not found in builtinCRDs", alias)
 			}
-			if obj.GetKind() != "CustomResourceDefinition" {
-				t.Errorf("alias %q: expected kind CustomResourceDefinition, got %q", alias, obj.GetKind())
+			if crd.Name == "" {
+				t.Error("CRD has no name")
 			}
-			if obj.GetName() == "" {
-				t.Errorf("alias %q: CRD has no name", alias)
+			if crd.Spec.Group == "" {
+				t.Error("CRD has no group")
+			}
+			if len(crd.Spec.Versions) == 0 {
+				t.Error("CRD has no versions")
 			}
 		})
 	}
 }
 
 func TestEnsureCRDsInstalled_UnknownAlias(t *testing.T) {
-	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	client := fakeapiextensions.NewClientset()
 	err := EnsureCRDsInstalled(context.Background(), client, []string{"nonexistent"})
 	if err == nil || !strings.Contains(err.Error(), "unknown CRD alias") {
 		t.Fatalf("expected 'unknown CRD alias' error, got: %v", err)
@@ -66,23 +65,22 @@ func TestEnsureCRDsInstalled_UnknownAlias(t *testing.T) {
 }
 
 func TestEnsureCRDsInstalled_EmptyAliases(t *testing.T) {
-	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	client := fakeapiextensions.NewClientset()
 	if err := EnsureCRDsInstalled(context.Background(), client, []string{"", "  "}); err != nil {
 		t.Fatalf("expected no error for empty aliases, got: %v", err)
 	}
 }
 
 func TestEnsureCRDsInstalled_AlreadyExists(t *testing.T) {
-	existing := parseCRDForFake(t)
-	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), existing)
+	existing := hcpCRD()
+	client := fakeapiextensions.NewClientset(existing)
 	if err := EnsureCRDsInstalled(context.Background(), client, []string{"hcp"}); err != nil {
 		t.Fatalf("expected no error when CRD already exists, got: %v", err)
 	}
 }
 
 func TestEnsureCRDsInstalled_Forbidden(t *testing.T) {
-	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
-	client.PrependReactor("get", "customresourcedefinitions", notFoundReactor)
+	client := fakeapiextensions.NewClientset()
 	client.PrependReactor("create", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "customresourcedefinitions"}, "test", nil)
 	})
@@ -94,17 +92,10 @@ func TestEnsureCRDsInstalled_Forbidden(t *testing.T) {
 }
 
 func TestEnsureCRDsInstalled_RaceConditionAlreadyExists(t *testing.T) {
-	// First Get → not found; Create → AlreadyExists (concurrent creator won the race);
-	// subsequent Gets → established CRD so waitForCRDEstablished returns quickly.
-	established := parseCRDForFake(t)
-	if err := unstructured.SetNestedSlice(established.Object, []interface{}{
-		map[string]interface{}{"type": "Established", "status": "True"},
-	}, "status", "conditions"); err != nil {
-		t.Fatalf("SetNestedSlice: %v", err)
-	}
+	established := establishedCRD()
 
 	getCallCount := 0
-	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	client := fakeapiextensions.NewClientset()
 	client.PrependReactor("get", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		getCallCount++
 		if getCallCount == 1 {
@@ -125,50 +116,39 @@ func TestEnsureCRDsInstalled_RaceConditionAlreadyExists(t *testing.T) {
 }
 
 func TestWaitForCRDEstablished_AlreadyEstablished(t *testing.T) {
-	crdObj := parseCRDForFake(t)
-	if err := unstructured.SetNestedSlice(crdObj.Object, []interface{}{
-		map[string]interface{}{"type": "Established", "status": "True"},
-	}, "status", "conditions"); err != nil {
-		t.Fatalf("SetNestedSlice: %v", err)
-	}
-
-	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), crdObj)
-	if err := waitForCRDEstablished(context.Background(), client, crdObj.GetName(), 5*time.Second); err != nil {
+	established := establishedCRD()
+	client := fakeapiextensions.NewClientset(established)
+	if err := waitForCRDEstablished(context.Background(), client, established.Name, 5*time.Second); err != nil {
 		t.Fatalf("expected no error for already-established CRD, got: %v", err)
 	}
 }
 
 func TestWaitForCRDEstablished_TimesOut(t *testing.T) {
-	crdObj := parseCRDForFake(t)
-	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme(), crdObj)
+	crd := hcpCRD()
+	client := fakeapiextensions.NewClientset(crd)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	if err := waitForCRDEstablished(ctx, client, crdObj.GetName(), 2*time.Second); err == nil {
+	if err := waitForCRDEstablished(ctx, client, crd.Name, 2*time.Second); err == nil {
 		t.Fatal("expected timeout error for non-established CRD")
 	}
 }
 
 func TestEnsureCRDsInstalled_EstablishmentTimeout(t *testing.T) {
-	// Create succeeds but CRD never reaches Established state — exercises the
-	// "not Established after install" error path in EnsureCRDsInstalled.
-	// First Get → NotFound (triggers install); subsequent Gets → CRD with no
-	// conditions (waitForCRDEstablished keeps polling until context deadline).
-	crdObj := parseCRDForFake(t)
+	crd := hcpCRD()
 
 	getCallCount := 0
-	client := dynamicfake.NewSimpleDynamicClient(runtime.NewScheme())
+	client := fakeapiextensions.NewClientset()
 	client.PrependReactor("get", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		getCallCount++
 		if getCallCount == 1 {
 			return notFoundReactor(action)
 		}
-		// Return CRD with no status conditions — never Established.
-		return true, crdObj, nil
+		return true, crd, nil
 	})
 	client.PrependReactor("create", "customresourcedefinitions", func(action k8stesting.Action) (bool, runtime.Object, error) {
-		return true, crdObj, nil
+		return true, crd, nil
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/pkg/common/mcsimulation/restart.go
+++ b/pkg/common/mcsimulation/restart.go
@@ -1,0 +1,75 @@
+package mcsimulation
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// RestartOperator deletes pods matching labelSelector in the given namespace,
+// then waits for the owning Deployment to reach ready state. This is used
+// after CRD installation so the operator detects the newly registered CRDs.
+//
+// The Deployment's own replica controller recreates deleted pods automatically,
+// making this equivalent to "kubectl rollout restart" without mutating the
+// Deployment spec.
+func RestartOperator(ctx context.Context, clientset kubernetes.Interface, namespace, labelSelector string) error {
+	// Find the Deployment that owns these pods so we can wait on its readiness.
+	deployments, err := clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return fmt.Errorf("listing deployments in %s: %w", namespace, err)
+	}
+	if len(deployments.Items) == 0 {
+		return fmt.Errorf("no deployment found in %s matching %q", namespace, labelSelector)
+	}
+	deploy := &deployments.Items[0]
+
+	// Resolve the Deployment's pod selector to find matching pods.
+	podSelector := labels.SelectorFromSet(deploy.Spec.Selector.MatchLabels).String()
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: podSelector,
+	})
+	if err != nil {
+		return fmt.Errorf("listing pods in %s: %w", namespace, err)
+	}
+	if len(pods.Items) == 0 {
+		klog.InfoS("No pods found to restart", "namespace", namespace, "selector", podSelector)
+		return nil
+	}
+
+	for i := range pods.Items {
+		name := pods.Items[i].Name
+		klog.V(2).InfoS("Deleting pod to trigger restart", "pod", name, "namespace", namespace)
+		if err := clientset.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+			return fmt.Errorf("deleting pod %s: %w", name, err)
+		}
+	}
+
+	// Wait for the Deployment to have at least one ready replica.
+	klog.V(2).InfoS("Waiting for deployment readiness after restart", "deployment", deploy.Name, "namespace", namespace)
+	if err := waitForDeploymentReady(ctx, clientset, namespace, deploy.Name, 2*time.Minute); err != nil {
+		return fmt.Errorf("deployment %s did not become ready: %w", deploy.Name, err)
+	}
+	klog.V(2).InfoS("Deployment restarted successfully", "deployment", deploy.Name)
+	return nil
+}
+
+// waitForDeploymentReady polls until the named Deployment has at least one
+// ready replica or the timeout expires.
+func waitForDeploymentReady(ctx context.Context, clientset kubernetes.Interface, namespace, name string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		deploy, err := clientset.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return deploy.Status.ReadyReplicas > 0, nil
+	})
+}

--- a/pkg/common/mcsimulation/restart.go
+++ b/pkg/common/mcsimulation/restart.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog/v2"
@@ -30,10 +30,22 @@ func RestartOperator(ctx context.Context, clientset kubernetes.Interface, namesp
 	if len(deployments.Items) == 0 {
 		return fmt.Errorf("no deployment found in %s matching %q", namespace, labelSelector)
 	}
+	if len(deployments.Items) > 1 {
+		names := make([]string, len(deployments.Items))
+		for i := range deployments.Items {
+			names[i] = deployments.Items[i].Name
+		}
+		return fmt.Errorf("multiple deployments found in %s matching %q, expected exactly one: %v", namespace, labelSelector, names)
+	}
 	deploy := &deployments.Items[0]
 
 	// Resolve the Deployment's pod selector to find matching pods.
-	podSelector := labels.SelectorFromSet(deploy.Spec.Selector.MatchLabels).String()
+	// Use LabelSelectorAsSelector to honour both matchLabels and matchExpressions.
+	selector, err := metav1.LabelSelectorAsSelector(deploy.Spec.Selector)
+	if err != nil {
+		return fmt.Errorf("converting deployment selector: %w", err)
+	}
+	podSelector := selector.String()
 	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: podSelector,
 	})
@@ -49,6 +61,10 @@ func RestartOperator(ctx context.Context, clientset kubernetes.Interface, namesp
 		name := pods.Items[i].Name
 		klog.V(2).InfoS("Deleting pod to trigger restart", "pod", name, "namespace", namespace)
 		if err := clientset.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.V(2).InfoS("Pod already deleted", "pod", name, "namespace", namespace)
+				continue
+			}
 			return fmt.Errorf("deleting pod %s: %w", name, err)
 		}
 	}

--- a/pkg/common/mcsimulation/restart_test.go
+++ b/pkg/common/mcsimulation/restart_test.go
@@ -1,0 +1,107 @@
+package mcsimulation
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const testNS = "openshift-test-operator"
+
+const testDeploymentName = "controller-manager"
+
+func newDeployment(ready int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testDeploymentName,
+			Namespace: testNS,
+			Labels:    map[string]string{"app": "test-operator"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": "test-operator"},
+			},
+		},
+		Status: appsv1.DeploymentStatus{
+			ReadyReplicas: ready,
+		},
+	}
+}
+
+func newPod(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNS,
+			Labels:    map[string]string{"app": "test-operator"},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+}
+
+func TestRestartOperator_DeletesPodsAndWaitsReady(t *testing.T) {
+	deploy := newDeployment(1)
+	pod := newPod("controller-manager-abc12")
+	client := fake.NewSimpleClientset(deploy, pod)
+
+	err := RestartOperator(context.Background(), client, testNS, "app=test-operator")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Pod should have been deleted.
+	pods, _ := client.CoreV1().Pods(testNS).List(context.Background(), metav1.ListOptions{})
+	if len(pods.Items) != 0 {
+		t.Errorf("expected pod to be deleted, got %d pods", len(pods.Items))
+	}
+}
+
+func TestRestartOperator_NoDeployment(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	err := RestartOperator(context.Background(), client, testNS, "app=nonexistent")
+	if err == nil || !strings.Contains(err.Error(), "no deployment found") {
+		t.Fatalf("expected 'no deployment found' error, got: %v", err)
+	}
+}
+
+func TestRestartOperator_NoPods(t *testing.T) {
+	deploy := newDeployment(1)
+	client := fake.NewSimpleClientset(deploy)
+
+	// No pods exist — should succeed without error (nothing to restart).
+	err := RestartOperator(context.Background(), client, testNS, "app=test-operator")
+	if err != nil {
+		t.Fatalf("unexpected error when no pods: %v", err)
+	}
+}
+
+func TestRestartOperator_ReadinessTimeout(t *testing.T) {
+	deploy := newDeployment(0) // never ready
+	pod := newPod("controller-manager-abc12")
+	client := fake.NewSimpleClientset(deploy, pod)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := RestartOperator(ctx, client, testNS, "app=test-operator")
+	if err == nil || !strings.Contains(err.Error(), "did not become ready") {
+		t.Fatalf("expected 'did not become ready' error, got: %v", err)
+	}
+}
+
+func TestWaitForDeploymentReady_AlreadyReady(t *testing.T) {
+	deploy := newDeployment(1)
+	client := fake.NewSimpleClientset(deploy)
+
+	err := waitForDeploymentReady(context.Background(), client, testNS, deploy.Name, 5*time.Second)
+	if err != nil {
+		t.Fatalf("expected no error for already-ready deployment, got: %v", err)
+	}
+}

--- a/pkg/common/mcsimulation/restart_test.go
+++ b/pkg/common/mcsimulation/restart_test.go
@@ -71,6 +71,18 @@ func TestRestartOperator_NoDeployment(t *testing.T) {
 	}
 }
 
+func TestRestartOperator_MultipleDeployments(t *testing.T) {
+	deploy1 := newDeployment(1)
+	deploy2 := newDeployment(1)
+	deploy2.Name = "controller-manager-2"
+	client := fake.NewSimpleClientset(deploy1, deploy2)
+
+	err := RestartOperator(context.Background(), client, testNS, "app=test-operator")
+	if err == nil || !strings.Contains(err.Error(), "multiple deployments") {
+		t.Fatalf("expected 'multiple deployments' error, got: %v", err)
+	}
+}
+
 func TestRestartOperator_NoPods(t *testing.T) {
 	deploy := newDeployment(1)
 	client := fake.NewSimpleClientset(deploy)

--- a/pkg/e2e/adhoctestimages/adhoctestimages.go
+++ b/pkg/e2e/adhoctestimages/adhoctestimages.go
@@ -49,14 +49,16 @@ var _ = ginkgo.Describe("Ad Hoc Test Images", ginkgo.Ordered, ginkgo.ContinueOnF
 		testImageEntries = []ginkgo.TableEntry{}
 		testSuites       []config.TestSuite
 		exeConfig        = &executor.Config{
-			CCS:                 viper.GetBool(ocmprovider.CCS),
-			CloudProviderID:     viper.GetString(config.CloudProvider.CloudProviderID),
-			CloudProviderRegion: viper.GetString(config.CloudProvider.Region),
-			ClusterID:           viper.GetString(config.Cluster.ID),
-			Environment:         ocm.Environment(viper.GetString(ocmprovider.Env)),
-			PassthruSecrets:     viper.GetStringMapString(config.NonOSDe2eSecrets),
-			SkipCleanup:         viper.GetBool(config.Cluster.SkipDestroyCluster),
-			Timeout:             viper.GetDuration(config.Tests.AdHocTestContainerTimeout),
+			CCS:                   viper.GetBool(ocmprovider.CCS),
+			CloudProviderID:       viper.GetString(config.CloudProvider.CloudProviderID),
+			CloudProviderRegion:   viper.GetString(config.CloudProvider.Region),
+			ClusterID:             viper.GetString(config.Cluster.ID),
+			Environment:           ocm.Environment(viper.GetString(ocmprovider.Env)),
+			PassthruSecrets:       viper.GetStringMapString(config.NonOSDe2eSecrets),
+			SkipCleanup:           viper.GetBool(config.Cluster.SkipDestroyCluster),
+			Timeout:               viper.GetDuration(config.Tests.AdHocTestContainerTimeout),
+			MCSimulationEnabled:   viper.GetBool(config.MCSimulation.Enable),
+			MCSimulationSkipInfra: viper.GetBool(config.MCSimulation.SkipInfraCheck),
 		}
 		exe *executor.Executor
 	)

--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -22,6 +22,7 @@ import (
 	viper "github.com/openshift/osde2e/pkg/common/concurrentviper"
 	"github.com/openshift/osde2e/pkg/common/config"
 	"github.com/openshift/osde2e/pkg/common/helper"
+	"github.com/openshift/osde2e/pkg/common/mcsimulation"
 	"github.com/openshift/osde2e/pkg/common/orchestrator"
 	"github.com/openshift/osde2e/pkg/common/phase"
 	"github.com/openshift/osde2e/pkg/common/providers"
@@ -33,6 +34,9 @@ import (
 	"github.com/openshift/osde2e/pkg/common/util"
 	"github.com/openshift/osde2e/pkg/debug"
 	"github.com/openshift/osde2e/pkg/e2e/adhoctestimages"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 	ctrlog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -164,6 +168,54 @@ func (o *E2EOrchestrator) Provision(ctx context.Context) error {
 		return fmt.Errorf("addon installation failed: %w", err)
 	}
 
+	if viper.GetBool(config.MCSimulation.Enable) {
+		if err := o.setupMCSimulation(ctx); err != nil {
+			o.result.ExitCode = config.Failure
+			return fmt.Errorf("MC simulation setup failed: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// setupMCSimulation installs stub HCP CRDs and optionally restarts the
+// operator under test so it detects the newly registered CRDs.
+func (o *E2EOrchestrator) setupMCSimulation(ctx context.Context) error {
+	log.Println("Setting up MC simulation environment...")
+
+	restCfg, err := clientcmd.RESTConfigFromKubeConfig(
+		[]byte(viper.GetString(config.Kubeconfig.Contents)),
+	)
+	if err != nil {
+		return fmt.Errorf("building rest config: %w", err)
+	}
+
+	extClient, err := apiextensionsclient.NewForConfig(restCfg)
+	if err != nil {
+		return fmt.Errorf("building apiextensions client: %w", err)
+	}
+
+	aliases := strings.Split(viper.GetString(config.MCSimulation.CRDs), ",")
+	if err := mcsimulation.EnsureCRDsInstalled(ctx, extClient, aliases); err != nil {
+		return err
+	}
+
+	ns := viper.GetString(config.MCSimulation.OperatorNamespace)
+	label := viper.GetString(config.MCSimulation.OperatorDeploymentLabel)
+	if (ns == "") != (label == "") {
+		return fmt.Errorf("operator restart requires both namespace and label, or neither: namespace=%q label=%q", ns, label)
+	}
+	if ns != "" {
+		kubeClient, err := kubernetes.NewForConfig(restCfg)
+		if err != nil {
+			return fmt.Errorf("building kubernetes client: %w", err)
+		}
+		if err := mcsimulation.RestartOperator(ctx, kubeClient, ns, label); err != nil {
+			return err
+		}
+	}
+
+	log.Println("MC simulation environment ready")
 	return nil
 }
 


### PR DESCRIPTION
Wires the mcsimulation package into the osde2e test lifecycle so that operators depending on HyperShift HostedControlPlane resources can be tested on a ROSA Classic cluster without a real Management Cluster.

Test plan

- [x]  go build ./... — passes

- [x]  go test ./pkg/common/mcsimulation/... -race — 16 tests pass

- [x]  go vet — no warnings

- [ ]  Manual: run example-operator e2e with --configs=...,mc-simulation

Depends on:
- [#PR 3254 ](https://github.com/openshift/osde2e/pull/3254)— CRD install logic
- [#PR 3255](https://github.com/openshift/osde2e/pull/3255) — operator restart logic

Review scope: only commit e7841d4. First 4 commits belong to #PR 3254 and #PR 3255.

Co-authored-by: Cursor <cursoragent@cursor.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced multi-cluster simulation capability that automatically configures and validates required components during cluster provisioning
  * Added configuration options to enable multi-cluster simulation and optionally skip infrastructure validation checks

* **Dependencies**
  * Updated Kubernetes API extensions dependency version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->