### PR TITLE
[SDCICD-1948]: Treat unreachable AWS regions as recoverable secrets cleanup errors

### DIFF
--- a/cmd/osde2e/cleanup/cmd.go
+++ b/cmd/osde2e/cleanup/cmd.go
@@ -437,7 +437,14 @@ func run(ctx context.Context) (msg Message, err error) {
 		secretsCounters, err := aws.CcsAwsSession.CleanupSecrets(ctx, secretClusters, oidcARNs, fmtDuration, args.dryRun, args.sendSummary, &secretsErrorBuilder)
 		summaryBuilder.WriteString("Secrets: " + strconv.Itoa(secretsCounters.Deleted) + "/" + strconv.Itoa(secretsCounters.Failed) + "\n")
 		if err != nil {
-			return msg, fmt.Errorf("could not delete secrets: %s", err.Error())
+			if !errors.Is(err, aws.ErrSecretsCleanup) {
+				return msg, fmt.Errorf("could not delete secrets: %s", err.Error())
+			}
+			secretsErrorMessage := err.Error()
+			if len(secretsErrorMessage) > config.SlackMessageLength {
+				secretsErrorMessage = secretsErrorMessage[:config.SlackMessageLength]
+			}
+			secretsErrorBuilder.WriteString(secretsErrorMessage)
 		}
 	}
 

--- a/pkg/common/aws/secrets.go
+++ b/pkg/common/aws/secrets.go
@@ -20,6 +20,10 @@ const (
 	rosaOIDCSecretPref = "rosa-private-key-oidc-"
 )
 
+// ErrSecretsCleanup is returned when secrets cleanup completes with recoverable
+// errors, such as unreachable AWS regions from the CI network.
+var ErrSecretsCleanup = fmt.Errorf("secrets cleanup encountered errors")
+
 // CleanupSecrets deletes leftover Secrets Manager secrets created by osde2e ROSA STS/HCP
 // provision (unmanaged OIDC private keys and CAPA userdata) that are not tied to a live cluster.
 // activeClusters and activeOIDCSecretARNs must be non-nil. Nil means listing was
@@ -342,7 +346,10 @@ func cleanupSecrets(ctx context.Context, in cleanupSecretsInput, deps cleanupSec
 			regionErrs = append(regionErrs, regionErr)
 		}
 	}
-	return result, errors.Join(regionErrs...)
+	if len(regionErrs) > 0 {
+		return result, fmt.Errorf("%w: %v", ErrSecretsCleanup, errors.Join(regionErrs...))
+	}
+	return result, nil
 }
 
 // listSecretCleanupRegions returns enabled AWS regions to scan, or the session region on DescribeRegions failure.

--- a/pkg/common/aws/secrets_test.go
+++ b/pkg/common/aws/secrets_test.go
@@ -619,6 +619,9 @@ func TestCleanupSecretsContinuesAfterRegionListError(t *testing.T) {
 	if err == nil {
 		t.Fatal("cleanupSecrets() error = nil, want region list error")
 	}
+	if !errors.Is(err, ErrSecretsCleanup) {
+		t.Fatalf("cleanupSecrets() error = %v, want ErrSecretsCleanup", err)
+	}
 	if !strings.Contains(err.Error(), "us-east-1") {
 		t.Fatalf("error = %v, want us-east-1 list failure", err)
 	}


### PR DESCRIPTION
[SDCICD-1948]:Treat unreachable AWS regions as recoverable secrets cleanup errors

Secrets cleanup scans all enabled regions, but Prow build clusters cannot
reach every Secrets Manager endpoint. Continue cleanup in reachable regions
and report inaccessible ones in the summary instead of failing the job.

[SDCICD-1948]: https://redhat.atlassian.net/browse/SDCICD-1948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ