### PR TITLE
SDCICD-1948 Clean up rosa-private-key-osde2e-*-oidc-* secrets

### DIFF
--- a/pkg/common/aws/secrets.go
+++ b/pkg/common/aws/secrets.go
@@ -16,8 +16,10 @@ import (
 )
 
 const (
-	leftoverNameMarker = "osde2e"
-	rosaOIDCSecretPref = "rosa-private-key-oidc-"
+	leftoverNameMarker  = "osde2e"
+	rosaPrivateKeyPref  = "rosa-private-key-"
+	rosaOIDCSecretPref  = rosaPrivateKeyPref + "oidc-"
+	rosaOIDCBucketInfix = "-oidc-"
 )
 
 // ErrSecretsCleanup is returned when secrets cleanup completes with recoverable
@@ -177,13 +179,12 @@ func tagHasOSDe2eCluster(tagText string) bool {
 }
 
 // isLeftoverSecret reports whether a secret is in a class this janitor may delete.
-// Unmanaged ROSA OIDC private keys are named rosa-private-key-oidc-*. That prefix
-// is the leak: abort/timeout often leaves the key without an osde2e marker.
-// Live keys are kept by the OCM SecretArn skip set and --older-than, not by
-// requiring the marker. Other secrets (CAPA bootstrap userdata) are leftovers
-// when a tag key or value is an osde2e- cluster name. CAPA stores that name in
-// the tag key; a user-defined secret whose name merely contains "osde2e" is not
-// deleted.
+// Unmanaged ROSA OIDC private keys use either rosa-private-key-oidc-* (no cluster
+// prefix) or rosa-private-key-<prefix>-oidc-* (ROSA --prefix, e.g. osde2e-btf9i).
+// Live keys are kept by the OCM SecretArn skip set and --older-than. Other
+// secrets (CAPA bootstrap userdata) are leftovers when a tag key or value is an
+// osde2e- cluster name. CAPA stores that name in the tag key; a user-defined
+// secret whose name merely contains "osde2e" is not deleted.
 func isLeftoverSecret(secret secretIdentity) bool {
 	if isUnmanagedOIDCSecret(secret) {
 		return true
@@ -245,8 +246,19 @@ func awsSecretARNNameHasSuffix(full, base string) bool {
 }
 
 // isUnmanagedOIDCSecret reports whether the secret name is an unmanaged ROSA OIDC private key.
+// ROSA/ocm-common names secrets rosa-private-key-{bucket}; buckets are either oidc-{random}
+// or {clusterPrefix}-oidc-{random} when created with --prefix.
 func isUnmanagedOIDCSecret(secret secretIdentity) bool {
-	return strings.HasPrefix(secret.Name, rosaOIDCSecretPref)
+	name := secret.Name
+	if strings.HasPrefix(name, rosaOIDCSecretPref) {
+		return true
+	}
+	if !strings.HasPrefix(name, rosaPrivateKeyPref) {
+		return false
+	}
+	rest := name[len(rosaPrivateKeyPref):]
+	idx := strings.Index(rest, rosaOIDCBucketInfix)
+	return idx > 0 && idx+len(rosaOIDCBucketInfix) < len(rest)
 }
 
 // shouldSkipSecret reports whether a leftover must be kept. A nil OIDC skip set is

--- a/pkg/common/aws/secrets_test.go
+++ b/pkg/common/aws/secrets_test.go
@@ -38,6 +38,16 @@ func TestIsLeftoverSecret(t *testing.T) {
 			want:   true,
 		},
 		{
+			name:   "unmanaged rosa oidc with osde2e cluster prefix",
+			secret: secretIdentity{Name: "rosa-private-key-osde2e-btf9i-oidc-b5x9"},
+			want:   true,
+		},
+		{
+			name:   "rosa private key without oidc bucket segment",
+			secret: secretIdentity{Name: "rosa-private-key-osde2e-btf9i-installer"},
+			want:   false,
+		},
+		{
 			name:   "user-defined name containing osde2e",
 			secret: secretIdentity{Name: "osde2e-shared-token"},
 			want:   false,
@@ -133,6 +143,12 @@ func TestBelongsToActiveCluster(t *testing.T) {
 		{
 			name:        "cluster name in secret name",
 			secret:      secretIdentity{Name: "osde2e-live1-oidc"},
+			wantCluster: "osde2e-live1",
+			wantSkip:    true,
+		},
+		{
+			name:        "rosa oidc key with osde2e cluster prefix in name",
+			secret:      secretIdentity{Name: "rosa-private-key-osde2e-live1-oidc-a1b2"},
 			wantCluster: "osde2e-live1",
 			wantSkip:    true,
 		},
@@ -439,10 +455,13 @@ func TestCleanupSecretsEmptyOIDCSkipSet(t *testing.T) {
 
 func TestCleanupSecretsKeepsLiveUnmarkedOIDC(t *testing.T) {
 	t.Parallel()
-	live := leftoverSecret("rosa-private-key-oidc-live", "arn:aws:secretsmanager:us-east-1:1:secret:rosa-private-key-oidc-live-AbCdEf")
+	live := leftoverSecret(
+		"rosa-private-key-osde2e-live1-oidc-a1b2",
+		"arn:aws:secretsmanager:us-east-1:1:secret:rosa-private-key-osde2e-live1-oidc-a1b2-AbCdEf",
+	)
 	live.Description = nil
 	client, result, err := runSecretsCleanup([]secretsmanagertypes.SecretListEntry{live}, cleanupSecretsInput{
-		ActiveClusters:       map[string]bool{},
+		ActiveClusters:       map[string]bool{"osde2e-live1": true},
 		ActiveOIDCSecretARNs: map[string]bool{aws.ToString(live.ARN): true},
 		OlderThan:            24 * time.Hour,
 	}, nil)
@@ -456,7 +475,10 @@ func TestCleanupSecretsKeepsLiveUnmarkedOIDC(t *testing.T) {
 
 func TestCleanupSecretsUnmarkedOIDCPrefix(t *testing.T) {
 	t.Parallel()
-	orphan := leftoverSecret("rosa-private-key-oidc-other", "arn:aws:secretsmanager:us-east-1:1:secret:rosa-private-key-oidc-other-AbCdEf")
+	orphan := leftoverSecret(
+		"rosa-private-key-osde2e-dead1-oidc-a1b2",
+		"arn:aws:secretsmanager:us-east-1:1:secret:rosa-private-key-osde2e-dead1-oidc-a1b2-XyZ123",
+	)
 	orphan.Description = nil
 	client, result, err := runSecretsCleanup([]secretsmanagertypes.SecretListEntry{orphan}, cleanupSecretsInput{
 		ActiveClusters:       map[string]bool{},


### PR DESCRIPTION
## Summary

Extend `--secrets` cleanup to include unmanaged ROSA OIDC private keys matching:

`rosa-private-key-*-oidc-*`

This covers osde2e-created secrets such as `rosa-private-key-osde2e-<id>-oidc-<suffix>`, which were previously missed and left ~330 orphaned secrets.

Existing safety checks remain unchanged.

## Test plan

* [x] Unit tests
* [x] Dry-run against `888577049525`
* [x] Confirm orphaned secrets are selected
* [x] Confirm live OIDC secrets are skipped
* [ ] Verify periodic cleanup reduces the secret count after merge

Made with [Cursor](https://cursor.com/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup handling for ROSA OIDC secrets with cluster-specific prefixes.
  - Prevents unrelated private-key secrets from being incorrectly identified as OIDC secrets.
  - Correctly distinguishes active-cluster secrets from leftover secrets during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->